### PR TITLE
Add Redis Guestbook sample

### DIFF
--- a/serving/samples/README.md
+++ b/serving/samples/README.md
@@ -15,7 +15,7 @@ to learn more about Knative Serving resources.
 | Github Webhook | A simple webhook handler that demonstrates interacting with Github. | [Go](gitwebhook-go/README.md) |
 | gRPC | A simple gRPC server. | [Go](grpc-ping-go/README.md) |
 | Knative Routing | An example of mapping multiple Knative services to different paths under a single domain name using the Istio VirtualService concept. | [Go](knative-routing-go/README.md) |
-| Redis Guestbook | A sample that shows how to deploy Redis alongside a Knative Serving Service. | [Go](guestbook-redis-go/README.md) |
+| Redis Guestbook | A sample that deploys Redis alongside a Knative Serving Service. | [Go](guestbook-redis-go/README.md) |
 | REST API | A simple Restful service that exposes an endpoint defined by an environment variable described in the Knative Configuration. | [Go](rest-api-go/README.md) |
 | Source to URL | A sample that shows how to use Knative to go from source code in a git repository to a running application with a URL. | [Go](source-to-url-go/README.md) |
 | Telemetry | This sample runs a simple web server that makes calls to other in-cluster services and responds to requests with "Hello World!". The purpose of this sample is to show generating metrics, logs, and distributed traces. | [Go](telemetry-go/README.md) |

--- a/serving/samples/README.md
+++ b/serving/samples/README.md
@@ -15,6 +15,7 @@ to learn more about Knative Serving resources.
 | Github Webhook | A simple webhook handler that demonstrates interacting with Github. | [Go](gitwebhook-go/README.md) |
 | gRPC | A simple gRPC server. | [Go](grpc-ping-go/README.md) |
 | Knative Routing | An example of mapping multiple Knative services to different paths under a single domain name using the Istio VirtualService concept. | [Go](knative-routing-go/README.md) |
+| Redis Guestbook | A sample that shows how to deploy Redis alongside a Knative Serving Service. | [Go](guestbook-redis-go/README.md) |
 | REST API | A simple Restful service that exposes an endpoint defined by an environment variable described in the Knative Configuration. | [Go](rest-api-go/README.md) |
 | Source to URL | A sample that shows how to use Knative to go from source code in a git repository to a running application with a URL. | [Go](source-to-url-go/README.md) |
 | Telemetry | This sample runs a simple web server that makes calls to other in-cluster services and responds to requests with "Hello World!". The purpose of this sample is to show generating metrics, logs, and distributed traces. | [Go](telemetry-go/README.md) |

--- a/serving/samples/guestbook-redis-go/Dockerfile
+++ b/serving/samples/guestbook-redis-go/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang as builder
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+FROM gcr.io/distroless/base
+
+COPY --from=builder /go/bin/app /
+COPY --from=builder /go/src/app/template.html /
+EXPOSE 8080
+
+CMD ["/app"]

