### PR TITLE
Make Python example use the PORT env var instead of 8080

### DIFF
--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -39,7 +39,7 @@ The following instructions recreate the source files from this folder.
         return 'Hello World: {}!\n'.format(target)
 
     if __name__ == "__main__":
-        app.run(debug=True,host='0.0.0.0',port=8080)
+        app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
     ```
 
 1. Create a file named `Dockerfile` and copy the code block below into it.

--- a/serving/samples/helloworld-python/app.py
+++ b/serving/samples/helloworld-python/app.py
@@ -10,4 +10,4 @@ def hello_world():
     return 'Hello World: {}!\n'.format(target)
 
 if __name__ == "__main__":
-    app.run(debug=True,host='0.0.0.0',port=8080)
+    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))


### PR DESCRIPTION
Fixes #(issue-number)

## Proposed Changes
According to the runtime contract, the service should connect to the PORT env var, not just use 8080.

https://github.com/knative/serving/blob/master/docs/runtime-contract.md#process
