### PR TITLE
Add manual instructions for img string replacement

### DIFF
--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -27,7 +27,7 @@ Build the application container and publish it to a container registry:
    ```
    * This example shows how to use Google Container Registry (GCR). You will need a
    Google Cloud Project and to enable the
-   [Google Container Registry API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).  
+   [Google Container Registry API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).
 
 1. Use Docker to build your application container:
    ```
@@ -37,16 +37,21 @@ Build the application container and publish it to a container registry:
    ```
 
 1. Push your container to a container registry:
-   ```  
+   ```
    docker push "${REPO}/serving/samples/autoscale-go"
    ```
 
-1. Replace the image reference with our published image:
-   ```
-   perl -pi -e \
-   "s@github.com/knative/docs/serving/samples/autoscale-go@${REPO}/serving/samples/autoscale-go@g" \
-   serving/samples/autoscale-go/service.yaml
-   ```
+1. Replace the image reference path with our published image path in the configuration files (`serving/samples/autoscale-go/service.yaml`:
+   * Manually replace:
+
+     `image: github.com/knative/docs/serving/samples/autoscale-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/autoscale-go`
+
+    Or
+
+   * Run this command:
+     ```
+     perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/autoscale-go/service.yaml
+     ```
 
 ## Deploy the Service
 

--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -21,15 +21,24 @@ Save a copy of `buildpack.yaml`, then install it:
 kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/buildpack/buildpack.yaml
 ```
 
-Then you can deploy this to Knative Serving from the root directory
-by entering the following commands:
+Before you can deploy this to Knative Serving, the image reference paths need to be replaced with the published image.  From the root directory:
 
-```shell
-# Replace <your-project-here> with your own registry
-export REPO="gcr.io/<your-project-here>"
+* Manually replace in `sample.yaml`:
+  `DOCKER_REPO_OVERRIDE` with `<YOUR_CONTAINER_REGISTRY>`
 
-perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+  Or
 
+* Run this command:
+  ```shell
+  # Replace <your-project-here> with your own registry
+  export REPO="gcr.io/<your-project-here>"
+
+  perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+  ```
+
+Then deploy:
+
+```
 # Create the Kubernetes resources
 kubectl apply -f sample.yaml
 ```

--- a/serving/samples/buildpack-function-nodejs/README.md
+++ b/serving/samples/buildpack-function-nodejs/README.md
@@ -22,14 +22,26 @@ Save a copy of `buildpack.yaml`, then install it:
 kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/buildpack/buildpack.yaml
 ```
 
-Then you can deploy this to Knative Serving from the root directory via:
+Before you can deploy this to Knative Serving, the image reference paths need to be replaced with the published image.  From the root directory:
 
-```shell
-# Replace <your-project-here> with your own registry
-export REPO="gcr.io/<your-project-here>"
+* Manually replace in `sample.yaml`:
 
-perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+  `DOCKER_REPO_OVERRIDE` with `<YOUR_CONTAINER_REGISTRY>`
 
+  Or
+
+* Run this command
+  ```shell
+  # Replace <your-project-here> with your own registry
+  export REPO="gcr.io/<your-project-here>"
+
+  perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+  ```
+
+Then deploy:
+
+```
+# Create the Kubernetes resources
 kubectl apply -f sample.yaml
 ```
 

--- a/serving/samples/grpc-ping-go/README.md
+++ b/serving/samples/grpc-ping-go/README.md
@@ -13,22 +13,33 @@ This sample is dependent on [this issue](https://github.com/knative/serving/issu
 
 Build and run the gRPC server. This command will build the server and use `kubectl` to apply the configuration.
 
-```
-REPO="gcr.io/<your-project-here>"
+1. Build and push the image:
+   ```
+   REPO="gcr.io/<your-project-here>"
 
-# Build and publish the container, run from the root directory.
-docker build \
-  --tag "${REPO}/serving/samples/grpc-ping-go" \
-  --file=serving/samples/grpc-ping-go/Dockerfile .
-docker push "${REPO}/serving/samples/grpc-ping-go"
+   # Build and publish the container, run from the root directory.
+   docker build \
+     --tag "${REPO}/serving/samples/grpc-ping-go" \
+     --file=serving/samples/grpc-ping-go/Dockerfile .
+   docker push "${REPO}/serving/samples/grpc-ping-go"
+   ```
+2. Replace the image references in `serving/samples/grpc-ping-go/sample.yaml`
+   with our published image:
+   * Manually replace:
 
-# Replace the image reference with our published image.
-perl -pi -e "s@github.com/knative/docs/serving/samples/grpc-ping-go@${REPO}/serving/samples/grpc-ping-go@g" serving/samples/grpc-ping-go/*.yaml
+     `image: github.com/knative/docs/serving/samples/grpc-ping-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/grpc-ping-go`
 
-# Deploy the Knative sample
-kubectl apply -f serving/samples/grpc-ping-go/sample.yaml
+    Or
 
-```
+   * Run this command:
+     ```
+     perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/grpc-ping-go/sample.yaml
+     ```
+
+3. Deploy the Knative sample
+   ```
+   kubectl apply -f serving/samples/grpc-ping-go/sample.yaml
+   ```
 
 ## Use the client to stream messages to the gRPC server
 

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -30,40 +30,41 @@ go get -d github.com/knative/docs/serving/samples/knative-routing-go
 
 Build the application container and publish it to a container registry:
 
-1. Move into the sample directory:  
+1. Move into the sample directory:
 ```
 cd $GOPATH/src/github.com/knative/docs
 ```
 
-2. Set your preferred container registry:  
+2. Set your preferred container registry:
 ```
 export REPO="gcr.io/<YOUR_PROJECT_ID>"
 ```
    This example shows how to use Google Container Registry (GCR). You will need a Google Cloud Project and to enable the [Google Container Registry
-API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).  
+API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).
 
-3. Use Docker to build your application container:  
+3. Use Docker to build your application container:
 ```
 docker build \
   --tag "${REPO}/serving/samples/knative-routing-go" \
   --file=serving/samples/knative-routing-go/Dockerfile .
 ```
 
-4. Push your container to a container registry:  
-```  
+4. Push your container to a container registry:
+```
 docker push "${REPO}/serving/samples/knative-routing-go"
 ```
 
-5. Replace the image reference path with our published image path in the configuration file (`serving/samples/knative-routing-go/sample.yaml`):  
-   * Manually replace:  
-    `image: github.com/knative/docs/serving/samples/knative-routing-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/knative-routing-go`  
+5. Replace the image reference path with our published image path in the configuration file (`serving/samples/knative-routing-go/sample.yaml`):
+   * Manually replace:
+
+     `image: github.com/knative/docs/serving/samples/knative-routing-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/knative-routing-go`
 
     Or
 
-   * Use run this command:  
-    ```
-    perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/knative-routing-go/sample.yaml
-    ```
+   * Run this command:
+     ```
+     perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/knative-routing-go/sample.yaml
+     ```
 
 ## Deploy the Service
 
@@ -94,25 +95,25 @@ kubectl get service.serving.knative.dev
 ```
 You should see 2 Knative services: search-service and login-service.
 
-### Access the Services  
+### Access the Services
 
-1. Find the shared Gateway IP and export as an environment variable:  
+1. Find the shared Gateway IP and export as an environment variable:
 ```
 export GATEWAY_IP=`kubectl get svc knative-ingressgateway -n istio-system \
 -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
 ```
 
-2. Find the "Search" service route and export as an environment variable:  
+2. Find the "Search" service route and export as an environment variable:
 ```
 export SERVICE_HOST=`kubectl get route search-service -o jsonpath="{.status.domain}"`
 ```
-3. Make a curl request to the service:  
+3. Make a curl request to the service:
 ```
 curl http://${GATEWAY_IP} --header "Host:${SERVICE_HOST}"
 ```
 You should see: `Search Service is called !`
 
-4. Similarly, you can also directly access "Login" service with:  
+4. Similarly, you can also directly access "Login" service with:
 ```
 export SERVICE_HOST=`kubectl get route login-service -o jsonpath="{.status.domain}"`
 ```
@@ -123,31 +124,31 @@ You should see: `Login Service is called !`
 
 ## Apply Custom Routing Rule
 
-1. Apply the custom routing rules defined in `routing.yaml` file with:  
+1. Apply the custom routing rules defined in `routing.yaml` file with:
 ```
 kubectl apply -f serving/samples/knative-routing-go/routing.yaml
 ```
 
 2. The `routing.yaml` file will generate a new VirtualService "entry-route" for
-domain "example.com". View the VirtualService:  
+domain "example.com". View the VirtualService:
 ```
 kubectl get VirtualService entry-route -oyaml
 ```
 
 3. Send a request to the "Search" service and the "Login" service by using
-corresponding URIs. You should get the same results as directly accessing these services.  
-    * Get the ingress IP:  
+corresponding URIs. You should get the same results as directly accessing these services.
+    * Get the ingress IP:
     ```
     export GATEWAY_IP=`kubectl get svc knative-ingressgateway -n istio-system \
     -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
     ```
 
-    * Send a request to the Search service:  
+    * Send a request to the Search service:
     ```
     curl http://${GATEWAY_IP}/search --header "Host:example.com"
     ```
 
-    * Send a request to the Login service:  
+    * Send a request to the Login service:
     ```
     curl http://${GATEWAY_IP}/login --header "Host:example.com"
     ```

--- a/serving/samples/rest-api-go/README.md
+++ b/serving/samples/rest-api-go/README.md
@@ -16,40 +16,41 @@ go get -d github.com/knative/docs/serving/samples/rest-api-go
 
 Build the application container and publish it to a container registry:
 
-1. Move into the sample directory:  
+1. Move into the sample directory:
 ```
 cd $GOPATH/src/github.com/knative/docs
 ```
 
-2. Set your preferred container registry:  
+2. Set your preferred container registry:
 ```
 export REPO="gcr.io/<YOUR_PROJECT_ID>"
 ```
    To run the sample, you need to have a Google Cloud Platform project, and you also need to enable the [Google Container Registry
-API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).  
+API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).
 
