### PR TITLE
Change MiniKube installation to require 1.12 cluster.

### DIFF
--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -9,8 +9,9 @@ You can find [guides for other platforms here](README.md).
 
 ## Before you begin
 
-Knative requires a Kubernetes cluster v1.11 or newer. If you don't have one, you
-can create one using [Minikube](https://github.com/kubernetes/minikube).
+Although Knative requires a Kubernetes cluster v1.11 or newer, installing
+Knative on [Minikube](https://github.com/kubernetes/minikube) requires a cluster
+v1.12 or newer.
 
 ### Install kubectl and Minikube
 
@@ -27,14 +28,14 @@ can create one using [Minikube](https://github.com/kubernetes/minikube).
 
 ## Creating a Kubernetes cluster
 
-After kubectl and Minikube are installed, create a cluster with version 1.11 or
+After kubectl and Minikube are installed, create a cluster with version 1.12 or
 greater and your chosen VM driver:
 
 For Linux use:
 
 ```shell
 minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.11.5 \
+  --kubernetes-version=v1.12.0 \
   --vm-driver=kvm2 \
   --disk-size=30g \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
@@ -44,7 +45,7 @@ For macOS use:
 
 ```shell
 minikube start --memory=8192 --cpus=4 \
-  --kubernetes-version=v1.11.5 \
+  --kubernetes-version=v1.12.0 \
   --vm-driver=hyperkit \
   --disk-size=30g \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"


### PR DESCRIPTION
Due to a bug in CoreDNS that is fixed only in a version that ships
on MiniKube when installing Kubernetes v1.12 or newer. See
https://github.com/coredns/coredns/issues/2038

Fixes knative/serving#3067

## Proposed Changes

- Change MiniKube installation to require 1.12 cluster.