### PR TITLE
Clean up formatting on with-any-k8s steps

### DIFF
--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -27,7 +27,9 @@ Containers.
     kubectl label namespace default istio-injection=enabled
     ```
 1.  Monitor the Istio components until all of the components show a `STATUS` of
-    `Running` or `Completed`: `bash kubectl get pods --namespace istio-system`
+    `Running` or `Completed`:
+    ```bash kubectl get pods --namespace istio-system
+    ```
 
 It will take a few minutes for all the components to be up and running; you can
 rerun the command to see the current status.

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -28,7 +28,8 @@ Containers.
     ```
 1.  Monitor the Istio components until all of the components show a `STATUS` of
     `Running` or `Completed`:
-    ```bash kubectl get pods --namespace istio-system
+    ```bash
+    kubectl get pods --namespace istio-system
     ```
 
 It will take a few minutes for all the components to be up and running; you can


### PR DESCRIPTION
Fixes #(issue-number)

This cleans up some example text for the Knative install on any k8s documentation.
