### PR TITLE
Argument must be "--sink" exactly for the sink to be filled in for ContainerSource

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -197,8 +197,8 @@ FTP server for new files or generate events at a set time interval.
 **Spec fields**:
 
 - `image` (**required**): `string` A docker image of the container to be run.
-- `args`: `[]string` Command-line arguments. Any `--sink=` argument will be
-  filled in with the DNS address of the `sink` object.
+- `args`: `[]string` Command-line arguments. If no `--sink` flag is provided, 
+   one will be added and filled in with the DNS address of the `sink` object.
 - `env`: `map[string]string` Environment variables to be set in the container.
 - `serviceAccountName`: `string` The name of the ServiceAccount to run the
   container as.


### PR DESCRIPTION
Fixes #600

## Proposed Changes

Assuming this is intended behavior,  I wanted to clarify the --sink argument for a ContainerSource a bit after getting tripped up a bit on it myself, where the argument must be exactly "--sink"
