### PR TITLE
api-reference: Add API reference docs

### DIFF
--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# This script is for generating API reference docs for Knative components.
+
+# Copyright 2018 Knative authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+[[ -n "${DEBUG:-}" ]] && set -x
+
+REFDOCS_PKG="github.com/ahmetb/gen-crd-api-reference-docs"
+REFDOCS_REPO="https://${REFDOCS_PKG}.git"
+REFDOCS_VER="5c208a6"
+
+KNATIVE_SERVING_REPO="github.com/knative/serving"
+KNATIVE_SERVING_COMMIT="v0.2.3"
+KNATIVE_SERVING_OUT_FILE="serving.md"
+
+KNATIVE_BUILD_REPO="github.com/knative/build"
+KNATIVE_BUILD_COMMIT="v0.2.0"
+KNATIVE_BUILD_OUT_FILE="build.md"
+
+KNATIVE_EVENTING_REPO="github.com/knative/eventing"
+KNATIVE_EVENTING_COMMIT="v0.2.1"
+KNATIVE_EVENTING_OUT_FILE="eventing/eventing.md"
+
+KNATIVE_EVENTING_SOURCES_REPO="github.com/knative/eventing-sources"
+KNATIVE_EVENTING_SOURCES_COMMIT="v0.2.1"
+KNATIVE_EVENTING_SOURCES_OUT_FILE="eventing/eventing-sources.md"
+
+log() {
+    echo "$@" >&2
+}
+
+fail() {
+    log "error: $*"
+    exit 1
+}
+
+install_go_bin() {
+    local pkg
+    pkg="$1"
+    (
+        cd "$(mktemp -d)"
+        go mod init tmp
+        go get -u "$pkg"
+        # will be downloaded to "$(go env GOPATH)/bin/$(basename $pkg)"
+    )
+}
+
+repo_tarball_url() {
+    local repo commit
+    repo="$1"
+    commit="$2"
+    echo "https://$repo/archive/$commit.tar.gz"
+}
+
+dl_and_extract() {
+    # TODO(ahmetb) remove this function. no longer dl'ing tarballs since they
+    # won't have a .git dir to infer the commit ID from to be used by refdocs.
+    local url dest
+    url="$1"
+    dest="$2"
+    mkdir -p "${dest}"
+    curl -sSLf "$url" | tar zxf - --directory="$dest"  --strip 1
+}
+
+clone_at_commit() {
+    local repo commit dest
+    repo="$1"
+    commit="$2"
+    dest="$3"
+    mkdir -p "${dest}"
+    git clone "${repo}" "${dest}"
+    git --git-dir="${dest}/.git" --work-tree="${dest}" checkout --detach --quiet "${commit}"
+}
+
+gen_refdocs() {
+    local refdocs_bin gopath out_file repo_root
+    refdocs_bin="$1"
+    gopath="$2"
+    out_file="$3"
+    repo_root="$4"
+
+    (
+        cd "${repo_root}"
+        env GOPATH="${gopath}" "${refdocs_bin}" \
+            -out-file "${gopath}/out/${out_file}" \
+            -api-dir "./pkg/apis" \
+            -config "${SCRIPTDIR}/reference-docs-gen-config.json"
+    )
+}
+
+
+main() {
+    if [[ -n "${GOPATH:-}" ]]; then
+        fail "GOPATH should not be set."
+    fi
+    if ! command -v "go" 1>/dev/null ; then
+        fail "\"go\" is not in PATH"
+    fi
+    if ! command -v "git" 1>/dev/null ; then
+        fail "\"git\" is not in PATH"
+    fi
+
+    # install and place the refdocs tool
+    local refdocs_bin refdocs_bin_expected refdocs_dir
+    refdocs_dir="$(mktemp -d)"
+    refdocs_bin="${refdocs_dir}/refdocs"
+    # clone repo for ./templates
+    git clone --quiet --depth=1 "${REFDOCS_REPO}" "${refdocs_dir}"
+    # install bin
+    install_go_bin "${REFDOCS_PKG}@${REFDOCS_VER}"
+    # move bin to final location
+    refdocs_bin_expected="$(go env GOPATH)/bin/$(basename ${REFDOCS_PKG})"
+    mv "${refdocs_bin_expected}" "${refdocs_bin}"
+    [[ ! -f "${refdocs_bin}" ]] && fail "refdocs failed to install"
+
+    local clone_root
+    clone_root="$(mktemp -d)"
+
+    local knative_serving_root
+    knative_serving_root="${clone_root}/src/${KNATIVE_SERVING_REPO}"
+    clone_at_commit "https://${KNATIVE_SERVING_REPO}.git" "${KNATIVE_SERVING_COMMIT}" \
+        "${knative_serving_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_SERVING_OUT_FILE}" \
+        "${knative_serving_root}"
+
+    local knative_build_root
+    knative_build_root="${clone_root}/src/${KNATIVE_BUILD_REPO}"
+    clone_at_commit "https://${KNATIVE_BUILD_REPO}.git" "${KNATIVE_BUILD_COMMIT}" \
+        "${knative_build_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_BUILD_OUT_FILE}" \
+        "${knative_build_root}"
+
+    local knative_eventing_root
+    knative_eventing_root="${clone_root}/src/${KNATIVE_EVENTING_REPO}"
+    clone_at_commit "https://${KNATIVE_EVENTING_REPO}.git" "${KNATIVE_EVENTING_COMMIT}" \
+        "${knative_eventing_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_EVENTING_OUT_FILE}" \
+        "${knative_eventing_root}"
+
+    local knative_eventing_sources_root
+    knative_eventing_sources_root="${clone_root}/src/${KNATIVE_EVENTING_SOURCES_REPO}"
+    clone_at_commit "https://${KNATIVE_EVENTING_SOURCES_REPO}.git" "${KNATIVE_EVENTING_SOURCES_COMMIT}" \
+        "${knative_eventing_sources_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_EVENTING_SOURCES_OUT_FILE}" \
+        "${knative_eventing_sources_root}"
+
+    log "Generated files written to ${clone_root}/out/."
+    log "Copy the files in reference/ directory to knative/docs."
+    if command -v open >/dev/null; then
+        open "${clone_root}/out/"
+    fi
+}
+
+main "$@"

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -1,0 +1,28 @@
+{
+    "hideMemberFields": [
+        "TypeMeta"
+    ],
+    "hideTypePatterns": [
+        "ParseError$",
+        "List$"
+    ],
+    "externalPackages": [
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
+            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",
+            "docsURLTemplate": "https://godoc.org/github.com/knative/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        }
+    ],
+    "typeDisplayNamePrefixOverrides": {
+        "k8s.io/api/": "Kubernetes ",
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+    },
+    "markdownDisabled": false
+}

--- a/reference/README.md
+++ b/reference/README.md
@@ -1,0 +1,6 @@
+# Knative API Reference documentation
+
+- [Serving API](serving.md)
+- [Build API](build.md)
+- [Eventing API](eventing/eventing.md)
+- [Event Sources API](eventing/eventing-sources.md)