-3. Use Docker to build your application container:  
+3. Use Docker to build your application container:
 ```
 docker build \
   --tag "${REPO}/serving/samples/rest-api-go" \
   --file serving/samples/rest-api-go/Dockerfile .
 ```
 
-4. Push your container to a container registry:  
-```  
+4. Push your container to a container registry:
+```
 docker push "${REPO}/serving/samples/rest-api-go"
 ```
 
-5. Replace the image reference path with our published image path in the configuration files (`serving/samples/rest-api-go/sample.yaml`:  
-   * Manually replace:  
-    `image: github.com/knative/docs/serving/samples/rest-api-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/rest-api-go`  
+5. Replace the image reference path with our published image path in the configuration files (`serving/samples/rest-api-go/sample.yaml`:
+   * Manually replace:
+
+     `image: github.com/knative/docs/serving/samples/rest-api-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/rest-api-go`
 
     Or
 
-   * Use run this command:  
-    ```
-    perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/rest-api-go/sample.yaml
-    ```
+   * Run this command:
+     ```
+     perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/rest-api-go/sample.yaml
+     ```
 
 ## Deploy the Configuration
 

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -26,43 +26,44 @@ go get -d github.com/knative/docs/serving/samples/telemetry-go
 
 Build the application container and publish it to a container registry:
 
-1. Move into the sample directory:  
+1. Move into the sample directory:
 ```
 cd $GOPATH/src/github.com/knative/docs
 ```
 
-2. Set your preferred container registry:  
+2. Set your preferred container registry:
 ```
 export REPO="gcr.io/<YOUR_PROJECT_ID>"
 ```
    This example shows how to use Google Container Registry (GCR). You will need
    a Google Cloud Project and to enable the [Google Container Registry
-API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).  
+API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).
 
-3. Use Docker to build your application container:  
+3. Use Docker to build your application container:
 ```
 docker build \
   --tag "${REPO}/serving/samples/telemetry-go" \
   --file=serving/samples/telemetry-go/Dockerfile .
 ```
 
-4. Push your container to a container registry:  
-```  
+4. Push your container to a container registry:
+```
 docker push "${REPO}/serving/samples/telemetry-go"
 ```
 
 5. Replace the image reference path with our published image path in the
