### PR TITLE
serving/samples/helloworld-kotlin: simplify and standardize Dockerfile

### DIFF
--- a/serving/samples/helloworld-kotlin/Dockerfile
+++ b/serving/samples/helloworld-kotlin/Dockerfile
@@ -1,7 +1,25 @@
-FROM gradle
+# Use the official gradle image to create a build artifact.
+# https://hub.docker.com/_/gradle
+FROM gradle as builder
 
-ADD build.gradle ./build.gradle
-ADD src ./src
-RUN gradle clean build
-ENTRYPOINT ["java","-jar","-Djava.security.egd=file:/dev/./urandom","/home/gradle/build/libs/gradle.jar"]
+# Copy local code to the container image.
+COPY build.gradle .
+COPY src ./src
 
+# Build a release artifact.
+RUN gradle clean build --no-daemon
+
+# Use the Official OpenJDK image for a lean production stage of our multi-stage build.
+# https://hub.docker.com/_/openjdk
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM openjdk:8-jre-alpine
+
+# Copy the jar to the production image from the builder stage.
+COPY --from=builder /home/gradle/build/libs/gradle.jar /helloworld.jar
+
+# Configure and document the service HTTP port.
+ENV PORT 8080
+EXPOSE $PORT
+
+# Run the web service on container startup.
+CMD [ "java", "-jar", "-Djava.security.egd=file:/dev/./urandom", "/helloworld.jar" ]


### PR DESCRIPTION
Addresses #497 for Kotlin.

Tested with $TARGET and $PORT.

Filed #515 as that issue remains consistent with existing master branch as well as these changes.

Note this moves the Kotlin Dockerfile to a multi-stage build in line with the other JVM languages.