### PR TITLE
Update vendored test-infra version

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,88 +3,113 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:8679b8a64f3613e9749c5640c3535c83399b8e69f67ce54d91dc73f6d77373af"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "NUT"
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  digest = "1:15042ad3498153684d09f393bbaec6b216c8eec6d61f63dff711de7d64ed8861"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:51bee9f1987dcdb9f9a1b4c20745d78f6bf6f5f14ad4e64ca883eb64df4c0045"
   name = "github.com/google/go-github"
   packages = ["github"]
+  pruneopts = "NUT"
   revision = "e48060a28fac52d0f1cb758bc8b87c07bac4a87d"
   version = "v15.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = "NUT"
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:c01767916c59f084bb7c41a7d5877c0f3099b1595cfa066e84ec6ad6b084dd89"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:bf5cf1d53d703332e9bd8984c69784645b73a938317bf5ace9aadf20ac49379a"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:93345670566b1c84a83d5f7b0e6b9229d72fbe88a86003849e7dcb44664b567a"
   name = "github.com/knative/eventing"
   packages = ["pkg/event"]
+  pruneopts = "NUT"
   revision = "2b0383b8e4d67ffac446b17a7922bf7e5d9f5362"
 
 [[projects]]
   branch = "master"
-  digest = "1:36968d4eb1d52090841ae868d7125d8ff10afabdea0d6b622c1f4a662f94be58"
+  digest = "1:e2b69720fb704bbd32b9440b9a74f3be9e8b5ab7879281c69981f51c6ae40e35"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "51872094d69a5b0266fd92a38978819e20ee70c8"
+  revision = "13055d769cc5e1756e605fcb3bcc1c25376699f1"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "NUT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:fef6881712308105a1b1574fbd3df5ead89109b43849ee00941cf1f084247115"
   name = "github.com/openzipkin/zipkin-go"
   packages = [
     ".",
@@ -92,48 +117,58 @@
     "model",
     "propagation",
     "reporter",
-    "reporter/http"
+    "reporter/http",
   ]
+  pruneopts = "NUT"
   revision = "f197ec29e729f226d23370ea60f0e49b8f44ccf4"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:03bca087b180bf24c4f9060775f137775550a0834e18f0bca0520a868679dbd7"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "NUT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "NUT"
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
+  digest = "1:768b555b86742de2f28beb37f1dedce9a75f91f871d75b5717c96399c1a78c08"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "NUT"
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
+  digest = "1:6621142cd60b7150ab66f38ff36303ca55843dc5a635c1f9a28f95ecddab72b4"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "NUT"
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
+  digest = "1:bb38c0571e5ffeb394f2a7e4056fa5a7a6ea1acabb7fe71976340719fd104d02"
   name = "go.opencensus.io"
   packages = [
     ".",
@@ -149,13 +184,15 @@
     "tag",
     "trace",
     "trace/internal",
-    "trace/propagation"
+    "trace/propagation",
   ]
+  pruneopts = "NUT"
   revision = "e262766cd0d230a1bb7c37281e345e465f19b41b"
   version = "v0.14.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8aa99dcd40ebdb7ff01d2ebcc6057794a155c0e5f1fcb9e42f0dcf9bedb14040"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -163,20 +200,24 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
+  pruneopts = "NUT"
   revision = "d0887baf81f4598189d4e12a37c6da86f0bba4d0"
 
 [[projects]]
   branch = "master"
+  digest = "1:806685616259192286b80e5924f92aad0a1cd880959cecd6441925f393a4a34d"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
+  pruneopts = "NUT"
   revision = "ef147856a6ddbb60760db74283d2424e98c87bff"
 
 [[projects]]
+  digest = "1:e7071ed636b5422cc51c0e3a6cebc229d6c9fffc528814b519a980641422d619"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -192,12 +233,14 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "NUT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:af71cb57ffcbc389c2f8af1e6a763c0d2e6f08d2ceb64140c0fd4c57fdbc2898"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -206,34 +249,42 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "NUT"
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:d98a45237ffb67adfb77bf618a164407d476ecd925a9a987e2fa1cda9137db5e"
   name = "gopkg.in/go-playground/webhooks.v3"
   packages = [
     ".",
-    "github"
+    "github",
   ]
