### PR TITLE
Update metrics and ingress gateway documentation

### DIFF
--- a/serving/accessing-metrics.md
+++ b/serving/accessing-metrics.md
@@ -3,9 +3,11 @@
 You access metrics through the [Grafana](https://grafana.com/) UI. Grafana is
 the visualization tool for [Prometheus](https://prometheus.io/).
 
+## Grafana
+
 1. To open Grafana, enter the following command:
 
-```
+```shell
 kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespace knative-monitoring --selector=app=grafana --output=jsonpath="{.items..metadata.name}") 3000
 ```
 
@@ -33,8 +35,37 @@ The following dashboards are pre-installed with Knative Serving:
 4. Set up an administrator account to modify or add dashboards by signing in
    with username: `admin` and password: `admin`.
 
-- Before you expose the Grafana UI outside the cluster, make sure to change the
+  - Before you expose the Grafana UI outside the cluster, make sure to change the
   password.
+
+
+## Prometheus
+
+Grafana provides a richer set of graphing functionality than Prometheus.
+However, it can often times be useful to access Prometheus for debugging.
+
+1. To open Prometheus, enter the following command:
+```shell
+kubectl port-forward -n knative-monitoring $(kubectl get pods -n knative-monitoring --selector=app=prometheus --output=jsonpath="{.items[0].metadata.name}") 9090
+```
+
+  - This starts a local proxy of Prometheus on port 9090. For security reasons,
+    the Prometheus UI is exposed only within the cluster.
+
+2. Navigate to the Prometheus UI at
+   [http://localhost:9090](http://localhost:9090)
+
+### Metrics Troubleshooting
+
+You can use the Prometheus web UI to troubleshoot publishing and service
+discovery issues for metrics.
+
+- To see the targets that are being scraped, go to Status -> Targets
+- To see what Prometheus service discovery is picking up vs. dropping, go to
+  Status -> Service Discovery
+- To see a specific metric you can search for in the in search box on the top of
+  the page
+
 
 ---
 

--- a/serving/accessing-metrics.md
+++ b/serving/accessing-metrics.md
@@ -8,7 +8,10 @@ the visualization tool for [Prometheus](https://prometheus.io/).
 1. To open Grafana, enter the following command:
 
 ```shell
-kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespace knative-monitoring --selector=app=grafana --output=jsonpath="{.items..metadata.name}") 3000
+kubectl port-forward --namespace knative-monitoring \
+$(kubectl get pods --namespace knative-monitoring \
+--selector=app=grafana --output=jsonpath="{.items..metadata.name}") \
+3000
 ```
 
 - This starts a local proxy of Grafana on port 3000. For security reasons, the
@@ -36,7 +39,9 @@ The following dashboards are pre-installed with Knative Serving:
    with username: `admin` and password: `admin`.
 
   - Before you expose the Grafana UI outside the cluster, make sure to change the
-  password.
+  password. You will be prompted to set a password on first login, and it can
+  later be changed at
+  [http://localhost:3000/org/users](http://localhost:3000/org/users).
 
 
 ## Prometheus
@@ -46,7 +51,10 @@ However, it can often times be useful to access Prometheus for debugging.
 
 1. To open Prometheus, enter the following command:
 ```shell
