### PR TITLE
Update references to monitoring namespace (#407)

### DIFF
--- a/eventing/samples/k8s-events/README.md
+++ b/eventing/samples/k8s-events/README.md
@@ -96,7 +96,7 @@ kubectl apply --filename serviceaccount.yaml
     ```
 
     Then visit the
-    [Kibana interface](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana#/discover%3F_g%3D%28%29%26_a%3D%28columns%3A%21%28log%29%2Cindex%3AAWSnR1TW-6k0tY2-zd9_%2Cinterval%3Aauto%2Cquery%3A%28query_string%3A%28query%3A%27kubernetes.container_name%3Auser-container+kubernetes.labels.serving_knative_dev%255C%252Fconfiguration%3Aread-k8s-events%27%29%29%2Csort%3A%21%28%27@timestamp%27%2Cdesc%29%29)
+    [Kibana interface](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover%3F_g%3D%28%29%26_a%3D%28columns%3A%21%28log%29%2Cindex%3AAWSnR1TW-6k0tY2-zd9_%2Cinterval%3Aauto%2Cquery%3A%28query_string%3A%28query%3A%27kubernetes.container_name%3Auser-container+kubernetes.labels.serving_knative_dev%255C%252Fconfiguration%3Aread-k8s-events%27%29%29%2Csort%3A%21%28%27@timestamp%27%2Cdesc%29%29)
     and search for the following string (or use the link above):
 
     ```

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -144,9 +144,9 @@ accounts istio will use:
 oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
 oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
 oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
-oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
-oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
-oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n knative-monitoring
 oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
 oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
 ```

--- a/install/scripts/knative-with-openshift.sh
+++ b/install/scripts/knative-with-openshift.sh
@@ -78,9 +78,9 @@ header_text "Setting up security policy for knative"
 oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
 oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
 oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
-oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
-oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
-oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n knative-monitoring
 oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
 oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
 

--- a/serving/debugging-application-issues.md
+++ b/serving/debugging-application-issues.md
@@ -119,7 +119,7 @@ kubectl get build $(kubectl get revision <revision-name> --output jsonpath="{.sp
 ```
 
 If there is any failure, the `conditions` in `status` provide the reason. To
-access build logs, first execute `kubectl proxy` and then open [Kibana UI](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana).
+access build logs, first execute `kubectl proxy` and then open [Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana).
 Use any of the following filters within Kibana UI to
 see build logs. _(See [telemetry guide](../telemetry.md) for more information on
 logging and monitoring features of Knative Serving.)_

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -112,7 +112,7 @@ ceil(8.75) = 9
 View the Knative Serving Scaling and Request dashboards (if configured).
 
 ```
-kubectl port-forward --namespace monitoring $(kubectl get pods --namespace monitoring --selector=app=grafana --output=jsonpath="{.items..metadata.name}") 3000
+kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespace knative-monitoring --selector=app=grafana --output=jsonpath="{.items..metadata.name}") 3000
 ```
 
 ![scale dashboard](scale-dashboard.png)

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -13,7 +13,7 @@ using the default installation.
 installed.
 2. Check if Knative monitoring components are installed:
 ```
-kubectl get pods --namespace monitoring
+kubectl get pods --namespace knative-monitoring
 ```
   * If pods aren't found, install [Knative monitoring component](../../installing-logging-metrics-traces.md).
 3. Install [Docker](https://docs.docker.com/get-started/#prepare-your-docker-environment).

--- a/serving/samples/telemetry-go/telemetrysample.go
+++ b/serving/samples/telemetry-go/telemetrysample.go
@@ -188,7 +188,7 @@ func rootHandler(client *http.Client) http.HandlerFunc {
 		// In sequence, call three different other services. For each call, we will create a new span
 		// to track that call in the call graph. See http://opentracing.io/documentation/ for more information
 		// on these concepts.
-		res, err := getWithContext("http://prometheus-system-np.monitoring.svc.cluster.local:8080")
+		res, err := getWithContext("http://prometheus-system-np.knative-monitoring.svc.cluster.local:8080")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -197,7 +197,7 @@ func rootHandler(client *http.Client) http.HandlerFunc {
 		// end of this function. This applies to the remaining res.Body().Close calls below.
 		res.Body.Close()
 
-		res, err = getWithContext("http://grafana.monitoring.svc.cluster.local:30802")
+		res, err = getWithContext("http://grafana.knative-monitoring.svc.cluster.local:30802")
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Renames the `monitoring` namespace to `knative-monitoring` to reflect the changes in https://github.com/knative/serving/pull/1851. 

Some files have not been updated, see comments in #407.

cc @RichieEscarez 