### PR TITLE
Fix Dart sample

### DIFF
--- a/serving/samples/helloworld-dart/README.md
+++ b/serving/samples/helloworld-dart/README.md
@@ -7,11 +7,12 @@ that you can use for testing. It reads in the env variable `TARGET` and prints
 ## Prerequisites
 
 * A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md) if you need
-  to create one.
+  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  if you need to create one.
 * [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).
-* [dart-sdk](https://www.dartlang.org/tools/sdk#install) installed and configured.
+* [dart-sdk](https://www.dartlang.org/tools/sdk#install) installed and configured
+  if you want to run the program locally.
 
 ## Recreating the sample code
 
@@ -32,7 +33,8 @@ created using the following instructions.
       sdk: '>=2.0.0 <3.0.0'
     ```
 
-2. Install dependencies
+2. If you want to run locally, install dependencies. If you only want to run in
+   Docker or Knative, you can skip this step.
 
     ```shell
     pub get

--- a/serving/samples/helloworld-dart/service.yaml
+++ b/serving/samples/helloworld-dart/service.yaml
@@ -1,15 +1,15 @@
 apiVersion: serving.knative.dev/v1alpha1
-  kind: Service
-  metadata:
-    name: helloworld-dart
-    namespace: default
-  spec:
-    runLatest:
-      configuration:
-        revisionTemplate:
-          spec:
-            container:
-              image: docker.io/{username}/helloworld-dart
-              env:
-              - name: TARGET
-                value: "Dart Sample v1"
+kind: Service
+metadata:
+  name: helloworld-dart
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: docker.io/{username}/helloworld-dart
+            env:
+            - name: TARGET
+              value: "Dart Sample v1"


### PR DESCRIPTION
Fix Dart service.yaml (indentation) and indicate that local dart is only needed for local development.

## Proposed Changes

* Fix indentation in `service.yaml` (discovered via `kubectl apply -f <(sed 's/{username}/evankanderson/' service.yaml)`
* Indicate that local dart steps are only needed if you want to run locally as opposed to simply using Docker/Knative