### PR TITLE
Close response body in autoscale-go sample test program

### DIFF
--- a/serving/samples/autoscale-go/test/test.go
+++ b/serving/samples/autoscale-go/test/test.go
@@ -52,6 +52,7 @@ func get(url string, client *http.Client, report chan *result) {
 		}
 		return
 	}
+	defer res.Body.Close()
 	result.statusCode = res.StatusCode
 	if result.statusCode != http.StatusOK {
 		if *verbose {


### PR DESCRIPTION
## Proposed Changes

The test program doesn't close the http response Body causing the connection to
not be released and the creation of new connections until the exhaustion of the
process file descriptors.

This patch closes the response body (actually a defer also if not really needed but useful if in future the body will be read)