--- a/reference/build.md
+++ b/reference/build.md
@@ -1,0 +1,1241 @@
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#build.knative.dev">build.knative.dev</a>
+</li>
+</ul>
+<h2 id="build.knative.dev">build.knative.dev</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#Build">Build</a>
+</li><li>
+<a href="#BuildTemplate">BuildTemplate</a>
+</li><li>
+<a href="#ClusterBuildTemplate">ClusterBuildTemplate</a>
+</li></ul>
+<h3 id="Build">Build
+</h3>
+<p>
+<p>Build represents a build of a container image. A Build is made up of a
+source, and a set of steps. Steps can mount volumes to share data between
+themselves. A build may be created by instantiating a BuildTemplate.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+build.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Build</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#BuildSpec">
+BuildSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+<a href="#SourceSpec">
+SourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Source specifies the input to the build.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the service account as which to run this build.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#TemplateInstantiationSpec">
+TemplateInstantiationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template, if specified, references a BuildTemplate resource to use to
+populate fields in the build, and optional Arguments to pass to the
+template. The default Kind of template is BuildTemplate</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is a selector which must be true for the pod to fit on a node.
+Selector which must match a node&rsquo;s labels for the pod to be scheduled on that node.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/assign-pod-node/">https://kubernetes.io/docs/concepts/configuration/assign-pod-node/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the build times out. Defaults to 10 minutes.
+Specified build timeout should be less than 24h.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If specified, the pod&rsquo;s scheduling constraints</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#BuildStatus">
+BuildStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="BuildTemplate">BuildTemplate
+</h3>
+<p>
+<p>BuildTemplate is a template that can used to easily create Builds.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+build.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>BuildTemplate</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#BuildTemplateSpec">
+BuildTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>parameters</code></br>
+<em>
+<a href="#ParameterSpec">
+[]ParameterSpec
+</a>
+</em>
+</td>
+<td>
+<p>Parameters defines the parameters that can be populated in a template.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterBuildTemplate">ClusterBuildTemplate
+</h3>
+<p>
+<p>ClusterBuildTemplate is a template that can used to easily create Builds.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+build.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ClusterBuildTemplate</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#BuildTemplateSpec">
+BuildTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>parameters</code></br>
+<em>
+<a href="#ParameterSpec">
+[]ParameterSpec
+</a>
+</em>
+</td>
+<td>
+<p>Parameters defines the parameters that can be populated in a template.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ArgumentSpec">ArgumentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#TemplateInstantiationSpec">TemplateInstantiationSpec</a>)
+</p>
+<p>
+<p>ArgumentSpec defines the actual values to use to populate a template&rsquo;s
+parameters.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the name of the argument.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>value</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Value is the value of the argument.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="BuildProvider">BuildProvider
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildStatus">BuildStatus</a>)
+</p>
+<p>
+<p>BuildProvider defines a build execution implementation.</p>
+</p>
+<h3 id="BuildSpec">BuildSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Build">Build</a>)
+</p>
+<p>
+<p>BuildSpec is the spec for a Build resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+<a href="#SourceSpec">
+SourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Source specifies the input to the build.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>The name of the service account as which to run this build.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#TemplateInstantiationSpec">
+TemplateInstantiationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template, if specified, references a BuildTemplate resource to use to
+populate fields in the build, and optional Arguments to pass to the
+template. The default Kind of template is BuildTemplate</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nodeSelector</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeSelector is a selector which must be true for the pod to fit on a node.
+Selector which must match a node&rsquo;s labels for the pod to be scheduled on that node.
+More info: <a href="https://kubernetes.io/docs/concepts/configuration/assign-pod-node/">https://kubernetes.io/docs/concepts/configuration/assign-pod-node/</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Time after which the build times out. Defaults to 10 minutes.
+Specified build timeout should be less than 24h.
+Refer Go&rsquo;s ParseDuration documentation for expected format: <a href="https://golang.org/pkg/time/#ParseDuration">https://golang.org/pkg/time/#ParseDuration</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>affinity</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#affinity-v1-core">
+Kubernetes core/v1.Affinity
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>If specified, the pod&rsquo;s scheduling constraints</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="BuildStatus">BuildStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Build">Build</a>)
+</p>
+<p>
+<p>BuildStatus is the status for a Build resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>builder</code></br>
+<em>
+<a href="#BuildProvider">
+BuildProvider
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>cluster</code></br>
+<em>
+<a href="#ClusterSpec">
+ClusterSpec
+</a>
+</em>
+</td>
+<td>
+<p>Cluster provides additional information if the builder is Cluster.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>google</code></br>
+<em>
+<a href="#GoogleSpec">
+GoogleSpec
+</a>
+</em>
+</td>
+<td>
+<p>Google provides additional information if the builder is Google.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>startTime,omitEmpty</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>StartTime is the time the build is actually started.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>completionTime,omitEmpty</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<p>CompletionTime is the time the build completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepStates,omitEmpty</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#containerstate-v1-core">
+[]Kubernetes core/v1.ContainerState
+</a>
+</em>
+</td>
+<td>
+<p>StepStates describes the state of each build step container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>stepsCompleted</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>StepsCompleted lists the name of build steps completed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<p>Conditions describes the set of conditions of this build.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="BuildTemplateInterface">BuildTemplateInterface
+</h3>
+<p>
+<p>BuildTemplateInterface is implemented by BuildTemplate and ClusterBuildTemplate</p>
+</p>
+<h3 id="BuildTemplateSpec">BuildTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildTemplate">BuildTemplate</a>, 
+<a href="#ClusterBuildTemplate">ClusterBuildTemplate</a>)
+</p>
+<p>
+<p>BuildTemplateSpec is the spec for a BuildTemplate.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>parameters</code></br>
+<em>
+<a href="#ParameterSpec">
+[]ParameterSpec
+</a>
+</em>
+</td>
+<td>
+<p>Parameters defines the parameters that can be populated in a template.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+[]Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<p>Steps are the steps of the build; each step is run sequentially with the
+source mounted into /workspace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes is a collection of volumes that are available to mount into the
+steps of the build.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterSpec">ClusterSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildStatus">BuildStatus</a>)
+</p>
+<p>
+<p>ClusterSpec provides information about the on-cluster build, if applicable.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace is the namespace in which the pod is running.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>podName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>PodName is the name of the pod responsible for executing this build&rsquo;s steps.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GCSSourceSpec">GCSSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#SourceSpec">SourceSpec</a>)
+</p>
+<p>
+<p>GCSSourceSpec describes source input to the Build in the form of an archive,
+or a source manifest describing files to fetch.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+<a href="#GCSSourceType">
+GCSSourceType
+</a>
+</em>
+</td>
+<td>
+<p>Type declares the style of source to fetch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>location</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Location specifies the location of the source archive or manifest file.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GCSSourceType">GCSSourceType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GCSSourceSpec">GCSSourceSpec</a>)
+</p>
+<p>
+<p>GCSSourceType defines a type of GCS source fetch.</p>
+</p>
+<h3 id="GitSourceSpec">GitSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#SourceSpec">SourceSpec</a>)
+</p>
+<p>
+<p>GitSourceSpec describes a Git repo source input to the Build.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>url</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URL of the Git repository to clone from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>revision</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Git revision (branch, tag, commit SHA or ref) to clone.  See
+<a href="https://git-scm.com/docs/gitrevisions#_specifying_revisions">https://git-scm.com/docs/gitrevisions#_specifying_revisions</a> for more
+information.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GoogleSpec">GoogleSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildStatus">BuildStatus</a>)
+</p>
+<p>
+<p>GoogleSpec provides information about the GCB build, if applicable.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>operation</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Operation is the unique name of the GCB API Operation for the build.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ParameterSpec">ParameterSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildTemplateSpec">BuildTemplateSpec</a>)
+</p>
+<p>
+<p>ParameterSpec defines the possible parameters that can be populated in a
+template.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the unique name of this template parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Description is a human-readable explanation of this template parameter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Default, if specified, defines the default value that should be applied if
+the build does not specify the value for this parameter.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="SourceSpec">SourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildSpec">BuildSpec</a>)
+</p>
+<p>
+<p>SourceSpec defines the input to the Build</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>git</code></br>
+<em>
+<a href="#GitSourceSpec">
+GitSourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Git represents source in a Git repository.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>gcs</code></br>
+<em>
+<a href="#GCSSourceSpec">
+GCSSourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>GCS represents source in Google Cloud Storage.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>custom</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<p>Custom indicates that source should be retrieved using a custom
+process defined in a container invocation.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subPath</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SubPath specifies a path within the fetched source which should be
+built. This option makes parent directories <em>inaccessible</em> to the
+build steps. (The specific source type may, in fact, not even fetch
+files not in the SubPath.)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Template">Template
+</h3>
+<p>
+<p>Template is an interface for accessing the BuildTemplateSpec
+from various forms of template (namespace-/cluster-scoped).</p>
+</p>
+<h3 id="TemplateInstantiationSpec">TemplateInstantiationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildSpec">BuildSpec</a>)
+</p>
+<p>
+<p>TemplateInstantiationSpec specifies how a BuildTemplate is instantiated into
+a Build.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name references the BuildTemplate resource to use.</p>
+<p>The template is assumed to exist in the Build&rsquo;s namespace.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+<a href="#TemplateKind">
+TemplateKind
+</a>
+</em>
+</td>
+<td>
+<p>The Kind of the template to be used, possible values are BuildTemplate
+or ClusterBuildTemplate. If nothing is specified, the default if is BuildTemplate</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arguments</code></br>
+<em>
+<a href="#ArgumentSpec">
+[]ArgumentSpec
+</a>
+</em>
+</td>
+<td>
+<p>Arguments, if specified, lists values that should be applied to the
+parameters specified by the template.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<p>Env, if specified will provide variables to all build template steps.
+This will override any of the template&rsquo;s steps environment variables.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="TemplateKind">TemplateKind
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#TemplateInstantiationSpec">TemplateInstantiationSpec</a>)
+</p>
+<p>
+<p>TemplateKind defines the type of BuildTemplate used by the build.</p>
+</p>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+on git commit <code>9485975</code>.
+</em></p>

