### PR TITLE
Don't pass -n default to `ko`

### DIFF
--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -26,22 +26,22 @@
         1. Give that Service Account the 'Pub/Sub Editor' role on your GCP project.
         1. Download a new JSON private key for that Service Account.
         1. Create a secret for the downloaded key:
-            
+
             ```shell
             kubectl -n knative-sources create secret generic gcppubsub-source-key --from-file=key.json=PATH_TO_KEY_FILE.json
             ```
-            
+
             - Note that you can change the secret's name and the secret's key, but will need to modify `default-gcppubsub.yaml` in a later step with the updated values (they are environment variables on the `StatefulSet`).
     - The Receive Adapter's Service Account.
         1. Determine the Service Account to use, or create a new one.
         1. Give that Service Account the 'Pub/Sub Subscriber' role on your GCP project.
         1. Download a new JSON private key for that Service Account.
         1. Create a secret for the downloaded key in the namespace that the `Source` will be created in:
-            
+
             ```shell
             kubectl -n default create secret generic google-cloud-key --from-file=key.json=PATH_TO_KEY_FILE.json
             ```
-            
+
             - Note that you can change the secret's name and the secret's key, but will need to modify `gcp-pubsub-source.yaml`'s `spec.gcpCredsSecret` in a later step with the updated values.
 1. Create a GCP PubSub Topic. Replace `TOPIC-NAME` with your desired topic name.
 
@@ -56,21 +56,21 @@
     ```shell
     kubectl apply -f https://knative-releases.storage.googleapis.com/eventing-sources/latest/release-with-gcppubsub.yaml
     ```
-    
+
     - Note that if the `Source` Service Account secret is in a non-default location, you will need to update the YAML first.
-    
+
 1. Replace the place holders in `gcp-pubsub-source.yaml`.
     - `MY_GCP_PROJECT` should be replaced with your [Google Cloud Project](https://cloud.google.com/resource-manager/docs/creating-managing-projects)'s ID.
     - `TOPIC_NAME` should be replaced with your GCP PubSub Topic's name. It should be the unique portion within the project. E.g. `laconia`, not `projects/my-gcp-project/topics/laconia`.
     - `qux-1` should be replaced with the name of the `Channel` you want messages sent to. If you deployed an unaltered `channel.yaml`, then you can leave it as `qux-1`.
     - `gcpCredsSecret` should be replaced if you are using a non-default secret or key name for the receive adapter's credentials.
-    
+
 1. Deploy `gcp-pubsub-source.yaml`.
 
     ```shell
     kubectl -n default apply -f eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
     ```
-    
+
 ### Subscriber
 
 In order to check the `GcpPubSubSource` is fully working, we will create a simple Knative Service that dumps incoming messages to its log and create a `Subscription` from the `Channel` to that Knative Service.
@@ -80,7 +80,7 @@ In order to check the `GcpPubSubSource` is fully working, we will create a simpl
 1. Deploy `subscriber.yaml`.
 
     ```shell
-    ko -n default apply -f eventing/samples/gcp-pubsub-source/subscriber.yaml
+    ko apply -f eventing/samples/gcp-pubsub-source/subscriber.yaml
     ```
 
 ### Publish


### PR DESCRIPTION
Fixes #529

## Proposed Changes

* Removes passing `-n default` to the `ko` command as this doesn't do anything.

