### PR TITLE
Really fix URL to the WG meeting

### DIFF
--- a/community/WORKING-GROUPS.md
+++ b/community/WORKING-GROUPS.md
@@ -142,7 +142,7 @@ Artifact                   | Link
 -------------------------- | ----
 Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)
 Community Meeting VC       | [Hangouts](https://meet.google.com/sps-vbhg-rfx)
-Community Meeting Calendar | Every other Thursday at 2PM Pacific: [Calendar Invitation](https://calendar.google.com/calendar/event?eid=NTJ2cWJuMTZxazNydWQyY2NtZ2t0MDJzajJfMjAxODA4MzBUMTczMDAwWiBnb29nbGUuY29tXzE4dW40ZnVoNnJva3FmOGhtZmZ0bTVvcXE0QGc)
+Community Meeting Calendar | Every other Thursday at 2PM Pacific: [Calendar Invitation](https://calendar.google.com/calendar/event?eid=NW5zM21rbHVwZWgyNHFoMGpyY2JhMjB2bHRfMjAxODA5MTNUMjEwMDAwWiBnb29nbGUuY29tXzE4dW40ZnVoNnJva3FmOGhtZmZ0bTVvcXE0QGc)
 Meeting Notes              | [Notes](https://docs.google.com/document/d/1aPRwYGD4XscRIqlBzbNsSB886PJ0G-vZYUAAUjoydko)
 Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1oMYB4LQHjySuMChmcWYCyhH7-CSkz2r_)
 Slack Channel              | [#productivity](https://knative.slack.com)

--- a/community/WORKING-GROUPS.md
+++ b/community/WORKING-GROUPS.md
@@ -142,7 +142,7 @@ Artifact                   | Link
 -------------------------- | ----
 Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)
 Community Meeting VC       | [Hangouts](https://meet.google.com/sps-vbhg-rfx)
-Community Meeting Calendar | [Calendar Invitation](https://calendar.google.com/event?action=TEMPLATE&tmeid=NW5zM21rbHVwZWgyNHFoMGpyY2JhMjB2bHRfMjAxODA4MzBUMjEwMDAwWiBnb29nbGUuY29tXzE4dW40ZnVoNnJva3FmOGhtZmZ0bTVvcXE0QGc&tmsrc=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com&scp=ALL)
+Community Meeting Calendar | Every other Thursday at 2PM Pacific: [Calendar Invitation](https://calendar.google.com/calendar/event?eid=NTJ2cWJuMTZxazNydWQyY2NtZ2t0MDJzajJfMjAxODA4MzBUMTczMDAwWiBnb29nbGUuY29tXzE4dW40ZnVoNnJva3FmOGhtZmZ0bTVvcXE0QGc)
 Meeting Notes              | [Notes](https://docs.google.com/document/d/1aPRwYGD4XscRIqlBzbNsSB886PJ0G-vZYUAAUjoydko)
 Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1oMYB4LQHjySuMChmcWYCyhH7-CSkz2r_)
 Slack Channel              | [#productivity](https://knative.slack.com)


### PR DESCRIPTION
I copied the URL into my browser in an incognito window, and it appears to work, but please double-check.

<!--
/assign samodell
/assign @jessiezcc 
-->