### PR TITLE
Correct spec documentation for GitHubSource

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -168,8 +168,8 @@ The GitHubSource fires a new event for selected
   [SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#secretkeyselector-v1-core)
   containing a GitHub secret token for configuring a GitHub webhook. One of this
   or `accessToken` must be set.
-- `serviceAccountName`: `string` The name of the ServiceAccount running as the
-  container.
+- `serviceAccountName`: `string` The name of the ServiceAccount to run the
+  container as.
 - `sink`:
   [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core)
   A reference to the object that should receive events.

--- a/eventing/README.md
+++ b/eventing/README.md
@@ -168,8 +168,8 @@ The GitHubSource fires a new event for selected
   [SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#secretkeyselector-v1-core)
   containing a GitHub secret token for configuring a GitHub webhook. One of this
   or `accessToken` must be set.
-- `serviceAccountName`: `string` The name of the ServiceAccount to run the
-  container as.
+- `serviceAccountName`: `string` The name of the ServiceAccount running as the
+  container.
 - `sink`:
   [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core)
   A reference to the object that should receive events.

--- a/eventing/README.md
+++ b/eventing/README.md
@@ -158,7 +158,7 @@ The GitHubSource fires a new event for selected
   events from. The repository may be left off to receive events from an entire
   organization.
 - `eventTypes`: `[]string` A list of
-  [event types](https://developer.github.com/v3/activity/events/types/)in
+  [event types](https://developer.github.com/v3/activity/events/types/) in
   "Webhook event name" format (lower_case).
 - `accessToken.secretKeyRef`:
   [SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#secretkeyselector-v1-core)
@@ -168,8 +168,8 @@ The GitHubSource fires a new event for selected
   [SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#secretkeyselector-v1-core)
   containing a GitHub secret token for configuring a GitHub webhook. One of this
   or `accessToken` must be set.
-- `serviceAccountName`: `string` The name of the ServiceAccount used to access
-  the `gcpCredsSecret`.
+- `serviceAccountName`: `string` The name of the ServiceAccount to run the
+  container as.
 - `sink`:
   [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core)
   A reference to the object that should receive events.


### PR DESCRIPTION
Correct the `serviceAccountName` description for the `GitHubSource` and fix a missing space.