### PR TITLE
Change slack link to slack guidelines

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -77,7 +77,7 @@ following resources are available for you:
 * [Knative Users](https://groups.google.com/forum/#!forum/knative-users)
 * [Knative Developers](https://groups.google.com/forum/#!forum/knative-dev)
 
-For contributors to Knative, we also have [Knative Slack](https://knative.slack.com)
+For contributors to Knative, we also have [Knative Slack](SLACK-GUIDELINES.md).
 
 ---
 


### PR DESCRIPTION


Fixes #428

## Proposed Changes

*  Change the Slack link in the community page to show the Slack Guidelines page that contains the invite.

