### PR TITLE
Use the ksvc shortname for services

### DIFF
--- a/eventing/samples/k8s-events/README.md
+++ b/eventing/samples/k8s-events/README.md
@@ -69,7 +69,7 @@ kubectl apply --filename serviceaccount.yaml
 1.  Check that your service is running using:
 
     ```shell
-    kubectl get services.serving.knative.dev --output "custom-columns=NAME:.metadata.name,READY:.status.conditions[2].status,REASON:.status.conditions[2].message"
+    kubectl get ksvc --output "custom-columns=NAME:.metadata.name,READY:.status.conditions[2].status,REASON:.status.conditions[2].message"
     NAME              READY     REASON
     read-k8s-events   True      <none>
     ```

--- a/install/getting-started-knative-app.md
+++ b/install/getting-started-knative-app.md
@@ -107,7 +107,7 @@ asssigned an external IP address.
 1. To find the host URL for your service, enter:
 
     ```shell
-    kubectl get services.serving.knative.dev helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-go       helloworld-go.default.example.com
     ```
@@ -115,7 +115,7 @@ asssigned an external IP address.
     You can also export the host URL as a variable using the following command:
     
     ```shell
-    export HOST_URL=$(kubectl get services.serving.knative.dev helloworld-go  --output jsonpath='{.status.domain}')
+    export HOST_URL=$(kubectl get ksvc helloworld-go  --output jsonpath='{.status.domain}')
     ```
 
     If you changed the name from `helloworld-go` to something else when creating

--- a/serving/samples/blue-green-deployment.md
+++ b/serving/samples/blue-green-deployment.md
@@ -79,7 +79,7 @@ use with Knative.
    Knative creates the host URL by combining the name of your Route object,
    the namespace, and `example.com`, if you haven't configured a custom domain.
    For example, `[route-name].[namespace].example.com`.
-   You can get the IP address by entering `kubectl get svc knative-ingressgateway -n istio-system`
+   You can get the IP address by entering `kubectl get svc knative-ingressgateway --namespace istio-system`
    and copying the `EXTERNAL-IP` returned by that command.
    See [Interacting with your app](../../install/getting-started-knative-app.md#interacting-with-your-app)
    for more information.

--- a/serving/samples/gitwebhook-go/README.md
+++ b/serving/samples/gitwebhook-go/README.md
@@ -102,7 +102,7 @@ service "gitwebhook" created
     1. Retrieve the hostname for this service, using the following command:
 
         ```shell
-        $ kubectl get services.serving.knative.dev gitwebhook \
+        $ kubectl get ksvc gitwebhook \
            --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
 
         NAME                DOMAIN
@@ -124,7 +124,7 @@ Once deployed, you can inspect the created resources with `kubectl` commands:
 
 ```shell
 # This will show the Knative service that we created:
-kubectl get service.serving.knative.dev --output yaml
+kubectl get ksvc --output yaml
 
 # This will show the Route, created by the service:
 kubectl get route --output yaml

--- a/serving/samples/helloworld-clojure/README.md
+++ b/serving/samples/helloworld-clojure/README.md
@@ -133,7 +133,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -147,7 +147,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-clojure --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-clojure --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-clojure  helloworld-clojure.default.example.com
     ```

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -121,7 +121,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -135,7 +135,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-csharp  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-csharp  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-csharp   helloworld-csharp.default.example.com
     ```

--- a/serving/samples/helloworld-dart/README.md
+++ b/serving/samples/helloworld-dart/README.md
@@ -127,7 +127,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -141,7 +141,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-dart  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-dart  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-dart   helloworld-dart.default.example.com
     ```

--- a/serving/samples/helloworld-elixir/README.md
+++ b/serving/samples/helloworld-elixir/README.md
@@ -157,7 +157,7 @@ directions above.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -171,7 +171,7 @@ knative-ingressgateway   LoadBalancer   10.35.254.218   35.225.171.32   80:32380
 1. To find the URL for your service, use
 
     ```
-    kubectl get services.serving.knative.dev helloworld-elixir --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-elixir --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
 
     NAME                DOMAIN
     helloworld-elixir   helloworld-elixir.default.example.com

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -131,7 +131,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -145,7 +145,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-go       helloworld-go.default.example.com
     ```

--- a/serving/samples/helloworld-haskell/README.md
+++ b/serving/samples/helloworld-haskell/README.md
@@ -156,7 +156,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, enter
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take some time for the service to get assigned
    an external IP address.
 
@@ -177,7 +177,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, enter:
 	```
-    kubectl get services.serving.knative.dev helloworld-haskell  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-haskell  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                   DOMAIN
     helloworld-haskell     helloworld-haskell.default.example.com
     ```

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -140,7 +140,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -154,7 +154,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-java  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-java  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-java     helloworld-java.default.example.com
     ```

--- a/serving/samples/helloworld-kotlin/README.md
+++ b/serving/samples/helloworld-kotlin/README.md
@@ -167,12 +167,12 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 4. To find the IP address for your service, use
-   `kubectl get service knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get service knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get assigned
    an external IP address.
 
     ```shell
-    kubectl get service knative-ingressgateway -n istio-system
+    kubectl get service knative-ingressgateway --namespace istio-system
     ```
     ```shell
     NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
@@ -181,7 +181,7 @@ folder) you're ready to build and deploy the sample app.
 
 5. To find the URL for your service, use
     ```shell
-    kubectl get services.serving.knative.dev helloworld-kotlin  -o=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-kotlin  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     ```
     ```shell
     NAME                DOMAIN

--- a/serving/samples/helloworld-kotlin/README.md
+++ b/serving/samples/helloworld-kotlin/README.md
@@ -158,7 +158,7 @@ folder) you're ready to build and deploy the sample app.
    the previous step. Apply the configuration using `kubectl`:
 
     ```shell
