### PR TITLE
Cut v0.2 branch + add v0.2.x tag

### DIFF
--- a/doc-releases.md
+++ b/doc-releases.md
@@ -1,6 +1,6 @@
 # Documentation Releases
 
-Use the following list to view the version of the Knative documentation for your
+The following list shows the available versions of Knative documentation.
 version of Knative cluster that you installed.
 
 ## Released versions

--- a/doc-releases.md
+++ b/doc-releases.md
@@ -1,7 +1,7 @@
 # Documentation Releases
 
 The following list shows the available versions of Knative documentation.
-version of Knative cluster that you installed.
+Select the version that matches your installed version of Knative.
 
 ## Released versions
 

--- a/doc-releases.md
+++ b/doc-releases.md
@@ -1,0 +1,12 @@
+# Documentation Releases
+
+Use the following list to view the version of the Knative documentation for your
+version of Knative cluster that you installed.
+
+## Released versions
+
+* [Branch: **`release-0.2`**](https://github.com/knative/docs/tree/release-0.2)
+
+## In development (pre-release) version
+
+* [Branch: **`master`**](https://github.com/knative/docs/tree/master)


### PR DESCRIPTION
Cutting the long overdue 0.2.x version of the knative/docs repo (into a maintenance branch).