### PR TITLE
eventing/samples/gcp-pubsub: correct installation

### DIFF
--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -20,7 +20,7 @@ source is most useful as a bridge from other GCP services, such as
 
 1. Setup
    [Knative Eventing](https://github.com/knative/docs/tree/master/eventing).
-   In addition, install GCP PubSub eventing components from `release-gcppubsub.yaml`:
+   In addition, install the GCP PubSub event source from `release-gcppubsub.yaml`:
 
       kubectl apply --filename kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release-gcppubsub.yaml
 


### PR DESCRIPTION
My previous PR incorrectly stated users can install eventing sources with
"release-gcppubsub.yaml", but they still need to install "release.yaml" first,
so providing full command here.