-    kubectl apply -f service.yaml
+    kubectl apply --filename service.yaml
     ```
 
 3. Now that your service is created, Knative will perform the following steps:
@@ -203,5 +203,5 @@ folder) you're ready to build and deploy the sample app.
 To remove the sample app from your cluster, delete the service record:
 
 ```shell
-kubectl delete -f service.yaml
+kubectl delete --filename service.yaml
 ```

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -155,7 +155,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -169,7 +169,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-nodejs  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-nodejs  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-nodejs   helloworld-nodejs.default.example.com
     ```

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -100,7 +100,7 @@ you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -114,7 +114,7 @@ you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-php  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-php  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-php      helloworld-php.default.example.com
     ```

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -111,7 +111,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -125,7 +125,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-python  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-python  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-python   helloworld-python.default.example.com
     ```

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -126,7 +126,7 @@ you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -140,7 +140,7 @@ you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
     ```
-    kubectl get services.serving.knative.dev helloworld-ruby  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-ruby  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-ruby     helloworld-ruby.default.example.com
     ```

--- a/serving/samples/helloworld-rust/README.md
+++ b/serving/samples/helloworld-rust/README.md
@@ -153,7 +153,7 @@ folder) you're ready to build and deploy the sample app.
    * Automatically scale your pods up and down (including to zero active pods).
 
 1. To find the IP address for your service, enter
-   `kubectl get svc knative-ingressgateway -n istio-system` to get the ingress IP for your
+   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the ingress IP for your
    cluster. If your cluster is new, it may take sometime for the service to get asssigned
    an external IP address.
 
@@ -167,7 +167,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, enter:
     ```
-    kubectl get services.serving.knative.dev helloworld-rust  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    kubectl get ksvc helloworld-rust  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     helloworld-rust     helloworld-rust.default.example.com
     ```

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -90,7 +90,7 @@ kubectl get svc knative-ingressgateway --namespace istio-system --output yaml
 
 * Inspect the deployed Knative services with:
 ```
-kubectl get service.serving.knative.dev
+kubectl get ksvc
 ```
 You should see 2 Knative services: search-service and login-service.
 

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -168,7 +168,7 @@ container for the application.
    status block:
 
    ```shell
-   $ kubectl get service.serving.knative.dev app-from-source --output yaml
+   $ kubectl get ksvc app-from-source --output yaml
 
    [...]
    status:
@@ -213,7 +213,7 @@ container for the application.
 1. To find the URL for your service, type:
 
     ```shell
