### PR TITLE
Add link to source code

### DIFF
--- a/serving/samples/blue-green-deployment.md
+++ b/serving/samples/blue-green-deployment.md
@@ -13,6 +13,9 @@ You need:
 - (Optional)
   [A custom domain configured](../../serving/using-a-custom-domain.md) for use
   with Knative.
+  
+Note: The source code for the gcr.io/knative-samples/knative-route-demo image that is used in this sample, is located at 
+https://github.com/mchmarny/knative-route-demo.
 
 ## Deploying Revision 1 (Blue)
 


### PR DESCRIPTION
Fixes #628

Provide access to source so users can learn more about how it works.