### PR TITLE
Format markdown

### DIFF
--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -81,8 +81,8 @@ per pod (concurrency). The system has a default
 [target concurrency of 100.0](https://github.com/knative/serving/blob/3f00c39e289ed4bfb84019131651c2e4ea660ab5/config/config-autoscaler.yaml#L35).
 
 For example, if a Revision is receiving 350 requests per second, each of which
-takes about .5 seconds, Knative Serving will determine the Revision needs
-about 2 pods
+takes about .5 seconds, Knative Serving will determine the Revision needs about
+2 pods
 
 ```
 350 * .5 = 175


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`