### PR TITLE
Update Minikube intructions

### DIFF
--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -119,11 +119,13 @@ guide.
 If you'd like to view the available sample apps and deploy one of your choosing,
 head to the [sample apps](../serving/samples/README.md) repo.
 
-*NOTE:* When looking up the IP address to use for accessing your app you need to look up the NodePort for the `knative-ingressgateway` as well as the IP address used for Minikube. 
-You can use the following to look up the value to use for the {IP_ADDRESS} placeholder used in the samples:
-```shell
-echo $(minikube ip):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
-```
+> Note: When looking up the IP address to use for accessing your app, you need to look up
+  the NodePort for the `knative-ingressgateway` as well as the IP address used for Minikube.
+  You can use the following command to look up the value to use for the {IP_ADDRESS} placeholder
+  used in the samples:
+  ```shell
+  echo $(minikube ip):$(kubectl get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+  ```
 
 ## Cleaning up
 


### PR DESCRIPTION
- remove `DenyEscalatingExec`, it's not included in the Istio installation docs - https://istio.io/docs/setup/kubernetes/quick-start/#minikube and it prevents us from execing into running containers when sidecar injection is enabled

- add command for changing `LoadBalancer` to `NodePort` for the `knative-ingress` service

- update Kubernetes version to 1.10.5

- add note about looking up the IP address to use for accessing sample apps

Fixes #(issue-number)

## Proposed Changes

* 
* 
* 
