### PR TITLE
Use release.yaml instead of eventing.yaml

### DIFF
--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -166,7 +166,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -167,7 +167,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -103,7 +103,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -172,7 +172,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -80,7 +80,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -56,7 +56,7 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     ```bash
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml \
+    --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
     ```
 1. Monitor the Knative components until all of the components show a


### PR DESCRIPTION
`eventing.yaml` doesn't install the in-memory provisioner, `release.yaml` does. Since the provisioner is required to run the samples, we should be
telling users to install `release.yaml`.

This (hopefully) fixes the issues people are having running samples with 0.3.0.