### PR TITLE
serving/samples/helloworld-php: use development php.ini

### DIFF
--- a/serving/samples/helloworld-php/Dockerfile
+++ b/serving/samples/helloworld-php/Dockerfile
@@ -8,6 +8,12 @@ COPY index.php /var/www/html/
 # Use the PORT environment variable in Apache configuration files.
 RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
 
+# Configure PHP for development.
+# Switch to the production php.ini for production operations.
+# RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+# https://hub.docker.com/_/php#configuration
+RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
 # Configure and document the service HTTP port.
 ENV PORT 8080
 EXPOSE $PORT

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -47,6 +47,12 @@ recreate the source files from this folder.
    # Use the PORT environment variable in Apache configuration files.
    RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/apache2/ports.conf
 
+   # Configure PHP for development.
+   # Switch to the production php.ini for production operations.
+   # RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+   # https://hub.docker.com/_/php#configuration
+   RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+
    # Configure and document the service HTTP port.
    ENV PORT 8080
    EXPOSE $PORT


### PR DESCRIPTION
Fixes #695

## Proposed Changes

- Use the development php.ini shipped in the image but not "activated"
- Add comment pointing out the use of the production configuration
- Add comment linking to the documentation on the image README
