### PR TITLE
telemetry: document sd/prom manifest locations

### DIFF
--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -93,13 +93,23 @@ own Fluentd image and modify the configuration first. See
 2. [Set up a logging plugin](setting-up-a-logging-plugin.md).
 3. Install Knative monitoring components:
 
-  ```shell
-  kubectl apply -R -f config/monitoring/100-common \
-      -f config/monitoring/150-stackdriver-prod \
-      -f third_party/config/monitoring/common \
-      -f config/monitoring/200-common \
-      -f config/monitoring/200-common/100-istio.yaml
-  ```
+    a. Clone the Knative Serving repository:
+
+      ```shell
+      git clone https://github.com/knative/serving knative-serving
+      cd knative-serving
+      git checkout v0.1.1
+      ```
+
+    b. Apply the monitoring manifests:
+
+      ```shell
+      kubectl apply -R -f config/monitoring/100-common \
+          -f config/monitoring/150-stackdriver-prod \
+          -f third_party/config/monitoring/common \
+          -f config/monitoring/200-common \
+          -f config/monitoring/200-common/100-istio.yaml
+      ```
 
 ## Learn More
 


### PR DESCRIPTION
By reading the docs, I can't tell where are these config/monitoring stuff.

So I'm adding sub-steps to (a) clone repo + cd + checkout to the release tag,
then (b) apply them.

Please /cc someone who knows about this stuff to verify.