### PR TITLE
Add build component instructions throughout

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,8 +1,9 @@
 # Knative Build
 
-A `Build` is a custom resource in Knative that allows you to define an process that runs
-to completion and can provide status. For example, fetch, build, and package your
-code by using a Knative `Build` that communicates whether the process succeeds.
+A `Build` is a custom resource in Knative that allows you to define an process
+that runs to completion and can provide status. For example, fetch, build, and
+package your code by using a Knative `Build` that communicates whether the
+process succeeds.
 
 A Knative `Build` runs on-cluster and is implemented by a
 [Kubernetes Custom Resource Definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
@@ -10,19 +11,22 @@ A Knative `Build` runs on-cluster and is implemented by a
 Given a `Builder`, or container image that you have created to perform a task
 or action, you can define a Knative `Build` through a single configuration file.
 
-Also consider using a Knative `Build` to build the source code of your apps into container images,
-which you can then run on [Knative `serving`](https://github.com/knative/docs/blob/master/serving/README.md).
+Also consider using a Knative `Build` to build the source code of your apps into
+container images, which you can then run on
+[Knative `serving`](https://github.com/knative/docs/blob/master/serving/README.md).
 More information about this use case is demonstrated in
-[this sample](https://github.com/knative/docs/blob/master/serving/samples/source-to-url-go).
+[this sample](https://github.com/knative/docs/blob/master/serving/samples/source-to-
+url-go).
 
-## Key features of Knative builds
+## Key features of Knative Builds
 
 * A `Build` can include multiple `steps` where each step specifies a `Builder`.
-* A `Builder` is a type of container image that you create to accomplish any task, whether
-    that's a single step in a process, or the whole process itself.
+* A `Builder` is a type of container image that you create to accomplish any
+  task, whether that's a single step in a process, or the whole process itself.
 * The `steps` in a `Build` can push to a repository.
 * A `BuildTemplate` can be used to defined reusable templates.
-* The  `source` in a  `Build` can be defined to mount data to a Kubernetes Volume, and supports:
+* The  `source` in a  `Build` can be defined to mount data to a Kubernetes
+  Volume, and supports:
      * `git` repositories
      * Google Cloud Storage
      * An arbitrary container image
@@ -30,36 +34,38 @@ More information about this use case is demonstrated in
 
 ### Learn more
 
-See the following reference topics for information about each of the build components:
+See the following reference topics for information about each of the build
+components:
 
 * [`Build`](https://github.com/knative/docs/blob/master/build/builds.md)
 * [`BuildTemplate`](https://github.com/knative/docs/blob/master/build/build-templates.md)
 * [ `Builder`](https://github.com/knative/docs/blob/master/build/builder-contract.md)
 * [`ServiceAccount`](https://github.com/knative/docs/blob/master/build/auth.md)
 
-## Install the Knative build component
+## Install the Knative Build component
 
-Because all Knative components stand alone, you can decide which components to install.
-Knative Serving is not required to create and run builds.
+Because all Knative components stand alone, you can decide which components to
+install. Knative Serving is not required to create and run builds.
 
-Before you can run a Knative build, you must install the Knative build
+Before you can run a Knative Build, you must install the Knative Build
 component in your Kubernetes cluster:
 
 * For details about installing a new instance of Knative in your Kubernetes
   cluster, see [Installing Knative](../install/README.md).
 
 * If you have a component of Knative installed and running, you can
-  [add and install the Knative build component](installing-build-component.md).
+  [add and install the Knative Build component](installing-build-component.md).
 
 ## Configuration syntax example
 
-Use the following example to understand the syntax and structure of the various components of a
-Knative `Build`. Note that not all elements of a `Build` configuration file are included in the following
-example but you can reference the [Knative build samples](#get-started-with-knative-build-samples)
-section along with the [reference files](#learn-more) above for more information.
+Use the following example to understand the syntax and structure of the various
+components of a Knative `Build`. Note that not all elements of a `Build`
+configuration file are included in the following example but you can reference
+the [Knative Build samples](#get-started-with-knative-build-samples) section
+along with the [reference files](#learn-more) above for more information.
 
-The following example demonstrates a build that uses authentication and includes multiple `steps` and
-multiple repositories:
+The following example demonstrates a build that uses authentication and includes
+multiple `steps` and multiple repositories:
 
 ```yaml
 apiVersion: build.knative.dev/v1alpha1
@@ -82,9 +88,10 @@ spec:
 ```
 
 
-## Get started with Knative build samples
+## Get started with Knative Build samples
 
-Use the following samples to learn how to configure your Knative builds to perform simple tasks.
+Use the following samples to learn how to configure your Knative Builds to
+perform simple tasks.
 
 Tip: Review and reference multiple samples to piece together more complex builds.
 
@@ -103,7 +110,7 @@ Tip: Review and reference multiple samples to piece together more complex builds
 
  ## Related info
 
- If you are interested in contributing to the Knative build project, see the
+ If you are interested in contributing to the Knative Build project, see the
  [Knative Build code repository](https://github.com/knative/build).
 
 ---

--- a/build/README.md
+++ b/build/README.md
@@ -37,6 +37,22 @@ See the following reference topics for information about each of the build compo
 * [ `Builder`](https://github.com/knative/docs/blob/master/build/builder-contract.md)
 * [`ServiceAccount`](https://github.com/knative/docs/blob/master/build/auth.md)
 
+## Install the Knative build component
+
+You have the option to install and use only the build component of Knative. Not
+every component of Knative is required to be installed if you do not need that
+functionality, for example Knative serving is not required to create and run
+builds.
+
+Before you can run a Knative build, you must install the Knative build
+component in your Kubernetes cluster:
+
+* For details about installing a new instance of Knative in your Kubernetes
+  cluster, see [Installing Knative](../install/README.md).
+
+* If you have a component of Knative installed and running, you can easily
+  [add and install the Knative build component](installing-build-component.md).
+
 ## Configuration syntax example
 
 Use the following example to understand the syntax and structure of the various components of a

--- a/build/README.md
+++ b/build/README.md
@@ -40,8 +40,8 @@ See the following reference topics for information about each of the build compo
 ## Install the Knative build component
 
 You have the option to install and use only the build component of Knative. You
-can install only the component of Knative if you need that functionality, for
-example Knative serving is not required to create and run builds.
+can individually install the components of Knative, for example Knative serving
+is not required to create and run builds.
 
 Before you can run a Knative build, you must install the Knative build
 component in your Kubernetes cluster:

--- a/build/README.md
+++ b/build/README.md
@@ -39,9 +39,8 @@ See the following reference topics for information about each of the build compo
 
 ## Install the Knative build component
 
-You have the option to install and use only the build component of Knative. You
-can individually install the components of Knative, for example Knative serving
-is not required to create and run builds.
+Because all Knative components stand alone, you can decide which components to install.
+Knative Serving is not required to create and run builds.
 
 Before you can run a Knative build, you must install the Knative build
 component in your Kubernetes cluster:
@@ -49,7 +48,7 @@ component in your Kubernetes cluster:
 * For details about installing a new instance of Knative in your Kubernetes
   cluster, see [Installing Knative](../install/README.md).
 
-* If you have a component of Knative installed and running, you can easily
+* If you have a component of Knative installed and running, you can
   [add and install the Knative build component](installing-build-component.md).
 
 ## Configuration syntax example

--- a/build/README.md
+++ b/build/README.md
@@ -39,10 +39,9 @@ See the following reference topics for information about each of the build compo
 
 ## Install the Knative build component
 
-You have the option to install and use only the build component of Knative. Not
-every component of Knative is required to be installed if you do not need that
-functionality, for example Knative serving is not required to create and run
-builds.
+You have the option to install and use only the build component of Knative. You
+can install only the component of Knative if you need that functionality, for
+example Knative serving is not required to create and run builds.
 
 Before you can run a Knative build, you must install the Knative build
 component in your Kubernetes cluster:

--- a/build/installing-build-component.md
+++ b/build/installing-build-component.md
@@ -1,0 +1,37 @@
+# Installing the Knative build component
+
+Before you can run a Knative build, you must install the Knative build
+component in your Kubernetes cluster.
+
+You have the option to install and use only the components of Knative that you
+want, for example Knative serving is not required to create and run builds.
+
+For details about installing a new instance of Knative in your Kubernetes
+cluster, see [Installing Knative](../install/README.md).
+
+To install only the Knative build component:
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://storage.googleapis.com/knative-releases/build/latest/release.yaml
+    ```
+1. Monitor the Knative build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
+    ```
+
+    Tip: Instead of the `kubectl get` command multiple times, you can add
+    `--watch` to view the component's status updates in real time.
+    Use CTRL + C to exit watch mode.
+
+You are now ready to create and run Knative builds, see
+(Creating a simple Knative build)[../build/creating-builds.md] to get started.
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/build/installing-build-component.md
+++ b/build/installing-build-component.md
@@ -1,7 +1,7 @@
-# Installing the Knative build component
+# Installing the Knative Build component
 
-Before you can run a Knative build, you must install the Knative build
-component in your Kubernetes cluster. Use this page to add the Knative build
+Before you can run a Knative Build, you must install the Knative Build
+component in your Kubernetes cluster. Use this page to add the Knative Build
 component to an existing Knative installation.
 
 You have the option to install and use only the components of Knative that you
@@ -11,11 +11,11 @@ want, for example Knative serving is not required to create and run builds.
 
 You must have a component of Knative installed and running in your Kubernetes
 cluster. For complete installation instructions, including how to install the
-Knative build component, see [Installing Knative](../install/README.md).
+Knative Build component, see [Installing Knative](../install/README.md).
 
-## Adding the Knative build component
+## Adding the Knative Build component
 
-To add only the Knative build component to an existing installation:
+To add only the Knative Build component to an existing installation:
 
 1. Run the
    [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)
@@ -26,7 +26,7 @@ To add only the Knative build component to an existing installation:
     ```
 1. Run the
    [`kubectl get`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get)
-   command to monitor the Knative build components until all of the components
+   command to monitor the Knative Build components until all of the components
    show a `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-build
@@ -36,8 +36,8 @@ To add only the Knative build component to an existing installation:
     append the `--watch` flag to view the component's status updates in real
     time. Use CTRL + C to exit watch mode.
 
-You are now ready to create and run Knative builds, see
-[Creating a simple Knative build](../build/creating-builds.md) to get started.
+You are now ready to create and run Knative Builds, see
+[Creating a simple Knative Build](../build/creating-builds.md) to get started.
 
 ---
 

--- a/build/installing-build-component.md
+++ b/build/installing-build-component.md
@@ -17,20 +17,24 @@ Knative build component, see [Installing Knative](../install/README.md).
 
 To add only the Knative build component to an existing installation:
 
-1. Run the `kubectl apply` command to install
+1. Run the
+   [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)
+   command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
     ```bash
     kubectl apply -f https://storage.googleapis.com/knative-releases/build/latest/release.yaml
     ```
-1. Monitor the Knative build components until all of the components show a
-   `STATUS` of `Running`:
+1. Run the
+   [`kubectl get`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get)
+   command to monitor the Knative build components until all of the components
+   show a `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-build
     ```
 
     Tip: Instead of running the `kubectl get` command multiple times, you can
-    add `--watch` to view the component's status updates in real time.
-    Use CTRL + C to exit watch mode.
+    append the `--watch` flag to view the component's status updates in real
+    time. Use CTRL + C to exit watch mode.
 
 You are now ready to create and run Knative builds, see
 [Creating a simple Knative build](../build/creating-builds.md) to get started.

--- a/build/installing-build-component.md
+++ b/build/installing-build-component.md
@@ -1,15 +1,21 @@
 # Installing the Knative build component
 
 Before you can run a Knative build, you must install the Knative build
-component in your Kubernetes cluster.
+component in your Kubernetes cluster. Use this page to add the Knative build
+component to an existing Knative installation.
 
 You have the option to install and use only the components of Knative that you
 want, for example Knative serving is not required to create and run builds.
 
-For details about installing a new instance of Knative in your Kubernetes
-cluster, see [Installing Knative](../install/README.md).
+## Before you begin
 
-To install only the Knative build component:
+You must have a component of Knative installed and running in your Kubernetes
+cluster. For complete installation instructions, including how to install the
+Knative build component, see [Installing Knative](../install/README.md).
+
+## Adding the Knative build component
+
+To add only the Knative build component to an existing installation:
 
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
@@ -22,12 +28,12 @@ To install only the Knative build component:
     kubectl get pods -n knative-build
     ```
 
-    Tip: Instead of the `kubectl get` command multiple times, you can add
-    `--watch` to view the component's status updates in real time.
+    Tip: Instead of running the `kubectl get` command multiple times, you can
+    add `--watch` to view the component's status updates in real time.
     Use CTRL + C to exit watch mode.
 
 You are now ready to create and run Knative builds, see
-(Creating a simple Knative build)[../build/creating-builds.md] to get started.
+[Creating a simple Knative build](../build/creating-builds.md) to get started.
 
 ---
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -60,16 +60,16 @@ You need a GCP project to create a Google Kubernetes Engine cluster.
       gcloud projects create my-knative-project --set-as-default
       ```
       Replace `my-knative-project` with the name you'd like to use for your GCP project.
-      
+
       You also need to [enable billing](https://cloud.google.com/billing/docs/how-to/manage-billing-account)
       for your new project.
-      
+
     * If you already have a GCP project, make sure your project is set as your
       `gcloud` default:
       ```bash
       gcloud config set project my-knative-project
       ```
-      
+
       > Tip: Enter `gcloud config get-value project` to view the ID of your default GCP project.
 1. Enable the necessary APIs:
    ```
@@ -135,32 +135,55 @@ rerun the command to see the current status.
 > Note: Instead of rerunning the command, you can add `--watch` to the above
   command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative components
 
-1. Next, we will install [Knative Serving](https://github.com/knative/serving)
-and its dependencies:
+You have the option to install and use only the Knative components that you
+want. You can install only the component of Knative if you need that
+functionality, for example Knative serving is not required to create and run
+builds.
+
+### Installing Knative Serving
+
+1. Run the `kubectl apply` command to install
+   [Knative Serving](https://github.com/knative/serving) and its dependencies:
     ```bash
     kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
     ```
-1. Monitor the Knative components, until all of the components show a `STATUS` of
-`Running`:
+1. Monitor the Knative serving components until all of the components show a
+   `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-serving
     ```
 
+### Installing Knative build
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://storage.googleapis.com/knative-releases/build/latest/release.yaml
+    ```
+1. Monitor the Knative build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
+
 Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current status.
+components to be up and running; you can rerun the `kubectl get` command to see
+the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-  command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
-You are now ready to deploy an app to your new Knative cluster.
+You are now ready to deploy an app or create build in your new Knative cluster.
 
-## Deploying an app
+## Deploying apps or builds
 
-Now that your cluster has Knative installed, you're ready to deploy an app.
+Now that your cluster has Knative installed, you're ready to deploy an app or
+create a build.
 
-You have two options for deploying your first app:
+Depending on which Knative component you have installed, there are few options
+for getting started:
 
 * You can follow the step-by-step
   [Getting Started with Knative App Deployment](getting-started-knative-app.md)
@@ -168,6 +191,9 @@ You have two options for deploying your first app:
 
 * You can view the available [sample apps](../serving/samples/README.md) and
   deploy one of your choosing.
+
+* To get started by creating a build, see
+  (Creating a simple Knative build)[../build/creating-builds.md]
 
 ## Cleaning up
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -16,11 +16,10 @@ commands will need to be adjusted for use in a Windows environment.
 
 ### Installing the Google Cloud SDK
 
-1. If you already have `kubectl`, run `kubectl version` to check your client
-   version.
+1. If you already have `kubectl`, run `kubectl version` to check your client version.
 
-1. If you already have `gcloud` installed with the `kubectl` component later
-   than v1.10, you can skip these steps.
+1. If you already have `gcloud` installed with the `kubectl` component later than
+   v1.10, you can skip these steps.
 
 1. Download and install the `gcloud` command line tool:
    https://cloud.google.com/sdk/install
@@ -56,16 +55,13 @@ You need a GCP project to create a Google Kubernetes Engine cluster.
 
 1. Create a new GCP project and set it as your `gcloud` default, or set an
    existing GCP project as your `gcloud` default:
-    * If you don't already have a GCP project created, create a new project in
-    `gcloud`:
+    * If you don't already have a GCP project created, create a new project in `gcloud`:
       ```bash
       gcloud projects create my-knative-project --set-as-default
       ```
-      Replace `my-knative-project` with the name you'd like to use for your GCP
-      project.
+      Replace `my-knative-project` with the name you'd like to use for your GCP project.
 
-      You also need to
-      [enable billing](https://cloud.google.com/billing/docs/how-to/manage-billing-account)
+      You also need to [enable billing](https://cloud.google.com/billing/docs/how-to/manage-billing-account)
       for your new project.
 
     * If you already have a GCP project, make sure your project is set as your
@@ -74,9 +70,7 @@ You need a GCP project to create a Google Kubernetes Engine cluster.
       gcloud config set project my-knative-project
       ```
 
-      > Tip: Enter `gcloud config get-value project` to view the ID of your
-        default GCP project.
-
+      > Tip: Enter `gcloud config get-value project` to view the ID of your default GCP project.
 1. Enable the necessary APIs:
    ```
    gcloud services enable \
@@ -139,8 +133,7 @@ It will take a few minutes for all the components to be up and running; you can
 rerun the command to see the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-  command to view the component's status updates in real time. Use CTRL + C to
-  exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
 
 ## Installing Knative components
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -16,10 +16,11 @@ commands will need to be adjusted for use in a Windows environment.
 
 ### Installing the Google Cloud SDK
 
-1. If you already have `kubectl`, run `kubectl version` to check your client version.
+1. If you already have `kubectl`, run `kubectl version` to check your client
+   version.
 
-1. If you already have `gcloud` installed with the `kubectl` component later than
-   v1.10, you can skip these steps.
+1. If you already have `gcloud` installed with the `kubectl` component later
+   than v1.10, you can skip these steps.
 
 1. Download and install the `gcloud` command line tool:
    https://cloud.google.com/sdk/install
@@ -55,13 +56,16 @@ You need a GCP project to create a Google Kubernetes Engine cluster.
 
 1. Create a new GCP project and set it as your `gcloud` default, or set an
    existing GCP project as your `gcloud` default:
-    * If you don't already have a GCP project created, create a new project in `gcloud`:
+    * If you don't already have a GCP project created, create a new project in
+    `gcloud`:
       ```bash
       gcloud projects create my-knative-project --set-as-default
       ```
-      Replace `my-knative-project` with the name you'd like to use for your GCP project.
+      Replace `my-knative-project` with the name you'd like to use for your GCP
+      project.
 
-      You also need to [enable billing](https://cloud.google.com/billing/docs/how-to/manage-billing-account)
+      You also need to
+      [enable billing](https://cloud.google.com/billing/docs/how-to/manage-billing-account)
       for your new project.
 
     * If you already have a GCP project, make sure your project is set as your
@@ -70,7 +74,9 @@ You need a GCP project to create a Google Kubernetes Engine cluster.
       gcloud config set project my-knative-project
       ```
 
-      > Tip: Enter `gcloud config get-value project` to view the ID of your default GCP project.
+      > Tip: Enter `gcloud config get-value project` to view the ID of your
+        default GCP project.
+
 1. Enable the necessary APIs:
    ```
    gcloud services enable \
@@ -133,7 +139,8 @@ It will take a few minutes for all the components to be up and running; you can
 rerun the command to see the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-  command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
 ## Installing Knative components
 
@@ -155,14 +162,14 @@ builds.
     kubectl get pods -n knative-serving
     ```
 
-### Installing Knative build
+### Installing Knative Build
 
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
     ```bash
     kubectl apply -f https://storage.googleapis.com/knative-releases/build/latest/release.yaml
     ```
-1. Monitor the Knative build components until all of the components show a
+1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-build
@@ -194,7 +201,7 @@ for getting started:
   deploy one of your choosing.
 
 * To get started by creating a build, see
-  (Creating a simple Knative build)[../build/creating-builds.md]
+  (Creating a simple Knative Build)[../build/creating-builds.md]
 
 ## Cleaning up
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -175,7 +175,8 @@ the current status.
   command to view the component's status updates in real time. Use CTRL + C to
   exit watch mode.
 
-You are now ready to deploy an app or create build in your new Knative cluster.
+You are now ready to deploy an app or create a build in your new Knative
+cluster.
 
 ## Deploying apps or builds
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -183,7 +183,7 @@ cluster.
 Now that your cluster has Knative installed, you're ready to deploy an app or
 create a build.
 
-Depending on which Knative component you have installed, there are few options
+Depending on which Knative component you have installed, there are a few options
 for getting started:
 
 * You can follow the step-by-step


### PR DESCRIPTION

Fixes #246 

Added stand alone "add build component to existing installation"
Added mention of install in README.md (which is linked to from knative/build code repo)
Added build component option in knative/install GKE instructions