### PR TITLE
Node.js serving sample README.md has inconsistent response example

### DIFF
--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -186,7 +186,7 @@ folder) you're ready to build and deploy the sample app.
 
     ```shell
     curl -H "Host: helloworld-nodejs.default.example.com" http://{IP_ADDRESS}
-    Hello World: NOT SPECIFIED
+    Hello Node.js Sample v1!
     ```
 
 ## Removing the sample app deployment


### PR DESCRIPTION
**WARNING:** I didn't actually test this. **Consider this a bug report** with a suggestion, more than a fully tested patch.

Please, check that I didn't missing something, it's plausible that missed something obvious.

-----

We specify `TARGET='Node.js Sample v1'` in `service.yaml`, so it would be surprising if this isn't printed in the response.
