### PR TITLE
Add monitoring link to knative with any k8s doc

### DIFF
--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -57,7 +57,8 @@ your Knative installation, see [Performing a Custom Knative Installation](Knativ
     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
     --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
     --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
+    --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
+    --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
     ```
 1. Monitor the Knative components until all of the components show a
    `STATUS` of `Running`:


### PR DESCRIPTION
Adds the missing monitoring link to the "knative with any k8s" document.

Closes https://github.com/knative/docs/issues/809