### PR TITLE
Addressing a kubectl typo in helloworld-scala README

### DIFF
--- a/serving/samples/helloworld-scala/README.md
+++ b/serving/samples/helloworld-scala/README.md
@@ -132,5 +132,5 @@ curl -v -H "Host: helloworld-scala.default.example.com" http://$SERVING_GATEWAY
 ## Cleanup
 
 ```shell
-kubetl delete --filename helloworld-scala.yaml
+kubectl delete --filename helloworld-scala.yaml
 ```


### PR DESCRIPTION
## Proposed Changes

Noticed a typo at the very end of the README, this fixes that.
