### PR TITLE
Update the GCP PubSub sample

### DIFF
--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -23,7 +23,7 @@ source is most useful as a bridge from other GCP services, such as
    using the `release-with-gcppubsub.yaml` file. Start by creating a dummy
    `gcppubsub-source-key` (as directed), and we will replace it later.
 
-1. Enable the 'Cloud Pub/Sub API' on your project.
+1. Enable the 'Cloud Pub/Sub API' on your project:
 
    ```shell
    gcloud services enable pubsub.googleapis.com
@@ -52,7 +52,7 @@ source is most useful as a bridge from other GCP services, such as
       gcloud iam service-accounts keys create knative-source.json \
         --iam-account=knative-source@$PROJECT_ID.iam.gserviceaccount.com
       ```
-   1. Create two secrets on the kubernetes cluster with the downloaded key.
+   1. Create two secrets on the kubernetes cluster with the downloaded key:
       ```shell
       # Note that the first secret may already have been created when installing
       # Knative Eventing. The following command will overwrite it. If you don't
@@ -93,7 +93,7 @@ source is most useful as a bridge from other GCP services, such as
    ```
 
 1. Create a GCP PubSub Topic. If you change its name (`testing`), you also need to update the
-   `topic` in the [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml) file.
+   `topic` in the [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml) file:
 
    ```shell
    gcloud pubsub topics create testing
@@ -103,20 +103,20 @@ source is most useful as a bridge from other GCP services, such as
    [`MY_GCP_PROJECT` placeholder](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
    in [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml) and apply it.
 
-   If you're in the samples directory, you can replace and apply in one command.
+   If you're in the samples directory, you can replace and apply in one command:
 
    ```shell
     sed "s/MY_GCP_PROJECT/$PROJECT_ID/g" gcp-pubsub-source.yaml | \
         kubectl apply --filename -
    ```
 
-   If you are replacing it manually, do so, then apply the resulting YAML.
+   If you are replacing it manually, do so, then apply the resulting YAML:
 
    ```shell
    kubectl apply --filename gcp-pubsub-source.yaml
    ```
 
-1. Create a function and subscribe it to the `pubsub-test` channel.
+1. Create a function and subscribe it to the `pubsub-test` channel:
 
    ```shell
    kubectl apply --filename subscriber.yaml
@@ -124,7 +124,7 @@ source is most useful as a bridge from other GCP services, such as
 
 ## Publish
 
-Publish messages to your GCP PubSub Topic.
+Publish messages to your GCP PubSub Topic:
 
 ```shell
 gcloud pubsub topics publish testing --message="Hello World!"
@@ -147,7 +147,7 @@ not, then you will need to look downstream yourself.
 
       You should see at least one.
 
-1. Inspect the logs of the subscriber.
+1. Inspect the logs of the subscriber:
 
    ```shell
    kubectl logs --selector serving.knative.dev/service=message-dumper -c user-container

--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -63,11 +63,11 @@ source is most useful as a bridge from other GCP services, such as
       kubectl -n default create secret generic google-cloud-key --from-file=key.json=knative-source.json
       ```
 
-      The name `gcppubsub-source-key` and `key.json` are pre-configured values
+      `gcppubsub-source-key` and `key.json` are pre-configured values
       in the `controller-manager` StatefulSet which manages your Eventing
       sources.
 
-      The name `google-cloud-key` and `key.json` are pre-configured values in [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml).
+      `google-cloud-key` and `key.json` are pre-configured values in [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml).
 
 ## Deployment
 
@@ -103,14 +103,14 @@ source is most useful as a bridge from other GCP services, such as
    [`MY_GCP_PROJECT` placeholder](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
    in [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml) and apply it.
 
-   If you're in the samples directory, you can replace and apply in one command:
+   If you're in the samples directory, you can replace `MY_GCP_PROJECT` and apply in one command:
 
    ```shell
     sed "s/MY_GCP_PROJECT/$PROJECT_ID/g" gcp-pubsub-source.yaml | \
         kubectl apply --filename -
    ```
 
-   If you are replacing it manually, do so, then apply the resulting YAML:
+   If you are replacing `MY_GCP_PROJECT` manually, then make sure you apply the resulting YAML:
 
    ```shell
    kubectl apply --filename gcp-pubsub-source.yaml
