### PR TITLE
use public image instead of requiring ko

### DIFF
--- a/eventing/samples/kubernetes-event-source/README.md
+++ b/eventing/samples/kubernetes-event-source/README.md
@@ -43,7 +43,7 @@ In order to check the `KubernetesEventSource` is fully working, we will create a
 1. Deploy `subscription.yaml`.
 
 ```shell
-ko apply -f eventing/samples/kubernetes-event-source/subscription.yaml
+kubectl apply -f eventing/samples/kubernetes-event-source/subscription.yaml
 ```
 
 

--- a/eventing/samples/kubernetes-event-source/subscription.yaml
+++ b/eventing/samples/kubernetes-event-source/subscription.yaml
@@ -28,4 +28,4 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: github.com/knative/eventing-sources/cmd/message_dumper
+            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper@sha256:73a95b05b5b937544af7c514c3116479fa5b6acf7771604b313cfc1587bf0940


### PR DESCRIPTION
Addresses #541

## Proposed Changes

* Use a public docker image for the messagedumper so ko is not required for the k8s events sample.
* 
* 
