### PR TITLE
Remove space from command

### DIFF
--- a/serving/outbound-network-access.md
+++ b/serving/outbound-network-access.md
@@ -14,7 +14,7 @@ depending on your platform:
 * For Google Container Engine (GKE) run the following command to determine the scope. Make sure
 to replace the variables or export these values first.
   ```shell
-  gcloud container clusters describe ${CLUSTER_ID} \ 
+  gcloud container clusters describe ${CLUSTER_ID} \
     --zone=${GCP_ZONE} | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
   ```
 * For IBM Cloud Private run the following command: 


### PR DESCRIPTION
## Proposed Changes

* Remove a trailing space in the command that caused copy & paste to fail