--- a/serving/samples/guestbook-redis-go/README.md
+++ b/serving/samples/guestbook-redis-go/README.md
@@ -1,0 +1,152 @@
+# Guestbook - Go sample
+
+A simple web app written in Go that demonstrates how to to use vanilla
+Kubernetes `Deployment`s/`Service`s (Redis in this case) with a Knative
+application. The Guestbook application shows a page with a form that allows
+users to leave a message under a name of their choosing. Names and messages map
+to keys and values in Redis, so only one message per user is saved at a time.
+
+## Prerequisites
+
+1. [Install Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)
+1. Install [Docker](https://www.docker.com/)
+
+## Deploy Redis
+
+Although the configuration in this sample is intentionally very simple, [Redis]
+can require relatively complex configuration that Knative does not support.
+Luckily, Knative allows you to mix and match Knative components with vanilla
+Kubernetes components.
+
+There are two files containing Redis configuration:
+
+`redis-deployment.yaml`
+:  contains a minimal configuration for a single Redis instance, named
+`redis-master`.
+
+`redis-service`
+:  contains a Kubernetes `Service` that finds `redis-master` by its name and
+role labels and routes requests to it.
+
+Don't confuse a Kubernetes `Service` with a Knative `Service`. A Knative
+`Service` handles the deployment, scaling, and routing for a container. A
+Kubernetes `Service` routes requests to an existing deployment.
+
+Apply them both with `kubectl`:
+
+```shell
+kubectl apply -f serving/samples/guestbook-redis-go/redis-deployment.yaml
+kubectl apply -f serving/samples/guestbook-redis-go/redis-service.yaml
+```
+
+## Build and Deploy the Guestbook Application
+
+Build the app container and publish it to your registry of choice:
+
+```shell
+REPO=... # "docker.io/{username}" or "gcr.io/{project}"
+
+# Build and publish the container, run from the root directory.
+docker build --tag "${REPO}/serving/samples/guestbook-redis-go" \
+  serving/samples/guestbook-redis-go
+docker push "${REPO}/serving/samples/guestbook-redis-go"
+
+# Replace the image reference with our published image.
+perl -pi -e "s@github.com/knative/docs/serving/samples/guestbook-redis-go@${REPO}/serving/samples/guestbook-redis-go@g" serving/samples/guestbook-redis-go/guestbook.yaml
+
+# Deploy the Guestbook Service
+kubectl apply -f serving/samples/guestbook-redis-go/guestbook.yaml
+```
+
+## Exploring
+
+Note: the following example uses `curl` to make requests to the application. You
+can also use your browser by following the steps in the
+[routing sample](https://github.com/knative/docs/tree/master/serving/samples/knative-routing-go)
+to route requests from `/` to the Guestbook `Service`.
+
+To access this service, you need to determine its ingress address:
+
+```shell
+kubectl get svc knative-ingressgateway -n istio-system
+```
+
+When the service is ready, you'll see an IP address in the EXTERNAL-IP field:
+
+```
+NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+```
+
+Once the `ADDRESS` gets assigned to the cluster, you can run:
+
+```shell
+# Put the host name into an environment variable.
+export SERVICE_HOST=`kubectl get route guestbook -o jsonpath="{.status.domain}"`
+
+# Put the ingress IP into an environment variable.
+export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+```
+
+Now use curl with the service IP as if DNS were properly configured:
+
+```shell
+curl --header "Host:$SERVICE_HOST" http://${SERVICE_IP}
+# [...]
+# <form action="/" method="post">
+#  <div>Name: <input name="name"></div>
+#  <div>Message: <input name="message"></div>
+#  <input type="submit">
+# </form>
+# <ul>
+#
+# </ul>
+# [...]
+```
+
+Note that the inputs are named `name` and `message`. You can use `curl` to POST
+data to the form as shown below:
+
+```shell
+curl -X POST -F "name=someone" -F "message=Hello, Knative!" --header "Host:$SERVICE_HOST" http://${SERVICE_IP}
+# [...]
+# <ul>
+#   <li><strong>someone</strong>: Hello, Knative!</li>
+# </ul>
+# [...]
+```
+
+```shell
+curl -X POST -F "name=knative_user" -F "message=I love Knative!" --header "Host:$SERVICE_HOST" http://${SERVICE_IP}
+# [...]
+# <ul>
+#   <li><strong>knative_user</strong>: I love Knative!</li>
+#   <li><strong>someone</strong>: Hello, Knative!</li>
+# </ul>
+# [...]
+```
+
+## Cleaning up
+
+When you're done, clean up the sample resources:
+
+```shell
+kubectl delete -f serving/samples/guestbook-redis-go/redis-deployment.yaml
+kubectl delete -f serving/samples/guestbook-redis-go/redis-service.yaml
+kubectl delete -f serving/samples/guestbook-redis-go/guestbook.yaml
+```
+
+## Next Steps
+
+For simplicity, this sample showed a configuration for Redis with a single
+server. In practice, that wouldn't scale very well for a real application. See
+the [Kubernetes example repository](https://github.com/kubernetes/examples/tree/master/staging/storage/redis)
+for a more scalable deployment configuration for Redis on Kubernetes. That
+example does not include a service that allows other applications to connect to
+Redis, but you can use `redis-service.yaml` since it selects on the same name
+and role labels.
+
+Alternatively, you may prefer to use a managed solution from your cloud provider
+(e.g. [Cloud Memorystore](https://cloud.google.com/memorystore/). To access
+services outside of the cluster, you'll have to
+[configure outbound network access](https://github.com/knative/docs/blob/master/serving/outbound-network-access.md).

--- a/serving/samples/guestbook-redis-go/README.md
+++ b/serving/samples/guestbook-redis-go/README.md
@@ -69,7 +69,7 @@ To access this service, you need to determine its ingress address:
 kubectl get svc knative-ingressgateway -n istio-system
 ```
 
-When the service is ready, you'll see an IP address in the EXTERNAL-IP field:
+When the service is ready, you'll see an IP address in the `EXTERNAL-IP` field:
 
 ```
 NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
@@ -150,5 +150,5 @@ services outside of the cluster, you'll have to
 [configure outbound network access](https://github.com/knative/docs/blob/master/serving/outbound-network-access.md).
 
 Whichever way you go, you can use the guestbook container to test your Redis
-deployment -- just change the `REDIS_HOST` environment variable in
+deployment. Just change the `REDIS_HOST` environment variable in
 `guestbook.yaml` to the correct host name.

--- a/serving/samples/guestbook-redis-go/README.md
+++ b/serving/samples/guestbook-redis-go/README.md
@@ -1,14 +1,14 @@
 # Deploying Redis alongside a Knative Service
 
 A simple web app written in Go that demonstrates how to deploy Redis (using
-vanilla Kubernetes components) alongside with a Knative Service that relies on
+vanilla Kubernetes components) alongside a Knative Service that relies on
 it. The guestbook application shows a page with a form that allows users to
 leave a message under a name of their choosing. Names and messages map to keys
 and values in Redis, so only one message per user is saved at a time.
 
 ## Prerequisites
 
-1. [Install Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)
+1. [Install Knative Serving](/install/README.md)
 1. Install [Docker](https://www.docker.com/)
 
 ## Deploy Redis
@@ -60,7 +60,7 @@ kubectl apply -f serving/samples/guestbook-redis-go/guestbook.yaml
 
 Note: the following example uses `curl` to make requests to the application. You
 can also use your browser by following the steps in the
-[routing sample](https://github.com/knative/docs/tree/master/serving/samples/knative-routing-go)
+[routing sample](/serving/samples/knative-routing-go)
 to route requests to `/` to the guestbook `Service`.
 
 To access this service, you need to determine its ingress address:
@@ -147,7 +147,7 @@ and role labels.
 Alternatively, you may prefer to use a managed solution from your cloud provider
 (e.g. [Cloud Memorystore](https://cloud.google.com/memorystore/)). To access
 services outside of the cluster, you'll have to
-[configure outbound network access](https://github.com/knative/docs/blob/master/serving/outbound-network-access.md).
+[configure outbound network access](/serving/outbound-network-access.md).
 
 Whichever way you go, you can use the guestbook container to test your Redis
 deployment. Just change the `REDIS_HOST` environment variable in

--- a/serving/samples/guestbook-redis-go/guestbook.yaml
+++ b/serving/samples/guestbook-redis-go/guestbook.yaml
@@ -1,0 +1,29 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: guestbook
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: github.com/knative/docs/serving/samples/guestbook-redis-go
+            env:
+            - name: REDIS_HOST
+              value: redis-master

--- a/serving/samples/guestbook-redis-go/main.go
+++ b/serving/samples/guestbook-redis-go/main.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+		https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+const (
+	redisPort = 6379
+)
+
+var (
+	indexTemplate = template.Must(template.ParseFiles("template.html"))
+
+	pool *redis.Pool
+)
+
+// handler displays a form for new posts and shows a list of current posts.
+func handler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	ctx := r.Context()
+
+	conn, err := pool.GetContext(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer conn.Close()
+
+	// If name and message are non-empty, set name=message in Redis.
+	if r.Method == "POST" {
+		name := r.FormValue("name")
+		message := r.FormValue("message")
+
+		if name == "" || message == "" {
+			http.Error(w, "name and message should both be non-empty", http.StatusBadRequest)
+			return
+		}
+
+		if _, err := redis.String(conn.Do("SET", name, message)); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Get all keys (names) from Redis.
+	keys, err := redis.Strings(conn.Do("KEYS", "*"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Get the message associated with each name.
+	params := make(map[string]string)
+	for _, key := range keys {
+		value, err := redis.String(conn.Do("GET", key))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		params[key] = value
+	}
+
+	indexTemplate.Execute(w, params)
+}
+
+func main() {
+	redisHost := os.Getenv("REDIS_HOST")
+	if redisHost == "" {
+		log.Fatal("Environment variable REDIS_HOST is unset.")
+	}
+
+	addr := fmt.Sprintf("%s:%d", redisHost, redisPort)
+	pool = &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", addr)
+		},
+	}
+
+	log.Print("Guestbook sample started.")
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/serving/samples/guestbook-redis-go/redis-deployment.yaml
+++ b/serving/samples/guestbook-redis-go/redis-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: redis
+        role: master
+    spec:
+      containers:
+      - name: master
+        image: k8s.gcr.io/redis
+        ports:
+        - containerPort: 6379

--- a/serving/samples/guestbook-redis-go/redis-service.yaml
+++ b/serving/samples/guestbook-redis-go/redis-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    name: redis
+    role: master

--- a/serving/samples/guestbook-redis-go/template.html
+++ b/serving/samples/guestbook-redis-go/template.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+	<title>Knative Guestbook</title>
+</head>
+<body>
+<h1>Knative Guestbook</h1>
+
+<form action="/" method="post">
+  <div>Name: <input name="name"></div>
+  <div>Message: <input name="message"></div>
+  <input type="submit">
+</form>
+
+<h2>Posts</h2>
+<ul>
+	{{ range $name, $message := . }}
+	<li><strong>{{ $name }}</strong>: {{ $message }}</li>
+	{{ end }}
+</ul>
+</body>
+</html>


### PR DESCRIPTION
Add new serving sample, showing how to deploy Redis alongside a Knative Service.

This is basically a cleaned-up version of a test application that I made when I was when I was learning Knative. Although it might seem obvious to us that you just can drop in Kubernetes Deployments into a cluster that has Knative installed, that was not immediately clear to me when I was starting out. Based on my own experience, I think this sample will be helpful to users who are learning Knative and Kubernetes at the same time.