### PR TITLE
Remove flag package import

### DIFF
--- a/serving/samples/helloworld-go/helloworld.go
+++ b/serving/samples/helloworld-go/helloworld.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -34,7 +33,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	flag.Parse()
 	log.Print("Hello world sample started.")
 
 	http.HandleFunc("/", handler)


### PR DESCRIPTION
Fixes #(issue-number)
#290

## Proposed Changes

Removes the `flag` package import and flag parsing as it is noted that this is done elsewhere.
