### PR TITLE
golang format tools

### DIFF
--- a/serving/samples/helloworld-shell/invoke.go
+++ b/serving/samples/helloworld-shell/invoke.go
@@ -9,8 +9,8 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-    cmd := exec.CommandContext(r.Context(), "/bin/sh", "script.sh")
-    cmd.Stderr = os.Stderr
+	cmd := exec.CommandContext(r.Context(), "/bin/sh", "script.sh")
+	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
 		w.WriteHeader(500)


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
