### PR TITLE
Removed the unnecessary create namespace command under section for setting up GCP pubsub source

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -82,7 +82,6 @@ and loading the released source yaml (the `-with-gcppubsub` release includes all
 the above sources, and adds GCP PubSub, which requires the listed secret):
 
 ```bash
-kubectl create namespace knative-sources
 kubectl --namespace knative-sources create secret generic gcppubsub-source-key --from-literal=key.json=''
 kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.2.0/release-with-gcppubsub.yaml
 ```


### PR DESCRIPTION
Removed kubectl command to create namespace "knative-sources" from section that covers setting up of GCP pubsub source as installation of eventing core sources already creates the namespace

Fixes #(issue-number)
#567 

## Proposed Changes
Removed the create namespace kubectl command that is not required from the README.md