### PR TITLE
cleanup remaining kubectl shorthand -o flags

### DIFF
--- a/eventing/samples/github-events/README.md
+++ b/eventing/samples/github-events/README.md
@@ -130,7 +130,7 @@ kubectl apply --filename auth.yaml
 1.  Check that your service is running using:
 
     ```shell
-    kubectl get ksvc -o "custom-columns=NAME:.metadata.name,READY:.status.conditions[2].status,REASON:.status.conditions[2].message"
+    kubectl get ksvc --output "custom-columns=NAME:.metadata.name,READY:.status.conditions[2].status,REASON:.status.conditions[2].message"
     NAME              READY     REASON
     legit             True      <none>
     ```

--- a/serving/samples/gitwebhook-go/README.md
+++ b/serving/samples/gitwebhook-go/README.md
@@ -103,7 +103,7 @@ service "gitwebhook" created
 
         ```shell
         $ kubectl get ksvc gitwebhook \
-           -o=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+           --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
 
         NAME                DOMAIN
         gitwebhook          gitwebhook.default.example.com

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -139,7 +139,7 @@ corresponding URIs. You should get the same results as directly accessing these 
     * Get the ingress IP:  
     ```
     export GATEWAY_IP=`kubectl get svc knative-ingressgateway --namespace istio-system \
-    -o jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+    --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
     ```
 
     * Send a request to the Search service:  

--- a/serving/samples/traffic-splitting/README.md
+++ b/serving/samples/traffic-splitting/README.md
@@ -38,7 +38,7 @@ kubectl get route --output yaml
   ```
   export SERVICE_HOST=`kubectl get route stock-route-example --output jsonpath="{.status.domain}"`
   export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system \
-  -o jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+  --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
   ```
 
   * Make a request to the index endpoint:


### PR DESCRIPTION
Fixes #292

## Proposed Changes

Replace the remaining/missed shorthand `kubectl` `-o` flags with `--output`

Related PR #372 