### PR TITLE
golang format tools

### DIFF
--- a/eventing/sources/generator/main.go
+++ b/eventing/sources/generator/main.go
@@ -18,12 +18,13 @@ package main
 
 import (
 	"flag"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
 	"sort"
 	"text/template"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 var (


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