@@ -164,7 +164,7 @@ You should see log lines similar to:
 }
 ```
 
-The log message is a dump of the message sent by `GCP PubSub`. In particular, if you [base-64 decode](https://www.base64decode.org/) the `Data` field, you should see the message we sent:
+The log message is a dump of the message sent by `GCP PubSub`. In particular, if you [base-64 decode](https://www.base64decode.org/) the `Data` field, you should see the sent message:
 
 ```shell
 echo "SGVsbG8gV29ybGQh" | base64 --decode
@@ -172,5 +172,5 @@ echo "SGVsbG8gV29ybGQh" | base64 --decode
 
 Results in: `Hello World!".
 
-See the [PubsubMessage documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage) for more information about the format of the message.
+For more information about the format of the message, see the [PubsubMessage documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage).
 

--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -52,16 +52,17 @@ source is most useful as a bridge from other GCP services, such as
       gcloud iam service-accounts keys create knative-source.json \
         --iam-account=knative-source@$PROJECT_ID.iam.gserviceaccount.com
       ```
-   1. Create a secret on the kubernetes cluster for the downloaded key. You need
-      to store this key in `key.json` in a secret named `gcppubsub-source-key`
-
+   1. Create two secrets on the kubernetes cluster with the downloaded key.
       ```shell
       kubectl -n knative-sources create secret generic gcppubsub-source-key --from-file=key.json=knative-source.json
+      kubectl -n default create secret generic google-cloud-key --from-file=key.json=knative-source.json
       ```
 
       The name `gcppubsub-source-key` and `key.json` are pre-configured values
       in the `controller-manager` StatefulSet which manages your Eventing
       sources.
+
+      The name `google-cloud-key` and `key.json` are pre-configured values in [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml).
 
 ## Deployment
 
@@ -80,15 +81,14 @@ source is most useful as a bridge from other GCP services, such as
        name: in-memory-channel
    ```
 
-   If you're in the samples directory, you can also apply the `channel.yaml`
-   file:
+   If you're in the samples directory, you can apply the `channel.yaml` file:
 
    ```shell
    kubectl apply --filename channel.yaml
    ```
 
-1. Create a GCP PubSub Topic. If you change this, you also need to update the
-   `topic` in the `gcp-pubsub-source.yaml` file.
+1. Create a GCP PubSub Topic. If you change its name (`testing`), you also need to update the
+   `topic` in the [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml) file.
 
    ```shell
    gcloud pubsub topics create testing