--- a/reference/eventing/eventing-sources.md
+++ b/reference/eventing/eventing-sources.md
@@ -1,0 +1,1135 @@
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
+</li>
+</ul>
+<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#ContainerSource">ContainerSource</a>
+</li><li>
+<a href="#GcpPubSubSource">GcpPubSubSource</a>
+</li><li>
+<a href="#GitHubSource">GitHubSource</a>
+</li><li>
+<a href="#KubernetesEventSource">KubernetesEventSource</a>
+</li></ul>
+<h3 id="ContainerSource">ContainerSource
+</h3>
+<p>
+<p>ContainerSource is the Schema for the containersources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ContainerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#ContainerSourceSpec">
+ContainerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is the image to run inside of the container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Args are passed to the ContainerSpec as they are.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Env is the list of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#ContainerSourceStatus">
+ContainerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GcpPubSubSource">GcpPubSubSource
+</h3>
+<p>
+<p>GcpPubSubSource is the Schema for the gcppubsubsources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GcpPubSubSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#GcpPubSubSourceSpec">
+GcpPubSubSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>gcpCredsSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
+to create or delete the Subscription, only to poll it. The value of the secret entry must be
+a service account key in the JSON format (see
+<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>googleCloudProject</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>GoogleCloudProject is the ID of the Google Cloud Project that the PubSub Topic exists in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topic</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Topic is the ID of the GCP PubSub Topic to Subscribe to. It must be in the form of the
+unique identifier within the project, not the entire name. E.g. it must be &lsquo;laconia&rsquo;, not
+&lsquo;projects/my-gcp-project/topics/laconia&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
+Adapter Deployment.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#GcpPubSubSourceStatus">
+GcpPubSubSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GitHubSource">GitHubSource
+</h3>
+<p>
+<p>GitHubSource is the Schema for the githubsources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GitHubSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#GitHubSourceSpec">
+GitHubSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the GitHubSource exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ownerAndRepository</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OwnerAndRepository is the GitHub owner/org and repository to
+receive events from. The repository may be left off to receive
+events from an entire organization.
+Examples:
+myuser/project
+myorganization</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eventTypes</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>EventType is the type of event to receive from GitHub. These
+correspond to the &ldquo;Webhook event name&rdquo; values listed at
+<a href="https://developer.github.com/v3/activity/events/types/">https://developer.github.com/v3/activity/events/types/</a> - ie
+&ldquo;pull_request&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accessToken</code></br>
+<em>
+<a href="#SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>AccessToken is the Kubernetes secret containing the GitHub
+access token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretToken</code></br>
+<em>
+<a href="#SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>SecretToken is the Kubernetes secret containing the GitHub
+secret token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain
+name to use as the sink.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#GitHubSourceStatus">
+GitHubSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="KubernetesEventSource">KubernetesEventSource
+</h3>
+<p>
+<p>KubernetesEventSource is the Schema for the kuberneteseventsources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>KubernetesEventSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#KubernetesEventSourceSpec">
+KubernetesEventSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace that we watch kubernetes events in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use
+as the sink.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#KubernetesEventSourceStatus">
+KubernetesEventSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ContainerSourceSpec">ContainerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceSpec defines the desired state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Image is the image to run inside of the container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>args</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Args are passed to the ContainerSpec as they are.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>env</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+[]Kubernetes core/v1.EnvVar
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Env is the list of environment variables to set in the container.
+Cannot be updated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ContainerSourceStatus">ContainerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceStatus defines the observed state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions holds the state of a source at a point in time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the ContainerSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GcpPubSubSourceSpec">GcpPubSubSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GcpPubSubSource">GcpPubSubSource</a>)
+</p>
+<p>
+<p>GcpPubSubSourceSpec defines the desired state of the GcpPubSubSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>gcpCredsSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
+to create or delete the Subscription, only to poll it. The value of the secret entry must be
+a service account key in the JSON format (see
+<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>googleCloudProject</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>GoogleCloudProject is the ID of the Google Cloud Project that the PubSub Topic exists in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topic</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Topic is the ID of the GCP PubSub Topic to Subscribe to. It must be in the form of the
+unique identifier within the project, not the entire name. E.g. it must be &lsquo;laconia&rsquo;, not
+&lsquo;projects/my-gcp-project/topics/laconia&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
+Adapter Deployment.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GcpPubSubSourceStatus">GcpPubSubSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GcpPubSubSource">GcpPubSubSource</a>)
+</p>
+<p>
+<p>GcpPubSubSourceStatus defines the observed state of GcpPubSubSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions holds the state of a source at a point in time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the GcpPubSubSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GitHubSourceSpec">GitHubSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GitHubSource">GitHubSource</a>)
+</p>
+<p>
+<p>GitHubSourceSpec defines the desired state of GitHubSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the GitHubSource exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ownerAndRepository</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OwnerAndRepository is the GitHub owner/org and repository to
+receive events from. The repository may be left off to receive
+events from an entire organization.
+Examples:
+myuser/project
+myorganization</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eventTypes</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>EventType is the type of event to receive from GitHub. These
+correspond to the &ldquo;Webhook event name&rdquo; values listed at
+<a href="https://developer.github.com/v3/activity/events/types/">https://developer.github.com/v3/activity/events/types/</a> - ie
+&ldquo;pull_request&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accessToken</code></br>
+<em>
+<a href="#SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>AccessToken is the Kubernetes secret containing the GitHub
+access token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretToken</code></br>
+<em>
+<a href="#SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>SecretToken is the Kubernetes secret containing the GitHub
+secret token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain
+name to use as the sink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="GitHubSourceStatus">GitHubSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GitHubSource">GitHubSource</a>)
+</p>
+<p>
+<p>GitHubSourceStatus defines the observed state of GitHubSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions holds the state of a source at a point in time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhookIDKey</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>WebhookIDKey is the ID of the webhook registered with GitHub</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured
+for the GitHubSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="KubernetesEventSourceSpec">KubernetesEventSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#KubernetesEventSource">KubernetesEventSource</a>)
+</p>
+<p>
+<p>KubernetesEventSourceSpec defines the desired state of the source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>namespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Namespace that we watch kubernetes events in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use
+as the sink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="KubernetesEventSourceStatus">KubernetesEventSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#KubernetesEventSource">KubernetesEventSource</a>)
+</p>
+<p>
+<p>KubernetesEventSourceStatus defines the observed state of the source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions holds the state of a source at a point in time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#GitHubSourceSpec">GitHubSourceSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+on git commit <code>9741f15</code>.
+</em></p>

--- a/reference/eventing/eventing.md
+++ b/reference/eventing/eventing.md
@@ -1,0 +1,1127 @@
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#duck.knative.dev">duck.knative.dev</a>
+</li>
+<li>
+<a href="#eventing.knative.dev">eventing.knative.dev</a>
+</li>
+</ul>
+<h2 id="duck.knative.dev">duck.knative.dev</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="Channel">Channel
+</h3>
+<p>
+<p>Channel is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channel ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>ChannelSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ChannelSpec">ChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ChannelSubscriberSpec">ChannelSubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>ChannelSubscriberSpec defines a single subscriber to a Channel.
+Ref is a reference to the Subscription this ChannelSubscriberSpec was created for
+SubscriberURI is the endpoint for the subscriber
+ReplyURI is the endpoint for the reply
+At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ref</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Subscribable">Subscribable
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ChannelSpec">ChannelSpec</a>, 
+<a href="#ChannelSpec">ChannelSpec</a>)
+</p>
+<p>
+<p>Subscribable is the schema for the subscribable portion of the spec
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#ChannelSubscriberSpec">
+[]ChannelSubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>TODO: What is actually required here for Channel spec.
+This is the list of subscriptions for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="eventing.knative.dev">eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#Channel">Channel</a>
+</li><li>
+<a href="#ClusterChannelProvisioner">ClusterChannelProvisioner</a>
+</li><li>
+<a href="#Subscription">Subscription</a>
+</li></ul>
+<h3 id="Channel">Channel
+</h3>
+<p>
+<p>Channel is an abstract resource that implements the Addressable contract.
+The Provisioner provisions infrastructure to accepts events and
+deliver to Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Channel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisioner</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Provisioner defines the name of the Provisioner backing this channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arguments</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments defines the arguments to pass to the Provisioner which
+provisions this Channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+<p>Channel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#ChannelStatus">
+ChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Channel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterChannelProvisioner">ClusterChannelProvisioner
+</h3>
+<p>
+<p>ClusterChannelProvisioner encapsulates a provisioning strategy for the
+backing resources required to realize a particular resource type.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ClusterChannelProvisioner</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#ClusterChannelProvisionerSpec">
+ClusterChannelProvisionerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the Types provisioned by this Provisioner.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#ClusterChannelProvisionerStatus">
+ClusterChannelProvisionerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the current status of the Provisioner.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Subscription">Subscription
+</h3>
+<p>
+<p>Subscription routes events received on a Channel to a DNS name and
+corresponds to the subscriptions.channels.knative.dev CRD.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Subscription</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#SubscriptionSpec">
+SubscriptionSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation used to not work correctly with CRD. They were scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once the above bug gets rolled out to production
+clusters, remove this and use ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Reference to a channel that will be used to create the subscription
+for receiving events. The channel must have spec.subscriptions
+list which will then be modified accordingly.</p>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+Kind must be &ldquo;Channel&rdquo; and APIVersion must be
+&ldquo;eventing.knative.dev/v1alpha1&rdquo;</p>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a channel as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="#ReplyStrategy">
+ReplyStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#SubscriptionStatus">
+SubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ChannelProvisionerDefaulter">ChannelProvisionerDefaulter
+</h3>
+<p>
+<p>ChannelProvisionerDefaulter sets the default Provisioner and Arguments on Channels that do not
+specify any Provisioner.</p>
+</p>
+<h3 id="ChannelSpec">ChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelSpec specifies the Provisioner backing a channel and the configuration
+arguments for a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisioner</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Provisioner defines the name of the Provisioner backing this channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arguments</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments defines the arguments to pass to the Provisioner which
+provisions this Channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+<p>Channel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ChannelStatus">ChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the most recent generation observed for this Channel.
+It corresponds to the Channel&rsquo;s generation, which is updated on mutation by
+the API Server.
+TODO: The above comment is only true once
+<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a> is fixed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Addressable">
+github.com/knative/pkg/apis/duck/v1alpha1.Addressable
+</a>
+</em>
+</td>
+<td>
+<p>Channel is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {channel}.{namespace}.svc.cluster.local</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Represents the latest available observations of a channel&rsquo;s current state.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterChannelProvisionerSpec">ClusterChannelProvisionerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
+</p>
+<p>
+<p>ClusterChannelProvisionerSpec is the spec for a ClusterChannelProvisioner resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterChannelProvisionerStatus">ClusterChannelProvisionerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
+</p>
+<p>
+<p>ClusterChannelProvisionerStatus is the status for a ClusterChannelProvisioner resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions holds the state of a cluster provisioner at a point in time.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the ClusterChannelProvisioner that
+was last reconciled by the controller.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ReplyStrategy">ReplyStrategy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>ReplyStrategy specifies the handling of the SubscriberSpec&rsquo;s returned replies.
+If no SubscriberSpec is specified, the identity function is assumed.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>This object must be a Channel.</p>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+Kind must be &ldquo;Channel&rdquo; and APIVersion must be
+&ldquo;eventing.knative.dev/v1alpha1&rdquo;</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>SubscriberSpec specifies the reference to an object that&rsquo;s expected to
+provide the resolved target of the action.
+Currently we inspect the objects Status and see if there&rsquo;s a predefined
+Status field that we will then use to dispatch events to be processed by
+the target. Currently must resolve to a k8s service or Istio virtual
+service.
+Note that in the future we should try to utilize subresources (/resolve ?) to
+make this cleaner, but CRDs do not support subresources yet, so we need
+to rely on a specified Status field today. By relying on this behaviour
+we can utilize a dynamic client instead of having to understand all
+kinds of different types of objects. As long as they adhere to this
+particular contract, they can be used as a Target.</p>
+<p>This ensures that we can support external targets and for ease of use
+we also allow for an URI to be specified.
+There of course is also a requirement for the resolved SubscriberSpec to
+behave properly at the data plane level.
+TODO: Add a pointer to a real spec for this.
+For now, this means: Receive an event payload, and respond with one of:
+success and an optional response event, or failure.
+Delivery failures may be retried by the channel</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ref</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reference to an object that will be used to find the target
+endpoint, which should implement the Addressable duck type.
+For example, this could be a reference to a Route resource
+or a Knative Service resource.
+TODO: Specify the required fields the target object must
+have in the status.
+You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reference to a &lsquo;known&rsquo; endpoint where no resolving is done.
+<a href="http://k8s-service">http://k8s-service</a> for example
+<a href="http://myexternalhandler.example.com/foo/bar">http://myexternalhandler.example.com/foo/bar</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="SubscriptionSpec">SubscriptionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
+for processing those events and where to put the result of the processing. Only
+From (where the events are coming from) is always required. You can optionally
+only Process the events (results in no output events) by leaving out the Result.
+You can also perform an identity transformation on the invoming events by leaving
+out the Subscriber and only specifying Result.</p>
+<p>The following are all valid specifications:
+channel &ndash;[subscriber]&ndash;&gt; reply
+Sink, no outgoing events:
+channel &ndash; subscriber
+no-op function (identity transformation):
+channel &ndash;&gt; reply</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation used to not work correctly with CRD. They were scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once the above bug gets rolled out to production
+clusters, remove this and use ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Reference to a channel that will be used to create the subscription
+for receiving events. The channel must have spec.subscriptions
+list which will then be modified accordingly.</p>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+Kind must be &ldquo;Channel&rdquo; and APIVersion must be
+&ldquo;eventing.knative.dev/v1alpha1&rdquo;</p>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a channel as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="#ReplyStrategy">
+ReplyStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="SubscriptionStatus">SubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionStatus (computed) for a subscription</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<p>Represents the latest available observations of a subscription&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>physicalSubscription,omitEmpty</code></br>
+<em>
+<a href="#SubscriptionStatusPhysicalSubscription">
+SubscriptionStatusPhysicalSubscription
+</a>
+</em>
+</td>
+<td>
+<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#SubscriptionStatus">SubscriptionStatus</a>)
+</p>
+<p>
+<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
+Subscription.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscriberURI,omitEmpty</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyURI,omitEmpty</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+on git commit <code>90852711</code>.
+</em></p>

