### PR TITLE
Improve Docker for Mac installation guide

### DIFF
--- a/install/Knative-with-Docker-for-Mac.md
+++ b/install/Knative-with-Docker-for-Mac.md
@@ -32,7 +32,7 @@ Knative depends on Istio. Run the following to install Istio. (This changes
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://raw.githubusercontent.com/knative/serving/v0.2.1/third_party/istio-1.0.2/istio.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -59,12 +59,13 @@ rerun the command to see the current status.
 Next, install [Knative Serving](https://github.com/knative/serving).
 
 Because you have limited resources available, use the
-`https://github.com/knative/serving/releases/download/v0.2.1/release-lite.yaml`
+`https://github.com/knative/serving/releases/download/v0.2.2/release-lite.yaml`
 file, which omits some of the monitoring components to reduce the memory used by
 the Knative components. To use the provided `release-lite.yaml` release, run:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.2.1/release-lite.yaml
+curl -L https://github.com/knative/serving/releases/download/v0.2.2/release-lite.yaml \
+  | kubectl apply --filename -
 ```
 
 > Note: Unlike minikube, we're not changing the LoadBalancer to a NodePort here.


### PR DESCRIPTION
## Proposed Changes

 + Use knative v0.2.2 like on minikube
 + Fix the instructions to install knative serving

Signed-off-by: David Gageot <david@gageot.net>

Fixes #696
