### PR TITLE
Update docs to use correct ingress gateway service.

### DIFF
--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -123,12 +123,22 @@ If you'd like to view the available sample apps and deploy one of your choosing,
 head to the [sample apps](../serving/samples/README.md) repo.
 
 > Note: When looking up the IP address to use for accessing your app, you need
-> to look up the NodePort for the `knative-ingressgateway` as well as the IP
+> to look up the NodePort for the `istio-ingressgateway` well as the IP
 > address used for Minikube. You can use the following command to look up the
 > value to use for the {IP_ADDRESS} placeholder used in the samples:
 
 ```shell
-echo $(minikube ip):$(kubectl get svc knative-ingressgateway --namespace istio-system --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+echo $(minikube ip):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 ```
 
 ## Cleaning up

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -131,9 +131,9 @@ head to the [sample apps](../serving/samples/README.md) repo.
 # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -258,7 +258,7 @@ spec:
 # Wait for the hello pod to enter its `Running` state
 oc get pod --watch
 
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -261,9 +261,9 @@ oc get pod --watch
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -257,8 +257,19 @@ spec:
 ' | oc create -f -
 # Wait for the hello pod to enter its `Running` state
 oc get pod --watch
+
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
 # Call the service
-export IP_ADDRESS=$(oc get svc knative-ingressgateway -n istio-system -o 'jsonpath={.status.loadBalancer.ingress[0].ip}')
+export IP_ADDRESS=$(oc get svc $INGRESSGATEWAY -n istio-system -o 'jsonpath={.status.loadBalancer.ingress[0].ip}')
 # This should output 'Hello World: Go Sample v1!'
 curl -H "Host: helloworld-go.myproject.example.com" http://$IP_ADDRESS
 ```

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -219,9 +219,9 @@ head to the [sample apps](../serving/samples/README.md) repo.
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -216,7 +216,7 @@ head to the [sample apps](../serving/samples/README.md) repo.
 > value to use for the {IP_ADDRESS} placeholder used in the samples:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -211,12 +211,22 @@ If you'd like to view the available sample apps and deploy one of your choosing,
 head to the [sample apps](../serving/samples/README.md) repo.
 
 > Note: When looking up the IP address to use for accessing your app, you need
-> to look up the NodePort for the `knative-ingressgateway` as well as the IP
+> to look up the NodePort for the `istio-ingressgateway` well as the IP
 > address used for OpenShift. You can use the following command to look up the
 > value to use for the {IP_ADDRESS} placeholder used in the samples:
 
 ```shell
