### PR TITLE
Format markdown

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -8,7 +8,7 @@ process succeeds.
 A Knative `Build` runs on-cluster and is implemented by a
 [Kubernetes Custom Resource Definition (CRD)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 
-Given a *builder*, or container image that you have created to perform a task or
+Given a _builder_, or container image that you have created to perform a task or
 action, you can define a Knative `Build` through a single configuration file.
 
 Also consider using a Knative `Build` to build the source code of your apps into
@@ -20,7 +20,7 @@ More information about this use case is demonstrated in
 ## Key features of Knative Builds
 
 - A `Build` can include multiple `steps` where each step specifies a `Builder`.
-- A *builder* is a type of container image that you create to accomplish any
+- A _builder_ is a type of container image that you create to accomplish any
   task, whether that's a single step in a process, or the whole process itself.
 - The `steps` in a `Build` can push to a repository.
 - A `BuildTemplate` can be used to defined reusable templates.

--- a/build/builder-contract.md
+++ b/build/builder-contract.md
@@ -5,8 +5,8 @@ expected to adhere.
 
 ## What is a builder?
 
-A builder image is a special classification for images that run as a part of
-the Build CRD's `steps:`.
+A builder image is a special classification for images that run as a part of the
+Build CRD's `steps:`.
 
 For example, in the following Build the images, `gcr.io/cloud-builders/gcloud`
 and `gcr.io/cloud-builders/docker` are "builders".:

--- a/serving/samples/blue-green-deployment.md
+++ b/serving/samples/blue-green-deployment.md
@@ -13,8 +13,9 @@ You need:
 - (Optional)
   [A custom domain configured](../../serving/using-a-custom-domain.md) for use
   with Knative.
-  
-Note: The source code for the gcr.io/knative-samples/knative-route-demo image that is used in this sample, is located at 
+
+Note: The source code for the gcr.io/knative-samples/knative-route-demo image
+that is used in this sample, is located at
 https://github.com/mchmarny/knative-route-demo.
 
 ## Deploying Revision 1 (Blue)


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`