### PR TITLE
Update the serving + build sample to use the new style.

### DIFF
--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -119,16 +119,19 @@ container for the application.
      runLatest:
        configuration:
          build:
-           serviceAccountName: build-bot
-           source:
-             git:
-               url: https://github.com/mchmarny/simple-app.git
-               revision: master
-           template:
-             name: kaniko
-             arguments:
-             - name: IMAGE
-               value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
+           apiVersion: build.knative.dev/v1alpha1
+           kind: Build
+           spec:
+             serviceAccountName: build-bot
+             source:
+               git:
+                 url: https://github.com/mchmarny/simple-app.git
+                 revision: master
+             template:
+               name: kaniko
+               arguments:
+               - name: IMAGE
+                 value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
          revisionTemplate:
            spec:
              container:

--- a/serving/samples/source-to-url-go/service.yaml
+++ b/serving/samples/source-to-url-go/service.yaml
@@ -7,15 +7,19 @@ spec:
   runLatest:
     configuration:
       build:
-        source:
-          git:
-            url: https://github.com/mchmarny/simple-app.git
-            revision: master
-        template:
-          name: kaniko
-          arguments:
-          - name: IMAGE
-            value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
+        apiVersion: build.knative.dev/v1alpha1
+        kind: Build
+        spec:
+          serviceAccountName: build-bot
+          source:
+            git:
+              url: https://github.com/mchmarny/simple-app.git
+              revision: master
+          template:
+            name: kaniko
+            arguments:
+            - name: IMAGE
+              value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
       revisionTemplate:
         spec:
           container:


### PR DESCRIPTION
Add TypeMeta and wrap the existing field in `spec:` so that Build is used through the new dynamically linked style.