### PR TITLE
Deploy using private registry

### DIFF
--- a/serving/README.md
+++ b/serving/README.md
@@ -80,6 +80,9 @@ in the Knative Serving repository.
 - [Using a custom domain](./using-a-custom-domain.md)
 - [Assigning a static IP address for Knative on Google Kubernetes Engine](./gke-assigning-static-ip-address.md)
 
+## Private Container Registry
+- [Deploying to Knative using a Private Container Registry](./deploying-with-private-registry.md)
+
 ## Known Issues
 
 See the [Knative Serving Issues](https://github.com/knative/serving/issues) page

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -101,7 +101,7 @@ To build our application from the source on GitHub, and push the resulting image
 
 1. You need to create a service manifest which defines the service to deploy, including where the source code is and which build-template to use. Create a file named `service.yaml` and copy the following definition. Make sure to replace {NAMESPACE} with your own namespace you created earlier:
 
-    ```
+    ```yaml
     apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     metadata:

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -197,7 +197,7 @@ To build our application from the source on GitHub, and push the resulting image
 
    ```shell
    curl -H "Host: helloworld-go.default.example.com" http://35.203.155.229
-   Hello World: Go Sample v1!
+   Hello Go Sample v1!
    ```
 
    > Note: Add `-v` option to get more detail if the `curl` command failed.

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -44,7 +44,7 @@ kind: Secret
 metadata:
   name: registry-push-secret
   annotations:
-    build.knative.dev/docker-0: registry.ng.bluemix.net
+    build.knative.dev/docker-0: https://registry.ng.bluemix.net
 type: kubernetes.io/basic-auth
 stringData:
   username: token
@@ -74,7 +74,7 @@ kind: ServiceAccount
 metadata:
   name: build-bot
 secrets:
-- name: basic-user-pass
+- name: registry-push-secret
 imagePullSecrets:
 - name: ibm-cr-secret
 ```
@@ -139,9 +139,4 @@ kubectl apply -f service.yaml
 
 ```
  ibmcloud cr image-list
-```
-
-1. To find the URL for your service, use the `ksvc` command:
-```
-kubectl get ksvc app-from-source  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
 ```

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -1,0 +1,88 @@
+# Deploying to Knative using a Private Container Registry
+This guide walks you through deploying an application to Knative from source code in a git repository using a private container registry for the container image. The source code should contain a dockerfile. For this guide, we'll use this [simple app](https://github.com/mchmarny/simple-app), but you could use your own.
+
+
+## Set up a private container registry and obtain credentials.
+If you do not want your container image to be publicly available, you may want to use a private container registry. In this example, we'll use IBM Container Registry, but most of these concepts will be similar for other clouds.
+
+1. Ensure you have the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/reference/ibmcloud/download_cli.html#install_use) installed.  
+
+1. Install the container registry plugin:
+
+```
+ibmcloud plugin install container-registry
+```
+
+1. Choose a name for your first namespace, and create it. A namespace represents the spot within a registry that holds your images. You can set up multiple namespaces as well as control access to your namespaces by using IAM policies.
+
+```
+ibmcloud cr namespace-add <my_namespace>
+```
+
+1. Create a token. The automated build processes you'll be setting up will use this token to access your images.
+
+```
+ibmcloud cr token-add --description "token description" --non-expiring --readwrite
+```
+
+1. The CLI output should include a token identifier and the token. Make note of the token. You can verify that the token was created by listing all tokens.
+
+```
+ibmcloud cr token-list
+```
+
+# Provide Container Registry Credentials to Knative
+You will use the credentials you obtained in the previous section to authenticate to your private container registry. First, you'll need to create a secret to store the credentials for this registry. This secret will be used to push the built image to the container registry.
+
+A Secret is a Kubernetes object containing sensitive data such as a password, a token, or a key. You can also read more about [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+1. Create a file named registry-push-secret.yaml containing the following .yaml.
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-user-pass
+  annotations:
+    build.knative.dev/docker-0: registry.ng.bluemix.net
+type: kubernetes.io/basic-auth
+stringData:
+  username: token
+  password: <token_value>
+```
+
+1. Update the "password" with your token_value>. Note that username will be the string `token`. Save the file.
+
+1. Apply the secret to your cluster.
+
+```
+kubectl apply --filename registry-push-secret.yaml
+```
+
+1. You will also need a secret for the knative-serving component to pull down an image from the private container registry. This secret will be a `docker-registry` type secret. You can create this via the commandline. For username, simply use the string `token`. For <token_value>, use the token you made note of earlier.
+
+```
+kubectl create secret docker-registry ibm-cr-secret --docker-server=https://registry.ng.bluemix.net --docker-username=token --docker-password=<token_value>
+```
+
+A Service Account provides an identity for processes that run in a Pod. This Service Account will be used to link the build process for Knative to the Secrets you just created.
+
+1. Create a file named service-account.yaml containing the following .yaml.
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+- name: basic-user-pass
+imagePullSecrets:
+- name: ibm-cr-secret
+```
+
+# Deploy to Knative using the credentials you just set up.
+To build our application from the source on github, and push the resulting image to the IBM Container Registry, we will use the Kaniko build template.
+
+1. Install the Kaniko build template
+```
+kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
+```

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -2,7 +2,7 @@
 This guide walks you through deploying an application to Knative from source code in a git repository using a private container registry for the container image. The source code should contain a dockerfile. For this guide, we'll use this [simple app](https://github.com/mchmarny/simple-app), but you could use your own.
 
 
-## Set up a private container registry and obtain credentials.
+## Set up a private container registry and obtain credentials
 If you do not want your container image to be publicly available, you may want to use a private container registry. In this example, we'll use IBM Container Registry, but most of these concepts will be similar for other clouds.
 
 1. Ensure you have the [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/reference/ibmcloud/download_cli.html#install_use) installed.  

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -40,7 +40,7 @@ You will use the credentials you obtained in the previous section to authenticat
 
 A Secret is a Kubernetes object containing sensitive data such as a password, a token, or a key. You can also read more about [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
-1. Create a file named registry-push-secret.yaml containing the following .yaml.
+1. Create a file named `registry-push-secret.yaml` containing the following:
 
     ```
     apiVersion: v1

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -81,7 +81,7 @@ A Service Account provides an identity for processes that run in a Pod. This Ser
     ```
 
 ## Deploy to Knative
-To build our application from the source on github, and push the resulting image to the IBM Container Registry, we will use the Kaniko build template.
+To build our application from the source on GitHub, and push the resulting image to the IBM Container Registry, we will use the Kaniko build template.
 
 1. Install the Kaniko build template
 

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -13,17 +13,21 @@ If you do not want your container image to be publicly available, you may want t
     ibmcloud plugin install container-registry
     ```
 
-1. Choose a name for your first namespace, and then create it. A namespace represents the spot within a registry that holds your images. You can set up multiple namespaces as well as control access to your namespaces by using IAM policies.
+1. Choose a name for your first namespace, and then create it: 
 
     ```
     ibmcloud cr namespace-add <my_namespace>
     ```
+    
+    A namespace represents the spot within a registry that holds your images. You can set up multiple namespaces as well as control access to your namespaces by using IAM policies.
 
-1. Create a token. The automated build processes you'll be setting up will use this token to access your images.
+1. Create a token:
 
     ```
     ibmcloud cr token-add --description "token description" --non-expiring --readwrite
     ```
+    
+    The automated build processes you'll be setting up will use this token to access your images.
 
 1. The CLI output should include a token identifier and the token. Make note of the token. You can verify that the token was created by listing all tokens:
 
@@ -124,15 +128,18 @@ To build our application from the source on GitHub, and push the resulting image
                   value: "Hello from the sample app!"
     ```
 
-1. Apply the configuration using `kubectl`. Applying this service definition will kick off a series of events:
-- Fetch the revision specified from GitHub and build it into a container, using the Kaniko build template.
-- the latest image will be pushed to the private registry using the registry-push-secret
-- the latest image will be pulled down from the private registry using the ibm-cr-secret.
-- the service will start, and your app will be running.
-
+1. Apply the configuration using `kubectl`:
+    
     ```
     kubectl apply -f service.yaml
     ```
+
+    Applying this service definition will kick off a series of events:
+    - Fetches the revision specified from GitHub and builds it into a container, using the Kaniko build template.
+    - Pushes the latest image to the private registry using the registry-push-secret
+    - Pulls down the latest image from the private registry using the ibm-cr-secret.
+    - Starts the service, and your app will be live.
+
 
 1. You can run `kubectl get pods --watch` to see the pods initializing.
 

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -25,7 +25,7 @@ If you do not want your container image to be publicly available, you may want t
     ibmcloud cr token-add --description "token description" --non-expiring --readwrite
     ```
 
-1. The CLI output should include a token identifier and the token. Make note of the token. You can verify that the token was created by listing all tokens.
+1. The CLI output should include a token identifier and the token. Make note of the token. You can verify that the token was created by listing all tokens:
 
     ```
     ibmcloud cr token-list

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -93,7 +93,7 @@ To build our application from the source on GitHub, and push the resulting image
     kubectl apply -f https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
     ```
 
-1. You need to create a service manifest which defines the service to deploy, including where the source code is and which build-template to use. Create a file named service.yaml and copy the following definition. Make sure to replace {NAMESPACE} with your own namespace you created earlier:
+1. You need to create a service manifest which defines the service to deploy, including where the source code is and which build-template to use. Create a file named `service.yaml` and copy the following definition. Make sure to replace {NAMESPACE} with your own namespace you created earlier:
 
     ```
     apiVersion: serving.knative.dev/v1alpha1

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -31,7 +31,7 @@ ibmcloud cr token-add --description "token description" --non-expiring --readwri
 ibmcloud cr token-list
 ```
 
-# Provide Container Registry Credentials to Knative
+## Provide Container Registry Credentials to Knative
 You will use the credentials you obtained in the previous section to authenticate to your private container registry. First, you'll need to create a secret to store the credentials for this registry. This secret will be used to push the built image to the container registry.
 
 A Secret is a Kubernetes object containing sensitive data such as a password, a token, or a key. You can also read more about [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
@@ -79,7 +79,7 @@ imagePullSecrets:
 - name: ibm-cr-secret
 ```
 
-# Deploy to Knative using the credentials you just set up.
+## Deploy to Knative using the credentials you just set up.
 To build our application from the source on github, and push the resulting image to the IBM Container Registry, we will use the Kaniko build template.
 
 1. Install the Kaniko build template

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -124,7 +124,7 @@ To build our application from the source on github, and push the resulting image
                   value: "Hello from the sample app!"
     ```
 
-1. Apply the configuration using `kubectl`. Applying this service definition will enable a number of events to happen:
+1. Apply the configuration using `kubectl`. Applying this service definition will kick off a series of events:
 - Fetch the revision specified from GitHub and build it into a container, using the Kaniko build template.
 - the latest image will be pushed to the private registry using the registry-push-secret
 - the latest image will be pulled down from the private registry using the ibm-cr-secret.

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -80,7 +80,7 @@ A Service Account provides an identity for processes that run in a Pod. This Ser
     - name: ibm-cr-secret
     ```
 
-## Deploy to Knative using the credentials
+## Deploy to Knative
 To build our application from the source on github, and push the resulting image to the IBM Container Registry, we will use the Kaniko build template.
 
 1. Install the Kaniko build template

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -42,7 +42,7 @@ A Secret is a Kubernetes object containing sensitive data such as a password, a 
 
 1. Create a file named `registry-push-secret.yaml` containing the following:
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: Secret
     metadata:

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -55,7 +55,7 @@ A Secret is a Kubernetes object containing sensitive data such as a password, a 
       password: <token_value>
     ```
 
-1. Update the "password" with your token_value>. Note that username will be the string `token`. Save the file.
+1. Update the "password" with your <token_value>. Note that username will be the string `token`. Save the file.
 
 1. Apply the secret to your cluster.
 

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -71,7 +71,7 @@ A Secret is a Kubernetes object containing sensitive data such as a password, a 
 
 A Service Account provides an identity for processes that run in a Pod. This Service Account will be used to link the build process for Knative to the Secrets you just created.
 
-1. Create a file named service-account.yaml containing the following .yaml.
+1. Create a file named `service-account.yaml` containing the following:
 
     ```yaml
     apiVersion: v1

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -156,3 +156,56 @@ To build our application from the source on GitHub, and push the resulting image
     ```
     ibmcloud cr image-list
     ```
+
+## Test Application Behavior
+1. Run the following command to find the external IP address for your service:
+
+   ```shell
+   INGRESSGATEWAY=istio-ingressgateway
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
+   ```
+
+   Example:
+
+   ```shell
+   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   ```
+
+1. Run the following command to find the domain URL for your service:
+
+   ```shell
+   kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+   ```
+
+   Example:
+
+   ```shell
+   NAME                DOMAIN
+   helloworld-go       helloworld-go.default.example.com
+   ```
+
+1. Test your app by sending it a request. Use the following `curl` command with
+   the domain URL `helloworld-go.default.example.com` and `EXTERNAL-IP` address
+   that you retrieved in the previous steps:
+
+   ```shell
+   curl -H "Host: helloworld-go.default.example.com" http://{EXTERNAL_IP_ADDRESS}
+   ```
+
+   Example:
+
+   ```shell
+   curl -H "Host: helloworld-go.default.example.com" http://35.203.155.229
+   Hello World: Go Sample v1!
+   ```
+
+   > Note: Add `-v` option to get more detail if the `curl` command failed.
+
+## Removing the sample app deployment
+
+To remove the sample app from your cluster, delete the service record:
+
+```shell
+kubectl delete --filename service.yaml
+```

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -13,7 +13,7 @@ If you do not want your container image to be publicly available, you may want t
 ibmcloud plugin install container-registry
 ```
 
-1. Choose a name for your first namespace, and create it. A namespace represents the spot within a registry that holds your images. You can set up multiple namespaces as well as control access to your namespaces by using IAM policies.
+1. Choose a name for your first namespace, and then create it. A namespace represents the spot within a registry that holds your images. You can set up multiple namespaces as well as control access to your namespaces by using IAM policies.
 
 ```
 ibmcloud cr namespace-add <my_namespace>

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -1,4 +1,4 @@
-# Deploying to Knative using a Private Container Registry
+# Deploying to Knative using a private container registry
 This guide walks you through deploying an application to Knative from source code in a git repository using a private container registry for the container image. The source code should contain a dockerfile. For this guide, we'll use this [simple app](https://github.com/mchmarny/simple-app), but you could use your own.
 
 
@@ -31,7 +31,7 @@ ibmcloud cr token-add --description "token description" --non-expiring --readwri
 ibmcloud cr token-list
 ```
 
-## Provide Container Registry Credentials to Knative
+## Provide container registry credentials to Knative
 You will use the credentials you obtained in the previous section to authenticate to your private container registry. First, you'll need to create a secret to store the credentials for this registry. This secret will be used to push the built image to the container registry.
 
 A Secret is a Kubernetes object containing sensitive data such as a password, a token, or a key. You can also read more about [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
@@ -79,7 +79,7 @@ imagePullSecrets:
 - name: ibm-cr-secret
 ```
 
-## Deploy to Knative using the credentials you just set up.
+## Deploy to Knative using the credentials
 To build our application from the source on github, and push the resulting image to the IBM Container Registry, we will use the Kaniko build template.
 
 1. Install the Kaniko build template

--- a/serving/deploying-with-private-registry.md
+++ b/serving/deploying-with-private-registry.md
@@ -73,7 +73,7 @@ A Service Account provides an identity for processes that run in a Pod. This Ser
 
 1. Create a file named service-account.yaml containing the following .yaml.
 
-    ```
+    ```yaml
     apiVersion: v1
     kind: ServiceAccount
     metadata:


### PR DESCRIPTION
Fixes #819

## Proposed Changes
- As per our discussion in issue #819, I've created a new doc called: "Deploying to Knative using a Private Registry"
- This doc uses IBM Container Registry as the example