### PR TITLE
Format markdown

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -131,15 +131,16 @@ recommended configuration for a cluster is:
 Knative depends on Istio.
 
 1. Install Istio:
+
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
    ```
-   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-   also included in the `istio.yaml` file, but they are pulled out so that
-   the CRD definitions are created first. If you see an error when creating
-   resources about an unknown type, run the second `kubectl apply` command
-   again.
+
+   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+   included in the `istio.yaml` file, but they are pulled out so that the CRD
+   definitions are created first. If you see an error when creating resources
+   about an unknown type, run the second `kubectl apply` command again.
 
 1. Label the default namespace with `istio-injection=enabled`:
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -131,15 +131,16 @@ Admin permissions are required to create the necessary
 Knative depends on Istio.
 
 1. Install Istio:
+
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
    ```
-   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-   also included in the `istio.yaml` file, but they are pulled out so that
-   the CRD definitions are created first. If you see an error when creating
-   resources about an unknown type, run the second `kubectl apply` command
-   again.
+
+   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+   included in the `istio.yaml` file, but they are pulled out so that the CRD
+   definitions are created first. If you see an error when creating resources
+   about an unknown type, run the second `kubectl apply` command again.
 
 1. Label the default namespace with `istio-injection=enabled`:
    ```bash

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -70,15 +70,16 @@ of this guide be sure you have `export KUBECONFIG=my-cluster.yaml` set.
 Knative depends on Istio.
 
 1.  Install Istio:
+
     ```bash
-	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
     ```
-    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-    also included in the `istio.yaml` file, but they are pulled out so that
-    the CRD definitions are created first. If you see an error when creating
-    resources about an unknown type, run the second `kubectl apply` command
-    again.
+
+    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+    included in the `istio.yaml` file, but they are pulled out so that the CRD
+    definitions are created first. If you see an error when creating resources
+    about an unknown type, run the second `kubectl apply` command again.
 
 2.  Label the default namespace with `istio-injection=enabled`:
     ```bash

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -136,15 +136,16 @@ components, the recommended configuration for a cluster is:
 Knative depends on Istio.
 
 1.  Install Istio:
+
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
     ```
-	Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-	also included in the `istio.yaml` file, but they are pulled out so that
-	the CRD definitions are created first. If you see an error when creating
-	resources about an unknown type, run the second `kubectl apply` command
-	again.
+
+    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+    included in the `istio.yaml` file, but they are pulled out so that the CRD
+    definitions are created first. If you see an error when creating resources
+    about an unknown type, run the second `kubectl apply` command again.
 
 1.  Label the default namespace with `istio-injection=enabled`:
     ```bash

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -167,11 +167,11 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/is
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
    oc apply -f https://storage.googleapis.com/knative-releases/serving/latest/istio.yaml
    ```
-   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-   also included in the `istio.yaml` file, but they are pulled out so that
-   the CRD definitions are created first. If you see an error when creating
-   resources about an unknown type, run the second `kubectl apply` command
-   again.
+
+   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+   included in the `istio.yaml` file, but they are pulled out so that the CRD
+   definitions are created first. If you see an error when creating resources
+   about an unknown type, run the second `kubectl apply` command again.
 
 2. Ensure the istio-sidecar-injector pods runs as provileged:
    ```shell

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -47,15 +47,16 @@ Knative depends on Istio. Istio workloads require privileged mode for Init
 Containers
 
 1. Install Istio:
+
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml
    ```
-   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-   also included in the `istio.yaml` file, but they are pulled out so that
-   the CRD definitions are created first. If you see an error when creating
-   resources about an unknown type, run the second `kubectl apply` command
-   again.
+
+   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+   included in the `istio.yaml` file, but they are pulled out so that the CRD
+   definitions are created first. If you see an error when creating resources
+   about an unknown type, run the second `kubectl apply` command again.
 
 1. Label the default namespace with `istio-injection=enabled`:
    ```bash

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -20,15 +20,16 @@ Knative depends on Istio. Istio workloads require privileged mode for Init
 Containers.
 
 1.  Install Istio:
+
     ```bash
-	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.2/istio-crds.yaml && \
     kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.2/third_party/istio-1.0.2/istio.yaml
     ```
-    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
-    also included in the `istio.yaml` file, but they are pulled out so that
-    the CRD definitions are created first. If you see an error when creating
-    resources about an unknown type, run the second `kubectl apply` command
-    again.
+
+    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
+    included in the `istio.yaml` file, but they are pulled out so that the CRD
+    definitions are created first. If you see an error when creating resources
+    about an unknown type, run the second `kubectl apply` command again.
 
 1.  Label the default namespace with `istio-injection=enabled`:
     ```bash

--- a/install/README.md
+++ b/install/README.md
@@ -48,8 +48,8 @@ Now you're ready to deploy an app:
 
 - View the available [sample apps](../serving/samples) and deploy one of your
   choosing.
-  
-- Walk through the Google codelab, 
+
+- Walk through the Google codelab,
   [Using Knative to deploy serverless applications to Kubernetes](https://codelabs.developers.google.com/codelabs/knative-intro/#0).
 
 ## Configuring Knative Serving


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`