### PR TITLE
Use revision everywhere in builds instead of branch

### DIFF
--- a/build/builds.md
+++ b/build/builds.md
@@ -79,7 +79,7 @@ specifications.  For examples of Builds leveraging templates, see [the build
 template documentation](./build-templates.md).
 
 
-#### With `git` by `branch`
+#### With `git` by branch, tag, commit or ref
 
 ```yaml
 spec:
@@ -91,6 +91,10 @@ spec:
   - image: ubuntu
     args: ["cat", "README.md"]
 ```
+
+The `revision` field accepts a branch name, tag name, commit SHA, or any ref.
+See https://git-scm.com/docs/gitrevisions#_specifying_revisions for more
+information.
 
 #### With a `gcs` source
 

--- a/serving/samples/buildpack-app-dotnet/sample.yaml
+++ b/serving/samples/buildpack-app-dotnet/sample.yaml
@@ -18,7 +18,7 @@ spec:
     source:
       git:
         url: https://github.com/cloudfoundry-samples/dotnet-core-hello-world
-        branch: master
+        revision: master
     template:
       name: buildpack
       arguments:

--- a/serving/samples/buildpack-function-nodejs/sample.yaml
+++ b/serving/samples/buildpack-function-nodejs/sample.yaml
@@ -18,7 +18,7 @@ spec:
     source:
       git:
         url: https://github.com/projectriff-samples/node-square
-        branch: master
+        revision: master
     template:
       name: buildpack
       arguments:

--- a/serving/samples/thumbnailer-go/sample.yaml
+++ b/serving/samples/thumbnailer-go/sample.yaml
@@ -32,7 +32,7 @@ spec:
     source:
       git:
         url: https://github.com/mchmarny/rester-tester
-        branch: master
+        revision: master
     template:
       name: kaniko
       arguments:


### PR DESCRIPTION
Fixes more examples of #100

/assign rgregg