### PR TITLE
Update docs to require `kubectl` version later than v1.10.

### DIFF
--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -7,7 +7,6 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-
 Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
 required.  This guide walks you through creating a cluster with the correct
 specifications for Knative on Google Cloud Platform.
@@ -19,7 +18,8 @@ commands will need to be adjusted for use in a Windows environment.
 
 1. If you already have `kubectl`, run `kubectl version` to check your client version.
 
-> If you already have `gcloud` installed with the `kubectl` component later than v1.10, you can skip these steps.
+1. If you already have `gcloud` installed with the `kubectl` component later than
+   v1.10, you can skip these steps.
 
 1. Download and install the `gcloud` command line tool:
    https://cloud.google.com/sdk/install

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -15,8 +15,8 @@ you can create one using [Minikube](https://github.com/kubernetes/minikube).
 ### Install kubectl and Minikube
 
 1. If you already have `kubectl` CLI, run `kubectl version` to check the
-   version.  We will need v1.10 or newer.  If your `kubectl` is older, follow
-   the next step to install newer version.
+   version.  You need v1.10 or newer.  If your `kubectl` is older, follow
+   the next step to install a newer version.
 
 1. [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
 


### PR DESCRIPTION
See https://github.com/knative/serving/issues/1500 for cases where older `kubectl` fails to install Knative.