### PR TITLE
Make samples less scary when no env var is provided

### DIFF
--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -40,8 +40,8 @@ recreate the source files from this folder.
     ```csharp
     app.Run(async (context) =>
     {
-        var target = Environment.GetEnvironmentVariable("TARGET") ?? "NOT SPECIFIED";
-        await context.Response.WriteAsync($"Hello World: {target}\n");
+        var target = Environment.GetEnvironmentVariable("TARGET") ?? "World";
+        await context.Response.WriteAsync($"Hello {target}\n");
     });
     ```
 

--- a/serving/samples/helloworld-csharp/Startup.cs
+++ b/serving/samples/helloworld-csharp/Startup.cs
@@ -27,8 +27,8 @@ namespace helloworld_csharp
 
             app.Run(async (context) =>
             {
-                var target = Environment.GetEnvironmentVariable("TARGET") ?? "NOT SPECIFIED";
-                await context.Response.WriteAsync($"Hello World: {target}\n");
+                var target = Environment.GetEnvironmentVariable("TARGET") ?? "World";
+                await context.Response.WriteAsync($"Hello {target}\n");
             });
         }
     }

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -36,9 +36,9 @@ following instructions recreate the source files from this folder.
       log.Print("Hello world received a request.")
       target := os.Getenv("TARGET")
       if target == "" {
-        target = "NOT SPECIFIED"
+        target = "World"
       }