@@ -96,39 +96,25 @@ source is most useful as a bridge from other GCP services, such as
 
 1. Replace the
    [`MY_GCP_PROJECT` placeholder](https://cloud.google.com/resource-manager/docs/creating-managing-projects)
-   in `gcp-pubsub-source.yaml`. You should end up with a file which looks like
-   this:
+   in [`gcp-pubsub-source.yaml`](./gcp-pubsub-source.yaml) and apply it.
 
-   ```yaml
-   apiVersion: sources.eventing.knative.dev/v1alpha1
-   kind: GcpPubSubSource
-   metadata:
-   name: testing-source
-   spec:
-     gcpCredsSecret: # A secret in the knative-sources namespace
-       name: google-cloud-key
-       key: key.json
-     googleCloudProject: MY_GCP_PROJECT # Replace this with $PROJECT_ID
-     topic: testing
-     sink:
-       apiVersion: eventing.knative.dev/v1alpha1
-       kind: Channel
-       name: pubsub-test
+   If you're in the samples directory, you can replace and apply in one command.
+
+   ```shell
+    sed "s/MY_GCP_PROJECT/$PROJECT_ID/g" gcp-pubsub-source.yaml | \
+        kubectl apply --filename -
    ```
 
-   You can now create the PubSub Source:
+   If you are replacing it manually, do so, then apply the resulting YAML.
 
    ```shell
    kubectl apply --filename gcp-pubsub-source.yaml
    ```
 
-1. Create a function and subscribe it to the `pubsub-test` channel. For this,
-   you currently need the
-   [`ko` tool](https://github.com/google/go-containerregistry/tree/master/cmd/ko),
-   but this will be replaced with a pre-built image shortly:
+1. Create a function and subscribe it to the `pubsub-test` channel.
 
    ```shell
-   ko apply --filename subscriber.yaml
+   kubectl apply --filename subscriber.yaml
    ```
 
 ## Publish
@@ -162,3 +148,13 @@ You should see log lines similar to:
   "PublishTime": "2018-10-31T00:00:00.00Z"
 }
 ```
+
+The log message is a dump of the message sent by `GCP PubSub`. In particular, if you [base-64 decode](https://www.base64decode.org/) the `Data` field, you should see the message we sent:
+
+```shell
+echo "SGVsbG8gV29ybGQh" | base64 --decode
+```
+
+Results in: `Hello World!".
+
+See the [PubsubMessage documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage) for more information about the format of the message.

--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -54,7 +54,12 @@ source is most useful as a bridge from other GCP services, such as
       ```
    1. Create two secrets on the kubernetes cluster with the downloaded key.
       ```shell
-      kubectl -n knative-sources create secret generic gcppubsub-source-key --from-file=key.json=knative-source.json
+      # Note that the first secret may already have been created when installing
+      # Knative Eventing. The following command will overwrite it. If you don't
+      # want to overwrite it, then skip this command.
+      kubectl -n knative-sources create secret generic gcppubsub-source-key --from-file=key.json=knative-source.json --dry-run -o yaml | kubectl apply --filename -
+
+      # The second secret should not already exist, so just try to create it.
       kubectl -n default create secret generic google-cloud-key --from-file=key.json=knative-source.json
       ```
 

--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -137,6 +137,16 @@ system by looking at what is downstream of the `GcpPubSubSource`. If you
 deployed the [Subscriber](#subscriber), then continue using this section. If
 not, then you will need to look downstream yourself.
 
+1. We need to wait for the downstream pods to get started and receive our event, wait 60 seconds.
+
+    - You can check the status of the downstream pods with:
+
+      ```shell
+      kubectl get pods --selector serving.knative.dev/service=message-dumper
+      ```
+
+      You should see at least one.
+
 1. Inspect the logs of the subscriber.
 
    ```shell

--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -132,10 +132,10 @@ system by looking at what is downstream of the `GcpPubSubSource`. If you
 deployed the [Subscriber](#subscriber), then continue using this section. If
 not, then you will need to look downstream yourself.
 
-1. Use [`kail`](https://github.com/boz/kail) to tail the logs of the subscriber.
+1. Inspect the logs of the subscriber.
 
    ```shell
-   kail -d message-dumper -c user-container --since=10m
+   kubectl logs --selector serving.knative.dev/service=message-dumper -c user-container
    ```
 
 You should see log lines similar to:
@@ -158,3 +158,4 @@ echo "SGVsbG8gV29ybGQh" | base64 --decode
 Results in: `Hello World!".
 
 See the [PubsubMessage documentation](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage) for more information about the format of the message.
+

--- a/eventing/samples/gcp-pubsub-source/subscriber.yaml
+++ b/eventing/samples/gcp-pubsub-source/subscriber.yaml
@@ -10,8 +10,12 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: github.com/knative/eventing-sources/cmd/message_dumper
+            # This corresponds to
+            # https://github.com/knative/eventing-sources/blob/v0.2.1/cmd/message_dumper/dumper.go.
+            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper@sha256:ab5391755f11a5821e7263686564b3c3cd5348522f5b31509963afb269ddcd63
+
 ---
+
 # Subscription from the GcpPubSubSource's output Channel to the Knative Service below.
 
 apiVersion: eventing.knative.dev/v1alpha1
@@ -28,3 +32,4 @@ spec:
       apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: message-dumper
+


### PR DESCRIPTION
Helps with #548 and #541.

## Proposed Changes

- Update the GCP PubSub sample.  
    1. Add the second secret, erroneously removed in #559.
    1. Make the examples easier to apply by using `sed` to replace the required placeholder.
    1. Remove the dependency on `ko` by using the released image from https://github.com/knative/eventing-sources/tree/v0.2.1.
    1. Replace `kail` with `kubectl logs`.
    1. Tolerate `gcppubsub-source-key` already existing.