### PR TITLE
Clarifies working directory to run command

### DIFF
--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -14,7 +14,7 @@ If you installed the
 skip this step and continue to
 [Create Elasticsearch Indices](#Create-Elasticsearch-Indices)
 
-- Install Knative monitoring components from the root of the serving repository:
+- Install Knative monitoring components from the root of the [Serving repository](https://github.com/knative/serving):
 
   ```shell
   kubectl apply -R -f config/monitoring/100-common \

--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -14,7 +14,7 @@ If you installed the
 skip this step and continue to
 [Create Elasticsearch Indices](#Create-Elasticsearch-Indices)
 
-- Install Knative monitoring components:
+- Install Knative monitoring components from the root of the serving repository:
 
   ```shell
   kubectl apply -R -f config/monitoring/100-common \


### PR DESCRIPTION
## Proposed Changes

* I found that I didn't know the starting point to run the command to add monitoring components, given it referenced relative file locations.  By specifying the starting point as the root of the serving repository, it is clear to readers. 
