### PR TITLE
Update old monitoring namespaces

### DIFF
--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -14,7 +14,7 @@ repository. To clone the repository, run the following commands:
 ```shell
 git clone https://github.com/knative/serving knative-serving
 cd knative-serving
-git checkout v0.2.1
+git checkout v0.2.3
 ```
 
 ## Elasticsearch, Kibana, Prometheus & Grafana Setup

--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -52,10 +52,10 @@ To configure and setup monitoring:
    reported `Running` or `Completed`:
 
    ```shell
-   kubectl get pods --namespace monitoring --watch
+   kubectl get pods --namespace knative-monitoring --watch
    ```
 
-   ```
+   ```shell
    NAME                                  READY     STATUS    RESTARTS   AGE
    elasticsearch-logging-0               1/1       Running   0          2d
    elasticsearch-logging-1               1/1       Running   0          2d
@@ -162,10 +162,10 @@ To configure and setup monitoring:
    reported `Running` or `Completed`:
 
    ```shell
-   kubectl get pods --namespace monitoring --watch
+   kubectl get pods --namespace knative-monitoring --watch
    ```
 
-   ```
+   ```shell
    NAME                                  READY     STATUS    RESTARTS   AGE
    fluentd-ds-5kc85                      1/1       Running   0          2d
    fluentd-ds-vhrcq                      1/1       Running   0          2d


### PR DESCRIPTION
Looks like these were lost and missed during a merge conflict.

Fixes #407 
