### PR TITLE
Fix doc bug in builds.md

### DIFF
--- a/build/builds.md
+++ b/build/builds.md
@@ -130,7 +130,8 @@ spec:
 spec:
   steps:
   - image: ubuntu
-    args: ["curl https://foo.com > /var/my-volume"]
+    entrypoint: ["bash"]
+    args: ["-c", "curl https://foo.com > /var/my-volume"]
     volumeMounts:
     - name: my-volume
       mountPath: /var/my-volume


### PR DESCRIPTION
Steps that want to `>` (or `|`, or use environment variables) need to invoke a shell with `bash -c`