### PR TITLE
#789: serving/samples/helloworld-csharp: update to dotnet sdk 2.2

### DIFF
--- a/serving/samples/helloworld-csharp/Dockerfile
+++ b/serving/samples/helloworld-csharp/Dockerfile
@@ -1,6 +1,6 @@
 # Use Microsoft's official .NET image.
 # https://hub.docker.com/r/microsoft/dotnet
-FROM microsoft/dotnet:2.1-sdk
+FROM microsoft/dotnet:2.2-sdk
 
 # Install production dependencies.
 # Copy csproj and restore as distinct layers.

--- a/serving/samples/helloworld-csharp/Properties/launchSettings.json
+++ b/serving/samples/helloworld-csharp/Properties/launchSettings.json
@@ -1,10 +1,10 @@
 ﻿{
   "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
+    "windowsAuthentication": false, 
+    "anonymousAuthentication": true, 
     "iisExpress": {
-      "applicationUrl": "http://localhost:39053",
-      "sslPort": 44372
+      "applicationUrl": "http://localhost:25270",
+      "sslPort": 44370
     }
   },
   "profiles": {

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -1,6 +1,6 @@
 # Hello World - .NET Core sample
 
-A simple web app written in C# using .NET Core 2.1 that you can use for testing.
+A simple web app written in C# using .NET Core 2.2 that you can use for testing.
 It reads in an env variable `TARGET` and prints "Hello \${TARGET}!". If TARGET
 is not specified, it will use "World" as the TARGET.
 
@@ -11,7 +11,7 @@ is not specified, it will use "World" as the TARGET.
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).
-- You have installed [.NET Core SDK 2.1](https://www.microsoft.com/net/core).
+- You have installed [.NET Core SDK 2.2](https://www.microsoft.com/net/core).
 
 ## Recreating the sample code
 
@@ -58,7 +58,7 @@ recreate the source files from this folder.
     ```docker
     # Use Microsoft's official .NET image.
     # https://hub.docker.com/r/microsoft/dotnet
-    FROM microsoft/dotnet:2.1-sdk
+    FROM microsoft/dotnet:2.2-sdk
 
     # Install production dependencies.
     # Copy csproj and restore as distinct layers.

--- a/serving/samples/helloworld-csharp/appsettings.Development.json
+++ b/serving/samples/helloworld-csharp/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/serving/samples/helloworld-csharp/appsettings.json
+++ b/serving/samples/helloworld-csharp/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/serving/samples/helloworld-csharp/helloworld-csharp.csproj
+++ b/serving/samples/helloworld-csharp/helloworld-csharp.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <RootNamespace>helloworld_csharp</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #789 

## Proposed Changes

- Update Dockerfile to use dotnet sdk 2.2
- Update code for dotnet 2.2 compatibility

## Steps Taken

1. Switch Dockerfile to extend from microsoft/dotnet:2.2-sdk

2. Update application code for dotnet 2.2:
```sh
cd serving/samples/helloworld-csharp
docker run --rm --workdir /app -v $PWD:/app/helloworld-csharp microsoft/dotnet:2.2-sdk dotnet new web --force -o helloworld-csharp
```

3. Confirm application code does not need refactor

4. Restore custom changes (e.g., listen to `$PORT` and `$TARGET`)

```sh
git checkout Startup.cs
git checkout Program.cs
```

5. Build & Test container image locally