### PR TITLE
Simplify Node.js package.json

### DIFF
--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -74,7 +74,10 @@ recreate the source files from this folder.
        "start": "node app.js"
      },
      "author": "",
-     "license": "Apache-2.0"
+     "license": "Apache-2.0",
+     "dependencies": {
+       "express": "^4.16.4"
+     }
    }
    ```
 

--- a/serving/samples/helloworld-nodejs/package.json
+++ b/serving/samples/helloworld-nodejs/package.json
@@ -6,16 +6,8 @@
   "scripts": {
     "start": "node app.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/knative/docs.git"
-  },
   "author": "",
   "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/knative/serving/issues"
-  },
-  "homepage": "https://github.com/knative/serving#readme",
   "dependencies": {
     "express": "^4.16.4"
   }


### PR DESCRIPTION
Since this is a Hello World, I do not think we need the `homepage`, `bugs` and `repository` attributes of package.json, but instead I suggest to keep it short in order to show the actual simplicity of the sample
