### PR TITLE
serving/helloworld-php: Respect the PORT env var

### DIFF
--- a/serving/samples/helloworld-php/Dockerfile
+++ b/serving/samples/helloworld-php/Dockerfile
@@ -2,5 +2,6 @@ FROM php:7.2.6-apache
 
 COPY index.php /var/www/html/
 
-# Run on port 8080 rather than 80
-RUN sed -i 's/80/8080/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+ENV PORT 8080
+
+RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf

--- a/serving/samples/helloworld-php/Dockerfile
+++ b/serving/samples/helloworld-php/Dockerfile
@@ -4,4 +4,5 @@ COPY index.php /var/www/html/
 
 ENV PORT 8080
 
+# Use the PORT environment variable in Apache configuration files.
 RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -1,8 +1,8 @@
 # Hello World - PHP sample
 
 A simple web app written in PHP that you can use for testing.
-It reads in an env variable `TARGET` and prints "Hello World: ${TARGET}". If
-TARGET is not specified, it will use "NOT SPECIFIED" as the TARGET.
+It reads in an env variable `TARGET` and prints "Hello ${TARGET}!". If
+TARGET is not specified, it will use "World" as the TARGET.
 
 ## Prerequisites
 
@@ -29,9 +29,8 @@ following instructions recreate the source files from this folder.
 
     ```php
     <?php
-      $target = getenv('TARGET', true) ?: "World";
-      echo sprintf("Hello %s!\n", $target);
-    ?>
+    $target = getenv('TARGET', true) ?: "World";
+    echo sprintf("Hello %s!\n", $target);
     ```
 
 1. Create a file named `Dockerfile` and copy the code block below into it.
@@ -42,8 +41,10 @@ following instructions recreate the source files from this folder.
 
     COPY index.php /var/www/html/
 
-    # Run on port 8080 rather than 80
-    RUN sed -i 's/80/8080/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+    ENV PORT 8080
+
+    RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
+
     ```
 
 1. Create a new file, `service.yaml` and copy the following service definition

--- a/serving/samples/helloworld-php/index.php
+++ b/serving/samples/helloworld-php/index.php
@@ -1,4 +1,3 @@
 <?php
-  $target = getenv('TARGET', true) ?: "World";
-  echo sprintf("Hello %s!\n", $target);
-?>
+$target = getenv('TARGET', true) ?: 'World';
+echo sprintf('Hello %s!\n', $target);


### PR DESCRIPTION
Work towards #456

Tested locally with success.

## Proposed Changes

* Respect the $PORT environment variable as a default behavior
* [Do not indent code after opening PHP tag or have a closing PHP tag](https://stackoverflow.com/questions/14989525/indent-after-opening-php-tag).
* Update the duplicated sample code in the README to match changes
* Note that the default behavior if no $TARGET variable is set will be 'Hello World'
