### PR TITLE
Organizing install guides; adding link to Custom Install guide.

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -157,47 +157,25 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative components
+## Installing Knative
 
-You can install the Knative Serving and Build components together, or Build on
-its own.
-
-### Installing Knative Serving and Build components
+The following commands install all available Knative components. To customize
+your Knative installation, see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-   ```
-1. Monitor the Knative components until all of the components show a `STATUS` of
-   `Running`:
-   ```bash
-   kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
-   ```
-
-### Installing Knative Build only
-
-1. Run the `kubectl apply` command to install
-   [Knative Build](https://github.com/knative/build) and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
-   ```
-1. Monitor the Knative Build components until all of the components show a
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    ```
+1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
-   ```bash
-   kubectl get pods --namespace knative-build
-   ```
-
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the `kubectl get` command to see
-the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
-
-You are now ready to deploy an app or create a build in your new Knative
-cluster.
+    ```bash
+    kubectl get pods --namespace knative-serving
+    kubectl get pods --namespace knative-build
+    kubectl get pods --namespace knative-eventing
+    kubectl get pods --namespace knative-sources
+    kubectl get pods --namespace knative-monitoring
+    ```
 
 ## Deploying an app
 

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -164,9 +164,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -132,8 +132,8 @@ Knative depends on Istio.
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
    ```
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
    also included in the `istio.yaml` file, but they are pulled out so that
@@ -164,7 +164,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
     --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -166,6 +166,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
@@ -177,18 +178,20 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl get pods --namespace knative-monitoring
     ```
 
-## Deploying an app
+## What's next
 
-Now that your cluster has Knative installed, you're ready to deploy an app.
+Now that your cluster has Knative installed, you can see what Knative has to
+offer.
 
-You have two options for deploying your first app:
+To deploy your first app with Knative, follow the step-by-step
+[Getting Started with Knative App Deployment](getting-started-knative-app.md)
+guide.
 
-- You can follow the step-by-step
-  [Getting Started with Knative App Deployment](getting-started-knative-app.md)
-  guide.
+To get started with Knative Eventing, pick one of the
+[Eventing Samples](../eventing/samples/) to walk through.
 
-- You can view the available [sample apps](../serving/samples/README.md) and
-  deploy one of your choosing.
+To get started with Knative Build, read the
+[Build README](../build/README.md), then choose a sample to walk through.
 
 ## Cleaning up
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -132,8 +132,8 @@ Knative depends on Istio.
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
    ```
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
    also included in the `istio.yaml` file, but they are pulled out so that
@@ -165,7 +165,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
     --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -1,7 +1,7 @@
 # Knative Install on Google Kubernetes Engine
 
-This guide walks you through the installation of the latest version of Knative
-using pre-built images.
+This guide walks you through the installation of the latest version of all
+Knative components using pre-built images.
 
 You can find [guides for other platforms here](README.md).
 
@@ -158,36 +158,25 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative components
+## Installing Knative
 
-You can install the Knative Serving and Build components together, or Build on
-its own.
-
-### Installing Knative Serving and Build components
+The following commands install all available Knative components. To customize
+your Knative installation, see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-   ```
-1. Monitor the Knative components until all of the components show a `STATUS` of
-   `Running`:
-   ```bash
-   kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
-   ```
-
-### Installing Knative Build only
-
-1. Run the `kubectl apply` command to install
-   [Knative Build](https://github.com/knative/build) and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
-   ```
-1. Monitor the Knative Build components until all of the components show a
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    ```
+1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
-   ```bash
-   kubectl get pods --namespace knative-build
-   ```
+    ```bash
+    kubectl get pods --namespace knative-serving
+    kubectl get pods --namespace knative-build
+    kubectl get pods --namespace knative-eventing
+    kubectl get pods --namespace knative-sources
+    kubectl get pods --namespace knative-monitoring
+    ```
 
 Just as with the Istio components, it will take a few seconds for the Knative
 components to be up and running; you can rerun the `kubectl get` command to see

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -167,6 +167,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
@@ -178,34 +179,20 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl get pods --namespace knative-monitoring
     ```
 
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the `kubectl get` command to see
-the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
-
-You are now ready to deploy an app or create a build in your new Knative
-cluster.
-
 ## What's next
 
