### PR TITLE
Remove port from the probes of sample.

### DIFF
--- a/serving/samples/knative-routing/sample.yaml
+++ b/serving/samples/knative-routing/sample.yaml
@@ -32,7 +32,6 @@ spec:
             readinessProbe:
               httpGet:
                 path: /
-                port: 8080
               initialDelaySeconds: 3
               periodSeconds: 3
 ---
@@ -56,6 +55,5 @@ spec:
             readinessProbe:
               httpGet:
                 path: /
-                port: 8080
               initialDelaySeconds: 3
               periodSeconds: 3

--- a/serving/samples/stock-rest-app/sample.yaml
+++ b/serving/samples/stock-rest-app/sample.yaml
@@ -43,6 +43,5 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3

--- a/serving/samples/stock-rest-app/updated_configuration.yaml
+++ b/serving/samples/stock-rest-app/updated_configuration.yaml
@@ -33,6 +33,5 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 8080
           initialDelaySeconds: 3
           periodSeconds: 3


### PR DESCRIPTION
These should default properly today, and this is consistent with our omission of Ports from the container spec.  A forthcoming change will actually disallow specifying this.

