### PR TITLE
Format markdown

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -67,8 +67,8 @@ Learn more about Eventing development in the
 ## Installation
 
 Knative Eventing currently requires Knative Serving and Istio version 1.0 or
-later installed. [Follow the instructions to install on the platform of your
-choice](../install/README.md).
+later installed.
+[Follow the instructions to install on the platform of your choice](../install/README.md).
 
 Install the core Knative Eventing (which provides an in-memory
 ChannelProvisioner) and the core sources (which provides the Kubernetes Events,

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -140,9 +140,9 @@ Knative depends on Istio.
    ```
 1. Monitor the Istio components until all of the components show a `STATUS` of
    `Running` or `Completed`:
-    ```bash
-    kubectl get pods --namespace istio-system
-    ```
+   ```bash
+   kubectl get pods --namespace istio-system
+   ```
 
 It will take a few minutes for all the components to be up and running; you can
 rerun the command to see the current status.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`