### PR TITLE
Update Scaling WG VC link

### DIFF
--- a/community/WORKING-GROUPS.md
+++ b/community/WORKING-GROUPS.md
@@ -85,7 +85,7 @@ Autoscaling
 Artifact                   | Link
 -------------------------- | ----
 Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)
-Community Meeting VC       | [scaling-wg](https://hangouts.google.com/hangouts/_/google.com/scaling-wg)
+Community Meeting VC       | [scaling-wg](https://meet.google.com/ick-mumc-mjv)
 Community Meeting Calendar | [Calendar](https://calendar.google.com/calendar?cid=Z29vZ2xlLmNvbV9sNHY5NnJocWJoMGk1dWsyMnU1MGhudDY2c0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
 Meeting Notes              | [Notes](https://docs.google.com/document/d/1FoLJqbDJM8_tw7CON-CJZsO2mlF8Ia1cWzCjWX8HDAI/edit#heading=h.c0ufqy5rucfa)
 Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1qpGIPXVGoMm6IXb74gPrrHkudV_bjIZ9)


### PR DESCRIPTION
## Proposed Changes
* The scaling WG VC link does not match what is currently in the calendar invite,
updating to match with the assumption the calendar invite is correct.
