### PR TITLE
Discover the K8S version for IKS deployment

### DIFF
--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -61,7 +61,7 @@ environment variables.
 To make sure the cluster is large enough to host all the Knative and Istio
 components, the recommended configuration for a cluster is:
 
-- Kubernetes version 1.10 or later
+- Kubernetes version  or later
 - 4 vCPU nodes with 16GB memory (`b2c.4x16`)
 
 1.  Set `ibmcloud` to the appropriate region:
@@ -71,6 +71,7 @@ components, the recommended configuration for a cluster is:
 1.  Select a Kubernetes version:
     ```bash
     ibmcloud cs kube-versions
+    export CLUSTER_K8S_VERSION=[a version from the list, must be >1.10]
     ```
 1.  Create a Kubernetes cluster on IKS with the required specifications:
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -68,12 +68,16 @@ components, the recommended configuration for a cluster is:
     ```bash
     ibmcloud cs region-set $CLUSTER_REGION
     ```
+1.  Select a Kubernetes version:
+    ```bash
+    ibmcloud cs kube-versions
+    ```
 1.  Create a Kubernetes cluster on IKS with the required specifications:
 
     ```bash
     ibmcloud cs cluster-create --name=$CLUSTER_NAME \
       --zone=$CLUSTER_ZONE \
-      --kube-version=1.10.3 \
+      --kube-version=$CLUSTER_K8S_VERSION \
       --machine-type=b2c.4x16 \
       --workers=3
     ```
@@ -86,7 +90,7 @@ components, the recommended configuration for a cluster is:
     ```bash
     ibmcloud cs cluster-create --name=$CLUSTER_NAME \
       --zone=$CLUSTER_ZONE \
-      --kube-version=1.10.3 \
+      --kube-version=$CLUSTER_K8S_VERSION \
       --machine-type=b2c.4x16 \
       --workers=3 \
       --private-vlan $PRIVATE_VLAN_ID \

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -61,7 +61,7 @@ environment variables.
 To make sure the cluster is large enough to host all the Knative and Istio
 components, the recommended configuration for a cluster is:
 
-- Kubernetes version  or later
+- Kubernetes version 1.10 or later
 - 4 vCPU nodes with 16GB memory (`b2c.4x16`)
 
 1.  Set `ibmcloud` to the appropriate region:


### PR DESCRIPTION
Version 1.10.3 is not available anymore in IKS. Having a fixed
version will become stale eventually. The default version is
now >1.10 but that may change, so ask installers to select an
appropriate version based on the minimum requirement.

Fixes #562

## Proposed Changes

* Add instructions on how to discover available k8s version
* Replace fixed k8s version with variable
* 
