### PR TITLE
Make helloworld a standalone executable

### DIFF
--- a/serving/samples/helloworld-go/Dockerfile
+++ b/serving/samples/helloworld-go/Dockerfile
@@ -8,7 +8,7 @@ COPY . /go/src/github.com/knative/docs/helloworld
 # Build the outyet command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
-RUN go install github.com/knative/docs/helloworld
+RUN CGO_ENABLED=0 go install github.com/knative/docs/helloworld
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -69,7 +69,7 @@ following instructions recreate the source files from this folder.
     # Build the helloworld command inside the container.
     # (You may fetch or manage dependencies here,
     # either manually or with a tool like "godep".)
-    RUN go install github.com/knative/docs/helloworld
+    RUN CGO_ENABLED=0 go install github.com/knative/docs/helloworld
 
     # Use a Docker multi-stage build to create a lean production image.
     # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds


### PR DESCRIPTION
Fixes #569 

## Proposed Changes

* Set CGO_ENABLED=0 in the Dockerfile line that builds the hello executable, to make it a standalone binary
* Update the copy of the Dockerfile in the docs to match