### PR TITLE
Switching to rbac v1

### DIFF
--- a/serving/samples/telemetry-go/prometheus-test.yaml
+++ b/serving/samples/telemetry-go/prometheus-test.yaml
@@ -17,7 +17,7 @@ kind: ServiceAccount
 metadata:
   name: prometheus-test
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-test
@@ -36,7 +36,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus-test

--- a/serving/using-external-dns-on-gcp.md
+++ b/serving/using-external-dns-on-gcp.md
@@ -213,7 +213,7 @@ kind: ServiceAccount
 metadata:
   name: external-dns
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-dns
@@ -231,7 +231,7 @@ rules:
     resources: ["nodes"]
     verbs: ["list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer
@@ -279,7 +279,7 @@ kind: ServiceAccount
 metadata:
   name: external-dns
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: external-dns
@@ -297,7 +297,7 @@ rules:
     resources: ["nodes"]
     verbs: ["list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: external-dns-viewer


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

## Proposed Changes

Since RBAC went into GA in 1.8, switching to use rbac v1 in yaml files in docs repo.
