### PR TITLE
Revert ksvc changes

### DIFF
--- a/eventing/samples/k8s-events/README.md
+++ b/eventing/samples/k8s-events/README.md
@@ -69,15 +69,10 @@ kubectl apply --filename serviceaccount.yaml
 1.  Check that your service is running using:
 
     ```shell
-    kubectl get ksvc --output "custom-columns=NAME:.metadata.name,READY:.status.conditions[2].status,REASON:.status.conditions[2].message"
+    kubectl get services.serving.knative.dev --output "custom-columns=NAME:.metadata.name,READY:.status.conditions[2].status,REASON:.status.conditions[2].message"
     NAME              READY     REASON
     read-k8s-events   True      <none>
     ```
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1.  Create the flow sending Kubernetes Events to the service:
 

--- a/install/getting-started-knative-app.md
+++ b/install/getting-started-knative-app.md
@@ -107,21 +107,15 @@ asssigned an external IP address.
 1. To find the host URL for your service, enter:
 
     ```shell
-    kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-go       helloworld-go.default.example.com
     ```
 
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](check-install-version.md)
-      to learn how to see what version you have installed.
-
     You can also export the host URL as a variable using the following command:
     
     ```shell
-    export HOST_URL=$(kubectl get ksvc helloworld-go  --output jsonpath='{.status.domain}')
+    export HOST_URL=$(kubectl get services.serving.knative.dev helloworld-go  --output jsonpath='{.status.domain}')
     ```
 
     If you changed the name from `helloworld-go` to something else when creating

--- a/serving/samples/gitwebhook-go/README.md
+++ b/serving/samples/gitwebhook-go/README.md
@@ -102,18 +102,12 @@ service "gitwebhook" created
     1. Retrieve the hostname for this service, using the following command:
 
         ```shell
-        $ kubectl get ksvc gitwebhook \
+        $ kubectl get services.serving.knative.dev gitwebhook \
            --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
 
         NAME                DOMAIN
         gitwebhook          gitwebhook.default.example.com
         ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
     1. Browse on GitHub to the repository where you want to create a webhook.
     1. Click **Settings**, then **Webhooks**, then **Add webhook**.

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -130,16 +130,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-csharp  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-csharp  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-csharp   helloworld-csharp.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-elixir/README.md
+++ b/serving/samples/helloworld-elixir/README.md
@@ -161,17 +161,11 @@ knative-ingressgateway   LoadBalancer   10.35.254.218   35.225.171.32   80:32380
 1. To find the URL for your service, use
 
     ```
-    kubectl get ksvc helloworld-elixir --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-elixir --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
 
     NAME                DOMAIN
     helloworld-elixir   helloworld-elixir.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the results. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -141,16 +141,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-go       helloworld-go.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the results. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-haskell/README.md
+++ b/serving/samples/helloworld-haskell/README.md
@@ -175,16 +175,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, enter:
 	```
-    kubectl get ksvc helloworld-haskell  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-haskell  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                   DOMAIN
     helloworld-haskell     helloworld-haskell.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app and see the result. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -154,16 +154,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-java  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-java  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-java     helloworld-java.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -172,16 +172,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-nodejs  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-nodejs  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-nodejs   helloworld-nodejs.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -113,16 +113,10 @@ you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-php  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-php  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-php      helloworld-php.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -125,16 +125,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-python  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-python  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-python   helloworld-python.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace `{IP_ADDRESS}`
    with the address you see returned in the previous step.

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -140,15 +140,10 @@ you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get ksvc helloworld-ruby  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-ruby  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-ruby     helloworld-ruby.default.example.com
     ```
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace `{IP_ADDRESS}`
    with the address you see returned in the previous step.

--- a/serving/samples/helloworld-rust/README.md
+++ b/serving/samples/helloworld-rust/README.md
@@ -156,16 +156,10 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, enter:
     ```
-    kubectl get ksvc helloworld-rust  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get services.serving.knative.dev helloworld-rust  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-rust     helloworld-rust.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app and see the result. Replace
    `{IP_ADDRESS}` with the address you see returned in the previous step.

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -213,16 +213,10 @@ container for the application.
 1. To find the URL for your service, type:
 
     ```shell
-    $ kubectl get ksvc app-from-source  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    $ kubectl get services.serving.knative.dev app-from-source  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     app-from-source     app-from-source.default.example.com
     ```
-
-    > Note: `ksvc` is an alias for `services.serving.knative.dev`. If you have
-      an older version (version 0.1.0) of Knative installed, you'll need to use
-      the long name until you upgrade to version 0.1.1 or higher. See
-      [Checking Knative Installation Version](../../../install/check-install-version.md)
-      to learn how to see what version you have installed.
 
 1. Now you can make a request to your app to see the result. Replace
    `{IP_ADDRESS}` with the address that you got in the previous step:


### PR DESCRIPTION
Fixes #379 

## Proposed Changes

* Revert the use of short-name `ksvc` since it isn't supported in the 0.1.1 release which is what the installation instructions are currently using.


