### PR TITLE
Add annotations to autoscale-go sample.

### DIFF
--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -194,6 +194,10 @@ spec:
 
 Note: for an `hpa.autoscaling.knative.dev` class service, the `autoscaling.knative.dev/target` specifies the CPU percentage target (default `"80"`).
 
+#### Demo
+
+View the [Kubecon Demo](https://youtu.be/OPSIPr-Cybs) of Knative autoscaler customization (32 minutes).
+
 ### Dashboards
 
 View the Knative Serving Scaling and Request dashboards (if configured).

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -212,43 +212,43 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 
 ### Other Experiments
 
-1. Maintain 1000 concurrent requests.
+1. Maintain 100 concurrent requests.
 
    ```
-   docker run --rm -i -t --entrypoint /load-generator -e IP_ADDRESS="${IP_ADDRESS}" \
-     gcr.io/knative-samples/autoscale-go:0.1 \
-     -qps 9999 -concurrency 1000
+   hey -z 60s -c 100 \
+     -host "autoscale-go.default.example.com" \
+     "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5"
    ```
 
-1. Maintain 100 qps with fast requests.
+1. Maintain 100 qps with short requests (10 ms).
 
    ```
-   docker run --rm -i -t --entrypoint /load-generator -e IP_ADDRESS="${IP_ADDRESS}" \
-     gcr.io/knative-samples/autoscale-go:0.1 \
-     -qps 100 -concurrency 9999
+   hey -z 60s -q 100 \
+     -host "autoscale-go.default.example.com" \
+     "http://${IP_ADDRESS?}?sleep=10"
    ```
 
-1. Maintain 100 qps with slow requests.
+1. Maintain 100 qps with long requests (1 sec).
 
    ```
-   docker run --rm -i -t --entrypoint /load-generator -e IP_ADDRESS="${IP_ADDRESS}" \
-     gcr.io/knative-samples/autoscale-go:0.1 \
-     -qps 100 -concurrency 9999 -sleep 500
+   hey -z 60s -q 100 \
+     -host "autoscale-go.default.example.com" \
+     "http://${IP_ADDRESS?}?sleep=1000"
    ```
 
-1. Heavy CPU usage.
+1. Heavy CPU usage (~1 cpu/sec).
 
    ```
-   docker run --rm -i -t --entrypoint /load-generator -e IP_ADDRESS="${IP_ADDRESS}" \
-     gcr.io/knative-samples/autoscale-go:0.1 \
-     -qps 9999 -concurrency 10 -prime 40000000
+   hey -z 60s -q 100 \
+     -host "autoscale-go.default.example.com" \
+     "http://${IP_ADDRESS?}?prime=40000000"
    ```
 
-1. Heavy memory usage.
+1. Heavy memory usage (1 gb/req).
    ```
-   docker run --rm -i -t --entrypoint /load-generator -e IP_ADDRESS="${IP_ADDRESS}" \
-     gcr.io/knative-samples/autoscale-go:0.1 \
-     -qps 9999 -concurrency 5 -bloat 1000
+   hey -z 60s -c 5 \
+     -host "autoscale-go.default.example.com" \
+     "http://${IP_ADDRESS?}?bloat=1000"
    ```
 
 ## Cleanup

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -212,7 +212,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 
 ### Other Experiments
 
-1. Maintain 100 concurrent requests.
+1. Send 60 seconds of traffic maintaining 100 concurrent requests.
 
    ```
    hey -z 60s -c 100 \
@@ -220,7 +220,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
      "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5"
    ```
 
-1. Maintain 100 qps with short requests (10 ms).
+1. Send 60 seconds of traffic maintaining 100 qps with short requests (10 ms).
 
    ```
    hey -z 60s -q 100 \
@@ -228,7 +228,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
      "http://${IP_ADDRESS?}?sleep=10"
    ```
 
-1. Maintain 100 qps with long requests (1 sec).
+1. Send 60 seconds of traffic maintaining 100 qps with long requests (1 sec).
 
    ```
    hey -z 60s -q 100 \
@@ -236,7 +236,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
      "http://${IP_ADDRESS?}?sleep=1000"
    ```
 
-1. Heavy CPU usage (~1 cpu/sec).
+1. Send 60 seconds of traffic with heavy CPU usage (~1 cpu/sec/request, total 100 cpus).
 
    ```
    hey -z 60s -q 100 \
@@ -244,7 +244,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
      "http://${IP_ADDRESS?}?prime=40000000"
    ```
 
-1. Heavy memory usage (1 gb/req).
+1. Send 60 seconds of traffic with heavy memory usage (1 gb/request, total 5 gb).
    ```
    hey -z 60s -c 5 \
      -host "autoscale-go.default.example.com" \

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -142,7 +142,7 @@ The autoscaler supports customization through annotations.  There are two autosc
 1. `kpa.autoscaling.knative.dev` which is the concurrency-based autoscaler described above (the default), and
 2. `hpa.autoscaling.knative.dev` which delegates to the Kubernetes HPA which autoscales on CPU usage.
 
-E.g.
+Example of a Service scaled on CPU:
 
 ```
 apiVersion: serving.knative.dev/v1alpha1
@@ -157,15 +157,14 @@ spec:
         metadata:
           annotations:
             # Standard Kubernetes CPU-based autoscaling.
-            autoscaling.knative.dev/class: hpa.autoscaling.knative.dev
+            autoscaling.knative.dev/class:  hpa.autoscaling.knative.dev
+            autoscaling.knative.dev/metric: cpu
         spec:
           container:
             image: gcr.io/knative-samples/autoscale-go:0.1
 ```
 
-Additionally the autoscaler targets and scaling bounds can be specified in annotations:
-
-E.g.
+Additionally the autoscaler targets and scaling bounds can be specified in annotations.  Example of a Service with custom targets and scale bounds:
 
 ```
 apiVersion: serving.knative.dev/v1alpha1
@@ -179,8 +178,9 @@ spec:
       revisionTemplate:
         metadata:
           annotations:
-            # Knative concurrency-based autoscaling.
-            autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
+            # Knative concurrency-based autoscaling (default).
+            autoscaling.knative.dev/class:  kpa.autoscaling.knative.dev
+            autoscaling.knative.dev/metric: concurrency
             # Target 10 requests in-flight per pod.
             autoscaling.knative.dev/target: "10"
             # Disable scale to zero with a minScale of 1.

--- a/serving/samples/autoscale-go/service.yaml
+++ b/serving/samples/autoscale-go/service.yaml
@@ -20,6 +20,10 @@ spec:
   runLatest:
     configuration:
       revisionTemplate:
+        metadata:
+          annotations:
+            # Target 10 in-flight-requests per pod.
+            autoscaling.knative.dev/target: "10"
         spec:
           container:
             image: gcr.io/knative-samples/autoscale-go:0.1


### PR DESCRIPTION
## Proposed Changes

- Add annotations to autoscale-go sample to demonstrate CPU-based autoscaling, setting custom targets and scale bounds.
- Use `hey` for load generation instead of custom tool.
- Link to Kubecon demo of autoscaler customization.