-configuration file (`serving/samples/telemetry-go/sample.yaml`):  
-   * Manually replace:  
-    `image: github.com/knative/docs/serving/samples/telemetry-go` with
-    `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/telemetry-go`  
+configuration file (`serving/samples/telemetry-go/sample.yaml`):
+   * Manually replace:
 
-    Or
+     `image: github.com/knative/docs/serving/samples/telemetry-go` with
+     `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/telemetry-go`
 
-   * Use run this command:  
-    ```
-    perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/telemetry-go/sample.yaml
-    ```
+   Or
+
+   * Run this command:
+     ```
+     perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/telemetry-go/sample.yaml
+     ```
 
 ## Deploy the Service
 
@@ -94,7 +95,7 @@ Inspect the created resources with the `kubectl` commands:
 
 To access this service via `curl`, you need to determine its ingress address.
 
-1. To determine if your service is ready:  
+1. To determine if your service is ready:
   Check the status of your Knative gateway:
   ```
   kubectl get svc knative-ingressgateway -n istio-system --watch

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -101,10 +101,16 @@ If you want to build the image yourself, follow these instructions. This sample 
 template](https://github.com/knative/build-templates/blob/master/kaniko/kaniko.yaml)
 from the [build-templates](https://github.com/knative/build-templates/) repo.
 
+First, either Manually substitute `DOCKER_REPO_OVERRIDE` in `sample.yaml` with a suitable registry,
+or run the following command:
 ```shell
 # Replace the token string with a suitable registry
 REPO="gcr.io/<your-project-here>"
 perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+```
+
+Next, build and deploy:
+```shell
 
 # Install the Kaniko build template used to build this sample (in the
 # build-templates repo).