--- a/reference/gen-api-reference-docs.sh
+++ b/reference/gen-api-reference-docs.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# This script is for generating API reference docs for Knative components.
+
+# Copyright 2018 Knative authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+[[ -n "${DEBUG:-}" ]] && set -x
+
+REFDOCS_PKG="github.com/ahmetb/gen-crd-api-reference-docs"
+REFDOCS_REPO="https://${REFDOCS_PKG}.git"
+REFDOCS_VER="5c208a6"
+
+KNATIVE_SERVING_REPO="github.com/knative/serving"
+KNATIVE_SERVING_COMMIT="v0.2.3"
+KNATIVE_SERVING_OUT_FILE="reference/serving.md"
+
+KNATIVE_BUILD_REPO="github.com/knative/build"
+KNATIVE_BUILD_COMMIT="v0.2.0"
+KNATIVE_BUILD_OUT_FILE="reference/build.md"
+
+KNATIVE_EVENTING_REPO="github.com/knative/eventing"
+KNATIVE_EVENTING_COMMIT="v0.2.1"
+KNATIVE_EVENTING_OUT_FILE="reference/eventing/eventing.md"
+
+KNATIVE_EVENTING_SOURCES_REPO="github.com/knative/eventing-sources"
+KNATIVE_EVENTING_SOURCES_COMMIT="v0.2.1"
+KNATIVE_EVENTING_SOURCES_OUT_FILE="reference/eventing/eventing-sources.md"
+
+log() {
+    echo "$@" >&2
+}
+
+fail() {
+    log "error: $*"
+    exit 1
+}
+
+install_go_bin() {
+    local pkg
+    pkg="$1"
+    (
+        cd "$(mktemp -d)"
+        go mod init tmp
+        go get -u "$pkg"
+        # will be downloaded to "$(go env GOPATH)/bin/$(basename $pkg)"
+    )
+}
+
+repo_tarball_url() {
+    local repo commit
+    repo="$1"
+    commit="$2"
+    echo "https://$repo/archive/$commit.tar.gz"
+}
+
+dl_and_extract() {
+    # TODO(ahmetb) remove this function. no longer dl'ing tarballs since they
+    # won't have a .git dir to infer the commit ID from to be used by refdocs.
+    local url dest
+    url="$1"
+    dest="$2"
+    mkdir -p "${dest}"
+    curl -sSLf "$url" | tar zxf - --directory="$dest"  --strip 1
+}
+
+clone_at_commit() {
+    local repo commit dest
+    repo="$1"
+    commit="$2"
+    dest="$3"
+    mkdir -p "${dest}"
+    git clone "${repo}" "${dest}"
+    git --git-dir="${dest}/.git" --work-tree="${dest}" checkout --detach --quiet "${commit}"
+}
+
+gen_refdocs() {
+    local refdocs_bin gopath out_file repo_root
+    refdocs_bin="$1"
+    gopath="$2"
+    out_file="$3"
+    repo_root="$4"
+
+    (
+        cd "${repo_root}"
+        env GOPATH="${gopath}" "${refdocs_bin}" \
+            -out-file "${gopath}/out/${out_file}" \
+            -api-dir "./pkg/apis" \
+            -config "${SCRIPTDIR}/knative-refdocs-gen-config.json"
+    )
+}
+
+
+main() {
+    if [[ -n "${GOPATH:-}" ]]; then
+        fail "GOPATH should not be set."
+    fi
+    if ! command -v "go" 1>/dev/null ; then
+        fail "\"go\" is not in PATH"
+    fi
+
+    # install and place the refdocs tool
+    local refdocs_bin refdocs_bin_expected refdocs_dir
+    refdocs_dir="$(mktemp -d)"
+    refdocs_bin="${refdocs_dir}/refdocs"
+    # clone repo for ./templates
+    git clone --quiet --depth=1 "${REFDOCS_REPO}" "${refdocs_dir}"
+    # install bin
+    install_go_bin "${REFDOCS_PKG}@${REFDOCS_VER}"
+    # move bin to final location
+    refdocs_bin_expected="$(go env GOPATH)/bin/$(basename ${REFDOCS_PKG})"
+    mv "${refdocs_bin_expected}" "${refdocs_bin}"
+    [[ ! -f "${refdocs_bin}" ]] && fail "refdocs failed to install"
+
+    local clone_root
+    clone_root="$(mktemp -d)"
+
+    local knative_serving_root
+    knative_serving_root="${clone_root}/src/${KNATIVE_SERVING_REPO}"
+    clone_at_commit "https://${KNATIVE_SERVING_REPO}.git" "${KNATIVE_SERVING_COMMIT}" \
+        "${knative_serving_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_SERVING_OUT_FILE}" \
+        "${knative_serving_root}"
+
+    local knative_build_root
+    knative_build_root="${clone_root}/src/${KNATIVE_BUILD_REPO}"
+    clone_at_commit "https://${KNATIVE_BUILD_REPO}.git" "${KNATIVE_BUILD_COMMIT}" \
+        "${knative_build_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_BUILD_OUT_FILE}" \
+        "${knative_build_root}"
+
+    local knative_eventing_root
+    knative_eventing_root="${clone_root}/src/${KNATIVE_EVENTING_REPO}"
+    clone_at_commit "https://${KNATIVE_EVENTING_REPO}.git" "${KNATIVE_EVENTING_COMMIT}" \
+        "${knative_eventing_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_EVENTING_OUT_FILE}" \
+        "${knative_eventing_root}"
+
+    local knative_eventing_sources_root
+    knative_eventing_sources_root="${clone_root}/src/${KNATIVE_EVENTING_SOURCES_REPO}"
+    clone_at_commit "https://${KNATIVE_EVENTING_SOURCES_REPO}.git" "${KNATIVE_EVENTING_SOURCES_COMMIT}" \
+        "${knative_eventing_sources_root}"
+    gen_refdocs "${refdocs_bin}" "${clone_root}" "${KNATIVE_EVENTING_SOURCES_OUT_FILE}" \
+        "${knative_eventing_sources_root}"
+
+    log "Generated files written to ${clone_root}/out/."
+    if command -v open >/dev/null; then
+        open "${clone_root}/out/"
+    fi
+}
+
+main "$@"

