### PR TITLE
 Use lowercase 'b' for builders

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -8,7 +8,7 @@ process succeeds.
 A Knative `Build` runs on-cluster and is implemented by a
 [Kubernetes Custom Resource Definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
-Given a `Builder`, or container image that you have created to perform a task or
+Given a *builder*, or container image that you have created to perform a task or
 action, you can define a Knative `Build` through a single configuration file.
 
 Also consider using a Knative `Build` to build the source code of your apps into
@@ -20,7 +20,7 @@ More information about this use case is demonstrated in
 ## Key features of Knative Builds
 
 - A `Build` can include multiple `steps` where each step specifies a `Builder`.
-- A `Builder` is a type of container image that you create to accomplish any
+- A *builder* is a type of container image that you create to accomplish any
   task, whether that's a single step in a process, or the whole process itself.
 - The `steps` in a `Build` can push to a repository.
 - A `BuildTemplate` can be used to defined reusable templates.
@@ -38,7 +38,7 @@ components:
 
 - [`Build`](https://github.com/knative/docs/blob/master/build/builds.md)
 - [`BuildTemplate`](https://github.com/knative/docs/blob/master/build/build-templates.md)
-- [ `Builder`](https://github.com/knative/docs/blob/master/build/builder-contract.md)
+- [Builder](https://github.com/knative/docs/blob/master/build/builder-contract.md)
 - [`ServiceAccount`](https://github.com/knative/docs/blob/master/build/auth.md)
 
 ## Install the Knative Build component

--- a/build/builder-contract.md
+++ b/build/builder-contract.md
@@ -1,15 +1,15 @@
 # Builders
 
-This document defines `Builder` images and the conventions to which they are
+This document defines builder images and the conventions to which they are
 expected to adhere.
 
-## What is a Builder?
+## What is a builder?
 
-A `Builder` image is a special classification for images that run as a part of
+A builder image is a special classification for images that run as a part of
 the Build CRD's `steps:`.
 
 For example, in the following Build the images, `gcr.io/cloud-builders/gcloud`
-and `gcr.io/cloud-builders/docker` are "Builders".:
+and `gcr.io/cloud-builders/docker` are "builders".:
 
 ```yaml
 spec:
@@ -20,9 +20,9 @@ spec:
     ...
 ```
 
-### Typical Builders
+### Typical builders
 
-A Builder is typically a purpose-built container whose entrypoint is a tool that
+A builder is typically a purpose-built container whose entrypoint is a tool that
 performs some action and exits with a zero status on success. These entrypoints
 are often command-line tools, for example, `git`, `docker`, `mvn`, and so on.
 
@@ -33,9 +33,9 @@ See [here](https://github.com/googlecloudplatform/cloud-builders) and
 [here](https://github.com/googlecloudplatform/cloud-builders-community) for more
 builders.
 
-### Atypical Builders
+### Atypical builders
 
-It it possible, although less typical to implement the Builder convention by
+It it possible, although less typical to implement the builder convention by
 overriding `command:` and `args:` for example:
 
 ```yaml
@@ -48,13 +48,13 @@ steps:
         value: "world"
 ```
 
-### Specialized Builders
+### Specialized builders
 
 It is also possible for advanced users to create purpose-built builders. One
 example of this are the
 ["FTL" builders](https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/ftl#ftl).
 
-## What are the Builder conventions?
+## What are the builder conventions?
 
 Builders should expect a Build to implement the following conventions:
 


### PR DESCRIPTION
Fixes #625 

Make it clear that a *builder* is a type of container image and is not a formal object in Knative.