### PR TITLE
Use golang:alpine instead of golang for example Dockerfile.

### DIFF
--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -187,7 +187,10 @@ The sample code is in a private Github repository consisting of two files.
 
 1. `Dockerfile`
    ```Dockerfile
-   FROM golang
+   # Use golang:alpine to optimize the image size.
+   # Please refer to https://hub.docker.com/_/golang/ for
+   # the difference of golang and golang:alpine.
+   FROM golang:alpine
 
    ENV GOPATH /go
 

--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -188,8 +188,8 @@ The sample code is in a private Github repository consisting of two files.
 1. `Dockerfile`
    ```Dockerfile
    # Use golang:alpine to optimize the image size.
-   # Please refer to https://hub.docker.com/_/golang/ for
-   # the difference of golang and golang:alpine.
+   # See https://hub.docker.com/_/golang/ for more information
+   # about the difference between golang and golang:alpine.
    FROM golang:alpine
 
    ENV GOPATH /go


### PR DESCRIPTION
This is a follow up action for https://github.com/knative/docs/pull/571

/cc @vdemeester 