-Now that your cluster has Knative installed, you're ready to deploy an app or
-create a build.
+Now that your cluster has Knative installed, you can see what Knative has to
+offer.
 
-Depending on which Knative component you have installed, there are a few options
-for getting started:
+To deploy your first app with Knative, follow the step-by-step
+[Getting Started with Knative App Deployment](getting-started-knative-app.md)
+guide.
 
-- You can follow the step-by-step
-  [Getting Started with Knative App Deployment](getting-started-knative-app.md)
-  guide.
+To get started with Knative Eventing, pick one of the
+[Eventing Samples](../eventing/samples/) to walk through.
 
-- You can view the available [sample apps](../serving/samples/README.md) and
-  deploy one of your choosing.
-
-- You can follow the step-by-step
-  [Creating a simple Knative Build](../build/creating-builds.md) guide.
+To get started with Knative Build, read the
+[Build README](../build/README.md), then choose a sample to walk through.
 
 ## Cleaning up
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -165,9 +165,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -94,47 +94,25 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative components
+## Installing Knative
 
-You can install the Knative Serving and Build components together, or Build on
-its own.
-
-### Installing Knative Serving and Build components
+The following commands install all available Knative components. To customize
+your Knative installation, see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-   ```
-1. Monitor the Knative components until all of the components show a `STATUS` of
-   `Running`:
-   ```bash
-   kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
-   ```
-
-### Installing Knative Build only
-
-1. Run the `kubectl apply` command to install
-   [Knative Build](https://github.com/knative/build) and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
-   ```
-1. Monitor the Knative Build components until all of the components show a
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    ```
+1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
-   ```bash
-   kubectl get pods --namespace knative-build
-   ```
-
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the `kubectl get` command to see
-the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
-
-You are now ready to deploy an app or create a build in your new Knative
-cluster.
+    ```bash
+    kubectl get pods --namespace knative-serving
+    kubectl get pods --namespace knative-build
+    kubectl get pods --namespace knative-eventing
+    kubectl get pods --namespace knative-sources
+    kubectl get pods --namespace knative-monitoring
+    ```
 
 ## Alternative way to enable Knative with Gardener
 

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -101,8 +101,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -71,8 +71,8 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
+	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
     ```
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
     also included in the `istio.yaml` file, but they are pulled out so that
@@ -101,7 +101,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
     --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
@@ -147,10 +147,10 @@ spec:
 And of course create the respective `ConfigMaps`:
 
 ```
-curl https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
+curl https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
 kubectl create configmap istio-chart-080 --from-file=istio.yaml
 
-curl https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
+curl https://github.com/knative/serving/releases/download/v0.2.3/release.yaml
 kubectl create configmap knative-chart-001 --from-file=release.yaml
 ```
 

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -188,17 +188,20 @@ kind: ConfigMap
   namespace: knative-serving
 ```
 
-## Deploying an app
+## What's next
 
-Now that your cluster has Knative installed, you're ready to deploy an app.
+Now that your cluster has Knative installed, you can see what Knative has to
+offer.
 
-If you'd like to follow a step-by-step guide for deploying your first app on
-Knative, check out the
+To deploy your first app with Knative, follow the step-by-step
 [Getting Started with Knative App Deployment](getting-started-knative-app.md)
 guide.
 
-If you'd like to view the available sample apps and deploy one of your choosing,
-head to the [sample apps](../serving/samples/README.md) repo.
+To get started with Knative Eventing, pick one of the
+[Eventing Samples](../eventing/samples/) to walk through.
+
+To get started with Knative Build, read the
+[Build README](../build/README.md), then choose a sample to walk through.
 
 ## Cleaning up
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -170,9 +170,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -137,8 +137,8 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
     ```
 	Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
 	also included in the `istio.yaml` file, but they are pulled out so that
@@ -170,7 +170,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
     --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -172,6 +172,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
