### PR TITLE
Make our BuildTemplate references use public GitHub URLs.

### DIFF
--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -137,7 +137,7 @@ template](https://github.com/knative/build-templates/blob/master/kaniko/kaniko.y
 in the [build-templates](https://github.com/knative/build-templates/) repo.
 
 ```shell
-kubectl apply -f kaniko.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
 ```
 
 ### Using this in Configuration.

--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -19,7 +19,7 @@ in the [build-templates](https://github.com/knative/build-templates/) repo.
 First, install the Buildpack build template from that repo:
 
 ```shell
-kubectl apply -f buildpack.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/buildpack/buildpack.yaml
 ```
 
 Then you can deploy this to Knative Serving from the root directory via:
@@ -82,5 +82,5 @@ To clean up the sample service:
 # Clean up the serving resources
 kubectl delete -f serving/samples/buildpack-app-dotnet/sample.yaml
 # Clean up the build template
-kubectl delete -f buildpack.yaml
+kubectl delete -f https://raw.githubusercontent.com/knative/build-templates/master/buildpack/buildpack.yaml
 ```

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -89,7 +89,7 @@ perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
 
 # Install the Kaniko build template used to build this sample (in the
 # build-templates repo).
-kubectl apply -f kaniko.yaml
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
 ```
 
 Now, if you look at the `status` of the revision, you will see that a build is in progress:


### PR DESCRIPTION
Following: https://github.com/knative/build-templates/pull/38