### PR TITLE
Update Dockerfile to use gunicorn w/ multithread

### DIFF
--- a/serving/samples/helloworld-python/Dockerfile
+++ b/serving/samples/helloworld-python/Dockerfile
@@ -9,10 +9,12 @@ COPY . .
 
 # Install production dependencies.
 RUN pip install Flask
+RUN pip install gunicorn
 
 # Service must listen to $PORT environment variable.
 # This default value facilitates local development.
 ENV PORT 8080
 
-# Run the web service on container startup.
-CMD ["python", "app.py"]
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+CMD exec gunicorn -b :$PORT -w 1 -t 8 app:app

--- a/serving/samples/helloworld-python/Dockerfile
+++ b/serving/samples/helloworld-python/Dockerfile
@@ -8,8 +8,7 @@ WORKDIR $APP_HOME
 COPY . .
 
 # Install production dependencies.
-RUN pip install Flask
-RUN pip install gunicorn
+RUN pip install Flask gunicorn
 
 # Service must listen to $PORT environment variable.
 # This default value facilitates local development.
@@ -17,4 +16,4 @@ ENV PORT 8080
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.
-CMD exec gunicorn -b :$PORT -w 1 -t 8 app:app
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app

--- a/serving/samples/helloworld-python/Dockerfile
+++ b/serving/samples/helloworld-python/Dockerfile
@@ -16,4 +16,6 @@ ENV PORT 8080
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
 CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app


### PR DESCRIPTION
## Proposed Changes

- Use gunicorn to serve hello world app instead of built-in Flask debug server (benefits: production-ready out of the box; drawbacks: more complex example, debug mode disabled for security reasons)
- In order to use $PORT properly in the CMD, switch to using shell syntax
- In order to ensure signals are received properly by gunicorn and not intercepted by the shell, use 'exec' 