--- a/serving/samples/traffic-splitting/README.md
+++ b/serving/samples/traffic-splitting/README.md
@@ -11,16 +11,17 @@ to illustrate applying a revision, then using that revision for manual traffic s
 
 This section describes how to create an revision by deploying a new configuration.
 
-1. Replace the image reference path with our published image path in the configuration files (`serving/samples/traffic-splitting/updated_configuration.yaml`:  
-    * Manually replace:  
-     `image: github.com/knative/docs/serving/samples/rest-api-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/rest-api-go`  
+1. Replace the image reference path with our published image path in the configuration files (`serving/samples/traffic-splitting/updated_configuration.yaml`:
+    * Manually replace:
+
+      `image: github.com/knative/docs/serving/samples/rest-api-go` with `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/rest-api-go`
 
      Or
 
-    * Use run this command:  
-     ```
-     perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/rest-api-go/updated_configuration.yaml
-     ```
+    * Use run this command:
+      ```
+      perl -pi -e "s@github.com/knative/docs@${REPO}@g" serving/samples/rest-api-go/updated_configuration.yaml
+      ```
 
 2. Deploy the new configuration to update the `RESOURCE` environment variable
 from `stock` to `share`:
@@ -33,8 +34,8 @@ kubectl apply -f serving/samples/traffic-splitting/updated_configuration.yaml
 kubectl get route -o yaml
 ```
 
-4. When the new route is ready, you can access the new endpoints:  
-  The hostname and IP address can be found in the same manner as the [Creating a RESTful Service](../rest-api-go) sample:  
+4. When the new route is ready, you can access the new endpoints:
+  The hostname and IP address can be found in the same manner as the [Creating a RESTful Service](../rest-api-go) sample:
   ```
   export SERVICE_HOST=`kubectl get route stock-route-example -o jsonpath="{.status.domain}"`
   export SERVICE_IP=`kubectl get svc knative-ingressgateway -n istio-system \


### PR DESCRIPTION
Examples currently use perl commands to magically replace
image locations in *.yaml files.  This change adds instructions
for manually updating the image path for added clarity.

Fixes #245
