### PR TITLE
Remove license header for Node.js sample

### DIFF
--- a/serving/samples/helloworld-nodejs/app.js
+++ b/serving/samples/helloworld-nodejs/app.js
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Knative Authors
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    https://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 const express = require('express');
 const app = express();
 


### PR DESCRIPTION
This is a 15 line trivial hello world, a 15 line license header adds unnecessary complexity.
Many other samples do not include a license header.
The license is already captured at the root of the repository.
