### PR TITLE
Fix cronjob sample bug

### DIFF
--- a/eventing/samples/cronjob-source/README.md
+++ b/eventing/samples/cronjob-source/README.md
@@ -27,7 +27,7 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: github.com/knative/eventing-sources/cmd/message_dumper
+            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper
 ```
 
 Use following command to create the service from `service.yaml`:

--- a/eventing/samples/cronjob-source/service.yaml
+++ b/eventing/samples/cronjob-source/service.yaml
@@ -10,4 +10,4 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: github.com/knative/eventing-sources/cmd/message_dumper
+            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper


### PR DESCRIPTION
Use real message_dumper image instead of ko image path.

Fixes #813 

Used `ko` image path in the spec however the installation command in README.rd was "kubectl apply ..."

## Proposed Changes

-  Use a real message_dumper image instead of `ko` image path, so that user can try out the samples without `ko`.
