### PR TITLE
serving/helloworld-nodejs: Respect the PORT env var

### DIFF
--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -1,8 +1,8 @@
 # Hello World - Node.js sample
 
 A simple web app written in Node.js that you can use for testing.
-It reads in an env variable `TARGET` and prints "Hello World: ${TARGET}!". If
-TARGET is not specified, it will use "NOT SPECIFIED" as the TARGET.
+It reads in an env variable `TARGET` and prints "Hello ${TARGET}!". If
+TARGET is not specified, it will use "World" as the TARGET.
 
 ## Prerequisites
 
@@ -52,13 +52,13 @@ recreate the source files from this folder.
     app.get('/', function (req, res) {
       console.log('Hello world received a request.');
 
-      var target = process.env.TARGET || 'World';
-      res.send('Hello ' + target);
+      const target = process.env.TARGET || 'World';
+      res.send('Hello ' + target + '!');
     });
 
-    var port = 8080;
+    const port = process.env.PORT || 8080;
     app.listen(port, function () {
-      console.log('Hello world listening on port',  port);
+      console.log('Hello world listening on port', port);
     });
     ```
 

--- a/serving/samples/helloworld-nodejs/app.js
+++ b/serving/samples/helloworld-nodejs/app.js
@@ -20,11 +20,11 @@ const app = express();
 app.get('/', function (req, res) {
   console.log('Hello world received a request.');
 
-  var target = process.env.TARGET || 'World';
-  res.send('Hello ' + target);
+  const target = process.env.TARGET || 'World';
+  res.send('Hello ' + target + '!');
 });
 
-var port = 8080;
+const port = process.env.PORT || 8080;
 app.listen(port, function () {
-  console.log('Hello world listening on port',  port);
+  console.log('Hello world listening on port', port);
 });


### PR DESCRIPTION
Works towards #456 and makes a minor README update follow-up to #443

## Proposed Changes

* Respect the $PORT environment variable as a default behavior
* Replace use of `var` with `const`
* Add exclamation mark back to the message!
* Update the duplicated sample code in the README to match changes
* Note that the default behavior if no $TARGET variable is set will be 'Hello World'