### PR TITLE
Fix kubectl apply command for install on GKE

### DIFF
--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -165,9 +165,9 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:


### PR DESCRIPTION
## Proposed Changes

This PR removes a duplicate `--filename` flag as well as replaces forward slashes with back slashes in the `kubectl apply` command for installing Knative.
