### PR TITLE
Reverting the namespace rename knative-monitoring

### DIFF
--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -144,9 +144,9 @@ accounts istio will use:
 oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
 oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
 oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
-oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n knative-monitoring
-oc adm policy add-scc-to-user anyuid -z node-exporter -n knative-monitoring
-oc adm policy add-scc-to-user anyuid -z prometheus-system -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
 oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
 oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
 ```

--- a/install/scripts/knative-with-openshift.sh
+++ b/install/scripts/knative-with-openshift.sh
@@ -78,9 +78,9 @@ header_text "Setting up security policy for knative"
 oc adm policy add-scc-to-user anyuid -z build-controller -n knative-build
 oc adm policy add-scc-to-user anyuid -z controller -n knative-serving
 oc adm policy add-scc-to-user anyuid -z autoscaler -n knative-serving
-oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n knative-monitoring
-oc adm policy add-scc-to-user anyuid -z node-exporter -n knative-monitoring
-oc adm policy add-scc-to-user anyuid -z prometheus-system -n knative-monitoring
+oc adm policy add-scc-to-user anyuid -z kube-state-metrics -n monitoring
+oc adm policy add-scc-to-user anyuid -z node-exporter -n monitoring
+oc adm policy add-scc-to-user anyuid -z prometheus-system -n monitoring
 oc adm policy add-cluster-role-to-user cluster-admin -z build-controller -n knative-build
 oc adm policy add-cluster-role-to-user cluster-admin -z controller -n knative-serving
 

--- a/serving/accessing-logs.md
+++ b/serving/accessing-logs.md
@@ -16,7 +16,7 @@ start a local proxy with the following command:
   the Kibana UI is exposed only within the cluster.
 
 * Navigate to the
-[Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana).
+[Kibana UI](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana).
 *It might take a couple of minutes for the proxy to work*.
 
   The Discover tab of the Kibana UI looks like this:

--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -51,7 +51,7 @@ To configure and setup monitoring:
    reported `Running` or `Completed`:
 
      ```shell
-     kubectl get pods --namespace knative-monitoring --watch
+     kubectl get pods --namespace monitoring --watch
      ```
 
      ```
@@ -90,7 +90,7 @@ for request traces.
   reasons, the Kibana UI is exposed only within the cluster.
 
 - Navigate to the
-  [Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana).
+  [Kibana UI](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana).
   _It might take a couple of minutes for the proxy to work_.
 
 - Within the "Configure an index pattern" page, enter `logstash-*` to
@@ -135,7 +135,7 @@ To configure and setup monitoring:
    reported `Running` or `Completed`:
 
      ```shell
-     kubectl get pods --namespace knative-monitoring --watch
+     kubectl get pods --namespace monitoring --watch
      ```
 
      ```

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -13,7 +13,7 @@ using the default installation.
 installed.
 2. Check if Knative monitoring components are installed:
 ```
-kubectl get pods --namespace knative-monitoring
+kubectl get pods --namespace monitoring
 ```
   * If pods aren't found, install [Knative monitoring component](../../installing-logging-metrics-traces.md).
 3. Install [Docker](https://docs.docker.com/get-started/#prepare-your-docker-environment).

--- a/serving/setting-up-a-logging-plugin.md
+++ b/serving/setting-up-a-logging-plugin.md
@@ -43,7 +43,7 @@ is in process to get rid of the sidecar. The steps to configure are:
 1. Replace `logging.fluentd-sidecar-output-config` flag in
    [config-observability](https://github.com/knative/serving/blob/master/config/config-observability.yaml)  with the
    desired output configuration. **NOTE**: The Fluentd DaemonSet is in
-   `knative-monitoring` namespace while the Fluentd sidecar is in the namespace same with
+   `monitoring` namespace while the Fluentd sidecar is in the namespace same with
    the app. There may be small differences between the configuration for DaemonSet
    and sidecar even though the desired backends are the same.
 1. Replace `logging.fluentd-sidecar-image` flag in


### PR DESCRIPTION
knative-monitoring does not work in serving 0.1.x
 #437 