--- a/reference/knative-refdocs-gen-config.json
+++ b/reference/knative-refdocs-gen-config.json
@@ -1,0 +1,28 @@
+{
+    "hideMemberFields": [
+        "TypeMeta"
+    ],
+    "hideTypePatterns": [
+        "ParseError$",
+        "List$"
+    ],
+    "externalPackages": [
+        {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/apis/meta/v1\\.Duration$",
+            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration"
+        },
+        {
+            "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",
+            "docsURLTemplate": "https://godoc.org/github.com/knative/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        }
+    ],
+    "typeDisplayNamePrefixOverrides": {
+        "k8s.io/api/": "Kubernetes ",
+        "k8s.io/apimachinery/pkg/apis/": "Kubernetes "
+    },
+    "markdownDisabled": false
+}

--- a/reference/serving.md
+++ b/reference/serving.md
@@ -1,0 +1,2995 @@
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#autoscaling.internal.knative.dev">autoscaling.internal.knative.dev</a>
+</li>
+<li>
+<a href="#networking.internal.knative.dev">networking.internal.knative.dev</a>
+</li>
+<li>
+<a href="#serving.knative.dev">serving.knative.dev</a>
+</li>
+</ul>
+<h2 id="autoscaling.internal.knative.dev">autoscaling.internal.knative.dev</h2>
+<p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#PodAutoscaler">PodAutoscaler</a>
+</li></ul>
+<h3 id="PodAutoscaler">PodAutoscaler
+</h3>
+<p>
+<p>PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
+components instantiate autoscalers.  This definition is an abstraction that may be backed
+by multiple definitions.  For more information, see the Knative Pluggability presentation:
+<a href="https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit">https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+autoscaling.internal.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>PodAutoscaler</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#PodAutoscalerSpec">
+PodAutoscalerSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the PodAutoscaler (from the client).</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>concurrencyModel</code></br>
+<em>
+<a href="#RevisionRequestConcurrencyModelType">
+RevisionRequestConcurrencyModelType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConcurrencyModel specifies the desired concurrency model
+(Single or Multi) for the scale target. Defaults to Multi.
+Deprecated in favor of ContainerConcurrency.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerConcurrency</code></br>
+<em>
+<a href="#RevisionContainerConcurrencyType">
+RevisionContainerConcurrencyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerConcurrency specifies the maximum allowed
+in-flight (concurrent) requests per container of the Revision.
+Defaults to <code>0</code> which means unlimited concurrency.
+This field replaces ConcurrencyModel. A value of <code>1</code>
+is equivalent to <code>Single</code> and <code>0</code> is equivalent to <code>Multi</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scaleTargetRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#crossversionobjectreference-v1-autoscaling">
+Kubernetes autoscaling/v1.CrossVersionObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
+is responsible for quickly right-sizing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceName holds the name of a core Kubernetes Service resource that
+load balances over the pods referenced by the ScaleTargetRef.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#PodAutoscalerStatus">
+PodAutoscalerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the observed state of the PodAutoscaler (from the controller).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="PodAutoscalerSpec">PodAutoscalerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#PodAutoscaler">PodAutoscaler</a>)
+</p>
+<p>
+<p>PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>concurrencyModel</code></br>
+<em>
+<a href="#RevisionRequestConcurrencyModelType">
+RevisionRequestConcurrencyModelType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConcurrencyModel specifies the desired concurrency model
+(Single or Multi) for the scale target. Defaults to Multi.
+Deprecated in favor of ContainerConcurrency.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerConcurrency</code></br>
+<em>
+<a href="#RevisionContainerConcurrencyType">
+RevisionContainerConcurrencyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerConcurrency specifies the maximum allowed
+in-flight (concurrent) requests per container of the Revision.
+Defaults to <code>0</code> which means unlimited concurrency.
+This field replaces ConcurrencyModel. A value of <code>1</code>
+is equivalent to <code>Single</code> and <code>0</code> is equivalent to <code>Multi</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>scaleTargetRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#crossversionobjectreference-v1-autoscaling">
+Kubernetes autoscaling/v1.CrossVersionObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
+is responsible for quickly right-sizing.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceName holds the name of a core Kubernetes Service resource that
+load balances over the pods referenced by the ScaleTargetRef.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="PodAutoscalerStatus">PodAutoscalerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#PodAutoscaler">PodAutoscaler</a>)
+</p>
+<p>
+<p>PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions communicates information about ongoing/complete
+reconciliation processes that bring the &ldquo;spec&rdquo; inline with the observed
+state of the world.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="networking.internal.knative.dev">networking.internal.knative.dev</h2>
+<p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#ClusterIngress">ClusterIngress</a>
+</li></ul>
+<h3 id="ClusterIngress">ClusterIngress
+</h3>
+<p>
+<p>ClusterIngress is a collection of rules that allow inbound connections to reach the
+endpoints defined by a backend. An ClusterIngress can be configured to give services
+externally-reachable urls, load balance traffic offer name based virtual hosting etc.</p>
+<p>This is heavily based on K8s Ingress <a href="https://godoc.org/k8s.io/api/extensions/v1beta1#Ingress">https://godoc.org/k8s.io/api/extensions/v1beta1#Ingress</a>
+which some highlighted modifications.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+networking.internal.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ClusterIngress</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Standard object&rsquo;s metadata.
+More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata">https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata</a></p>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#IngressSpec">
+IngressSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec is the desired state of the ClusterIngress.
+More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tls</code></br>
+<em>
+<a href="#ClusterIngressTLS">
+[]ClusterIngressTLS
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TLS configuration. Currently the ClusterIngress only supports a single TLS
+port, 443. If multiple members of this list specify different hosts, they
+will be multiplexed on the same port according to the hostname specified
+through the SNI TLS extension, if the ingress controller fulfilling the
+ingress supports SNI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rules</code></br>
+<em>
+<a href="#ClusterIngressRule">
+[]ClusterIngressRule
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A list of host rules used to configure the ClusterIngress.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#IngressStatus">
+IngressStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the current state of the ClusterIngress.
+More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterIngressBackend">ClusterIngressBackend
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ClusterIngressBackendSplit">ClusterIngressBackendSplit</a>)
+</p>
+<p>
+<p>ClusterIngressBackend describes all endpoints for a given service and port.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>serviceNamespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Specifies the namespace of the referenced service.</p>
+<p>NOTE: This differs from K8s Ingress to allow routing to different namespaces.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Specifies the name of the referenced service.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>servicePort</code></br>
+<em>
+k8s.io/apimachinery/pkg/util/intstr.IntOrString
+</em>
+</td>
+<td>
+<p>Specifies the port of the referenced service.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterIngressBackendSplit">ClusterIngressBackendSplit
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#HTTPClusterIngressPath">HTTPClusterIngressPath</a>)
+</p>
+<p>
+<p>ClusterIngressBackend describes all endpoints for a given service and port.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ClusterIngressBackend</code></br>
+<em>
+<a href="#ClusterIngressBackend">
+ClusterIngressBackend
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ClusterIngressBackend</code> are embedded into this type.)
+</p>
+<p>Specifies the backend receiving the traffic split.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>percent</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Specifies the split percentage, a number between 0 and 100.  If
+only one split is specified, we default to 100.</p>
+<p>NOTE: This differs from K8s Ingress to allow percentage split.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterIngressRule">ClusterIngressRule
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#IngressSpec">IngressSpec</a>)
+</p>
+<p>
+<p>ClusterIngressRule represents the rules mapping the paths under a specified host to
+the related backend services. Incoming requests are first evaluated for a host
+match, then routed to the backend associated with the matching ClusterIngressRuleValue.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>hosts</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Host is the fully qualified domain name of a network host, as defined
+by RFC 3986. Note the following deviations from the &ldquo;host&rdquo; part of the
+URI as defined in the RFC:
+1. IPs are not allowed. Currently a rule value can only apply to the
+IP in the Spec of the parent ClusterIngress.
+2. The <code>:</code> delimiter is not respected because ports are not allowed.
+Currently the port of an ClusterIngress is implicitly :80 for http and
+:443 for https.
+Both these may change in the future.
+If the host is unspecified, the ClusterIngress routes all traffic based on the
+specified ClusterIngressRuleValue.
+If multiple matching Hosts were provided, the first rule will take precedent.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>http</code></br>
+<em>
+<a href="#HTTPClusterIngressRuleValue">
+HTTPClusterIngressRuleValue
+</a>
+</em>
+</td>
+<td>
+<p>HTTP represents a rule to apply against incoming requests. If the
+rule is satisfied, the request is routed to the specified backend.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ClusterIngressTLS">ClusterIngressTLS
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#IngressSpec">IngressSpec</a>)
+</p>
+<p>
+<p>ClusterIngressTLS describes the transport layer security associated with an ClusterIngress.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>hosts</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Hosts are a list of hosts included in the TLS certificate. The values in
+this list must match the name/s used in the tlsSecret. Defaults to the
+wildcard host setting for the loadbalancer controller fulfilling this
+ClusterIngress, if left unspecified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SecretName is the name of the secret used to terminate SSL traffic.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretNamespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SecretNamespace is the namespace of the secret used to terminate SSL traffic.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serverCertificate</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServerCertificate identifies the certificate filename in the secret.
+Defaults to <code>tls.cert</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>privateKey</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PrivateKey identifies the private key filename in the secret.
+Defaults to <code>tls.key</code>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="HTTPClusterIngressPath">HTTPClusterIngressPath
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#HTTPClusterIngressRuleValue">HTTPClusterIngressRuleValue</a>)
+</p>
+<p>
+<p>HTTPClusterIngressPath associates a path regex with a backend. Incoming urls matching
+the path are forwarded to the backend.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>path</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Path is an extended POSIX regex as defined by IEEE Std 1003.1,
+(i.e this follows the egrep/unix syntax, not the perl syntax)
+matched against the path of an incoming request. Currently it can
+contain characters disallowed from the conventional &ldquo;path&rdquo;
+part of a URL as defined by RFC 3986. Paths must begin with
+a &lsquo;/&rsquo;. If unspecified, the path defaults to a catch all sending
+traffic to the backend.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>splits</code></br>
+<em>
+<a href="#ClusterIngressBackendSplit">
+[]ClusterIngressBackendSplit
+</a>
+</em>
+</td>
+<td>
+<p>Splits defines the referenced service endpoints to which the traffic
+will be forwarded to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>appendHeaders</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AppendHeaders allow specifying additional HTTP headers to add
+before forwarding a request to the destination service.</p>
+<p>NOTE: This differs from K8s Ingress which doesn&rsquo;t allow header appending.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeout</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Timeout for HTTP requests.</p>
+<p>NOTE: This differs from K8s Ingress which doesn&rsquo;t allow setting timeouts.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retries</code></br>
+<em>
+<a href="#HTTPRetry">
+HTTPRetry
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retry policy for HTTP requests.</p>
+<p>NOTE: This differs from K8s Ingress which doesn&rsquo;t allow retry settings.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="HTTPClusterIngressRuleValue">HTTPClusterIngressRuleValue
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ClusterIngressRule">ClusterIngressRule</a>)
+</p>
+<p>
+<p>HTTPClusterIngressRuleValue is a list of http selectors pointing to backends.
+In the example: http://<host>/<path>?<searchpart> -&gt; backend where
+where parts of the url correspond to RFC 3986, this resource will be used
+to match against everything after the last &lsquo;/&rsquo; and before the first &lsquo;?&rsquo;
+or &lsquo;#&rsquo;.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>paths</code></br>
+<em>
+<a href="#HTTPClusterIngressPath">
+[]HTTPClusterIngressPath
+</a>
+</em>
+</td>
+<td>
+<p>A collection of paths that map requests to backends.</p>
+<p>If they are multiple matching paths, the first match takes precendent.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="HTTPRetry">HTTPRetry
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#HTTPClusterIngressPath">HTTPClusterIngressPath</a>)
+</p>
+<p>
+<p>HTTPRetry describes the retry policy to use when a HTTP request fails.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>attempts</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Number of retries for a given request.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>perTryTimeout</code></br>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<p>Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="IngressSpec">IngressSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ClusterIngress">ClusterIngress</a>)
+</p>
+<p>
+<p>IngressSpec describes the ClusterIngress the user wishes to exist.</p>
+<p>In general this follow the same shape as K8s Ingress.  Some notable differences:
+- Backends now can have namespace:
+- Traffic can be split across multiple backends.
+- Timeout &amp; Retry can be configured.
+- Headers can be appended.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tls</code></br>
+<em>
+<a href="#ClusterIngressTLS">
+[]ClusterIngressTLS
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TLS configuration. Currently the ClusterIngress only supports a single TLS
+port, 443. If multiple members of this list specify different hosts, they
+will be multiplexed on the same port according to the hostname specified
+through the SNI TLS extension, if the ingress controller fulfilling the
+ingress supports SNI.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rules</code></br>
+<em>
+<a href="#ClusterIngressRule">
+[]ClusterIngressRule
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A list of host rules used to configure the ClusterIngress.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="IngressStatus">IngressStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ClusterIngress">ClusterIngress</a>)
+</p>
+<p>
+<p>IngressStatus describe the current state of the ClusterIngress.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>loadBalancer</code></br>
+<em>
+<a href="#LoadBalancerStatus">
+LoadBalancerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LoadBalancer contains the current status of the load-balancer.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="LoadBalancerIngressStatus">LoadBalancerIngressStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#LoadBalancerStatus">LoadBalancerStatus</a>)
+</p>
+<p>
+<p>LoadBalancerIngress represents the status of a load-balancer ingress point:
+traffic intended for the service should be sent to an ingress point.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ip</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IP is set for load-balancer ingress points that are IP based
+(typically GCE or OpenStack load-balancers)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>domain</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Domain is set for load-balancer ingress points that are DNS based
+(typically AWS load-balancers)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>domainInternal</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DomainInternal is set if there is a cluster-local DNS name to access the Ingress.</p>
+<p>NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+DNS name to allow routing in case of not having a mesh.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="LoadBalancerStatus">LoadBalancerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#IngressStatus">IngressStatus</a>)
+</p>
+<p>
+<p>LoadBalancerStatus represents the status of a load-balancer.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ingress</code></br>
+<em>
+<a href="#LoadBalancerIngressStatus">
+[]LoadBalancerIngressStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Ingress is a list containing ingress points for the load-balancer.
+Traffic intended for the service should be sent to these ingress points.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="serving.knative.dev">serving.knative.dev</h2>
+<p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#Configuration">Configuration</a>
+</li><li>
+<a href="#Revision">Revision</a>
+</li><li>
+<a href="#Route">Route</a>
+</li><li>
+<a href="#Service">Service</a>
+</li></ul>
+<h3 id="Configuration">Configuration
+</h3>
+<p>
+<p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions,
+and optionally how the containers those revisions reference are built.
+Users create new Revisions by updating the Configuration&rsquo;s spec.
+The &ldquo;latest created&rdquo; revision&rsquo;s name is available under status, as is the
+&ldquo;latest ready&rdquo; revision&rsquo;s name.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration">https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Configuration</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#ConfigurationSpec">
+ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Configuration (from the client).</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>build</code></br>
+<em>
+<a href="#RawExtension">
+RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Build optionally holds the specification for the build to
+perform to produce the Revision&rsquo;s container image.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>revisionTemplate</code></br>
+<em>
+<a href="#RevisionTemplateSpec">
+RevisionTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RevisionTemplate holds the latest specification for the Revision to
+be stamped out. If a Build specification is provided, then the
+RevisionTemplate&rsquo;s BuildName field will be populated with the name of
+the Build object created to produce the container for the Revision.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#ConfigurationStatus">
+ConfigurationStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the observed state of the Configuration (from the controller).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Revision">Revision
+</h3>
+<p>
+<p>Revision is an immutable snapshot of code and configuration.  A revision
+references a container image, and optionally a build that is responsible for
+materializing that container image from source. Revisions are created by
+updates to a Configuration.</p>
+<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision">https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Revision</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#RevisionSpec">
+RevisionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Revision (from the client).</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>servingState</code></br>
+<em>
+<a href="#DeprecatedRevisionServingStateType">
+DeprecatedRevisionServingStateType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedServingState holds a value describing the desired state the Kubernetes
+resources should be in for this Revision.
+Users must not specify this when creating a revision. These values are no longer
+updated by the system.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>concurrencyModel</code></br>
+<em>
+<a href="#RevisionRequestConcurrencyModelType">
+RevisionRequestConcurrencyModelType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConcurrencyModel specifies the desired concurrency model
+(Single or Multi) for the
+Revision. Defaults to Multi.
+Deprecated in favor of ContainerConcurrency.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerConcurrency</code></br>
+<em>
+<a href="#RevisionContainerConcurrencyType">
+RevisionContainerConcurrencyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerConcurrency specifies the maximum allowed
+in-flight (concurrent) requests per container of the Revision.
+Defaults to <code>0</code> which means unlimited concurrency.
+This field replaces ConcurrencyModel. A value of <code>1</code>
+is equivalent to <code>Single</code> and <code>0</code> is equivalent to <code>Multi</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the Revision exists.
+This may be used to provide access to private container images by
+following: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account">https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account</a>
+TODO(ZhiminXiang): verify the corresponding service account exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BuildName optionally holds the name of the Build responsible for
+producing the container image for its Revision.
+DEPRECATED: Use BuildRef instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BuildRef holds the reference to the build (if there is one) responsible
+for producing the container image for this Revision. Otherwise, nil</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Container defines the unit of execution for this Revision.
+In the context of a Revision, we disallow a number of the fields of
+this Container, including: name, resources, ports, and volumeMounts.
+TODO(mattmoor): Link to the runtime contract tracked by:
+<a href="https://github.com/knative/serving/issues/627">https://github.com/knative/serving/issues/627</a></p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#RevisionStatus">
+RevisionStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the observed state of the Revision (from the controller).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Route">Route
+</h3>
+<p>
+<p>Route is responsible for configuring ingress over a collection of Revisions.
+Some of the Revisions a Route distributes traffic over may be specified by
+referencing the Configuration responsible for creating them; in these cases
+the Route is additionally responsible for monitoring the Configuration for
+&ldquo;latest ready&rdquo; revision changes, and smoothly rolling out latest revisions.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#route">https://github.com/knative/serving/blob/master/docs/spec/overview.md#route</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Route</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#RouteSpec">
+RouteSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Route (from the client).</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>traffic</code></br>
+<em>
+<a href="#TrafficTarget">
+[]TrafficTarget
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Traffic specifies how to distribute traffic over a collection of Knative Serving Revisions and Configurations.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#RouteStatus">
+RouteStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the observed state of the Route (from the controller).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="Service">Service
+</h3>
+<p>
+<p>Service acts as a top-level container that manages a set of Routes and
+Configurations which implement a network service. Service exists to provide a
+singular abstraction which can be access controlled, reasoned about, and
+which encapsulates software lifecycle decisions such as rollout policy and
+team resource ownership. Service acts only as an orchestrator of the
+underlying Routes and Configurations (much as a kubernetes Deployment
+orchestrates ReplicaSets), and its usage is optional but recommended.</p>
+<p>The Service&rsquo;s controller will track the statuses of its owned Configuration
+and Route, reflecting their statuses and conditions as its own.</p>
+<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#service">https://github.com/knative/serving/blob/master/docs/spec/overview.md#service</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Service</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#ServiceSpec">
+ServiceSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runLatest</code></br>
+<em>
+<a href="#RunLatestType">
+RunLatestType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RunLatest defines a simple Service. It will automatically
+configure a route that keeps the latest ready revision
+from the supplied configuration running.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pinned</code></br>
+<em>
+<a href="#PinnedType">
+PinnedType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Pins this service to a specific revision name. The revision must
+be owned by the configuration provided.
+PinnedType is DEPRECATED in favor of ReleaseType</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>manual</code></br>
+<em>
+<a href="#ManualType">
+ManualType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Manual mode enables users to start managing the underlying Route and Configuration
+resources directly.  This advanced usage is intended as a path for users to graduate
+from the limited capabilities of Service to the full power of Route.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>release</code></br>
+<em>
+<a href="#ReleaseType">
+ReleaseType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Release enables gradual promotion of new revisions by allowing traffic
+to be split between two revisions. This type replaces the deprecated Pinned type.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#ServiceStatus">
+ServiceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ConfigurationSpec">ConfigurationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Configuration">Configuration</a>, 
+<a href="#PinnedType">PinnedType</a>, 
+<a href="#ReleaseType">ReleaseType</a>, 
+<a href="#RunLatestType">RunLatestType</a>)
+</p>
+<p>
+<p>ConfigurationSpec holds the desired state of the Configuration (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>build</code></br>
+<em>
+<a href="#RawExtension">
+RawExtension
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Build optionally holds the specification for the build to
+perform to produce the Revision&rsquo;s container image.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>revisionTemplate</code></br>
+<em>
+<a href="#RevisionTemplateSpec">
+RevisionTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RevisionTemplate holds the latest specification for the Revision to
+be stamped out. If a Build specification is provided, then the
+RevisionTemplate&rsquo;s BuildName field will be populated with the name of
+the Build object created to produce the container for the Revision.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ConfigurationStatus">ConfigurationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Configuration">Configuration</a>)
+</p>
+<p>
+<p>ConfigurationStatus communicates the observed state of the Configuration (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions communicates information about ongoing/complete
+reconciliation processes that bring the &ldquo;spec&rdquo; inline with the observed
+state of the world.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>latestReadyRevisionName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LatestReadyRevisionName holds the name of the latest Revision stamped out
+from this Configuration that has had its &ldquo;Ready&rdquo; condition become &ldquo;True&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>latestCreatedRevisionName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LatestCreatedRevisionName is the last revision that was created from this
+Configuration. It might not be ready yet, for that use LatestReadyRevisionName.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the Configuration that
+was last processed by the controller. The observed generation is updated
+even if the controller failed to process the spec and create the Revision.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="DeprecatedRevisionServingStateType">DeprecatedRevisionServingStateType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#RevisionSpec">RevisionSpec</a>)
+</p>
+<p>
+<p>DeprecatedRevisionServingStateType is an enumeration of the levels of serving readiness of the Revision.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/errors.md#error-conditions-and-reporting">https://github.com/knative/serving/blob/master/docs/spec/errors.md#error-conditions-and-reporting</a></p>
+</p>
+<h3 id="ManualType">ManualType
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ServiceSpec">ServiceSpec</a>)
+</p>
+<p>
+<p>ManualType contains the options for configuring a manual service. See ServiceSpec for
+more details.</p>
+</p>
+<h3 id="PinnedType">PinnedType
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ServiceSpec">ServiceSpec</a>)
+</p>
+<p>
+<p>PinnedType is DEPRECATED. ReleaseType should be used instead. To get the behavior of PinnedType set
+ReleaseType.Revisions to []string{PinnedType.RevisionName} and ReleaseType.RolloutPercent to 0.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>revisionName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The revision name to pin this service to until changed
+to a different service type.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#ConfigurationSpec">
+ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The configuration for this service.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RawExtension">RawExtension
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ConfigurationSpec">ConfigurationSpec</a>)
+</p>
+<p>
+<p>RawExtension is modeled after runtime.RawExtension, and should be
+replaced with it (or an alias) once we can stop supporting embedded
+BuildSpecs.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Raw</code></br>
+<em>
+[]byte
+</em>
+</td>
+<td>
+<p>Field order is the precedence for JSON marshaling if multiple
+fields are set.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>Object</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.Object
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>BuildSpec</code></br>
+<em>
+github.com/knative/build/pkg/apis/build/v1alpha1.BuildSpec
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ReleaseType">ReleaseType
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ServiceSpec">ServiceSpec</a>)
+</p>
+<p>
+<p>ReleaseType contains the options for slowly releasing revisions. See ServiceSpec for
+more details.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>revisions</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Revisions is an ordered list of 1 or 2 revisions. The first will
+have a TrafficTarget with a name of &ldquo;current&rdquo; and the second will have
+a name of &ldquo;candidate&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rolloutPercent</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RolloutPercent is the percent of traffic that should be sent to the &ldquo;candidate&rdquo;
+revision. Valid values are between 0 and 99 inclusive.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#ConfigurationSpec">
+ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The configuration for this service. All revisions from this service must
+come from a single configuration.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RevisionContainerConcurrencyType">RevisionContainerConcurrencyType
+(<code>int64</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#PodAutoscalerSpec">PodAutoscalerSpec</a>, 
+<a href="#RevisionSpec">RevisionSpec</a>)
+</p>
+<p>
+<p>RevisionContainerConcurrencyType is an integer expressing a number of
+in-flight (concurrent) requests.</p>
+</p>
+<h3 id="RevisionRequestConcurrencyModelType">RevisionRequestConcurrencyModelType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#PodAutoscalerSpec">PodAutoscalerSpec</a>, 
+<a href="#RevisionSpec">RevisionSpec</a>)
+</p>
+<p>
+<p>RevisionRequestConcurrencyModelType is an enumeration of the
+concurrency models supported by a Revision.
+Deprecated in favor of RevisionContainerConcurrencyType.</p>
+</p>
+<h3 id="RevisionSpec">RevisionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Revision">Revision</a>, 
+<a href="#RevisionTemplateSpec">RevisionTemplateSpec</a>)
+</p>
+<p>
+<p>RevisionSpec holds the desired state of the Revision (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>servingState</code></br>
+<em>
+<a href="#DeprecatedRevisionServingStateType">
+DeprecatedRevisionServingStateType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedServingState holds a value describing the desired state the Kubernetes
+resources should be in for this Revision.
+Users must not specify this when creating a revision. These values are no longer
+updated by the system.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>concurrencyModel</code></br>
+<em>
+<a href="#RevisionRequestConcurrencyModelType">
+RevisionRequestConcurrencyModelType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConcurrencyModel specifies the desired concurrency model
+(Single or Multi) for the
+Revision. Defaults to Multi.
+Deprecated in favor of ContainerConcurrency.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerConcurrency</code></br>
+<em>
+<a href="#RevisionContainerConcurrencyType">
+RevisionContainerConcurrencyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerConcurrency specifies the maximum allowed
+in-flight (concurrent) requests per container of the Revision.
+Defaults to <code>0</code> which means unlimited concurrency.
+This field replaces ConcurrencyModel. A value of <code>1</code>
+is equivalent to <code>Single</code> and <code>0</code> is equivalent to <code>Multi</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the Revision exists.
+This may be used to provide access to private container images by
+following: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account">https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account</a>
+TODO(ZhiminXiang): verify the corresponding service account exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BuildName optionally holds the name of the Build responsible for
+producing the container image for its Revision.
+DEPRECATED: Use BuildRef instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BuildRef holds the reference to the build (if there is one) responsible
+for producing the container image for this Revision. Otherwise, nil</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Container defines the unit of execution for this Revision.
+In the context of a Revision, we disallow a number of the fields of
+this Container, including: name, resources, ports, and volumeMounts.
+TODO(mattmoor): Link to the runtime contract tracked by:
+<a href="https://github.com/knative/serving/issues/627">https://github.com/knative/serving/issues/627</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RevisionStatus">RevisionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Revision">Revision</a>)
+</p>
+<p>
+<p>RevisionStatus communicates the observed state of the Revision (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>serviceName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceName holds the name of a core Kubernetes Service resource that
+load balances over the pods backing this Revision. When the Revision
+is Active, this service would be an appropriate ingress target for
+targeting the revision.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions communicates information about ongoing/complete
+reconciliation processes that bring the &ldquo;spec&rdquo; inline with the observed
+state of the world.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the Configuration that
+was last processed by the controller. The observed generation is updated
+even if the controller failed to process the spec and create the Revision.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>logUrl</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LogURL specifies the generated logging url for this particular revision
+based on the revision url template specified in the controller&rsquo;s config.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageDigest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImageDigest holds the resolved digest for the image specified
+within .Spec.Container.Image. The digest is resolved during the creation
+of Revision. This field holds the digest value regardless of whether
+a tag or digest was originally specified in the Container object. It
+may be empty if the image comes from a registry listed to skip resolution.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RevisionTemplateSpec">RevisionTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ConfigurationSpec">ConfigurationSpec</a>)
+</p>
+<p>
+<p>RevisionTemplateSpec describes the data a revision should have when created from a template.
+Based on: <a href="https://github.com/kubernetes/api/blob/e771f807/core/v1/types.go#L3179-L3190">https://github.com/kubernetes/api/blob/e771f807/core/v1/types.go#L3179-L3190</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#RevisionSpec">
+RevisionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>servingState</code></br>
+<em>
+<a href="#DeprecatedRevisionServingStateType">
+DeprecatedRevisionServingStateType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedServingState holds a value describing the desired state the Kubernetes
+resources should be in for this Revision.
+Users must not specify this when creating a revision. These values are no longer
+updated by the system.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>concurrencyModel</code></br>
+<em>
+<a href="#RevisionRequestConcurrencyModelType">
+RevisionRequestConcurrencyModelType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConcurrencyModel specifies the desired concurrency model
+(Single or Multi) for the
+Revision. Defaults to Multi.
+Deprecated in favor of ContainerConcurrency.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerConcurrency</code></br>
+<em>
+<a href="#RevisionContainerConcurrencyType">
+RevisionContainerConcurrencyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerConcurrency specifies the maximum allowed
+in-flight (concurrent) requests per container of the Revision.
+Defaults to <code>0</code> which means unlimited concurrency.
+This field replaces ConcurrencyModel. A value of <code>1</code>
+is equivalent to <code>Single</code> and <code>0</code> is equivalent to <code>Multi</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the Revision exists.
+This may be used to provide access to private container images by
+following: <a href="https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account">https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account</a>
+TODO(ZhiminXiang): verify the corresponding service account exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BuildName optionally holds the name of the Build responsible for
+producing the container image for its Revision.
+DEPRECATED: Use BuildRef instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>buildRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BuildRef holds the reference to the build (if there is one) responsible
+for producing the container image for this Revision. Otherwise, nil</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>container</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#container-v1-core">
+Kubernetes core/v1.Container
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Container defines the unit of execution for this Revision.
+In the context of a Revision, we disallow a number of the fields of
+this Container, including: name, resources, ports, and volumeMounts.
+TODO(mattmoor): Link to the runtime contract tracked by:
+<a href="https://github.com/knative/serving/issues/627">https://github.com/knative/serving/issues/627</a></p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RouteSpec">RouteSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Route">Route</a>)
+</p>
+<p>
+<p>RouteSpec holds the desired state of the Route (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>traffic</code></br>
+<em>
+<a href="#TrafficTarget">
+[]TrafficTarget
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Traffic specifies how to distribute traffic over a collection of Knative Serving Revisions and Configurations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RouteStatus">RouteStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Route">Route</a>)
+</p>
+<p>
+<p>RouteStatus communicates the observed state of the Route (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>domain</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Domain holds the top-level domain that will distribute traffic over the provided targets.
+It generally has the form {route-name}.{route-namespace}.{cluster-level-suffix}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>domainInternal</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DomainInternal holds the top-level domain that will distribute traffic over the provided
+targets from inside the cluster. It generally has the form
+{route-name}.{route-namespace}.svc.cluster.local
+DEPRECATED: Use Address instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Addressable">
+github.com/knative/pkg/apis/duck/v1alpha1.Addressable
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Address holds the information needed for a Route to be the target of an event.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>traffic</code></br>
+<em>
+<a href="#TrafficTarget">
+[]TrafficTarget
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Traffic holds the configured traffic distribution.
+These entries will always contain RevisionName references.
+When ConfigurationName appears in the spec, this will hold the
+LatestReadyRevisionName that we last observed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Conditions communicates information about ongoing/complete
+reconciliation processes that bring the &ldquo;spec&rdquo; inline with the observed
+state of the world.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the Configuration that
+was last processed by the controller. The observed generation is updated
+even if the controller failed to process the spec and create the Revision.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="RunLatestType">RunLatestType
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#ServiceSpec">ServiceSpec</a>)
+</p>
+<p>
+<p>RunLatestType contains the options for always having a route to the latest configuration. See
+ServiceSpec for more details.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>configuration</code></br>
+<em>
+<a href="#ConfigurationSpec">
+ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The configuration for this service.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ServiceSpec">ServiceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Service">Service</a>)
+</p>
+<p>
+<p>ServiceSpec represents the configuration for the Service object. Exactly one
+of its members (other than Generation) must be specified. Services can either
+track the latest ready revision of a configuration or be pinned to a specific
+revision.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO: Generation does not work correctly with CRD. They are scrubbed
+by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
+So, we add Generation here. Once that gets fixed, remove this and use
+ObjectMeta.Generation instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>runLatest</code></br>
+<em>
+<a href="#RunLatestType">
+RunLatestType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RunLatest defines a simple Service. It will automatically
+configure a route that keeps the latest ready revision
+from the supplied configuration running.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>pinned</code></br>
+<em>
+<a href="#PinnedType">
+PinnedType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Pins this service to a specific revision name. The revision must
+be owned by the configuration provided.
+PinnedType is DEPRECATED in favor of ReleaseType</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>manual</code></br>
+<em>
+<a href="#ManualType">
+ManualType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Manual mode enables users to start managing the underlying Route and Configuration
+resources directly.  This advanced usage is intended as a path for users to graduate
+from the limited capabilities of Service to the full power of Route.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>release</code></br>
+<em>
+<a href="#ReleaseType">
+ReleaseType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Release enables gradual promotion of new revisions by allowing traffic
+to be split between two revisions. This type replaces the deprecated Pinned type.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="ServiceStatus">ServiceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#Service">Service</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>conditions</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Conditions">
+github.com/knative/pkg/apis/duck/v1alpha1.Conditions
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>domain</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>From RouteStatus.
+Domain holds the top-level domain that will distribute traffic over the provided targets.
+It generally has the form {route-name}.{route-namespace}.{cluster-level-suffix}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>domainInternal</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>From RouteStatus.
+DomainInternal holds the top-level domain that will distribute traffic over the provided
+targets from inside the cluster. It generally has the form
+{route-name}.{route-namespace}.svc.cluster.local
+DEPRECATED: Use Address instead.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Addressable">
+github.com/knative/pkg/apis/duck/v1alpha1.Addressable
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Address holds the information needed for a Route to be the target of an event.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>traffic</code></br>
+<em>
+<a href="#TrafficTarget">
+[]TrafficTarget
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>From RouteStatus.
+Traffic holds the configured traffic distribution.
+These entries will always contain RevisionName references.
+When ConfigurationName appears in the spec, this will hold the
+LatestReadyRevisionName that we last observed.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>latestReadyRevisionName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>From ConfigurationStatus.
+LatestReadyRevisionName holds the name of the latest Revision stamped out
+from this Service&rsquo;s Configuration that has had its &ldquo;Ready&rdquo; condition become &ldquo;True&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>latestCreatedRevisionName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>From ConfigurationStatus.
+LatestCreatedRevisionName is the last revision that was created from this Service&rsquo;s
+Configuration. It might not be ready yet, for that use LatestReadyRevisionName.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the Service that
+was last processed by the controller.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="TrafficTarget">TrafficTarget
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#RouteSpec">RouteSpec</a>, 
+<a href="#RouteStatus">RouteStatus</a>, 
+<a href="#ServiceStatus">ServiceStatus</a>)
+</p>
+<p>
+<p>TrafficTarget holds a single entry of the routing table for a Route.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Name is optionally used to expose a dedicated hostname for referencing this
+target exclusively. It has the form: {name}.${route.status.domain}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>revisionName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RevisionName of a specific revision to which to send this portion of traffic.
+This is mutually exclusive with ConfigurationName.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>configurationName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConfigurationName of a configuration to whose latest revision we will send
+this portion of traffic. When the &ldquo;status.latestReadyRevisionName&rdquo; of the
+referenced configuration changes, we will automatically migrate traffic
+from the prior &ldquo;latest ready&rdquo; revision to the new one.
+This field is never set in Route&rsquo;s status, only its spec.
+This is mutually exclusive with RevisionName.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>percent</code></br>
+<em>
+int
+</em>
+</td>
+<td>
+<p>Percent specifies percent of the traffic to this Revision or Configuration.
+This defaults to zero if unspecified.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+on git commit <code>5cbee406</code>.
+</em></p>


### PR DESCRIPTION
Generated with https://github.com/ahmetb/gen-crd-api-reference-docs and
this patch includes the script to self-serve this process. I hope to improve
this stuff in the future, for now it works fine.

Fixes #636.