### PR TITLE
Update installing-logging-metrics-traces.md

### DIFF
--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -85,7 +85,7 @@ for request traces.
   reasons, the Kibana UI is exposed only within the cluster.
 
 - Navigate to the
-  [Kibana UI](http://localhost:8001/api/v1/namespaces/monitoring/services/kibana-logging/proxy/app/kibana).
+  [Kibana UI](http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana).
   _It might take a couple of minutes for the proxy to work_.
 
 - Within the "Configure an index pattern" page, enter `logstash-*` to


### PR DESCRIPTION
Docs are currently out of sync because paths have changed. This change Installs config/monitoring/ third_party/config/monitoring/ recursively making the install more resilient to path changes.

Fixes #(issue-number)

## Proposed Changes

* 
* 
* 
