### PR TITLE
Update OpenShift instructions to set Istio sidecar injector priviledged to true

### DIFF
--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -132,6 +132,26 @@ rerun the command to see the current status.
 
 > Note: Instead of rerunning the command, you can add `--watch` to the above
   command to view the component's status updates in real time. Use CTRL+C to exit watch mode.
+  
+Update sidecar injector priviledged to true
+
+```shell
+oc get cm istio-sidecar-injector -n istio-system -oyaml  \
+| sed -e 's/securityContext:/securityContext:\\n      privileged: true/' \
+| oc replace -f -
+```
+
+Check if SELinux is enabled in order to restart the sidecar-injector pod
+
+```shell
+if getenforce | grep -q Disabled
+then
+    echo "SELinux is disabled, no need to restart the pod"
+else
+    echo "SELinux is enabled, restarting sidecar-injector pod"
+    oc delete pod -n istio-system -l istio=sidecar-injector
+fi
+```
 
 ## Installing Knative Serving
 

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -133,7 +133,7 @@ rerun the command to see the current status.
 > Note: Instead of rerunning the command, you can add `--watch` to the above
   command to view the component's status updates in real time. Use CTRL+C to exit watch mode.
   
-Update sidecar injector priviledged to true
+Set `priviledged` to `true` for the `istio-sidecar-injector`:
 
 ```shell
 oc get cm istio-sidecar-injector -n istio-system -oyaml  \
@@ -141,7 +141,7 @@ oc get cm istio-sidecar-injector -n istio-system -oyaml  \
 | oc replace -f -
 ```
 
-Check if SELinux is enabled in order to restart the sidecar-injector pod
+Restart the `sidecar-injector` pod if `SELinux` is enabled:
 
 ```shell
 if getenforce | grep -q Disabled


### PR DESCRIPTION
Update istio-sidecar-injector configmap after Istio is ready in order to let knative activator and autoscaler pods running properly, setting Istio sidecar injector priviledged to true.

Fixes CrashLoopBackOff issue for knative activator and autoscaler pods

Fixes #417 

## Proposed Changes


* Add section to update istio-sidecar-injector configmap to set Istio sidecar injector priviledged to true