+  pruneopts = "NUT"
   revision = "8ffb2ffc32b7af2c7e940944eccba4dcd66c692a"
   version = "v3.13.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:f015c6307cf0c922ed22368ee73bf2c1382e0bd9ca3440074dc5b6a24aebb794"
   name = "k8s.io/api"
   packages = ["core/v1"]
+  pruneopts = "NUT"
   revision = "183f3326a9353bd6d41430fc80f96259331d029c"
 
 [[projects]]
   branch = "master"
+  digest = "1:c2f92b644e2da297333df386fcd7ebdc19e8e0235dcc6bddb872c01161ea03d6"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/resource",
@@ -257,13 +308,33 @@
     "pkg/util/validation/field",
     "pkg/util/wait",
     "pkg/watch",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NUT"
   revision = "121e72c8f836456b467f84d37a82b7b830b6f5e6"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "421a5898fa9c2e2553700a10820ee7c546ebeb69c1b8731b213917141894a22d"
+  input-imports = [
+    "github.com/google/go-github/github",
+    "github.com/gorilla/mux",
+    "github.com/knative/eventing/pkg/event",
+    "github.com/knative/test-infra",
+    "github.com/openzipkin/zipkin-go",
+    "github.com/openzipkin/zipkin-go/reporter/http",
+    "go.opencensus.io/exporter/prometheus",
+    "go.opencensus.io/exporter/zipkin",
+    "go.opencensus.io/plugin/ochttp",
+    "go.opencensus.io/plugin/ochttp/propagation/b3",
+    "go.opencensus.io/stats",
+    "go.opencensus.io/stats/view",
+    "go.opencensus.io/tag",
+    "go.opencensus.io/trace",
+    "golang.org/x/oauth2",
+    "gopkg.in/go-playground/webhooks.v3",
+    "gopkg.in/go-playground/webhooks.v3/github",
+    "k8s.io/api/core/v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -1,3 +1,62 @@
 # Helper scripts
 
-This directory contains helper scripts used by Prow test jobs, as well and local development scripts.
+This directory contains helper scripts used by Prow test jobs, as well and
+local development scripts.
+
+## Using the `e2e-tests.sh` helper script
+
+This is a helper script for Knative E2E test scripts. To use it:
+
+1. Source the script.
+
+1. [optional] Write the `teardown()` function, which will tear down your test
+resources.
+
+1. [optional] Write the `dump_extra_cluster_state()` function. It will be
+called when a test fails, and can dump extra information about the current state
+of the cluster (tipically using `kubectl`).
+
+1. Call the `initialize()` function passing `$@` (without quotes).
+
+1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
+(or `report_go_test()` if you need a more fine-grained control) and call
+`fail_test()` or `success()` if any of them failed. The environment variables
+`DOCKER_REPO_OVERRIDE`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be set
+according to the test cluster. You can also use the following boolean (0 is false,
+1 is true) environment variables for the logic:
+  * `EMIT_METRICS`: true if `--emit-metrics` is passed.
+  * `USING_EXISTING_CLUSTER`: true if the test cluster is an already existing one,
+and not a temporary cluster created by `kubetest`.
+All environment variables above are marked read-only.
+
+**Notes:**
+
+1. Calling your script without arguments will create a new cluster in the GCP
+project `$PROJECT_ID` and run the tests against it.
+
+1. Calling your script with `--run-tests` and the variables `K8S_CLUSTER_OVERRIDE`,
+`K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
+tests against the cluster.
+
+### A minimal end-to-end script runner
+
+This script will test that the latest Knative Serving nightly release works.
+
+```
+source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+function teardown() {
+  echo "TODO: tear down test resources"
+}
+
+initialize $@
+
+start_latest_knative_serving
+
+wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+
+# TODO: use go_test_e2e to run the tests.
+kubectl get pods || fail_test
+
+success
+```

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -14,30 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script for Knative E2E test scripts. To use it:
-# 1. Source this script.
-# 2. [optional] Write the teardown() function, which will tear down your test
-#    resources.
-# 3. [optional] Write the dump_extra_cluster_state() function. It will be called
-#    when a test fails, and can dump extra information about the current state of
-#    the cluster (tipically using kubectl).
-# 4. Call the initialize() function passing $@ (without quotes).
-# 5. Write logic for the end-to-end tests. Run all go tests using report_go_test()
-#    and call fail_test() or success() if any of them failed. The envitronment
-#    variables DOCKER_REPO_OVERRIDE, K8S_CLUSTER_OVERRIDE and K8S_USER_OVERRIDE
-#    will be set accordingly to the test cluster. You can also use the following
-#    boolean (0 is false, 1 is true) environment variables for the logic:
-#    EMIT_METRICS: true if --emit-metrics is passed.
-#    USING_EXISTING_CLUSTER: true if the test cluster is an already existing one,
-#                            and not a temporary cluster created by kubetest.
-#    All environment variables above are marked read-only.
-# Notes:
-# 1. Calling your script without arguments will create a new cluster in the GCP
-#    project $PROJECT_ID and run the tests against it.
-# 2. Calling your script with --run-tests and the variables K8S_CLUSTER_OVERRIDE,
-#    K8S_USER_OVERRIDE and DOCKER_REPO_OVERRIDE set will immediately start the
-#    tests against the cluster.
-
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Build a resource name based on $E2E_BASE_NAME, a suffix and $BUILD_NUMBER.
@@ -91,6 +67,14 @@ function fail_test() {
   exit 1
 }
 
+# Run the given E2E tests (must be tagged as such).
+# Parameters: $1..$n - directories containing the tests to run.
+function go_test_e2e() {
+  local options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test -v -tags=e2e -count=1 -timeout=20m $@ ${options}
+}
+
 # Download the k8s binaries required by kubetest.
 function download_k8s() {
   local version=${SERVING_GKE_VERSION}
@@ -103,7 +87,7 @@ function download_k8s() {
     local gke_versions=(`echo -n ${versions//;/ /}`)
     # Get first (latest) version, excluding the "-gke.#" suffix
     version="${gke_versions[0]%-*}"
-    echo "Latest GKE is ${version}, from [${versions//;/, /}]"
+    echo "Latest GKE is ${version}, from [${versions//;/, }]"
   elif [[ "${version}" == "default" ]]; then
     echo "ERROR: `default` GKE version is not supported yet"
     return 1
@@ -152,10 +136,14 @@ function dump_cluster_state() {
 
 # Create a test cluster with kubetest and call the current script again.
 function create_test_cluster() {
+  # Fail fast during setup.
+  set -o errexit
+  set -o pipefail
+
   header "Creating test cluster"
   # Smallest cluster required to run the end-to-end-tests
   local CLUSTER_CREATION_ARGS=(
-    --gke-create-args="--enable-autoscaling --min-nodes=1 --max-nodes=${E2E_CLUSTER_NODES} --scopes=cloud-platform"
+    --gke-create-args="--enable-autoscaling --min-nodes=1 --max-nodes=${E2E_CLUSTER_NODES} --scopes=cloud-platform --enable-basic-auth --no-issue-client-certificate"
     --gke-shape={\"default\":{\"Nodes\":${E2E_CLUSTER_NODES}\,\"MachineType\":\"${E2E_CLUSTER_MACHINE}\"}}
     --provider=gke
     --deployment=gke
@@ -171,6 +159,7 @@ function create_test_cluster() {
   fi
   # SSH keys are not used, but kubetest checks for their existence.
   # Touch them so if they don't exist, empty files are create to satisfy the check.
+  mkdir -p $HOME/.ssh
   touch $HOME/.ssh/google_compute_engine.pub
   touch $HOME/.ssh/google_compute_engine
   # Clear user and cluster variables, so they'll be set to the test cluster.
@@ -187,6 +176,9 @@ function create_test_cluster() {
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
   echo "Test script is ${E2E_SCRIPT}"
   download_k8s || return 1
+  # Don't fail test for kubetest, as it might incorrectly report test failure
+  # if teardown fails (for details, see success() below)
+  set +o errexit
   kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
@@ -195,6 +187,8 @@ function create_test_cluster() {
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}"
   echo "Test subprocess exited with code $?"
+  # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
+  set +o errexit
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.


### PR DESCRIPTION
This repo has fallen behind others in the vendored version of
test-infra and as a result integration tests are erroring out.

I'm using `dep` version `v0.5.0` locally, which matches what other
Knative repositories are using for generation of their Gopkg.lock
files. That does cause a bit more noise to this PR as the `digest` and
`pruneopts` fields in Gopkg.lock get filled in.
