### PR TITLE
Update install instructions to use release 0.1.0 files

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -123,7 +123,7 @@ Knative depends on Istio.
 
 1. Install Istio:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
     ```
 1. Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -147,7 +147,7 @@ rerun the command to see the current status.
 1. Next, we will install [Knative Serving](https://github.com/knative/serving)
 and its dependencies:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
 1. Monitor the Knative components, until all of the components show a `STATUS` of
 `Running`:

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -117,7 +117,7 @@ Knative depends on Istio.
 
 1. Install Istio:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
     ```
 1. Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -147,7 +147,7 @@ builds.
 1. Run the `kubectl apply` command to install
    [Knative Serving](https://github.com/knative/serving) and its dependencies:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
 1. Monitor the Knative serving components until all of the components show a
    `STATUS` of `Running`:
@@ -160,7 +160,7 @@ builds.
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/build/latest/release.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/config/build/release.yaml
     ```
 1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -71,7 +71,7 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
     ```
 2.  Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -91,7 +91,7 @@ rerun the command to see the current status.
 
 1.  Next, we will install [Knative Serving](https://github.com/knative/serving)
     and its dependencies:
-    `bash kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml`
+    `bash kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml`
 1.  Monitor the Knative components, until all of the components show a `STATUS`
     of `Running`: `bash kubectl get pods -n knative-serving`
 
@@ -137,10 +137,10 @@ spec:
 And of course create the respectve `ConfigMaps`:
 
 ```
-curl https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+curl https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
 kubectl create configmap istio-chart-080 --from-file=istio.yaml
 
-curl https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
+curl https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
 kubectl create configmap knative-chart-001 --from-file=release.yaml
 ```
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -126,7 +126,7 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
     ```
 1.  Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -150,7 +150,7 @@ rerun the command to see the current status.
 1.  Next, we will install [Knative Serving](https://github.com/knative/serving)
     and its dependencies:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
 1.  Monitor the Knative components until all of the components show a `STATUS`
     of `Running`:

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -59,7 +59,7 @@ Knative depends on Istio. Run the following to install Istio. (We are changing
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml \
+curl -L https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply -f -
 
@@ -85,12 +85,12 @@ rerun the command to see the current status.
 Next, install [Knative Serving](https://github.com/knative/serving):
 
 Because you have limited resources available, use the
-`https://storage.googleapis.com/knative-releases/serving/latest/release-lite.yaml`
+`https://github.com/knative/serving/releases/download/v0.1.0/release-lite.yaml`
 file, which omits some of the monitoring components to reduce the memory used by
 the Knative components. To use the provided `release-lite.yaml` release, run:
 
 ```shell
-curl -L https://storage.googleapis.com/knative-releases/serving/latest/release-lite.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.1.0/release-lite.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply -f -
 ```

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -32,7 +32,7 @@ Knative depends on Istio. Istio workloads require privileged mode for Init Conta
 
 1. Install Istio:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
     ```
 1. Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -55,7 +55,7 @@ rerun the command to see the current status.
 1. Next, we will install [Knative Serving](https://github.com/knative/serving)
 and its dependencies:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
 1. Monitor the Knative components, until all of the components show a `STATUS` of
 `Running`:

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -19,7 +19,7 @@ Containers
 
 1.  Install Istio:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/istio-0.8.0/istio.yaml
     ```
 1.  Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -40,7 +40,7 @@ rerun the command to see the current status.
 1.  Next, we will install [Knative Serving](https://github.com/knative/serving)
     and its dependencies:
     ```bash
-    kubectl apply -f https://storage.googleapis.com/knative-releases/serving/latest/release.yaml
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
 1.  Monitor the Knative components, until all of the components show a `STATUS`
     of `Running`:


### PR DESCRIPTION
Fixes #286

## Proposed Changes

* Update install instructions to use files from the Serving 0.1.0 release instead of latest