### PR TITLE
Fixed the dead link

### DIFF
--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -204,7 +204,7 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/kn
 
    ```shell
    oc apply -f https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   oc apply -f https://github.com/knative/build/releases/download/v0.3.0/build.yaml
+   oc apply -f https://github.com/knative/build/releases/download/v0.3.0/release.yaml
    ```
 
 2. Monitor the Knative components until all of the components show a `STATUS` of


### PR DESCRIPTION
Fixes #(844)

## Proposed Changes

- fixed the dead link in the installation file  [Knative-with-Minishift.md](https://github.com/knative/docs/blob/master/install/Knative-with-Minishift.md#install-knative-serving)
