### PR TITLE
serving/helloworld-go: Respect the PORT env var

### DIFF
--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -1,8 +1,8 @@
 # Hello World - Go sample
 
 A simple web app written in Go that you can use for testing.
-It reads in an env variable `TARGET` and prints "Hello World: ${TARGET}!". If
-TARGET is not specified, it will use "NOT SPECIFIED" as the TARGET.
+It reads in an env variable `TARGET` and prints "Hello ${TARGET}!". If
+TARGET is not specified, it will use "World" as the TARGET.
 
 ## Prerequisites
 
@@ -42,11 +42,16 @@ following instructions recreate the source files from this folder.
     }
 
     func main() {
-      flag.Parse()
       log.Print("Hello world sample started.")
 
       http.HandleFunc("/", handler)
-      http.ListenAndServe(":8080", nil)
+
+      port := os.Getenv("PORT")
+      if port == "" {
+        port = "8080"
+      }
+
+      log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
     }
     ```
 

--- a/serving/samples/helloworld-go/helloworld.go
+++ b/serving/samples/helloworld-go/helloworld.go
@@ -36,5 +36,11 @@ func main() {
 	log.Print("Hello world sample started.")
 
 	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }


### PR DESCRIPTION
Works towards #456 and makes a minor README update follow-up to #443

## Proposed Changes

* Respect the $PORT environment variable as a default behavior
* Log as fatal the result of http.ListenAndServe throwing an error per [common practice](https://golang.org/pkg/net/http/#ListenAndServe)
* Update the duplicated sample code in the README to match changes
* Note that the default behavior if no $TARGET variable is set will be Hello World