### PR TITLE
fix duplicate phrase `kubectl apply -f`

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -36,7 +36,7 @@ EventSources.
 You can install Knative Eventing with the following command:
 
 ```bash
-kubectl apply -f kubectl apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
+kubectl apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
 ```
 
 In addition to the core definitions, you'll need to install at least one


### PR DESCRIPTION
Hello, I fix duplicate phrase causing following error:

```
⟩ kubectl apply -f kubectl apply -f https://storage.googleapis.com/knative-releases/eventing/latest/release.yaml
error: Unexpected args: [apply]
See 'kubectl apply -h' for help and examples.
```