### PR TITLE
Add instructions for OpenShift

### DIFF
--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -1,0 +1,212 @@
+# Knative Install on OpenShift
+
+This guide walks you through the installation of the latest version of [Knative
+Serving](https://github.com/knative/serving) on an
+[OpenShift](https://github.com/openshift/origin) using pre-built images and
+demonstrates creating and deploying an image of a sample "hello world" app onto
+the newly created Knative cluster.
+
+You can find [guides for other platforms here](README.md).
+
+## Before you begin
+
+These instructions will run an OpenShift 3.10 (Kubernetes 1.10) cluster on your
+local machine using [`oc cluster up`](https://docs.openshift.org/latest/getting_started/administrators.html#running-in-a-docker-container)
+to test-drive knative.
+
+## Install `oc` (openshift cli)
+
+You can install the latest version of `oc`, the openshift CLI into your local
+directory by downloading the right release tarball for your OS from the
+[releases page](https://github.com/openshift/origin/releases/tag/v3.10.0).
+
+```shell
+export OS=<your OS here>
+curl https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-$OS-64bit.tar.gz -o oc.tar.gz
+tar zvf oc.tar.gz -x openshift-origin-client-tools-v3.10.0-dd10d17-$OS-64bit/oc --strip=1
+
+# You will now have the oc binary in your local directory
+```
+
+## Scripted cluster setup and installation
+
+For Linux and Mac, you can optionally run a
+[script](scripts/knative-with-openshift.sh) that automates the steps on this
+page.
+
+Once you have `oc` present on your machine and in your `PATH`, you can simply
+run [this script](scripts/knative-with-openshift.sh); it will:
+
+- Create a new OpenShift cluster on your local machine with `oc cluster up`
+- Install Istio and Knative serving
+- Log you in as the cluster administrator
+- Set up the default namespace for istio autoinjection
+
+Once the script completes, you'll be ready to test out Knative!
+
+## Creating a new OpenShift cluster
+
+Create a new OpenShift cluster on your local machine using `oc cluster up`:
+
+```shell
+oc cluster up --write-config
+
+# Enable admission webhooks
+sed -i -e 's/"admissionConfig":{"pluginConfig":null}/"admissionConfig": {\
+    "pluginConfig": {\
+        "ValidatingAdmissionWebhook": {\
+            "configuration": {\
+                "apiVersion": "v1",\
+                "kind": "DefaultAdmissionConfig",\
+                "disable": false\
+            }\
+        },\
+        "MutatingAdmissionWebhook": {\
+            "configuration": {\
+                "apiVersion": "v1",\
+                "kind": "DefaultAdmissionConfig",\
+                "disable": false\
+            }\
+        }\
+    }\
+}/' openshift.local.clusterup/kube-apiserver/master-config.yaml
+
+oc cluster up --server-loglevel=5
+```
+
+Once the cluster is up, login as the cluster administrator:
+
+```shell
+oc login -u system:admin
+```
+
+Now, we'll set up the default project for use with Knative.
+
+```shell
+oc project default
+
+# SCCs (Security Context Constraints) are the precursor to the PSP (Pod
+# Security Policy) mechanism in Kubernetes.
+oc adm policy add-scc-to-user privileged -z default -n default
+
+oc label namespace default istio-injection=enabled
+```
+
+## Installing Istio
+
+Knative depends on Istio. First, run the following to grant the necessary
+privileges to the service accounts istio will use:
+
+```shell
+oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z default -n istio-system
+oc adm policy add-scc-to-user anyuid -z prometheus -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-egressgateway-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-citadel-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-ingressgateway-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-cleanup-old-ca-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
+oc adm policy add-cluster-role-to-user cluster-admin -z istio-galley-service-account -n istio-system
+```
+
+Run the following to install Istio:
+
+```shell
+curl -L https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml \
+  | sed 's/LoadBalancer/NodePort/' \
+  | oc apply -f -
+```
+
+Monitor the Istio components until all of the components show a `STATUS` of
+`Running` or `Completed`:
+
+```shell
+oc get pods -n istio-system
+```
+
+It will take a few minutes for all the components to be up and running; you can
+rerun the command to see the current status.
+
+> Note: Instead of rerunning the command, you can add `--watch` to the above
+  command to view the component's status updates in real time. Use CTRL+C to exit watch mode.
+
+## Installing Knative Serving
+
+Next, we'll install [Knative Serving](https://github.com/knative/serving).
+
+First, run the following to grant the necessary privileges to the service
+accounts istio will use:
+
+```shell
+oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
+oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
+oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
+oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
+oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
+```
+
+Next, install Knative:
+
+```shell
+curl -L https://storage.googleapis.com/knative-releases/serving/latest/release-lite.yaml \
+  | sed 's/LoadBalancer/NodePort/' \
+  | oc apply -f -
+```
+
+Monitor the Knative components until all of the components show a `STATUS` of
+`Running`:
+
+```shell
+oc get pods -n knative-serving
+```
+
+Just as with the Istio components, it will take a few seconds for the Knative
+components to be up and running; you can rerun the command to see the current status.
+
+> Note: Instead of rerunning the command, you can add `--watch` to the above
+  command to view the component's status updates in real time. Use CTRL+C to exit watch mode.
+
+Now you can deploy an app to your newly created Knative cluster.
+
+## Deploying an app
+
+Now that your cluster has Knative installed, you're ready to deploy an app.
+
+If you'd like to follow a step-by-step guide for deploying your first app on
+Knative, check out the
+[Getting Started with Knative App Deployment](getting-started-knative-app.md)
+guide.
+
+If you'd like to view the available sample apps and deploy one of your choosing,
+head to the [sample apps](../serving/samples/README.md) repo.
+
+> Note: When looking up the IP address to use for accessing your app, you need to look up
+  the NodePort for the `knative-ingressgateway` as well as the IP address used for OpenShift.
+  You can use the following command to look up the value to use for the {IP_ADDRESS} placeholder
+  used in the samples:
+
+  ```shell
+  export IP_ADDRESS=$(oc get node  -o 'jsonpath={.items[0].status.addresses[0].address}'):$(oc get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+  ```
+
+## Cleaning up
+
+Delete your test cluster by running:
+
+```shell
+oc cluster down
+rm -rf openshift.local.clusterup
+```
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/install/README.md
+++ b/install/README.md
@@ -9,7 +9,7 @@ sure which Kubernetes platform is right for you, see
 [Picking the Right Solution](https://kubernetes.io/docs/setup/pick-right-solution/).
 
 We provide information for installing Knative on
-[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/), [IBM Cloud Kubernetes Service](https://www.ibm.com/cloud/container-service), [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/), [Minikube](https://kubernetes.io/docs/setup/minikube/) and [Pivotal Container Service](https://pivotal.io/platform/pivotal-container-service) clusters.
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/), [IBM Cloud Kubernetes Service](https://www.ibm.com/cloud/container-service), [Azure Kubernetes Service](https://docs.microsoft.com/en-us/azure/aks/), [Minikube](https://kubernetes.io/docs/setup/minikube/), [OpenShift](https://github.com/openshift/origin) and [Pivotal Container Service](https://pivotal.io/platform/pivotal-container-service) clusters.
 
 ## Installing Knative
 
@@ -21,6 +21,7 @@ Knative components on the following platforms:
 * [Knative Install on Google Kubernetes Engine](Knative-with-GKE.md)
 * [Knative Install on IBM Cloud Kubernetes Service](Knative-with-IKS.md)
 * [Knative Install on Minikube](Knative-with-Minikube.md)
+* [Knative Install on OpenShift](Knative-with-OpenShift.md)
 * [Knative Install on Pivotal Container Service](Knative-with-PKS.md)
 
 If you already have a Kubernetes cluster you're comfortable installing

--- a/install/scripts/knative-with-openshift.sh
+++ b/install/scripts/knative-with-openshift.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Turn colors in this script off by setting the NO_COLOR variable in your
+# environment to any value:
+#
+# $ NO_COLOR=1 test.sh
+NO_COLOR=${NO_COLOR:-""}
+if [ -z "$NO_COLOR" ]; then
+  header=$'\e[1;33m'
+  reset=$'\e[0m'
+else
+  header=''
+  reset=''
+fi
+
+function header_text {
+  echo "$header$*$reset"
+}
+
+header_text "Starting Knative test-drive on OpenShift!"
+
+echo "Using oc version:"
+oc version
+
+header_text "Writing config"
+oc cluster up --write-config
+sed -i -e 's/"admissionConfig":{"pluginConfig":null}/"admissionConfig": {\
+    "pluginConfig": {\
+        "ValidatingAdmissionWebhook": {\
+            "configuration": {\
+                "apiVersion": "v1",\
+                "kind": "DefaultAdmissionConfig",\
+                "disable": false\
+            }\
+        },\
+        "MutatingAdmissionWebhook": {\
+            "configuration": {\
+                "apiVersion": "v1",\
+                "kind": "DefaultAdmissionConfig",\
+                "disable": false\
+            }\
+        }\
+    }\
+}/' openshift.local.clusterup/kube-apiserver/master-config.yaml
+
+header_text "Starting OpenShift with 'oc cluster up'"
+oc cluster up --server-loglevel=5
+
+header_text "Logging in as system:admin and setting up default namespace"
+oc login -u system:admin
+oc project default
+oc adm policy add-scc-to-user privileged -z default -n default
+oc label namespace default istio-injection=enabled
+
+header_text "Setting up security policy for istio"
+oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z default -n istio-system
+oc adm policy add-scc-to-user anyuid -z prometheus -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-egressgateway-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-citadel-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-ingressgateway-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-cleanup-old-ca-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-mixer-post-install-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-mixer-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-pilot-service-account -n istio-system
+oc adm policy add-scc-to-user anyuid -z istio-sidecar-injector-service-account -n istio-system
+oc adm policy add-cluster-role-to-user cluster-admin -z istio-galley-service-account -n istio-system
+
+header_text "Installing istio"
+curl -L https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml \
+  | sed 's/LoadBalancer/NodePort/' \
+  | oc apply -f -
+
+header_text "Waiting for istio to become ready"
+sleep 5; while echo && oc get pods -n istio-system | grep -v -E "(Running|Completed|STATUS)"; do sleep 5; done
+
+header_text "Setting up security policy for knative"
+oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
+oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
+oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
+oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
+oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
+
+header_text "Installing Knative"
+curl -L https://storage.googleapis.com/knative-releases/serving/latest/release-lite.yaml \
+  | sed 's/LoadBalancer/NodePort/' \
+  | oc apply -f -
+
+header_text "Waiting for Knative to become ready"
+sleep 5; while echo && oc get pods -n knative-serving | grep -v -E "(Running|Completed|STATUS)"; do sleep 5; done
+


### PR DESCRIPTION
This PR adds instructions and a script for testing out Knative on OpenShift using `oc cluster up`.

Thanks to @bbrowning for a big assist with this.