### PR TITLE
Sync install instructions with GKE version

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -142,26 +142,45 @@ rerun the command to see the current status.
 > Note: Instead of rerunning the command, you can add `--watch` to the above
   command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative components
 
-1. Next, we will install [Knative Serving](https://github.com/knative/serving)
-and its dependencies:
+You can install the Knative Serving and Build components together, or Build on its own.
+
+### Installing Knative Serving and Build components
+
+1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
     kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
-1. Monitor the Knative components, until all of the components show a `STATUS` of
-`Running`:
+1. Monitor the Knative components until all of the components show a
+   `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-serving
+    kubectl get pods -n knative-build
     ```
 
+### Installing Knative Build only
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/config/build/release.yaml
+    ```
+1. Monitor the Knative Build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
+
 Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current status.
+components to be up and running; you can rerun the `kubectl get` command to see
+the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-  command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
-You are now ready to deploy an app to your new Knative cluster.
+You are now ready to deploy an app or create a build in your new Knative
+cluster.
 
 ## Deploying an app
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -154,7 +154,7 @@ You can install the Knative Serving and Build components together, or Build on i
     kubectl get pods -n knative-build
     ```
 
-### Installing Knative Build
+### Installing Knative Build only
 
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -87,23 +87,45 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative components
 
-1.  Next, we will install [Knative Serving](https://github.com/knative/serving)
-    and its dependencies:
-    `bash kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml`
-1.  Monitor the Knative components, until all of the components show a `STATUS`
-    of `Running`: `bash kubectl get pods -n knative-serving`
+You can install the Knative Serving and Build components together, or Build on its own.
+
+### Installing Knative Serving and Build components
+
+1. Run the `kubectl apply` command to install Knative and its dependencies:
+    ```bash
+    kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
+    ```
+1. Monitor the Knative components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-serving
+    kubectl get pods -n knative-build
+    ```
+
+### Installing Knative Build only
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/config/build/release.yaml
+    ```
+1. Monitor the Knative Build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
 
 Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current
-status.
+components to be up and running; you can rerun the `kubectl get` command to see
+the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
-You are now ready to deploy an app to your new Knative cluster.
+You are now ready to deploy an app or create a build in your new Knative
+cluster.
 
 ## Alternative way to enable Knative with Gardener
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -145,28 +145,45 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL+C to
 > exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative components
 
-1.  Next, we will install [Knative Serving](https://github.com/knative/serving)
-    and its dependencies:
+You can install the Knative Serving and Build components together, or Build on its own.
+
+### Installing Knative Serving and Build components
+
+1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
     kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
-1.  Monitor the Knative components until all of the components show a `STATUS`
-    of `Running`:
+1. Monitor the Knative components until all of the components show a
+   `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-serving
+    kubectl get pods -n knative-build
     ```
 
+### Installing Knative Build only
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/config/build/release.yaml
+    ```
+1. Monitor the Knative Build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
+
 Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current
-status.
+components to be up and running; you can rerun the `kubectl get` command to see
+the current status.
 
-> Note: Instead of re-running the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL+C to
-> exit watch mode.
+> Note: Instead of rerunning the command, you can add `--watch` to the above
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
-You are now ready to deploy an app to your new Knative cluster.
+You are now ready to deploy an app or create a build in your new Knative
+cluster.
 
 ## Deploying an app
 

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -50,26 +50,45 @@ rerun the command to see the current status.
 > Note: Instead of rerunning the command, you can add `--watch` to the above
   command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative components
 
-1. Next, we will install [Knative Serving](https://github.com/knative/serving)
-and its dependencies:
+You can install the Knative Serving and Build components together, or Build on its own.
+
+### Installing Knative Serving and Build components
+
+1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
     kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
-1. Monitor the Knative components, until all of the components show a `STATUS` of
-`Running`:
+1. Monitor the Knative components until all of the components show a
+   `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-serving
+    kubectl get pods -n knative-build
     ```
 
+### Installing Knative Build only
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/config/build/release.yaml
+    ```
+1. Monitor the Knative Build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
+
 Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current status.
+components to be up and running; you can rerun the `kubectl get` command to see
+the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-  command to view the component's status updates in real time. Use CTRL + C to exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
-You are now ready to deploy an app to your new Knative cluster.
+You are now ready to deploy an app or create a build in your new Knative
+cluster.
 
 ## Deploying an app
 

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -35,28 +35,45 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative components
 
-1.  Next, we will install [Knative Serving](https://github.com/knative/serving)
-    and its dependencies:
+You can install the Knative Serving and Build components together, or Build on its own.
+
+### Installing Knative Serving and Build components
+
+1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
     kubectl apply -f https://github.com/knative/serving/releases/download/v0.1.0/release.yaml
     ```
-1.  Monitor the Knative components, until all of the components show a `STATUS`
-    of `Running`:
+1. Monitor the Knative components until all of the components show a
+   `STATUS` of `Running`:
     ```bash
     kubectl get pods -n knative-serving
+    kubectl get pods -n knative-build
     ```
 
+### Installing Knative Build only
+
+1. Run the `kubectl apply` command to install
+   [Knative Build](https://github.com/knative/build) and its dependencies:
+    ```bash
+    kubectl apply -f https://raw.githubusercontent.com/knative/serving/v0.1.0/third_party/config/build/release.yaml
+    ```
+1. Monitor the Knative Build components until all of the components show a
+   `STATUS` of `Running`:
+    ```bash
+    kubectl get pods -n knative-build
+
 Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current
-status.
+components to be up and running; you can rerun the `kubectl get` command to see
+the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
+  command to view the component's status updates in real time. Use CTRL + C to
+  exit watch mode.
 
-You are now ready to deploy an app to your new Knative cluster.
+You are now ready to deploy an app or create a build in your new Knative
+cluster.
 
 ## Deploying an app
 


### PR DESCRIPTION
Fixes #(issue-number)

## Proposed Changes

* https://github.com/knative/docs/pull/318 changed the GKE install instructions; this syncs up the other install guides.
* Note: the Minikube and OpenShift instructions include a "lite" version of the install, and I'm not sure: 
   A. If the lite version installs both serving and build and
   B. if it installs both, whether or not there's a build-only "lite" install file. So, I left those two versions 
        alone for the moment.
