### PR TITLE
Update role reference in sample

### DIFF
--- a/eventing/samples/k8s-events/serviceaccount.yaml
+++ b/eventing/samples/k8s-events/serviceaccount.yaml
@@ -53,6 +53,6 @@ subjects:
     namespace: default
 roleRef:
   kind: ClusterRole
-  name: viewer
+  name: view
   apiGroup: rbac.authorization.k8s.io
 ---


### PR DESCRIPTION
This may require double check / confirmation, but my cluster did not have a `viewer` role. It did have a `view` role though, which once used allowed me to run a Flow
