### PR TITLE
Update kubectl apply URLs to use release artifacts

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -67,15 +67,10 @@ Learn more about Eventing development in the
 ## Installation
 
 Knative Eventing currently requires Knative Serving and Istio version 1.0 or
-later installed. Use this command to install the version of Istio which is
-tested with Knative:
+later installed. [Follow the instructions to install on the platform of your
+choice](../install/README.md).
 
-```shell
-kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.2/third_party/istio-1.0.2/istio.yaml
-kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
-```
-
-You can install the core Knative Eventing (which provides an in-memory
+Install the core Knative Eventing (which provides an in-memory
 ChannelProvisioner) and the core sources (which provides the Kubernetes Events,
 GitHub, and "Container" Sources) with the following commands:
 

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -159,7 +159,7 @@ its own.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
    ```
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -132,7 +132,7 @@ Knative depends on Istio.
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
    ```
 1. Label the default namespace with `istio-injection=enabled`:
 

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -173,7 +173,7 @@ its own.
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/config/build/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
    ```
 1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -174,7 +174,7 @@ its own.
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/config/build/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
    ```
 1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -139,7 +139,10 @@ Knative depends on Istio.
    kubectl label namespace default istio-injection=enabled
    ```
 1. Monitor the Istio components until all of the components show a `STATUS` of
-   `Running` or `Completed`: `bash kubectl get pods --namespace istio-system`
+   `Running` or `Completed`:
+    ```bash
+    kubectl get pods --namespace istio-system
+    ```
 
 It will take a few minutes for all the components to be up and running; you can
 rerun the command to see the current status.

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -132,7 +132,7 @@ Knative depends on Istio.
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
    ```
 1. Label the default namespace with `istio-injection=enabled`:
    ```bash

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -160,7 +160,7 @@ its own.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
    ```
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -71,7 +71,7 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
     ```
 2.  Label the default namespace with `istio-injection=enabled`:
     ```bash
@@ -161,7 +161,7 @@ spec:
 And of course create the respective `ConfigMaps`:
 
 ```
-curl https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml
+curl https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
 kubectl create configmap istio-chart-080 --from-file=istio.yaml
 
 curl https://github.com/knative/serving/releases/download/v0.2.1/release.yaml

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -110,7 +110,7 @@ its own.
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/config/build/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
    ```
 1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -96,7 +96,7 @@ its own.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
    ```
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -164,7 +164,7 @@ And of course create the respective `ConfigMaps`:
 curl https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
 kubectl create configmap istio-chart-080 --from-file=istio.yaml
 
-curl https://github.com/knative/serving/releases/download/v0.2.1/release.yaml
+curl https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
 kubectl create configmap knative-chart-001 --from-file=release.yaml
 ```
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -165,7 +165,7 @@ its own.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
    ```
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -137,7 +137,7 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
     ```
 1.  Label the default namespace with `istio-injection=enabled`:
     ```bash

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -179,7 +179,7 @@ its own.
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/config/build/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
    ```
 1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -56,7 +56,7 @@ Knative depends on Istio. Run the following to install Istio. (We are changing
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -83,12 +83,12 @@ rerun the command to see the current status.
 Next, install [Knative Serving](https://github.com/knative/serving):
 
 Because you have limited resources available, use the
-`https://github.com/knative/serving/releases/download/v0.2.1/release-lite.yaml`
+`https://github.com/knative/serving/releases/download/v0.2.2/release-lite.yaml`
 file, which omits some of the monitoring components to reduce the memory used by
 the Knative components. To use the provided `release-lite.yaml` release, run:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.2.1/release-lite.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.2.2/release-lite.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 ```

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -87,7 +87,7 @@ its own.
 1. Run the `kubectl apply` command to install
    [Knative Build](https://github.com/knative/build) and its dependencies:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/config/build/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/build.yaml
    ```
 1. Monitor the Knative Build components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -73,7 +73,7 @@ its own.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.1/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/release.yaml
    ```
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -48,7 +48,7 @@ Containers
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
    ```
 1. Label the default namespace with `istio-injection=enabled`:
    ```bash


### PR DESCRIPTION
A few things I noticed while going through the install procedure.

## Proposed Changes

- Use the istio release artifact in serving (https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml) to install Istio instead of a direct link to the file in the repo.
- Same as above for build-only.
- Install serving v0.2.2 instead of v0.2.1.
- Point users to the top-level install instructions from the eventing readme.