-kubectl port-forward -n knative-monitoring $(kubectl get pods -n knative-monitoring --selector=app=prometheus --output=jsonpath="{.items[0].metadata.name}") 9090
+kubectl port-forward -n knative-monitoring \
+$(kubectl get pods -n knative-monitoring \
+--selector=app=prometheus --output=jsonpath="{.items[0].metadata.name}") \
+9090
 ```
 
   - This starts a local proxy of Prometheus on port 9090. For security reasons,

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -15,7 +15,6 @@ external IP address of the `istio-ingressgateway` service to a static IP.
 If you have configured a [custom ingress
 gateway](setting-up-custom-ingress-gateway.md), replace `istio-ingressgateway` with the name of your
 gateway service in the steps below.
-gateway service in the steps below instead of `istio-ingressgateway`.
 
 ## Step 1: Reserve a static IP address
 

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -13,7 +13,8 @@ Therefore, in order to set a static IP for the gateway you must to set the
 external IP address of the `istio-ingressgateway` service to a static IP.
 
 If you have configured a [custom ingress
-gateway](setting-up-custom-ingress-gateway.md) you will use the name of your
+gateway](setting-up-custom-ingress-gateway.md), replace `istio-ingressgateway` with the name of your
+gateway service in the steps below.
 gateway service in the steps below instead of `istio-ingressgateway`.
 
 ## Step 1: Reserve a static IP address

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -12,6 +12,10 @@ the "istio-ingressgateway" service under the `istio-system` namespace.
 Therefore, in order to set a static IP for the gateway you must to set the
 external IP address of the `istio-ingressgateway` service to a static IP.
 
+If you have configured a [custom ingress
+gateway](setting-up-custom-ingress-gateway.md) you will use the name of your
+gateway service in the steps below instead of `istio-ingressgateway`.
+
 ## Step 1: Reserve a static IP address
 
 You can reserve a regional static IP address using the Google Cloud SDK or the

--- a/serving/setting-up-custom-ingress-gateway.md
+++ b/serving/setting-up-custom-ingress-gateway.md
@@ -1,5 +1,8 @@
 # Setting Up Custom Ingress Gateway
 
+[TODO: Update instructions using
+Helm](https://github.com/knative/docs/issues/875)
+
 Knative uses a shared ingress Gateway to serve all incoming traffic within Knative
 service mesh, which is the `knative-ingress-gateway` Gateway under
 `knative-serving` namespace. By default, we use Istio gateway service

--- a/serving/setting-up-custom-ingress-gateway.md
+++ b/serving/setting-up-custom-ingress-gateway.md
@@ -14,7 +14,7 @@ template in [Istio release](https://github.com/istio/istio/releases).
 
 Here is an example:
 
-```
+```yaml
 apiVersion: v1
 kind: Service
 metadata:

--- a/serving/setting-up-custom-ingress-gateway.md
+++ b/serving/setting-up-custom-ingress-gateway.md
@@ -1,0 +1,256 @@
+# Setting Up Custom Ingress Gateway
+
+Knative uses a shared ingress Gateway to serve all incoming traffic within Knative
+service mesh, which is the `knative-ingress-gateway` Gateway under
+`knative-serving` namespace. By default, we use Istio gateway service
+`istio-ingressgateway` under `istio-system` namespace as its underlying service.
+You can replace the service with that of your own as follows.
+
+## Step 1: Create Gateway Service and Deployment Instance
+
+You'll need to create the gateway service and deployment instance to handle
+traffic first. The simplest way should be making a copy of the Gateway service
+template in [Istio release](https://github.com/istio/istio/releases).
+
+Here is an example:
+
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: custom-ingressgateway
+  namespace: istio-system
+  annotations:
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: custom-ingressgateway
+    custom: ingressgateway
+spec:
+  type: LoadBalancer
+  selector:
+    app: custom-ingressgateway
+    custom: ingressgateway
+  ports:
+    -
+      name: http2
+      nodePort: 32380
+      port: 80
+      targetPort: 80
+    -
+      name: https
+      nodePort: 32390
+      port: 443
+    -
+      name: tcp
+      nodePort: 32400
+      port: 31400
+    -
+      name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    -
+      name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    -
+      name: tcp-dns-tls
+      port: 853
+      targetPort: 853
+    -
+      name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    -
+      name: http2-grafana
+      port: 15031
+      targetPort: 15031
+---
+# This is the corresponding Deployment to backed the aforementioned Service.
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: custom-ingressgateway
+  namespace: istio-system
+  labels:
+    chart: gateways-1.0.1
+    release: RELEASE-NAME
+    heritage: Tiller
+    app: custom-ingressgateway
+    custom: ingressgateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: custom-ingressgateway
+      custom: ingressgateway
+  template:
+    metadata:
+      labels:
+        app: custom-ingressgateway
+        custom: ingressgateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: istio-ingressgateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.0.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 853
+            - containerPort: 15030
+            - containerPort: 15031
+          args:
+          - proxy
+          - router
+          - -v
+          - "2"
+          - --discoveryRefreshDelay
+          - '1s' #discoveryRefreshDelay
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - custom-ingressgateway
+          - --zipkinAddress
+          - zipkin:9411
+          - --statsdUdpAddress
+          - istio-statsd-prom-bridge:9125
+          - --proxyAdminPort
+          - "15000"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot:8080
+          resources:
+            requests:
+              cpu: 10m
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          volumeMounts:
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: ingressgateway-certs
+            mountPath: "/etc/istio/ingressgateway-certs"
+            readOnly: true
+          - name: ingressgateway-ca-certs
+            mountPath: "/etc/istio/ingressgateway-ca-certs"
+            readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-ingressgateway-service-account
+          optional: true
+      - name: ingressgateway-certs
+        secret:
+          secretName: "istio-ingressgateway-certs"
+          optional: true
+      - name: ingressgateway-ca-certs
+        secret:
+          secretName: "istio-ingressgateway-ca-certs"
+          optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
+```
+
+## Step 2: Update Knative Gateway
+
+Update gateway instance `knative-ingress-gateway` under `knative-serving`
+namespace:
+
+```shell
+kubectl edit gateway knative-ingress-gateway -n knative-serving
+```
+
+Replace its label selector with the label of your service:
+
+```
+istio: ingressgateway
+```
+
+For the service above, it should be updated to
+
+```
+custom: ingressgateway
+```
+
+If there is a change in service ports (compared with that of
+`istio-ingressgateway`), update the port info in gateway accordingly.
+
+## Step 3: Update Gateway Configmap
+
+Update gateway configmap `config-ingressgateway` under `knative-serving`
+namespace:
+
+```shell
+kubectl edit configmap config-ingressgateway -n knative-serving
+```
+
+Replace the `ingress-gateway` field with fully qualified url of your service:
+
+For the service above, it should be updated to
+
+```
+custom-ingressgateway.istio-system.svc.cluster.local
+```


### PR DESCRIPTION
This change updates the metrics, logging, and ingress documentation with
information from documents in the Knative Serving repository. This is an
effort to centralize our user documentation in a single place.

This should allow us to remove the following files from Knative Serving
as they now contain either duplicative or out-dated information.

* https://github.com/knative/serving/blob/master/docs/telemetry.md
*
https://github.com/knative/serving/blob/master/docs/setting-up-custom-ingress-gateway.md
*
https://github.com/knative/serving/blob/master/docs/setting-up-ingress-static-ip.md
