### PR TITLE
Updating k8s version requirements.

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -7,9 +7,9 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
-required. This guide walks you through creating a cluster with the correct
-specifications for Knative on Azure Kubernetes Service (AKS).
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 or newer
+is also required. This guide walks you through creating a cluster with the
+correct specifications for Knative on Azure Kubernetes Service (AKS).
 
 This guide assumes you are using bash in a Mac or Linux environment; some
 commands will need to be adjusted for use in a Windows environment.
@@ -94,7 +94,7 @@ Next we will create a managed Kubernetes cluster using AKS. To make sure the
 cluster is large enough to host all the Knative and Istio components, the
 recommended configuration for a cluster is:
 
-- Kubernetes version 1.10 or later
+- Kubernetes version 1.11 or later
 - Three or more nodes
 - Standard_DS3_v2 nodes
 - RBAC enabled
@@ -110,7 +110,7 @@ recommended configuration for a cluster is:
    az aks create --resource-group $RESOURCE_GROUP \
    --name $CLUSTER_NAME \
    --generate-ssh-keys \
-   --kubernetes-version 1.10.5 \
+   --kubernetes-version 1.11.0 \
    --enable-rbac \
    --node-vm-size Standard_DS3_v2
    ```

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -7,9 +7,9 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
-required. This guide walks you through creating a cluster with the correct
-specifications for Knative on Google Cloud Platform (GCP).
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 or newer
+is also required. This guide walks you through creating a cluster with the
+correct specifications for Knative on Google Cloud Platform (GCP).
 
 This guide assumes you are using `bash` in a Mac or Linux environment; some
 commands will need to be adjusted for use in a Windows environment.
@@ -99,7 +99,7 @@ Engine cluster.
 To make sure the cluster is large enough to host all the Knative and Istio
 components, the recommended configuration for a cluster is:
 
-- Kubernetes version 1.10 or later
+- Kubernetes version 1.11 or later
 - 4 vCPU nodes (`n1-standard-4`)
 - Node autoscaling, up to 10 nodes
 - API scopes for `cloud-platform`, `logging-write`, `monitoring-write`, and

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -13,7 +13,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer.
+Knative requires a Kubernetes cluster v1.11 or newer.
 
 ### Install and configure kubectl
 

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -13,9 +13,9 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. This guide walks you
-through creating a cluster with the correct specifications for Knative on IBM
-Cloud Kubernetes Service.
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 or newer
+is also required. This guide walks you through creating a cluster with the
+correct specifications for Knative on IBM Cloud Kubernetes Service.
 
 This guide assumes you are using bash in a Mac or Linux environment; some
 commands need to be adjusted for use in a Windows environment.

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -7,9 +7,9 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
-required. This guide walks you through creating a cluster with the correct
-specifications for Knative on Pivotal Container Service.
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 or newer
+is also required. This guide walks you through creating a cluster with the
+correct specifications for Knative on Pivotal Container Service.
 
 This guide assumes you are using bash in a Mac or Linux environment; some
 commands will need to be adjusted for use in a Windows environment.


### PR DESCRIPTION
For Knative v0.3, kubernetes v1.11+ is required.

For the AKS guide, I need someone to review what k8s version should be recommended. @jeremyrickard  can you double-check that, or recommend someone who can?