### PR TITLE
Format markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ container-based applications that can run anywhere: on premises, in the cloud,
 or even in a third-party data center.
 
 Each of the components under the Knative project attempt to identify common
-patterns and codify the best practices that are shared by successful, real-world,
-Kubernetes-based frameworks and applications. Knative components focus on
-solving mundane but difficult tasks such as:
+patterns and codify the best practices that are shared by successful,
+real-world, Kubernetes-based frameworks and applications. Knative components
+focus on solving mundane but difficult tasks such as:
 
 - [Deploying a container](./install/getting-started-knative-app.md)
 - [Orchestrating source-to-URL workflows on Kubernetes](./serving/samples/source-to-url-go/)

--- a/community/WORKING-GROUPS.md
+++ b/community/WORKING-GROUPS.md
@@ -79,21 +79,22 @@ API
 
 ## Client
 
-[Client](https://github.com/knative/client), CLI, client libraries, and client conventions
+[Client](https://github.com/knative/client), CLI, client libraries, and client
+conventions
 
-Artifact                   | Link
--------------------------- | ----
-Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)
-Community Meeting VC       | [meet.google.com/spi-umby-dmw](https://meet.google.com/spi-umby-dmw) <br>Or dial in:<br>(US) +1 929-445-2235<br>PIN: 824 001#
-Community Meeting Calendar | Tuesdays 10:30a-11:00a Pacific <br>[Calendar Invitation](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com)
-Meeting Notes              | [Notes](https://docs.google.com/document/d/1Uh7jTWQruBBmic-WmTvtc9cMF95kQrKb5lsqWhNuikM/edit)
-Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1QF-job3rCEqCpJLm8nHkC4mBIi4XANE1)
-Slack Channel              | [#cli](https://knative.slack.com)
+| Artifact                   | Link                                                                                                                                                                       |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Forum                      | [knative-dev@](https://groups.google.com/forum/#!forum/knative-dev)                                                                                                        |
+| Community Meeting VC       | [meet.google.com/spi-umby-dmw](https://meet.google.com/spi-umby-dmw) <br>Or dial in:<br>(US) +1 929-445-2235<br>PIN: 824 001#                                              |
+| Community Meeting Calendar | Tuesdays 10:30a-11:00a Pacific <br>[Calendar Invitation](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) |
+| Meeting Notes              | [Notes](https://docs.google.com/document/d/1Uh7jTWQruBBmic-WmTvtc9cMF95kQrKb5lsqWhNuikM/edit)                                                                              |
+| Document Folder            | [Folder](https://drive.google.com/corp/drive/folders/1QF-job3rCEqCpJLm8nHkC4mBIi4XANE1)                                                                                    |
+| Slack Channel              | [#cli](https://knative.slack.com)                                                                                                                                          |
 
-&nbsp;                                                      | Leads           | Company | Profile
------------------------------------------------------------ | --------------- | ------- | -------
-<img width="30px" src="https://github.com/sixolet.png">     | Naomi Seyfer    | Google  | [sixolet](https://github.com/sixolet)
-<img width="30px" src="https://github.com/cppforlife.png">  | Dmitriy Kalinin | Pivotal | [cppforlife](https://github.com/cppforlife)
+| &nbsp;                                                     | Leads           | Company | Profile                                     |
+| ---------------------------------------------------------- | --------------- | ------- | ------------------------------------------- |
+| <img width="30px" src="https://github.com/sixolet.png">    | Naomi Seyfer    | Google  | [sixolet](https://github.com/sixolet)       |
+| <img width="30px" src="https://github.com/cppforlife.png"> | Dmitriy Kalinin | Pivotal | [cppforlife](https://github.com/cppforlife) |
 
 ## Documentation
 

--- a/eventing/sources/README.md
+++ b/eventing/sources/README.md
@@ -12,53 +12,47 @@ procedure:
 
 # Knative Event Sources
 
-Event Sources are Kubernetes Custom Resources which provide a mechanism for registering interest in
-a class of events from a particular software system. Since different event sources may be described
-by different Custom Resources, this page provides an index of the available source resource types as
-well as links to installation instructions.
+Event Sources are Kubernetes Custom Resources which provide a mechanism for
+registering interest in a class of events from a particular software system.
+Since different event sources may be described by different Custom Resources,
+this page provides an index of the available source resource types as well as
+links to installation instructions.
 
 This is a non-exhaustive list of Event sources for Knative.
 
-
 ### Inclusion in this list is not an endorsement, nor does it imply any level of support.
-
 
 ## Sources
 
 These are sources that are installed as `CRD`s.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[AWS SQS](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/aws_sqs_types.go) | Proof of Concept | None | Brings [AWS Simple Quele Service](https://aws.amazon.com/sqs/) messages into Knative.
-[Cron Job](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go) | Proof of Concept | None | Uses an in-memory timer to produce events on the specified Cron schedule.
-[GCP PubSub](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go) | Proof of Concept | None | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.
-[GitHub](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
-[GitLab](https://gitlab.com/triggermesh/gitlabsource) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
-[Google Cloud Scheduler](https://github.com/vaikas-google/csr) | Active Development | None | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative.
-[Google Cloud Storage](https://github.com/vaikas-google/gcs) | Active Development | None | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.
-[Kubernetes](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go) | Active Development | Knative | Brings Kubernetes cluster events into Knative. Uses ContainerSource for underlying infrastructure.
-
-
+| Name                                                                                                                           | Status             | Support | Description                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [AWS SQS](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/aws_sqs_types.go)                  | Proof of Concept   | None    | Brings [AWS Simple Quele Service](https://aws.amazon.com/sqs/) messages into Knative.                                                                           |
+| [Cron Job](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go)                | Proof of Concept   | None    | Uses an in-memory timer to produce events on the specified Cron schedule.                                                                                       |
+| [GCP PubSub](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go)            | Proof of Concept   | None    | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.                                                                                    |
+| [GitHub](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/githubsource_types.go)              | Proof of Concept   | None    | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.                                  |
+| [GitLab](https://gitlab.com/triggermesh/gitlabsource)                                                                          | Proof of Concept   | None    | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.                                               |
+| [Google Cloud Scheduler](https://github.com/vaikas-google/csr)                                                                 | Active Development | None    | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative. |
+| [Google Cloud Storage](https://github.com/vaikas-google/gcs)                                                                   | Active Development | None    | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.          |
+| [Kubernetes](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go) | Active Development | Knative | Brings Kubernetes cluster events into Knative. Uses ContainerSource for underlying infrastructure.                                                              |
 
 ## Meta Sources
 
 These are not directly usable, but make writing a Source much easier.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[Auto Container Source](https://github.com/Harwayne/auto-container-source) | Proof of Concept | None | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure.
-[Container Source](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.
-
-
+| Name                                                                                                                           | Status             | Support | Description                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Auto Container Source](https://github.com/Harwayne/auto-container-source)                                                     | Proof of Concept   | None    | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure. |
+| [Container Source](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.                      |
 
 ### ContainerSource Containers
 
 These are containers intended to be used with `ContainerSource`.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[Heartbeat](https://github.com/knative/eventing-sources/tree/master/cmd/heartbeats) | Proof of Concept | None | Uses an in-memory timer to produce events at the specified interval.
-[Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source) | Proof of Concept | None | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure.
-[K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source) | Proof of Concept | None | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.
-[WebSocket](https://github.com/knative/eventing-sources/tree/master/cmd/websocketsource) | Active Development | None | Opens a WebSocket to the specified source and packages each received message as a Knative event.
-
+| Name                                                                                        | Status             | Support | Description                                                                                                                  |
+| ------------------------------------------------------------------------------------------- | ------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [Heartbeat](https://github.com/knative/eventing-sources/tree/master/cmd/heartbeats)         | Proof of Concept   | None    | Uses an in-memory timer to produce events at the specified interval.                                                         |
+| [Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source) | Proof of Concept   | None    | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure. |
+| [K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source)       | Proof of Concept   | None    | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.                       |
+| [WebSocket](https://github.com/knative/eventing-sources/tree/master/cmd/websocketsource)    | Active Development | None    | Opens a WebSocket to the specified source and packages each received message as a Knative event.                             |

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -77,36 +77,25 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
      0.628 [14]    |
      0.686 [21]    |
      0.743 [13]    |
-
-
-   Latency distribution:
-     10% in 0.1805 secs
-     25% in 0.2197 secs
-     50% in 0.2801 secs
-     75% in 0.3129 secs
-     90% in 0.3596 secs
-     95% in 0.4020 secs
-     99% in 0.5457 secs
-
-   Details (average, fastest, slowest):
-     DNS+dialup:   0.0007 secs, 0.1672 secs, 0.7433 secs
-     DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs
-     req write:    0.0001 secs, 0.0000 secs, 0.0045 secs
-     resp wait:    0.2766 secs, 0.1669 secs, 0.6633 secs
-     resp read:    0.0002 secs, 0.0000 secs, 0.0065 secs
-
-   Status code distribution:
-     [200] 5424 responses
-
-
-
-   NAME                                             READY   STATUS    RESTARTS   AGE
-   autoscale-go-00001-deployment-78cdc67bf4-2w4sk   3/3     Running   0          26s
-   autoscale-go-00001-deployment-78cdc67bf4-dd2zb   3/3     Running   0          24s
-   autoscale-go-00001-deployment-78cdc67bf4-pg55p   3/3     Running   0          18s
-   autoscale-go-00001-deployment-78cdc67bf4-q8bf9   3/3     Running   0          1m
-   autoscale-go-00001-deployment-78cdc67bf4-thjbq   3/3     Running   0          26s
    ```
+
+Latency distribution: 10% in 0.1805 secs 25% in 0.2197 secs 50% in 0.2801 secs
+75% in 0.3129 secs 90% in 0.3596 secs 95% in 0.4020 secs 99% in 0.5457 secs
+
+Details (average, fastest, slowest): DNS+dialup: 0.0007 secs, 0.1672 secs,
+0.7433 secs DNS-lookup: 0.0000 secs, 0.0000 secs, 0.0000 secs req write: 0.0001
+secs, 0.0000 secs, 0.0045 secs resp wait: 0.2766 secs, 0.1669 secs, 0.6633 secs
+resp read: 0.0002 secs, 0.0000 secs, 0.0065 secs
+
+Status code distribution: [200] 5424 responses
+
+NAME READY STATUS RESTARTS AGE autoscale-go-00001-deployment-78cdc67bf4-2w4sk
+3/3 Running 0 26s autoscale-go-00001-deployment-78cdc67bf4-dd2zb 3/3 Running 0
+24s autoscale-go-00001-deployment-78cdc67bf4-pg55p 3/3 Running 0 18s
+autoscale-go-00001-deployment-78cdc67bf4-q8bf9 3/3 Running 0 1m
+autoscale-go-00001-deployment-78cdc67bf4-thjbq 3/3 Running 0 26s
+
+```
 
 ## Analysis
 
@@ -121,6 +110,7 @@ per pod (concurrency). The system has a default
 The autoscaler calculates average concurrency over a 60 second window so it takes a minute for the system to stablize at the desired level of concurrency.  However the autoscaler also calculates a 6 second "panic" window and will enter panic mode if that window reached 2x the target concurrency.  In panic mode the autoscaler operates on the shorter, more sensitive panic window.  Once the panic conditions are no longer met for 60 seconds, the autoscaler will return to the initial 60 second "stable" window.
 
 ```
+
                                                        |
                                   Panic Target--->  +--| 20
                                                     |  |
@@ -130,9 +120,9 @@ The autoscaler calculates average concurrency over a 60 second window so it take
                           |                         |  |
                           |                      <-----------Stable Window
                           |                         |  |
---------------------------+-------------------------+--+ 0
-120                       60                           0
-                     TIME
+
+--------------------------+-------------------------+--+ 0 120 60 0 TIME
+
 ```
 
 #### Customization
@@ -145,51 +135,30 @@ The autoscaler supports customization through annotations.  There are two autosc
 Example of a Service scaled on CPU:
 
 ```
-apiVersion: serving.knative.dev/v1alpha1
-kind: Service
-metadata:
-  name: autoscale-go
-  namespace: default
-spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        metadata:
-          annotations:
-            # Standard Kubernetes CPU-based autoscaling.
-            autoscaling.knative.dev/class:  hpa.autoscaling.knative.dev
-            autoscaling.knative.dev/metric: cpu
-        spec:
-          container:
-            image: gcr.io/knative-samples/autoscale-go:0.1
+
+apiVersion: serving.knative.dev/v1alpha1 kind: Service metadata: name:
+autoscale-go namespace: default spec: runLatest: configuration:
+revisionTemplate: metadata: annotations: # Standard Kubernetes CPU-based
+autoscaling. autoscaling.knative.dev/class: hpa.autoscaling.knative.dev
+autoscaling.knative.dev/metric: cpu spec: container: image:
+gcr.io/knative-samples/autoscale-go:0.1
+
 ```
 
 Additionally the autoscaler targets and scaling bounds can be specified in annotations.  Example of a Service with custom targets and scale bounds:
 
 ```
-apiVersion: serving.knative.dev/v1alpha1
-kind: Service
-metadata:
-  name: autoscale-go
-  namespace: default
-spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        metadata:
-          annotations:
-            # Knative concurrency-based autoscaling (default).
-            autoscaling.knative.dev/class:  kpa.autoscaling.knative.dev
-            autoscaling.knative.dev/metric: concurrency
-            # Target 10 requests in-flight per pod.
-            autoscaling.knative.dev/target: "10"
-            # Disable scale to zero with a minScale of 1.
-            autoscaling.knative.dev/minScale: "1"
-            # Limit scaling to 100 pods.
-            autoscaling.knative.dev/maxScale: "100"
-        spec:
-          container:
-            image: gcr.io/knative-samples/autoscale-go:0.1
+
+apiVersion: serving.knative.dev/v1alpha1 kind: Service metadata: name:
+autoscale-go namespace: default spec: runLatest: configuration:
+revisionTemplate: metadata: annotations: # Knative concurrency-based autoscaling
+(default). autoscaling.knative.dev/class: kpa.autoscaling.knative.dev
+autoscaling.knative.dev/metric: concurrency # Target 10 requests in-flight per
+pod. autoscaling.knative.dev/target: "10" # Disable scale to zero with a
+minScale of 1. autoscaling.knative.dev/minScale: "1" # Limit scaling to 100
+pods. autoscaling.knative.dev/maxScale: "100" spec: container: image:
+gcr.io/knative-samples/autoscale-go:0.1
+
 ```
 
 Note: for an `hpa.autoscaling.knative.dev` class service, the `autoscaling.knative.dev/target` specifies the CPU percentage target (default `"80"`).
@@ -203,7 +172,11 @@ View the [Kubecon Demo](https://youtu.be/OPSIPr-Cybs) of Knative autoscaler cust
 View the Knative Serving Scaling and Request dashboards (if configured).
 
 ```
-kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespace knative-monitoring --selector=app=grafana --output=jsonpath="{.items..metadata.name}") 3000
+
+kubectl port-forward --namespace knative-monitoring \$(kubectl get pods
+--namespace knative-monitoring --selector=app=grafana
+--output=jsonpath="{.items..metadata.name}") 3000
+
 ```
 
 ![scale dashboard](scale-dashboard.png)
@@ -214,49 +187,62 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 
 1. Send 60 seconds of traffic maintaining 100 concurrent requests.
 
-   ```
-   hey -z 60s -c 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5"
-   ```
+```
+
+hey -z 60s -c 100 \
+ -host "autoscale-go.default.example.com" \
+ "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5"
+
+```
 
 1. Send 60 seconds of traffic maintaining 100 qps with short requests (10 ms).
 
-   ```
-   hey -z 60s -q 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=10"
-   ```
+```
+
+hey -z 60s -q 100 \
+ -host "autoscale-go.default.example.com" \
+ "http://${IP_ADDRESS?}?sleep=10"
+
+```
 
 1. Send 60 seconds of traffic maintaining 100 qps with long requests (1 sec).
 
-   ```
-   hey -z 60s -q 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=1000"
-   ```
+```
+
+hey -z 60s -q 100 \
+ -host "autoscale-go.default.example.com" \
+ "http://${IP_ADDRESS?}?sleep=1000"
+
+```
 
 1. Send 60 seconds of traffic with heavy CPU usage (~1 cpu/sec/request, total 100 cpus).
 
-   ```
-   hey -z 60s -q 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?prime=40000000"
-   ```
+```
+
+hey -z 60s -q 100 \
+ -host "autoscale-go.default.example.com" \
+ "http://${IP_ADDRESS?}?prime=40000000"
+
+```
 
 1. Send 60 seconds of traffic with heavy memory usage (1 gb/request, total 5 gb).
-   ```
-   hey -z 60s -c 5 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?bloat=1000"
-   ```
+```
+
+hey -z 60s -c 5 \
+ -host "autoscale-go.default.example.com" \
+ "http://${IP_ADDRESS?}?bloat=1000"
+
+```
 
 ## Cleanup
 
 ```
+
 kubectl delete --filename serving/samples/autoscale-go/service.yaml
+
 ```
 
 ## Further reading
 
 1. [Autoscaling Developer Documentation](https://github.com/knative/serving/blob/master/docs/scaling/DEVELOPMENT.md)
+```


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`