### PR TITLE
Fix link typo: telemtry -> telemetry

### DIFF
--- a/serving/samples/README.md
+++ b/serving/samples/README.md
@@ -17,6 +17,6 @@ to learn more about Knative Serving resources.
 | Knative Routing | An example of mapping multiple Knative services to different paths under a single domain name using the Istio VirtualService concept. | [Go](knative-routing-go/README.md) |
 | REST API | A simple Restful service that exposes an endpoint defined by an environment variable described in the Knative Configuration. | [Go](rest-api-go/README.md) |
 | Source to URL | A sample that shows how to use Knative to go from source code in a git repository to a running application with a URL. | [Go](source-to-url/README.md) |
-| Telemetry | This sample runs a simple web server that makes calls to other in-cluster services and responds to requests with "Hello World!". The purpose of this sample is to show generating metrics, logs, and distributed traces. | [Go](telemtry-go/README.md) |
+| Telemetry | This sample runs a simple web server that makes calls to other in-cluster services and responds to requests with "Hello World!". The purpose of this sample is to show generating metrics, logs, and distributed traces. | [Go](telemetry-go/README.md) |
 | Thumbnailer | An example of deploying a "dockerized" application to Knative Serving which takes video URL as an input and generates its thumbnail image. | [Go](thumbnailer-go/README.md) |
 | Traffic Splitting | This samples builds off the [Creating a RESTful Service](../rest-api-go) sample to illustrate applying a revision, then using that revision for manual traffic splitting. | [YAML](traffic-splitting/README.md) |


### PR DESCRIPTION
## Proposed Changes

*  Fix a link typo: `telemtry` -> `telemetry`