-    $ kubectl get services.serving.knative.dev app-from-source  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+    $ kubectl get ksvc app-from-source  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
     NAME                DOMAIN
     app-from-source     app-from-source.default.example.com
     ```

--- a/serving/setting-up-a-logging-plugin.md
+++ b/serving/setting-up-a-logging-plugin.md
@@ -89,7 +89,7 @@ monitoring components.
 To uninstall a logging plugin, run:
 
 ```shell
-kubectl delete -f <the-fluentd-config-for-daemonset> \
+kubectl delete --filename <the-fluentd-config-for-daemonset> \
 	-f third_party/config/monitoring/common/kubernetes/fluentd/fluentd-ds.yaml \
 	-f config/monitoring/200-common/100-fluentd.yaml
 	-f config/monitoring/200-common/100-istio.yaml

--- a/serving/using-an-ssl-cert.md
+++ b/serving/using-an-ssl-cert.md
@@ -100,7 +100,7 @@ to automate the steps required to generate a TLS certificate using LetsEncrypt.
 To install cert-manager into your cluster, use kubectl to apply the cert-manager manifest:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.5/contrib/manifests/cert-manager/with-rbac.yaml
+kubectl apply --filename https://raw.githubusercontent.com/jetstack/cert-manager/release-0.5/contrib/manifests/cert-manager/with-rbac.yaml
 ```
 or see the [cert-manager docs](https://cert-manager.readthedocs.io/en/latest/getting-started/) for more ways to install and customize.
 

--- a/serving/using-cert-manager-on-gcp.md
+++ b/serving/using-cert-manager-on-gcp.md
@@ -47,7 +47,7 @@ choose a different name.
 
 ```shell
 # Upload that as a secret in your Kubernetes cluster.
-kubectl create secret -n cert-manager generic cloud-dns-key \
+kubectl create secret --namespace cert-manager generic cloud-dns-key \
   --from-file=key.json=$HOME/key.json
 
 # Delete the local secret
@@ -102,7 +102,7 @@ EOF
 To check if your ClusterIssuer is valid, enter:
 
 ```shell
-kubectl get clusterissuer -n cert-manager letsencrypt-issuer -o yaml
+kubectl get clusterissuer --namespace cert-manager letsencrypt-issuer --output yaml
 ```
 
 Then confirm that its conditions have `Ready=True`.  For example:
@@ -170,7 +170,7 @@ EOF
 To check that your certificate setting is valid, enter:
 
 ```shell
-kubectl get certificate -n istio-system my-certificate -o yaml
+kubectl get certificate --namespace istio-system my-certificate --output yaml
 ```
 
 Verify that its `Status.Conditions` have `Ready=True`.  For example:

--- a/serving/using-cert-manager-on-gcp.md
+++ b/serving/using-cert-manager-on-gcp.md
@@ -69,7 +69,7 @@ This example uses the `dns01` challenge type, which will
 enable certificate generation and wildcard certificates.
 
 ```shell
-kubectl apply -f - <<EOF
+kubectl apply --filename - <<EOF
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
 metadata:
@@ -129,7 +129,7 @@ The following steps will overwrite this Secret if it already exists.
 # Change this value to the domain you want to use.
 export DOMAIN=your-domain.com
 
-kubectl apply -f - <<EOF
+kubectl apply --filename - <<EOF
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -198,7 +198,7 @@ The key edit here is adding the `tls:` section to the end of the HTTPS port
 configuration.
 
 ```shell
-kubectl apply -f - <<EOF
+kubectl apply --filename - <<EOF
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:


### PR DESCRIPTION
Fixes #481 

## Proposed Changes

* Replace long knative service "services.serving.knative.dev" with "ksvc
* Pick off and fix new or overwritten references to kubectl CLI short flags (#292). Instead use long name flags:
   * --filename
   * --namespace
   * --output

    Note: Avoided changing the CLI short flags in the [Minishift](https://github.com/knative/docs/blob/master/install/Knative-with-Minishift.md) and [OpenShift](https://github.com/knative/docs/blob/master/install/Knative-with-OpenShift.md) install guides since I have no familiarity with those "oc" commands.
