### PR TITLE
Update pubsub sample

### DIFF
--- a/eventing/samples/gcp-pubsub-source/channel.yaml
+++ b/eventing/samples/gcp-pubsub-source/channel.yaml
@@ -1,8 +1,7 @@
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Channel
 metadata:
-  name: qux-1
-  namespace: default
+  name: pubsub-test
 spec:
   provisioner:
     apiVersion: eventing.knative.dev/v1alpha1

--- a/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
+++ b/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
@@ -1,18 +1,17 @@
 # Replace the following before applying this file:
-#   TOPIC_NAME: Replace with the GCP PubSub Topic name.
 #   MY_GCP_PROJECT: Replace with the GCP Project's ID.
 
 apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: GcpPubSubSource
 metadata:
-  name: TOPIC_NAME-source
+  name: testing-source
 spec:
-  gcpCredsSecret:
+  gcpCredsSecret:  # A secret in the knative-sources namespace
     name: google-cloud-key
     key: key.json
-  googleCloudProject: MY_GCP_PROJECT
-  topic: TOPIC_NAME
+  googleCloudProject: MY_GCP_PROJECT  # Replace this
+  topic: testing
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Channel
-    name: qux-1
+    name: pubsub-test

--- a/eventing/samples/gcp-pubsub-source/subscriber.yaml
+++ b/eventing/samples/gcp-pubsub-source/subscriber.yaml
@@ -1,30 +1,9 @@
-# Subscription from the GcpPubSubSource's output Channel to the Knative Service below.
-
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Subscription
-metadata:
-  name: gcppubsub-source-sample
-  namespace: default
-spec:
-  from:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    name: qux-1
-  call:
-    targetRef:
-      apiVersion: serving.knative.dev/v1alpha1
-      kind: Service
-      name: message-dumper
-
----
-
 # This is a very simple Knative Service that writes the input request to its log.
 
 apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: message-dumper
-  namespace: default
 spec:
   runLatest:
     configuration:
@@ -32,3 +11,20 @@ spec:
         spec:
           container:
             image: github.com/knative/eventing-sources/cmd/message_dumper
+---
+# Subscription from the GcpPubSubSource's output Channel to the Knative Service below.
+
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: gcppubsub-source-sample
+spec:
+  channel:
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: Channel
+    name: pubsub-test
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: message-dumper


### PR DESCRIPTION
## Proposed Changes

* Rewrites the PubSub sample to be able to be run using the GCP CLI (`gcloud only` after project creation).
* Updates eventing instructions based on #558
* Flattened one level of nesting.
* Added opinions about how to use the system, rather than options. It's a sample, not reference documentation.
* Couldn't get around to removing `ko`, though I have a public image published at gcr.io/argent-gke/message_dumper-147eae4dc6ef877ac915642c58dec291:latest
* Inlined some of the interesting yaml. I didn't inline the `subscriber.yaml` because it still needs to be de-`ko`-ed.