-      fmt.Fprintf(w, "Hello World: %s!\n", target)
+      fmt.Fprintf(w, "Hello %s!\n", target)
     }
 
     func main() {

--- a/serving/samples/helloworld-go/helloworld.go
+++ b/serving/samples/helloworld-go/helloworld.go
@@ -27,9 +27,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	log.Print("Hello world received a request.")
 	target := os.Getenv("TARGET")
 	if target == "" {
-		target = "NOT SPECIFIED"
+		target = "World"
 	}
-	fmt.Fprintf(w, "Hello World: %s!\n", target)
+	fmt.Fprintf(w, "Hello %s!\n", target)
 }
 
 func main() {

--- a/serving/samples/helloworld-haskell/README.md
+++ b/serving/samples/helloworld-haskell/README.md
@@ -64,14 +64,14 @@ following instructions recreate the source files from this folder.
 
 	main :: IO ()
 	main = do
-      t <- fromMaybe "NOT SPECIFIED" <$> lookupEnv "TARGET"
+      t <- fromMaybe "World" <$> lookupEnv "TARGET"
       scotty 8080 (route t)
 
 	route :: String -> ScottyM()
 	route t = get "/" $ hello t
 
 	hello :: String -> ActionM()
-	hello t = text $ pack ("Hello world: " ++ t)
+	hello t = text $ pack ("Hello " ++ t)
     ```
 
 1. In your project directory, create a file named `Dockerfile` and copy the code

--- a/serving/samples/helloworld-haskell/app/Main.hs
+++ b/serving/samples/helloworld-haskell/app/Main.hs
@@ -10,11 +10,11 @@ import           Web.Scotty.Trans
 
 main :: IO ()
 main = do
-  t <- fromMaybe "NOT SPECIFIED" <$> lookupEnv "TARGET"
+  t <- fromMaybe "World" <$> lookupEnv "TARGET"
   scotty 8080 (route t)
 
 route :: String -> ScottyM()
 route t = get "/" $ hello t
 
 hello :: String -> ActionM()
-hello t = text $ pack ("Hello world: " ++ t)
+hello t = text $ pack ("Hello " ++ t)

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -52,14 +52,14 @@ recreate the source files from this folder.
     @SpringBootApplication
     public class HelloworldApplication {
 
-        @Value("${TARGET:NOT SPECIFIED}")
+        @Value("${TARGET:World}")
         String target;
 
         @RestController
         class HelloworldController {
             @GetMapping("/")
             String hello() {
-                return "Hello World: " + target;
+                return "Hello " + target;
             }
         }
 

--- a/serving/samples/helloworld-java/src/main/java/com/example/helloworld/HelloworldApplication.java
+++ b/serving/samples/helloworld-java/src/main/java/com/example/helloworld/HelloworldApplication.java
@@ -9,14 +9,14 @@ import org.springframework.web.bind.annotation.RestController;
 @SpringBootApplication
 public class HelloworldApplication {
 
-	@Value("${TARGET:NOT SPECIFIED}")
+	@Value("${TARGET:World}")
 	String message;
 
 	@RestController
 	class HelloworldController {
 		@GetMapping("/")
 		String hello() {
-			return "Hello World: " + message;
+			return "Hello " + message;
 		}
 	}
 

--- a/serving/samples/helloworld-nodejs/Dockerfile
+++ b/serving/samples/helloworld-nodejs/Dockerfile
@@ -9,8 +9,6 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 RUN npm install --only=production
-# If you are building your code for production
-# RUN npm install --only=production
 
 # Bundle app source
 COPY . .

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -52,8 +52,8 @@ recreate the source files from this folder.
     app.get('/', function (req, res) {
       console.log('Hello world received a request.');
 
-      var target = process.env.TARGET || 'NOT SPECIFIED';
-      res.send('Hello world: ' + target);
+      var target = process.env.TARGET || 'World';
+      res.send('Hello ' + target);
     });
 
     var port = 8080;
@@ -71,8 +71,7 @@ recreate the source files from this folder.
       "description": "",
       "main": "app.js",
       "scripts": {
-        "start": "node app.js",
-        "test": "echo \"Error: no test specified\" && exit 1"
+        "start": "node app.js"
       },
       "author": "",
       "license": "Apache-2.0"
@@ -94,9 +93,7 @@ recreate the source files from this folder.
     # where available (npm@5+)
     COPY package*.json ./
 
-    RUN npm install
-    # If you are building your code for production
-    # RUN npm install --only=production
+    RUN npm install --production
 
     # Bundle app source
     COPY . .

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -93,7 +93,7 @@ recreate the source files from this folder.
     # where available (npm@5+)
     COPY package*.json ./
 
-    RUN npm install --production
+    RUN npm install --only=production
 
     # Bundle app source
     COPY . .

--- a/serving/samples/helloworld-nodejs/app.js
+++ b/serving/samples/helloworld-nodejs/app.js
@@ -20,8 +20,8 @@ const app = express();
 app.get('/', function (req, res) {
   console.log('Hello world received a request.');
 
-  var target = process.env.TARGET || 'NOT SPECIFIED';
-  res.send('Hello world: ' + target);
+  var target = process.env.TARGET || 'World';
+  res.send('Hello ' + target);
 });
 
 var port = 8080;

--- a/serving/samples/helloworld-nodejs/package.json
+++ b/serving/samples/helloworld-nodejs/package.json
@@ -4,12 +4,11 @@
   "description": "Simple hello world sample in Node",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node app.js"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/knative/serving.git"
+    "url": "git+https://github.com/knative/docs.git"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -29,8 +29,8 @@ following instructions recreate the source files from this folder.
 
     ```php
     <?php
-      $target = getenv('TARGET', true) ?: "NOT SPECIFIED";
-      echo sprintf("Hello World: %s!\n", $target);
+      $target = getenv('TARGET', true) ?: "World";
+      echo sprintf("Hello %s!\n", $target);
     ?>
     ```
 

--- a/serving/samples/helloworld-php/index.php
+++ b/serving/samples/helloworld-php/index.php
@@ -1,4 +1,4 @@
 <?php
-  $target = getenv('TARGET', true) ?: "NOT SPECIFIED";
-  echo sprintf("Hello World: %s!\n", $target);
+  $target = getenv('TARGET', true) ?: "World";
+  echo sprintf("Hello %s!\n", $target);
 ?>

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -35,8 +35,8 @@ The following instructions recreate the source files from this folder.
 
     @app.route('/')
     def hello_world():
-        target = os.environ.get('TARGET', 'NOT SPECIFIED')
-        return 'Hello World: {}!\n'.format(target)
+        target = os.environ.get('TARGET', 'World')
+        return 'Hello {}!\n'.format(target)
 
     if __name__ == "__main__":
         app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))

--- a/serving/samples/helloworld-python/app.py
+++ b/serving/samples/helloworld-python/app.py
@@ -6,8 +6,8 @@ app = Flask(__name__)
 
 @app.route('/')
 def hello_world():
-    target = os.environ.get('TARGET', 'NOT SPECIFIED')
-    return 'Hello World: {}!\n'.format(target)
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}!\n'.format(target)
 
 if __name__ == "__main__":
     app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -33,8 +33,8 @@ The following instructions recreate the source files from this folder.
     set :bind, '0.0.0.0'
 
     get '/' do
-      target = ENV['TARGET'] || 'NOT SPECIFIED'
-      "Hello World: #{target}!\n"
+      target = ENV['TARGET'] || 'World'
+      "Hello #{target}!\n"
     end
     ```
 

--- a/serving/samples/helloworld-ruby/app.rb
+++ b/serving/samples/helloworld-ruby/app.rb
@@ -3,6 +3,6 @@ require 'sinatra'
 set :bind, '0.0.0.0'
 
 get '/' do
-  target = ENV['TARGET'] || 'NOT SPECIFIED'
-  "Hello World: #{target}!\n"
+  target = ENV['TARGET'] || 'World'
+  "Hello #{target}!\n"
 end

--- a/serving/samples/helloworld-rust/README.md
+++ b/serving/samples/helloworld-rust/README.md
@@ -53,10 +53,10 @@ following instructions recreate the source files from this folder.
         let new_service = || {
             service_fn_ok(|_| {
 
-                let mut hello = "Hello world: ".to_string();
+                let mut hello = "Hello ".to_string();
                 match env::var("TARGET") {
                     Ok(target) => {hello.push_str(&target);},
-                    Err(_e) => {hello.push_str("NOT SPECIFIED")},
+                    Err(_e) => {hello.push_str("World")},
                 };
 
                 Response::new(Body::from(hello))

--- a/serving/samples/helloworld-rust/src/main.rs
+++ b/serving/samples/helloworld-rust/src/main.rs
@@ -15,10 +15,10 @@ fn main() {
     let new_service = || {
         service_fn_ok(|_| {
 
-            let mut hello = "Hello world: ".to_string();
+            let mut hello = "Hello ".to_string();
             match env::var("TARGET") {
                 Ok(target) => {hello.push_str(&target);},
-                Err(_e) => {hello.push_str("NOT SPECIFIED")},
+                Err(_e) => {hello.push_str("World")},
             };
 
             Response::new(Body::from(hello))


### PR DESCRIPTION
When no env var is provided (for example because the developer only has deployed the code without using the `service.yaml`), instead of displaying "Hello World: NOT SPECIFIED", display the more friendly message "Hello Word".
This means that when the `TARGET` env var is set, instead of displaying "Hello World: <TARGET>", the samples will display "Hello <TARGET>", which seems totally OK.

All sample changes have been tested.