### PR TITLE
Fix a typo in the path so that ko can be used to deploy the sample.

### DIFF
--- a/eventing/samples/k8s-events/function.yaml
+++ b/eventing/samples/k8s-events/function.yaml
@@ -24,4 +24,4 @@ spec:
         spec:
           container:
             # Replace this image with your {username}/k8s-events container
-            image: github.com/knative/docs/eventing/sample/k8s-events
+            image: github.com/knative/docs/eventing/samples/k8s-events


### PR DESCRIPTION
Fix a typo in the path so that ko can be used to deploy the sample.
