### PR TITLE
move to alpine base image

### DIFF
--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -46,7 +46,7 @@ The following instructions recreate the source files from this folder.
    See [official Python docker image](https://hub.docker.com/_/python/) for more details.
 
     ```docker
-    FROM python
+    FROM python:alpine
 
     ENV APP_HOME /app
     COPY . $APP_HOME


### PR DESCRIPTION
7 characters that save us 800 Mb.

If we want to stick to Debian base images, let's move to `python:slim`

