### PR TITLE
DOCKER_REPO_OVERRIDE should be replaced by KO_DOCKER_REPO in serving 0.5

### DIFF
--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -30,7 +30,7 @@ the following commands:
 # Replace <your-project-here> with your own registry
 export REPO="gcr.io/<your-project-here>"
 
-perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+perl -pi -e "s@KO_DOCKER_REPO@$REPO@g" sample.yaml
 
 # Create the Kubernetes resources
 kubectl apply --filename sample.yaml

--- a/serving/samples/buildpack-app-dotnet/sample.yaml
+++ b/serving/samples/buildpack-app-dotnet/sample.yaml
@@ -13,7 +13,7 @@ spec:
       name: buildpack
       arguments:
       - name: IMAGE
-        value: DOCKER_REPO_OVERRIDE/buildpack-sample-app
+        value: KO_DOCKER_REPO/buildpack-sample-app
     # - name: CACHE
     #   value: buildpack-sample-app-cache
     # volumes:
@@ -27,7 +27,7 @@ spec:
         knative.dev/type: app
     spec:
       container:
-        image: DOCKER_REPO_OVERRIDE/buildpack-sample-app 
+        image: KO_DOCKER_REPO/buildpack-sample-app 
 ---
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route

--- a/serving/samples/buildpack-function-nodejs/README.md
+++ b/serving/samples/buildpack-function-nodejs/README.md
@@ -29,7 +29,7 @@ Then you can deploy this to Knative Serving from the root directory via:
 # Replace <your-project-here> with your own registry
 export REPO="gcr.io/<your-project-here>"
 
-perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+perl -pi -e "s@KO_DOCKER_REPO@$REPO@g" sample.yaml
 
 kubectl apply --filename sample.yaml
 ```

--- a/serving/samples/buildpack-function-nodejs/sample.yaml
+++ b/serving/samples/buildpack-function-nodejs/sample.yaml
@@ -13,7 +13,7 @@ spec:
       name: buildpack
       arguments:
       - name: IMAGE
-        value: DOCKER_REPO_OVERRIDE/buildpack-function
+        value: KO_DOCKER_REPO/buildpack-function
       - name: BUILDPACK_ORDER
         value: https://github.com/projectriff/node-function-invoker.git#buildpack
       - name: SKIP_DETECT
@@ -31,7 +31,7 @@ spec:
         knative.dev/type: function
     spec:
       container:
-        image: DOCKER_REPO_OVERRIDE/buildpack-function 
+        image: KO_DOCKER_REPO/buildpack-function 
 ---
 apiVersion: serving.knative.dev/v1alpha1
 kind: Route

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -105,7 +105,7 @@ from the [build-templates](https://github.com/knative/build-templates/) repo.
 ```shell
 # Replace the token string with a suitable registry
 REPO="gcr.io/<your-project-here>"
-perl -pi -e "s@DOCKER_REPO_OVERRIDE@$REPO@g" sample.yaml
+perl -pi -e "s@KO_DOCKER_REPO@$REPO@g" sample.yaml
 
 # Install the Kaniko build template used to build this sample (in the
 # build-templates repo).

--- a/serving/samples/thumbnailer-go/sample.yaml
+++ b/serving/samples/thumbnailer-go/sample.yaml
@@ -37,14 +37,14 @@ spec:
       name: kaniko
       arguments:
       - name: IMAGE
-        value: DOCKER_REPO_OVERRIDE/rester-tester
+        value: KO_DOCKER_REPO/rester-tester
   revisionTemplate:
     metadata:
       labels:
         knative.dev/type: app
     spec:
       container:
-        image: DOCKER_REPO_OVERRIDE/rester-tester 
+        image: KO_DOCKER_REPO/rester-tester 
         env:
           - name: TARGET
             value: thumb_v1

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -129,7 +129,7 @@ This is a helper script for Knative E2E test scripts. To use it:
 1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
    (or `report_go_test()` if you need a more fine-grained control) and call
    `fail_test()` or `success()` if any of them failed. The environment variables
-   `DOCKER_REPO_OVERRIDE`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be
+   `KO_DOCKER_REPO`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be
    set according to the test cluster. You can also use the following boolean (0 is
    false, 1 is true) environment variables for the logic:
 
@@ -145,7 +145,7 @@ This is a helper script for Knative E2E test scripts. To use it:
    project `$PROJECT_ID` and run the tests against it.
 
 1. Calling your script with `--run-tests` and the variables `K8S_CLUSTER_OVERRIDE`,
-   `K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
+   `K8S_USER_OVERRIDE` and `KO_DOCKER_REPO` set will immediately start the
    tests against the cluster.
 
 1. You can force running the tests against a specific GKE cluster version by using

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -175,7 +175,7 @@ function create_test_cluster() {
   touch $HOME/.ssh/google_compute_engine.pub
   touch $HOME/.ssh/google_compute_engine
   # Clear user and cluster variables, so they'll be set to the test cluster.
-  # DOCKER_REPO_OVERRIDE is not touched because when running locally it must
+  # KO_DOCKER_REPO is not touched because when running locally it must
   # be a writeable docker repo.
   export K8S_USER_OVERRIDE=
   export K8S_CLUSTER_OVERRIDE=
@@ -252,15 +252,14 @@ function setup_test_cluster() {
   fi
   readonly USING_EXISTING_CLUSTER
 
-  if [[ -z ${DOCKER_REPO_OVERRIDE} ]]; then
-    export DOCKER_REPO_OVERRIDE=gcr.io/$(gcloud config get-value project)/${E2E_BASE_NAME}-e2e-img
+  if [[ -z ${KO_DOCKER_REPO} ]]; then
+    export KO_DOCKER_REPO=gcr.io/$(gcloud config get-value project)/${E2E_BASE_NAME}-e2e-img
   fi
 
   echo "- Cluster is ${K8S_CLUSTER_OVERRIDE}"
   echo "- User is ${K8S_USER_OVERRIDE}"
-  echo "- Docker is ${DOCKER_REPO_OVERRIDE}"
+  echo "- Docker is ${KO_DOCKER_REPO}"
 
-  export KO_DOCKER_REPO="${DOCKER_REPO_OVERRIDE}"
   export KO_DATA_PATH="${REPO_ROOT_DIR}/.git"
 
   trap teardown_test_resources EXIT
@@ -272,7 +271,7 @@ function setup_test_cluster() {
 
   readonly K8S_CLUSTER_OVERRIDE
   readonly K8S_USER_OVERRIDE
-  readonly DOCKER_REPO_OVERRIDE
+  readonly KO_DOCKER_REPO
 
   # Handle failures ourselves, so we can dump useful info.
   set +o errexit
@@ -367,8 +366,8 @@ function initialize() {
   (( IS_PROW )) && [[ -z "${GCP_PROJECT}" ]] && IS_BOSKOS=1
 
   # Safety checks
-  is_protected_gcr ${DOCKER_REPO_OVERRIDE} && \
-    abort "\$DOCKER_REPO_OVERRIDE set to ${DOCKER_REPO_OVERRIDE}, which is forbidden"
+  is_protected_gcr ${KO_DOCKER_REPO} && \
+    abort "\$KO_DOCKER_REPO set to ${KO_DOCKER_REPO}, which is forbidden"
 
   readonly RUN_TESTS
   readonly EMIT_METRICS


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/3200

## Proposed Changes

`DOCKER_REPO_OVERRIDE` replaced by `KO_DOCKER_REPO` in `knative doc`

/cc @mattmoor  @adrcunha