@@ -183,18 +184,20 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl get pods --namespace knative-monitoring
     ```
 
-## Deploying an app
+## What's next
 
-Now that your cluster has Knative installed, you're ready to deploy an app.
+Now that your cluster has Knative installed, you can see what Knative has to
+offer.
 
-You have two options for deploying your first app:
+To deploy your first app with Knative, follow the step-by-step
+[Getting Started with Knative App Deployment](getting-started-knative-app.md)
+guide.
 
-- Follow the step-by-step
-  [Getting Started with Knative App Deployment](getting-started-knative-app.md)
-  guide.
+To get started with Knative Eventing, pick one of the
+[Eventing Samples](../eventing/samples/) to walk through.
 
-- View the available [sample apps](../serving/samples) and deploy one of your
-  choosing.
+To get started with Knative Build, read the
+[Build README](../build/README.md), then choose a sample to walk through.
 
 ## Cleaning up
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -163,47 +163,25 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL+C to
 > exit watch mode.
 
-## Installing Knative components
+## Installing Knative
 
-You can install the Knative Serving and Build components together, or Build on
-its own.
-
-### Installing Knative Serving and Build components
+The following commands install all available Knative components. To customize
+your Knative installation, see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-   ```
-1. Monitor the Knative components until all of the components show a `STATUS` of
-   `Running`:
-   ```bash
-   kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
-   ```
-
-### Installing Knative Build only
-
-1. Run the `kubectl apply` command to install
-   [Knative Build](https://github.com/knative/build) and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
-   ```
-1. Monitor the Knative Build components until all of the components show a
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    ```
+1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
-   ```bash
-   kubectl get pods --namespace knative-build
-   ```
-
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the `kubectl get` command to see
-the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
-
-You are now ready to deploy an app or create a build in your new Knative
-cluster.
+    ```bash
+    kubectl get pods --namespace knative-serving
+    kubectl get pods --namespace knative-build
+    kubectl get pods --namespace knative-eventing
+    kubectl get pods --namespace knative-sources
+    kubectl get pods --namespace knative-monitoring
+    ```
 
 ## Deploying an app
 

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -78,9 +78,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -80,6 +80,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
@@ -88,21 +89,26 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl get pods --namespace knative-build
     kubectl get pods --namespace knative-eventing
     kubectl get pods --namespace knative-sources
+<<<<<<< HEAD
     kubectl get pods --namespace knative-monitoring
+=======
+>>>>>>> Adding links to samples for all components.
     ```
 
-## Deploying an app
+## What's next
 
-Now that your cluster has Knative installed, you're ready to deploy an app.
+Now that your cluster has Knative installed, you can see what Knative has to
+offer.
 
-You have two options for deploying your first app:
+To deploy your first app with Knative, follow the step-by-step
+[Getting Started with Knative App Deployment](getting-started-knative-app.md)
+guide.
 
-- You can follow the step-by-step
-  [Getting Started with Knative App Deployment](getting-started-knative-app.md)
-  guide.
+To get started with Knative Eventing, pick one of the
+[Eventing Samples](../eventing/samples/) to walk through.
 
-- You can view the available [sample apps](../serving/samples/README.md) and
-  deploy one of your choosing.
+To get started with Knative Build, read the
+[Build README](../build/README.md), then choose a sample to walk through.
 
 ## Cleaning up
 

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -71,47 +71,25 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative components
+## Installing Knative
 
-You can install the Knative Serving and Build components together, or Build on
-its own.
-
-### Installing Knative Serving and Build components
+The following commands install all available Knative components. To customize
+your Knative installation, see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-   ```
-1. Monitor the Knative components until all of the components show a `STATUS` of
-   `Running`:
-   ```bash
-   kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
-   ```
-
-### Installing Knative Build only
-
-1. Run the `kubectl apply` command to install
-   [Knative Build](https://github.com/knative/build) and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
-   ```
-1. Monitor the Knative Build components until all of the components show a
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    ```
+1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
-   ```bash
-   kubectl get pods --namespace knative-build
-   ```
-
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the `kubectl get` command to see
-the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
-
-You are now ready to deploy an app or create a build in your new Knative
-cluster.
+    ```bash
+    kubectl get pods --namespace knative-serving
+    kubectl get pods --namespace knative-build
+    kubectl get pods --namespace knative-eventing
+    kubectl get pods --namespace knative-sources
+    kubectl get pods --namespace knative-monitoring
+    ```
 
 ## Deploying an app
 

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -48,8 +48,8 @@ Containers
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
    ```
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
    also included in the `istio.yaml` file, but they are pulled out so that
@@ -78,7 +78,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
     --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
@@ -89,10 +89,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl get pods --namespace knative-build
     kubectl get pods --namespace knative-eventing
     kubectl get pods --namespace knative-sources
-<<<<<<< HEAD
     kubectl get pods --namespace knative-monitoring
-=======
->>>>>>> Adding links to samples for all components.
     ```
 
 ## What's next

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -56,6 +56,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
@@ -67,15 +68,17 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl get pods --namespace knative-monitoring
     ```
 
-## Deploying an app
+## What's next
 
-Now that your cluster has Knative installed, you're ready to deploy an app.
+Now that your cluster has Knative installed, you can see what Knative has to
+offer.
 
-You have two options for deploying your first app:
+To deploy your first app with Knative, follow the step-by-step
+[Getting Started with Knative App Deployment](getting-started-knative-app.md)
+guide.
 
-- You can follow the step-by-step
-  [Getting Started with Knative App Deployment](getting-started-knative-app.md)
-  guide.
+To get started with Knative Eventing, pick one of the
+[Eventing Samples](../eventing/samples/) to walk through.
 
-- You can view the available [sample apps](../serving/samples/README.md) and
-  deploy one of your choosing.
+To get started with Knative Build, read the
+[Build README](../build/README.md), then choose a sample to walk through.

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -21,8 +21,8 @@ Containers.
 
 1.  Install Istio:
     ```bash
-	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
-    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.2/third_party/istio-1.0.2/istio.yaml
+	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.3/third_party/istio-1.0.2/istio.yaml
     ```
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
     also included in the `istio.yaml` file, but they are pulled out so that
@@ -54,7 +54,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
     --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
     --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -54,9 +54,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
+    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -47,47 +47,25 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL + C to
 > exit watch mode.
 
-## Installing Knative components
+## Installing Knative
 
-You can install the Knative Serving and Build components together, or Build on
-its own.
-
-### Installing Knative Serving and Build components
+The following commands install all available Knative components. To customize
+your Knative installation, see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-   ```
-1. Monitor the Knative components until all of the components show a `STATUS` of
-   `Running`:
-   ```bash
-   kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
-   ```
-
-### Installing Knative Build only
-
-1. Run the `kubectl apply` command to install
-   [Knative Build](https://github.com/knative/build) and its dependencies:
-   ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.2/third_party/config/build/release.yaml
-   ```
-1. Monitor the Knative Build components until all of the components show a
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml /
+    --filename https://github.com/knative/eventing/releases/download/v0.2.0/eventing.yaml /
+    ```
+1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:
-   ```bash
-   kubectl get pods --namespace knative-build
-   ```
-
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the `kubectl get` command to see
-the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
-
-You are now ready to deploy an app or create a build in your new Knative
-cluster.
+    ```bash
+    kubectl get pods --namespace knative-serving
+    kubectl get pods --namespace knative-build
+    kubectl get pods --namespace knative-eventing
+    kubectl get pods --namespace knative-sources
+    kubectl get pods --namespace knative-monitoring
+    ```
 
 ## Deploying an app
 

--- a/install/README.md
+++ b/install/README.md
@@ -24,7 +24,7 @@ There are several options when installing Knative:
 * **Comprehensive install** -- Comes with the default versions of all Knative
   components. Quickest option for setup.
 
-* **Limited install** -- Installs a subset of Knative components.
+* **Limited install** -- Installs a subset of Knative features.
 
 * **Custom install** -- Takes longer, but allows you to choose exactly which
   components to install.
@@ -54,7 +54,8 @@ software on, use the following guide to install all Knative components:
 
 **Limited install guides**
 The guides below install some of the available Knative components, sometimes
-without all available observability plugins, to minimize disk use.
+without all available capabilities, to minimize the disk space used for install.
+* [Knative Install on Docker for Mac](Knative-with-Docker-for-Mac.md)
 * [Knative Install on Minikube](Knative-with-Minikube.md)
 * [Knative Install on Minishift](Knative-with-Minishift.md)
 * [Knative Install on OpenShift](Knative-with-OpenShift.md)

--- a/install/README.md
+++ b/install/README.md
@@ -54,7 +54,7 @@ software on, use the following guide to install all Knative components:
 
 **Limited install guides**
 The guides below install some of the available Knative components, sometimes
-without all available capabilities, to minimize the disk space used for install.
+without all available observability plugins, to minimize the disk space used for install.
 * [Knative Install on Docker for Mac](Knative-with-Docker-for-Mac.md)
 * [Knative Install on Minikube](Knative-with-Minikube.md)
 * [Knative Install on Minishift](Knative-with-Minishift.md)
@@ -70,6 +70,12 @@ follow the custom install guide:
   specifications to run Knative, you can follow any of the install
   instructions through the creation of the cluster, then follow the
   [Perfoming a Custom Knative Installation](knative-custom-install.md) guide.
+
+**Observability install guide**
+Follow this guide to install the available observability plugins on a Knative
+cluster.
+
+* [Monitoring, Logging and Tracing Installation](../serving/installing-logging-metrics-traces.md)  
 
 ## Deploying an app
 

--- a/install/README.md
+++ b/install/README.md
@@ -19,24 +19,56 @@ clusters.
 
 ## Installing Knative
 
+There are several options when installing Knative:
+
+* **Comprehensive install** -- Comes with the default versions of all Knative
+  components. Quickest option for setup.
+
+* **Limited install** -- Installs a subset of Knative components.
+
+* **Custom install** -- Takes longer, but allows you to choose exactly which
+  components to install.
+
+For new users, we recommend the comprehensive install to get you up and running
+quickly.
+
+### Install guides
+
 Follow these step-by-step guides for setting up Kubernetes and installing
-Knative components on the following platforms:
+Knative components.
 
-- [Knative Install on Azure Kubernetes Service](Knative-with-AKS.md)
-- [Knative Install on Gardener](Knative-with-Gardener.md)
-- [Knative Install on Google Kubernetes Engine](Knative-with-GKE.md)
-- [Knative Install on IBM Cloud Kubernetes Service](Knative-with-IKS.md)
-- [Knative Install on IBM Cloud Private](Knative-with-ICP.md)
-- [Knative Install on Minikube](Knative-with-Minikube.md)
-- [Knative Install on OpenShift](Knative-with-OpenShift.md)
-- [Knative Install on Minishift](Knative-with-Minishift.md)
-- [Knative Install on Pivotal Container Service](Knative-with-PKS.md)
-- [Knative Install on Docker for Mac](Knative-with-Docker-for-Mac.md)
+**Comprehensive install guides**
+The guides below show you how to create a Kubernetes cluster with the right
+specs for Knative on your platform of choice, then walk through installing all
+available Knative components.
+* [Knative Install on Azure Kubernetes Service](Knative-with-AKS.md)
+* [Knative Install on Gardener](Knative-with-Gardener.md)
+* [Knative Install on Google Kubernetes Engine](Knative-with-GKE.md)
+* [Knative Install on IBM Cloud Kubernetes Service](Knative-with-IKS.md)
+* [Knative Install on Pivotal Container Service](Knative-with-PKS.md)
 
-If you already have a Kubernetes cluster you're comfortable installing _alpha_
-software on, use the following instructions:
+If you already have a Kubernetes cluster you're comfortable installing *alpha*
+software on, use the following guide to install all Knative components:
 
 - [Knative Install on any Kubernetes](Knative-with-any-k8s.md)
+
+**Limited install guides**
+The guides below install some of the available Knative components, sometimes
+without all available observability plugins, to minimize disk use.
+* [Knative Install on Minikube](Knative-with-Minikube.md)
+* [Knative Install on Minishift](Knative-with-Minishift.md)
+* [Knative Install on OpenShift](Knative-with-OpenShift.md)
+
+**Custom install guide**
+To choose which components and which versions of each component to install,
+follow the custom install guide:
+
+* [Perfoming a Custom Knative Installation](Knative-custom-install.md)
+
+> **Note**: If need to set up a Kubernetes cluster with the correct
+  specifications to run Knative, you can follow any of the install
+  instructions through the creation of the cluster, then follow the
+  [Perfoming a Custom Knative Installation](knative-custom-install.md) guide.
 
 ## Deploying an app
 


### PR DESCRIPTION
## Proposed Changes

* Re-organize install guides by what kind of install they perform.
* Add link to new custom install guide
* Putting a HOLD on this for now, since this can't be merged in until #542 is merged.

Fixes: #295