### PR TITLE
Update installs to 3.0 releases; fixing error in some install commands

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -132,8 +132,8 @@ Knative depends on Istio.
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
    ```
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
    also included in the `istio.yaml` file, but they are pulled out so that
@@ -164,9 +164,10 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -132,8 +132,8 @@ Knative depends on Istio.
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
    ```
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
    also included in the `istio.yaml` file, but they are pulled out so that
@@ -165,9 +165,10 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml \
-    --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -71,8 +71,8 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
+	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
     ```
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
     also included in the `istio.yaml` file, but they are pulled out so that
@@ -101,9 +101,10 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -137,8 +137,8 @@ Knative depends on Istio.
 
 1.  Install Istio:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
     ```
 	Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
 	also included in the `istio.yaml` file, but they are pulled out so that
@@ -170,9 +170,10 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -48,8 +48,8 @@ Containers
 
 1. Install Istio:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
    ```
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
    also included in the `istio.yaml` file, but they are pulled out so that
@@ -78,9 +78,10 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -21,8 +21,8 @@ Containers.
 
 1.  Install Istio:
     ```bash
-	kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/istio-crds.yaml && \
-    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.2.3/third_party/istio-1.0.2/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
     ```
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are
     also included in the `istio.yaml` file, but they are pulled out so that
@@ -54,9 +54,10 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.2.3/release.yaml /
-    --filename https://github.com/knative/eventing/releases/download/v0.2.1/eventing.yaml /
-    --filename --filename https://github.com/knative/eventing-sources/releases/download/v0.2.1/release.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:


### PR DESCRIPTION
* Updates installs in most guides to 0.3.0 release. 

* Doesn't update guides that were using the release-lite.yamls to install Knative, since those release versions don't exist in 0.3.0. Created #740 to track this.

Some install commands had an extra --filename flag and were using incorrect slashes, same as #736 ; also fixes that issue