-export IP_ADDRESS=$(oc get node  -o 'jsonpath={.items[0].status.addresses[0].address}'):$(oc get svc knative-ingressgateway -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+export IP_ADDRESS=$(oc get node  -o 'jsonpath={.items[0].status.addresses[0].address}'):$(oc get svc $INGRESSGATEWAY -n istio-system -o 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 ```
 
 ## Cleaning up

--- a/install/getting-started-knative-app.md
+++ b/install/getting-started-knative-app.md
@@ -94,9 +94,9 @@ assigned an external IP address.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/install/getting-started-knative-app.md
+++ b/install/getting-started-knative-app.md
@@ -91,7 +91,7 @@ assigned an external IP address.
 1. To find the IP address for your service, enter:
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/install/getting-started-knative-app.md
+++ b/install/getting-started-knative-app.md
@@ -91,11 +91,20 @@ assigned an external IP address.
 1. To find the IP address for your service, enter:
 
    ```shell
-    kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
 
-    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-    knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
 
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
+
+   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+   istio-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
    Take note of the `EXTERNAL-IP` address.
@@ -103,8 +112,7 @@ assigned an external IP address.
    You can also export the IP address as a variable with the following command:
 
    ```shell
-   export IP_ADDRESS=$(kubectl get svc knative-ingressgateway --namespace istio-system --output 'jsonpath={.status.loadBalancer.ingress[0].ip}')
-
+   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY --namespace istio-system --output 'jsonpath={.status.loadBalancer.ingress[0].ip}')
    ```
 
    > Note: if you use minikube or a baremetal cluster that has no external load
@@ -113,7 +121,7 @@ assigned an external IP address.
    > `NodeIP` and `NodePort`, enter the following command:
 
    ```shell
-   export IP_ADDRESS=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc knative-ingressgateway --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+   export IP_ADDRESS=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
    ```
 
 1. To find the host URL for your service, enter:

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -60,9 +60,9 @@ Run following command to configure the external IP of the
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -57,7 +57,7 @@ Run following command to configure the external IP of the
 `istio-ingressgateway` service to the static IP that you reserved:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -51,22 +51,31 @@ In the
     address through a config-map later.
 1.  Copy the **External Address** of the static IP you created.
 
-## Step 2: Update the external IP of the `knative-ingressgateway` service
+## Step 2: Update the external IP of `istio-ingressgateway` service
 
 Run following command to configure the external IP of the
-`knative-ingressgateway` service to the static IP that you reserved:
+`istio-ingressgateway` service to the static IP that you reserved:
 
 ```shell
-kubectl patch svc knative-ingressgateway --namespace istio-system --patch '{"spec": { "loadBalancerIP": "<your-reserved-static-ip>" }}'
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+kubectl patch svc $INGRESSGATEWAY --namespace istio-system --patch '{"spec": { "loadBalancerIP": "<your-reserved-static-ip>" }}'
 ```
 
-## Step 3: Verify the static IP address of `knative-ingressgateway` service
+## Step 3: Verify the static IP address of `istio-ingressgateway` service
 
-Run the following command to ensure that the external IP of the
-"knative-ingressgateway" service has been updated:
+Run the following command to ensure that the external IP of the ingressgateway service has been updated:
 
 ```shell
-kubectl get svc knative-ingressgateway --namespace istio-system
+kubectl get svc $INGRESSGATEWAY --namespace istio-system
 ```
 
 The output should show the assigned static IP address under the EXTERNAL-IP
@@ -74,7 +83,7 @@ column:
 
 ```
 NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                      AGE
-knative-ingressgateway   LoadBalancer   12.34.567.890   98.765.43.210   80:32380/TCP,443:32390/TCP,32400:32400/TCP   5m
+xxxxxxx-ingressgateway   LoadBalancer   12.34.567.890   98.765.43.210   80:32380/TCP,443:32390/TCP,32400:32400/TCP   5m
 ```
 
 > Note: Updating the external IP address can take several minutes.

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -28,7 +28,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
 1. Find the ingress hostname and IP and export as an environment variable:
    ```
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -31,9 +31,9 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -28,7 +28,17 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
 1. Find the ingress hostname and IP and export as an environment variable:
    ```
-   export IP_ADDRESS=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   export IP_ADDRESS=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
    ```
 
 ## Load the Service

--- a/serving/samples/blue-green-deployment.md
+++ b/serving/samples/blue-green-deployment.md
@@ -87,10 +87,11 @@ with Knative.
 > Note: If you don't have a custom domain configured for use with Knative, you
 > can interact with your app using cURL requests if you have the host URL and IP
 > address:
-> `curl -H "Host: blue-green-demo.default.example.com" http://IP_ADDRESS`  
+> `curl -H "Host: blue-green-demo.default.example.com" http://IP_ADDRESS`
 >  Knative creates the host URL by combining the name of your Route object, the namespace,
 > and `example.com`, if you haven't configured a custom domain. For example, `[route-name].[namespace].example.com`.
-> You can get the IP address by entering `kubectl get svc knative-ingressgateway --namespace istio-system`
+> You can get the IP address by entering `kubectl get svc istio-ingressgateway --namespace istio-system` (or
+> `kubectl get svc istio-ingressgateway --namespace istio-system` if using Knative 0.2.x or prior versions)
 > and copying the `EXTERNAL-IP` returned by that command. See [Interacting with your app](../../install/getting-started-knative-app.md#interacting-with-your-app)
 > for more information.
 

--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -174,9 +174,21 @@ export SERVICE_HOST=$(kubectl get route private-repos \
 ```
 
 ```shell
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+INGRESSGATEWAY_LABEL=knative
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+    INGRESSGATEWAY_LABEL=istio
+fi
+
 # Put the IP address into an environment variable
-export SERVICE_IP=$(kubectl get svc knative-ingressgateway --namespace istio-system \
-  --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
+export SERVICE_IP=$(kubectl get svc $INGRESSGATEWAY --namespace istio-system \
+    --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
 ```
 
 > Note: If your cluster is running outside a cloud provider (for example, on
@@ -184,8 +196,8 @@ export SERVICE_IP=$(kubectl get svc knative-ingressgateway --namespace istio-sys
 > use the Istio `hostIP` and `nodePort` as the service IP:
 
 ```shell
-export SERVICE_IP=$(kubectl get po --selector knative=ingressgateway --namespace istio-system \
-  --output 'jsonpath= .  {.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway \
+export SERVICE_IP=$(kubectl get po --selector $INGRESSGATEWAY_LABEL=ingressgateway --namespace istio-system \
+  --output 'jsonpath= .  {.items[0].status.hostIP}'):$(kubectl get svc $INGRESSGATEWAY \
   --namespace istio-system --output 'jsonpath={.spec.ports[? (@.port==80)].nodePort}')
 ```
 

--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -178,9 +178,9 @@ export SERVICE_HOST=$(kubectl get route private-repos \
 INGRESSGATEWAY=knative-ingressgateway
 INGRESSGATEWAY_LABEL=knative
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
     INGRESSGATEWAY_LABEL=istio

--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -174,7 +174,7 @@ export SERVICE_HOST=$(kubectl get route private-repos \
 ```
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 INGRESSGATEWAY_LABEL=knative
 

--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -59,7 +59,7 @@ To access this service using `curl`, we first need to determine its ingress
 address:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -62,9 +62,9 @@ address:
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -59,9 +59,19 @@ To access this service using `curl`, we first need to determine its ingress
 address:
 
 ```shell
-$ watch kubectl get svc knative-ingressgateway --namespace istio-system
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+watch kubectl get svc $INGRESSGATEWAY --namespace istio-system
 NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 Once the `EXTERNAL-IP` gets assigned to the cluster, enter the follow commands
@@ -73,7 +83,7 @@ variables:
 export SERVICE_HOST=`kubectl get route buildpack-sample-app --output jsonpath="{.status.domain}"`
 
 # Put the ingress IP into an environment variable.
-export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 Now curl the service IP to make sure the deployment succeeded:

--- a/serving/samples/buildpack-function-nodejs/README.md
+++ b/serving/samples/buildpack-function-nodejs/README.md
@@ -60,9 +60,9 @@ address:
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/samples/buildpack-function-nodejs/README.md
+++ b/serving/samples/buildpack-function-nodejs/README.md
@@ -57,9 +57,19 @@ To access this service using `curl`, we first need to determine its ingress
 address:
 
 ```shell
-watch kubectl get svc knative-ingressgateway --namespace istio-system
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+watch kubectl get svc $INGRESSGATEWAY --namespace istio-system
 NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 Once the `EXTERNAL-IP` gets assigned to the cluster, enter the follow commands
@@ -71,7 +81,7 @@ variables:
 $ export SERVICE_HOST=`kubectl get route buildpack-function --output jsonpath="{.status.domain}"`
 
 # Put the ingress IP into an environment variable.
-$ export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+$ export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 Now curl the service IP to make sure the deployment succeeded:

--- a/serving/samples/buildpack-function-nodejs/README.md
+++ b/serving/samples/buildpack-function-nodejs/README.md
@@ -57,7 +57,7 @@ To access this service using `curl`, we first need to determine its ingress
 address:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/grpc-ping-go/README.md
+++ b/serving/samples/grpc-ping-go/README.md
@@ -42,9 +42,9 @@ export SERVICE_HOST=`kubectl get route grpc-ping --output jsonpath="{.status.dom
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/samples/grpc-ping-go/README.md
+++ b/serving/samples/grpc-ping-go/README.md
@@ -39,7 +39,7 @@ kubectl apply --filename serving/samples/grpc-ping-go/sample.yaml
 # Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route grpc-ping --output jsonpath="{.status.domain}"`
 
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/grpc-ping-go/README.md
+++ b/serving/samples/grpc-ping-go/README.md
@@ -39,8 +39,18 @@ kubectl apply --filename serving/samples/grpc-ping-go/sample.yaml
 # Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route grpc-ping --output jsonpath="{.status.domain}"`
 
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
 # Put the ingress IP into an environment variable.
-export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 1. Use the client to send message streams to the gRPC server.

--- a/serving/samples/helloworld-clojure/README.md
+++ b/serving/samples/helloworld-clojure/README.md
@@ -143,7 +143,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-clojure/README.md
+++ b/serving/samples/helloworld-clojure/README.md
@@ -138,16 +138,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 
    ```
 

--- a/serving/samples/helloworld-clojure/README.md
+++ b/serving/samples/helloworld-clojure/README.md
@@ -146,9 +146,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -143,9 +143,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -135,17 +135,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. To find the URL for your service, use

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -140,7 +140,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-dart/README.md
+++ b/serving/samples/helloworld-dart/README.md
@@ -144,9 +144,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-dart/README.md
+++ b/serving/samples/helloworld-dart/README.md
@@ -136,16 +136,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 
    ```
 

--- a/serving/samples/helloworld-dart/README.md
+++ b/serving/samples/helloworld-dart/README.md
@@ -141,7 +141,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-elixir/README.md
+++ b/serving/samples/helloworld-elixir/README.md
@@ -164,7 +164,7 @@ above.
     for the service to get asssigned an external IP address.
 
     ```shell
-    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+    # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
     INGRESSGATEWAY=knative-ingressgateway
 
     # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-elixir/README.md
+++ b/serving/samples/helloworld-elixir/README.md
@@ -167,9 +167,9 @@ above.
     # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
     INGRESSGATEWAY=knative-ingressgateway
 
-    # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-    # We should use `istio-ingressgateway` since `knative-ingressgateway`
-    # will be removed in 0.4.
+    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+    # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+    # will be removed in Knative v0.4.
     if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
         INGRESSGATEWAY=istio-ingressgateway
     fi

--- a/serving/samples/helloworld-elixir/README.md
+++ b/serving/samples/helloworld-elixir/README.md
@@ -159,22 +159,27 @@ above.
       for your app.
     - Automatically scale your pods up and down (including to zero active pods).
 
-1.  To find the IP address for your service, use
-    `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1.  To find the IP address for your service, use these commands to get the
     ingress IP for your cluster. If your cluster is new, it may take sometime
     for the service to get asssigned an external IP address.
 
-        ```
-        kubectl get svc knative-ingressgateway --namespace istio-system
+    ```shell
+    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+    INGRESSGATEWAY=knative-ingressgateway
 
-        NAME                     TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                      AGE
+    # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+    # We should use `istio-ingressgateway` since `knative-ingressgateway`
+    # will be removed in 0.4.
+    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+        INGRESSGATEWAY=istio-ingressgateway
+    fi
 
-    knative-ingressgateway LoadBalancer 10.35.254.218 35.225.171.32
-    80:32380/TCP,443:32390/TCP,32400:32400/TCP 1h
+    kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
+    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+    xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
     ```
 
-    ```
 
 1.  To find the URL for your service, use
 

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -148,15 +148,24 @@ folder) you're ready to build and deploy the sample app.
    asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
    ```
 
    Example:
 
    ```shell
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. Run the following command to find the domain URL for your service:

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -151,9 +151,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -148,7 +148,7 @@ folder) you're ready to build and deploy the sample app.
    asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-haskell/README.md
+++ b/serving/samples/helloworld-haskell/README.md
@@ -169,7 +169,7 @@ folder) you're ready to build and deploy the sample app.
    for the service to get assigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-haskell/README.md
+++ b/serving/samples/helloworld-haskell/README.md
@@ -172,9 +172,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-haskell/README.md
+++ b/serving/samples/helloworld-haskell/README.md
@@ -164,23 +164,32 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, enter
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, enter these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take some time
    for the service to get assigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 
    ```
 
    For minikube or bare-metal, get IP_ADDRESS by running the following command
 
    ```shell
-   echo $(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc knative-ingressgateway --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+   echo $(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 
    ```
 

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -174,10 +174,20 @@ folder) you're ready to build and deploy the sample app.
    take sometime for the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. To find the URL for your service, use

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -174,7 +174,7 @@ folder) you're ready to build and deploy the sample app.
    take sometime for the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -177,9 +177,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -170,7 +170,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -165,17 +165,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. To find the URL for your service, use

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -173,9 +173,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -115,9 +115,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -112,7 +112,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -107,16 +107,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 
    ```
 

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -123,17 +123,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. To find the URL for your service, use

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -131,9 +131,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -128,7 +128,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -139,7 +139,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -142,9 +142,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -134,17 +134,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, use these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. To find the URL for your service, use

--- a/serving/samples/helloworld-rust/README.md
+++ b/serving/samples/helloworld-rust/README.md
@@ -162,16 +162,25 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, enter
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
+1. To find the IP address for your service, enter these commands to get the
    ingress IP for your cluster. If your cluster is new, it may take sometime for
    the service to get asssigned an external IP address.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 
    ```
 

--- a/serving/samples/helloworld-rust/README.md
+++ b/serving/samples/helloworld-rust/README.md
@@ -167,7 +167,7 @@ folder) you're ready to build and deploy the sample app.
    the service to get asssigned an external IP address.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-rust/README.md
+++ b/serving/samples/helloworld-rust/README.md
@@ -170,9 +170,9 @@ folder) you're ready to build and deploy the sample app.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/helloworld-vertx/README.md
+++ b/serving/samples/helloworld-vertx/README.md
@@ -218,7 +218,7 @@ To verify that your sample app has been successfully deployed:
    created.
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/helloworld-vertx/README.md
+++ b/serving/samples/helloworld-vertx/README.md
@@ -218,14 +218,24 @@ To verify that your sample app has been successfully deployed:
    created.
 
    ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
    ```
 
    Example result:
 
    ```shell
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. Retrieve the URL for your service, by running the following `kubectl get`

--- a/serving/samples/helloworld-vertx/README.md
+++ b/serving/samples/helloworld-vertx/README.md
@@ -221,9 +221,9 @@ To verify that your sample app has been successfully deployed:
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -67,7 +67,7 @@ docker push "${REPO}/serving/samples/knative-routing-go"
 5. Replace the image reference path with our published image path in the
    configuration file `serving/samples/knative-routing-go/sample.yaml`:
 
-   - Manually replace:  
+   - Manually replace:
      `image: github.com/knative/docs/serving/samples/knative-routing-go` with
      `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/knative-routing-go`
 
@@ -102,7 +102,17 @@ kubectl get Gateway --namespace knative-serving --output yaml
 - Check the corresponding Kubernetes service for the shared Gateway:
 
 ```
-kubectl get svc knative-ingressgateway --namespace istio-system --output yaml
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+kubectl get svc $INGRESSGATEWAY --namespace istio-system --output yaml
 ```
 
 - Inspect the deployed Knative services with:
@@ -118,8 +128,18 @@ You should see 2 Knative services: `search-service` and `login-service`.
 1. Find the shared Gateway IP and export as an environment variable:
 
 ```shell
-export GATEWAY_IP=`kubectl get svc knative-ingressgateway --namespace istio-system \
-  --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+export GATEWAY_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system \
+    --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
 ```
 
 2. Find the `Search` service route and export as an environment variable:
@@ -165,12 +185,22 @@ kubectl get VirtualService entry-route --output yaml
 
 3.  Send a request to the `Search` service and the `Login` service by using
     corresponding URIs. You should get the same results as directly accessing
-    these services.  
+    these services.
      \_ Get the ingress IP:
 
     ```shell
-    export GATEWAY_IP=`kubectl get svc knative-ingressgateway --namespace istio-system \
-    --output jsonpath="{.status.loadBalancer.ingress[_]['ip']}"`
+    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+    INGRESSGATEWAY=knative-ingressgateway
+
+    # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+    # We should use `istio-ingressgateway` since `knative-ingressgateway`
+    # will be removed in 0.4.
+    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+        INGRESSGATEWAY=istio-ingressgateway
+    fi
+
+    export GATEWAY_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system \
+        --output jsonpath="{.status.loadBalancer.ingress[_]['ip']}"`
     ```
 
         * Send a request to the Search service:

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -102,7 +102,7 @@ kubectl get Gateway --namespace knative-serving --output yaml
 - Check the corresponding Kubernetes service for the shared Gateway:
 
 ```
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
@@ -128,7 +128,7 @@ You should see 2 Knative services: `search-service` and `login-service`.
 1. Find the shared Gateway IP and export as an environment variable:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
@@ -189,7 +189,7 @@ kubectl get VirtualService entry-route --output yaml
      \_ Get the ingress IP:
 
     ```shell
-    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+    # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
     INGRESSGATEWAY=knative-ingressgateway
 
     # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -105,9 +105,9 @@ kubectl get Gateway --namespace knative-serving --output yaml
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi
@@ -131,9 +131,9 @@ You should see 2 Knative services: `search-service` and `login-service`.
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi
@@ -192,9 +192,9 @@ kubectl get VirtualService entry-route --output yaml
     # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
     INGRESSGATEWAY=knative-ingressgateway
 
-    # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-    # We should use `istio-ingressgateway` since `knative-ingressgateway`
-    # will be removed in 0.4.
+    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+    # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+    # will be removed in Knative v0.4.
     if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
         INGRESSGATEWAY=istio-ingressgateway
     fi

--- a/serving/samples/rest-api-go/README.md
+++ b/serving/samples/rest-api-go/README.md
@@ -107,7 +107,7 @@ To access this service via `curl`, you need to determine its ingress address.
 1. To determine if your service is ready:
 
 ```
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 INGRESSGATEWAY_LABEL=knative
 

--- a/serving/samples/rest-api-go/README.md
+++ b/serving/samples/rest-api-go/README.md
@@ -111,9 +111,9 @@ To access this service via `curl`, you need to determine its ingress address.
 INGRESSGATEWAY=knative-ingressgateway
 INGRESSGATEWAY_LABEL=knative
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
     INGRESSGATEWAY_LABEL=istio

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -212,7 +212,7 @@ container for the application.
    address:
 
    ```shell
-   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
    # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -215,9 +215,9 @@ container for the application.
    # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
    INGRESSGATEWAY=knative-ingressgateway
 
-   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-   # We should use `istio-ingressgateway` since `knative-ingressgateway`
-   # will be removed in 0.4.
+   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+   # will be removed in Knative v0.4.
    if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
        INGRESSGATEWAY=istio-ingressgateway
    fi

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -212,11 +212,20 @@ container for the application.
    address:
 
    ```shell
-   $ kubectl get svc knative-ingressgateway --namespace istio-system
+   # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+   INGRESSGATEWAY=knative-ingressgateway
+
+   # In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+   # We should use `istio-ingressgateway` since `knative-ingressgateway`
+   # will be removed in 0.4.
+   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+       INGRESSGATEWAY=istio-ingressgateway
+   fi
+
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
 
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
 1. To find the URL for your service, type:

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -66,7 +66,7 @@ docker push "${REPO}/serving/samples/telemetry-go"
 5.  Replace the image reference path with our published image path in the
     configuration file (`serving/samples/telemetry-go/sample.yaml`):
 
-    - Manually replace:  
+    - Manually replace:
       `image: github.com/knative/docs/serving/samples/telemetry-go` with
       `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/telemetry-go`
 
@@ -114,18 +114,28 @@ kubectl get revisions --output yaml
 
 To access this service via `curl`, you need to determine its ingress address.
 
-1. To determine if your service is ready:  
+1. To determine if your service is ready:
    Check the status of your Knative gateway:
 
 ```
-kubectl get svc knative-ingressgateway --namespace istio-system --watch
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+kubectl get svc $INGRESSGATEWAY --namespace istio-system --watch
 ```
 
 When the service is ready, you'll see an IP address in the `EXTERNAL-IP` field:
 
 ```
 NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 CTRL+C to end watch.
@@ -151,7 +161,18 @@ status:
 
 ```
 export SERVICE_HOST=`kubectl get route telemetrysample-route --output jsonpath="{.status.domain}"`
-export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 3. Make a request to the service to see the `Hello World!` message:

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -118,7 +118,7 @@ To access this service via `curl`, you need to determine its ingress address.
    Check the status of your Knative gateway:
 
 ```
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
@@ -162,7 +162,7 @@ status:
 ```
 export SERVICE_HOST=`kubectl get route telemetrysample-route --output jsonpath="{.status.domain}"`
 
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -121,9 +121,9 @@ To access this service via `curl`, you need to determine its ingress address.
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi
@@ -165,9 +165,9 @@ export SERVICE_HOST=`kubectl get route telemetrysample-route --output jsonpath="
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -142,7 +142,7 @@ using `kubectl`. First, is there an ingress service, and does it have an
 `EXTERNAL-IP`:
 
 ```
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
@@ -174,7 +174,7 @@ IP, so let's capture the IP and Host URL in variables so that we can use them in
 # Put the Host URL into an environment variable.
 export SERVICE_HOST=`kubectl get route thumb --output jsonpath="{.status.domain}"`
 
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 INGRESSGATEWAY_LABEL=knative
 

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -145,9 +145,9 @@ using `kubectl`. First, is there an ingress service, and does it have an
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi
@@ -178,9 +178,9 @@ export SERVICE_HOST=`kubectl get route thumb --output jsonpath="{.status.domain}
 INGRESSGATEWAY=knative-ingressgateway
 INGRESSGATEWAY_LABEL=knative
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
     INGRESSGATEWAY_LABEL=istio

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -142,9 +142,19 @@ using `kubectl`. First, is there an ingress service, and does it have an
 `EXTERNAL-IP`:
 
 ```
-kubectl get svc knative-ingressgateway --namespace istio-system
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+kubectl get svc $INGRESSGATEWAY --namespace istio-system
 NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
 ```
 
 > Note: It can take a few seconds for the service to show an `EXTERNAL-IP`.
@@ -164,8 +174,20 @@ IP, so let's capture the IP and Host URL in variables so that we can use them in
 # Put the Host URL into an environment variable.
 export SERVICE_HOST=`kubectl get route thumb --output jsonpath="{.status.domain}"`
 
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+INGRESSGATEWAY_LABEL=knative
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+    INGRESSGATEWAY_LABEL=istio
+fi
+
 # Put the ingress IP into an environment variable.
-export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 If your cluster is running outside a cloud provider (for example on Minikube),
@@ -173,7 +195,7 @@ your services will never get an external IP address. In that case, use the istio
 `hostIP` and `nodePort` as the service IP:
 
 ```shell
-export SERVICE_IP=$(kubectl get po --selector knative=ingressgateway --namespace istio-system --output 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc knative-ingressgateway --namespace istio-system --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+export SERVICE_IP=$(kubectl get po --selector $INGRESSGATEWAY_LABEL=ingressgateway --namespace istio-system --output 'jsonpath={.items[0].status.hostIP}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 ```
 
 ### Ping

--- a/serving/samples/traffic-splitting/README.md
+++ b/serving/samples/traffic-splitting/README.md
@@ -17,7 +17,7 @@ configuration.
    configuration files
    (`serving/samples/traffic-splitting/updated_configuration.yaml`:
 
-   - Manually replace:  
+   - Manually replace:
      `image: github.com/knative/docs/serving/samples/rest-api-go` with
      `image: <YOUR_CONTAINER_REGISTRY>/serving/samples/rest-api-go`
 
@@ -43,14 +43,25 @@ kubectl apply --filename serving/samples/traffic-splitting/updated_configuration
 kubectl get route --output yaml
 ```
 
-4. When the new route is ready, you can access the new endpoints:  
+4. When the new route is ready, you can access the new endpoints:
    The hostname and IP address can be found in the same manner as the
    [Creating a RESTful Service](../rest-api-go) sample:
 
 ```
 export SERVICE_HOST=`kubectl get route stock-route-example --output jsonpath="{.status.domain}"`
-export SERVICE_IP=`kubectl get svc knative-ingressgateway --namespace istio-system \
---output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system \
+    --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
 - Make a request to the index endpoint:

--- a/serving/samples/traffic-splitting/README.md
+++ b/serving/samples/traffic-splitting/README.md
@@ -53,9 +53,9 @@ export SERVICE_HOST=`kubectl get route stock-route-example --output jsonpath="{.
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/samples/traffic-splitting/README.md
+++ b/serving/samples/traffic-splitting/README.md
@@ -50,7 +50,7 @@ kubectl get route --output yaml
 ```
 export SERVICE_HOST=`kubectl get route stock-route-example --output jsonpath="{.status.domain}"`
 
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/using-a-custom-domain.md
+++ b/serving/using-a-custom-domain.md
@@ -90,7 +90,7 @@ You should see the full customized domain: `helloworld-go.default.mydomain.com`.
 And you can check the IP address of your Knative gateway by running:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 export INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
@@ -109,7 +109,7 @@ You can map the domain to the IP address of your Knative gateway in your local
 machine with:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.

--- a/serving/using-a-custom-domain.md
+++ b/serving/using-a-custom-domain.md
@@ -90,7 +90,17 @@ You should see the full customized domain: `helloworld-go.default.mydomain.com`.
 And you can check the IP address of your Knative gateway by running:
 
 ```shell
-kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+export INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    export INGRESSGATEWAY=istio-ingressgateway
+fi
+
+kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"
 ```
 
 ## Local DNS setup
@@ -99,7 +109,17 @@ You can map the domain to the IP address of your Knative gateway in your local
 machine with:
 
 ```shell
-export GATEWAY_IP=`kubectl get svc knative-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+export GATEWAY_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
 
 # helloworld-go is the generated Knative Route of "helloworld-go" sample.
 # You need to replace it with your own Route in your project.

--- a/serving/using-a-custom-domain.md
+++ b/serving/using-a-custom-domain.md
@@ -93,9 +93,9 @@ And you can check the IP address of your Knative gateway by running:
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 export INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     export INGRESSGATEWAY=istio-ingressgateway
 fi
@@ -112,9 +112,9 @@ machine with:
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/using-external-dns-on-gcp.md
+++ b/serving/using-external-dns-on-gcp.md
@@ -371,9 +371,9 @@ into Knative gateway service:
 # In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
-# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
-# We should use `istio-ingressgateway` since `knative-ingressgateway`
-# will be removed in 0.4.
+# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+# will be removed in Knative v0.4.
 if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
     INGRESSGATEWAY=istio-ingressgateway
 fi

--- a/serving/using-external-dns-on-gcp.md
+++ b/serving/using-external-dns-on-gcp.md
@@ -368,7 +368,17 @@ In order to publish the Knative Gateway service, the annotation
 into Knative gateway service:
 
 ```shell
-kubectl edit svc knative-ingressgateway --namespace istio-system
+# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+INGRESSGATEWAY=knative-ingressgateway
+
+# In Knative 0.3.x the use of `knative-ingressgateway` is deprecated.
+# We should use `istio-ingressgateway` since `knative-ingressgateway`
+# will be removed in 0.4.
+if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+    INGRESSGATEWAY=istio-ingressgateway
+fi
+
+kubectl edit svc $INGRESSGATEWAY --namespace istio-system
 ```
 
 This command opens your default text editor and allows you to add the annotation

--- a/serving/using-external-dns-on-gcp.md
+++ b/serving/using-external-dns-on-gcp.md
@@ -368,7 +368,7 @@ In order to publish the Knative Gateway service, the annotation
 into Knative gateway service:
 
 ```shell
-# In Knative 0.2.x or prior versions, we use `knative-ingressgateway`.
+# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
 INGRESSGATEWAY=knative-ingressgateway
 
 # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.


### PR DESCRIPTION

## Proposed Changes

- Update docs to use `istio-ingressgateway` instead of `knative-ingressgateway` for Knative 0.3.x.

/assign @samodell 