### PR TITLE
Instruction to make a Route/KService visible only inside cluster.

### DIFF
--- a/serving/README.md
+++ b/serving/README.md
@@ -76,6 +76,7 @@ in the Knative Serving repository.
 ## Configuration and Networking
 
 - [Configuring outbound network access](./outbound-network-access.md)
+- [Configuring cluster local routes](./cluster-local-route.md)
 - [Using a custom domain](./using-a-custom-domain.md)
 - [Assigning a static IP address for Knative on Google Kubernetes Engine](./gke-assigning-static-ip-address.md)
 

--- a/serving/cluster-local-route.md
+++ b/serving/cluster-local-route.md
@@ -1,4 +1,4 @@
-# Making your Routes local to the cluster.
+# Making your Routes local to the cluster
 
 In Knative 0.3.x or later, all Routes with a domain suffix of
 `svc.cluster.local` will only be visible inside the cluster.

--- a/serving/cluster-local-route.md
+++ b/serving/cluster-local-route.md
@@ -1,0 +1,18 @@
+# Making your Routes local to the cluster.
+
+In Knative 0.3.x or later, all Routes with a domain suffix of
+`svc.cluster.local` will only be visible inside the cluster.
+
+This can be done by changing the `config-domain` config map as instructed
+[here](./using-a-custom-domain.md).
+
+In addition to that, you can set the label
+`serving.knative.dev/visibility=cluster-local` on your Route or KService to
+achieve the same effect.  For example, to make the Route `helloworld-go` in
+`default` namespace cluster local, run
+
+```shell
+kubectl label route helloworld-go serving.knative.dev/visibility=cluster-local
+```
+
+if such label was not already set when creating the Route.

--- a/serving/cluster-local-route.md
+++ b/serving/cluster-local-route.md
@@ -6,13 +6,12 @@ In Knative 0.3.x or later, all Routes with a domain suffix of
 This can be done by changing the `config-domain` config map as instructed
 [here](./using-a-custom-domain.md).
 
-In addition to that, you can set the label
+You can also set the label
 `serving.knative.dev/visibility=cluster-local` on your Route or KService to
-achieve the same effect.  For example, to make the Route `helloworld-go` in
-`default` namespace cluster local, run
+achieve the same effect.
+
+For example, if you didn't set a label when you created the Route `helloworld-go` and you want to make it local to the `default namespace cluster, run:
 
 ```shell
 kubectl label route helloworld-go serving.knative.dev/visibility=cluster-local
 ```
-
-if such label was not already set when creating the Route.


### PR DESCRIPTION
## Proposed Changes

- Update instructions to show how to make a Route/KService visible only inside a cluster.
