### PR TITLE
Bump required kube version to 1.11 to align with v0.3.0 release

### DIFF
--- a/install/Knative-custom-install.md
+++ b/install/Knative-custom-install.md
@@ -25,11 +25,11 @@ that you to run multiple and separate installation commands.
 
 - Kubernetes requirements:
 
-  - Your Kubernetes cluster version must be v1.10 or newer.
+  - Your Kubernetes cluster version must be v1.11 or newer.
 
   - Your version of the
     [`kubectl` CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-    must be v1.10 or newer.
+    must be v1.11 or newer.
 
 ## Installing Istio
 
@@ -83,7 +83,7 @@ service mesh. If you install any of the following options, you must install the
 
 1. If you choose to install the Istio service mesh with automatic sidecar
    injection, you must ensure that the
-   [`MutatingAdmissionWebhook` admission controller](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#mutatingwebhookconfiguration-v1beta1-admissionregistration-k8s-io)
+   [`MutatingAdmissionWebhook` admission controller](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#mutatingwebhookconfiguration-v1beta1-admissionregistration-k8s-io)
    is enabled on your cluster by running the following command:
 
    ```bash

--- a/install/Knative-custom-install.md
+++ b/install/Knative-custom-install.md
@@ -29,7 +29,7 @@ that you to run multiple and separate installation commands.
 
   - Your version of the
     [`kubectl` CLI tool](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-    must be v1.11 or newer.
+    must be v1.10 or newer.
 
 ## Installing Istio
 

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -7,7 +7,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.11 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Azure Kubernetes Service (AKS).
 
@@ -46,7 +46,7 @@ brew install azure-cli
 ### Installing kubectl
 
 1. If you already have `kubectl`, run `kubectl version` to check your client
-   version. If you have `kubectl` v1.10 installed, you can skip to the next
+   version. If you have `kubectl` v1.11 installed, you can skip to the next
    section and create an AKS cluster
 
 ```bash
@@ -94,7 +94,7 @@ Next we will create a managed Kubernetes cluster using AKS. To make sure the
 cluster is large enough to host all the Knative and Istio components, the
 recommended configuration for a cluster is:
 
-- Kubernetes version 1.10 or later
+- Kubernetes version 1.11 or later
 - Three or more nodes
 - Standard_DS3_v2 nodes
 - RBAC enabled
@@ -110,7 +110,7 @@ recommended configuration for a cluster is:
    az aks create --resource-group $RESOURCE_GROUP \
    --name $CLUSTER_NAME \
    --generate-ssh-keys \
-   --kubernetes-version 1.10.5 \
+   --kubernetes-version 1.11.5 \
    --enable-rbac \
    --node-vm-size Standard_DS3_v2
    ```

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -7,7 +7,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.11 is also
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Azure Kubernetes Service (AKS).
 
@@ -46,7 +46,7 @@ brew install azure-cli
 ### Installing kubectl
 
 1. If you already have `kubectl`, run `kubectl version` to check your client
-   version. If you have `kubectl` v1.11 installed, you can skip to the next
+   version. If you have `kubectl` v1.10 installed, you can skip to the next
    section and create an AKS cluster
 
 ```bash

--- a/install/Knative-with-Docker-for-Mac.md
+++ b/install/Knative-with-Docker-for-Mac.md
@@ -9,7 +9,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. If you don't have one, you
+Knative requires a Kubernetes cluster v1.11 or newer. If you don't have one, you
 can create one using [Docker for Mac](https://docs.docker.com/docker-for-mac/).
 If you haven't already,
 [install Docker for Mac](https://docs.docker.com/docker-for-mac/install/) before

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -7,7 +7,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.11 is also
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Google Cloud Platform (GCP).
 
@@ -16,7 +16,7 @@ commands will need to be adjusted for use in a Windows environment.
 
 ### Installing the Google Cloud SDK and `kubectl`
 
-1. If you already have `gcloud` installed with `kubectl` version 1.11 or newer,
+1. If you already have `gcloud` installed with `kubectl` version 1.10 or newer,
    you can skip these steps.
 
    > Tip: To check which version of `kubectl` you have installed, enter:

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -7,7 +7,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.11 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Google Cloud Platform (GCP).
 
@@ -16,7 +16,7 @@ commands will need to be adjusted for use in a Windows environment.
 
 ### Installing the Google Cloud SDK and `kubectl`
 
-1. If you already have `gcloud` installed with `kubectl` version 1.10 or newer,
+1. If you already have `gcloud` installed with `kubectl` version 1.11 or newer,
    you can skip these steps.
 
    > Tip: To check which version of `kubectl` you have installed, enter:
@@ -99,7 +99,7 @@ Engine cluster.
 To make sure the cluster is large enough to host all the Knative and Istio
 components, the recommended configuration for a cluster is:
 
-- Kubernetes version 1.10 or later
+- Kubernetes version 1.11 or later
 - 4 vCPU nodes (`n1-standard-4`)
 - Node autoscaling, up to 10 nodes
 - API scopes for `cloud-platform`, `logging-write`, `monitoring-write`, and

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -18,7 +18,7 @@ Knative requires a Kubernetes cluster v1.11 or newer.
 ### Install and configure kubectl
 
 1.  If you already have `kubectl` CLI, run `kubectl version --short` to check
-    the version. You need v1.11 or newer. If your `kubectl` is older, follow the
+    the version. You need v1.10 or newer. If your `kubectl` is older, follow the
     next step to install a newer version.
 
 2.  [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -13,12 +13,12 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer.
+Knative requires a Kubernetes cluster v1.11 or newer.
 
 ### Install and configure kubectl
 
 1.  If you already have `kubectl` CLI, run `kubectl version --short` to check
-    the version. You need v1.10 or newer. If your `kubectl` is older, follow the
+    the version. You need v1.11 or newer. If your `kubectl` is older, follow the
     next step to install a newer version.
 
 2.  [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -13,7 +13,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. This guide walks you
+Knative requires a Kubernetes cluster v1.11 or newer. This guide walks you
 through creating a cluster with the correct specifications for Knative on IBM
 Cloud Kubernetes Service.
 
@@ -67,7 +67,7 @@ environment variables.
 To make sure the cluster is large enough to host all the Knative and Istio
 components, the recommended configuration for a cluster is:
 
-- Kubernetes version 1.10 or later
+- Kubernetes version 1.11 or later
 - 4 vCPU nodes with 16GB memory (`b2c.4x16`)
 
 1.  Set `ibmcloud` to the appropriate region:
@@ -77,7 +77,7 @@ components, the recommended configuration for a cluster is:
 1.  Select a Kubernetes version:
     ```bash
     ibmcloud cs kube-versions
-    export CLUSTER_K8S_VERSION=[a version from the list, must be >1.10]
+    export CLUSTER_K8S_VERSION=[a version from the list, must be >1.11]
     ```
 1.  Create a Kubernetes cluster on IKS with the required specifications:
 

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -15,7 +15,7 @@ can create one using [Minikube](https://github.com/kubernetes/minikube).
 ### Install kubectl and Minikube
 
 1. If you already have `kubectl` CLI, run `kubectl version` to check the
-   version. You need v1.11 or newer. If your `kubectl` is older, follow the next
+   version. You need v1.10 or newer. If your `kubectl` is older, follow the next
    step to install a newer version.
 
 1. [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
@@ -34,7 +34,7 @@ For Linux use:
 
 ```shell
 minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.11.3 \
+  --kubernetes-version=v1.11.5 \
   --vm-driver=kvm2 \
   --disk-size=30g \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
@@ -44,7 +44,7 @@ For macOS use:
 
 ```shell
 minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.11.3 \
+  --kubernetes-version=v1.11.5 \
   --vm-driver=hyperkit \
   --disk-size=30g \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -9,13 +9,13 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. If you don't have one, you
+Knative requires a Kubernetes cluster v1.11 or newer. If you don't have one, you
 can create one using [Minikube](https://github.com/kubernetes/minikube).
 
 ### Install kubectl and Minikube
 
 1. If you already have `kubectl` CLI, run `kubectl version` to check the
-   version. You need v1.10 or newer. If your `kubectl` is older, follow the next
+   version. You need v1.11 or newer. If your `kubectl` is older, follow the next
    step to install a newer version.
 
 1. [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
@@ -27,7 +27,7 @@ can create one using [Minikube](https://github.com/kubernetes/minikube).
 
 ## Creating a Kubernetes cluster
 
-After kubectl and Minikube are installed, create a cluster with version 1.10 or
+After kubectl and Minikube are installed, create a cluster with version 1.11 or
 greater and your chosen VM driver:
 
 For Linux use:

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -10,7 +10,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-These instructions will run an OpenShift 3.10 (Kubernetes 1.10) cluster on your
+These instructions will run an OpenShift 3.10 (Kubernetes 1.11) cluster on your
 local machine using
 [`oc cluster up`](https://docs.openshift.org/latest/getting_started/administrators.html#running-in-a-docker-container)
 to test-drive knative.

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -7,7 +7,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.11 is also
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Pivotal Container Service.
 

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -7,7 +7,7 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer. `kubectl` v1.10 is also
+Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.11 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Pivotal Container Service.
 

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -5,9 +5,9 @@ using pre-built images.
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.10 or newer with the
+Knative requires a Kubernetes cluster v1.11 or newer with the
 [MutatingAdmissionWebhook admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#how-do-i-turn-on-an-admission-controller)
-enabled. `kubectl` v1.10 is also required. This guide assumes that you've
+enabled. `kubectl` v1.11 is also required. This guide assumes that you've
 already created a Kubernetes cluster which you're comfortable installing _alpha_
 software on.
 

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -7,7 +7,7 @@ using pre-built images.
 
 Knative requires a Kubernetes cluster v1.11 or newer with the
 [MutatingAdmissionWebhook admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#how-do-i-turn-on-an-admission-controller)
-enabled. `kubectl` v1.11 is also required. This guide assumes that you've
+enabled. `kubectl` v1.10 is also required. This guide assumes that you've
 already created a Kubernetes cluster which you're comfortable installing _alpha_
 software on.
 


### PR DESCRIPTION
Fixes #(issue-number)

## Proposed Changes

- use kube version 1.11
- the recommended version of knative was bumped to v0.3.0 - we need to adjust the kube version as well
