### PR TITLE
Remove some sections about eventing

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -14,27 +14,6 @@ produced.
 
 The above concerns are consistent with the [design goals](https://github.com/cloudevents/spec/blob/master/spec.md#design-goals) of CloudEvents, a common specification for cross-service interoperability being developed by the CNCF Serverless WG.
 
-## System design notes
-
-We’re following an agile process, starting from a working prototype that
-addresses a single use case and iterating to support additional use cases.
-
-Knative Events depends on [knative/serving](https://github.com/knative/serving) and
-together with [knative/build](https://github.com/knative/build) provides a
-complete serverless platform.
-
-The primary goal of *events* is interoperability; therefore, we expect to
-provide common libraries that can be used in other systems to emit or consume
-events.
-
-
-## Naming
-
-We'll be tracking the CloudEvents nomenclature as much as possible; however,
-that is in flux and many of the needed terms are outside of the current scope
-of the specification. We use the term "feed" to represent the concept of
-attaching an event (or filtered event stream via a "trigger) to an action.
-
 # Getting Started
 
 * [Setup Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)


### PR DESCRIPTION
These sections are vague and seem like they were written before we had any code at all. Removing them brings the relevant links closer to the top.

/cc @evankanderson @mogar1980 