### PR TITLE
Format markdown

### DIFF
--- a/eventing/samples/cronjob-source/README.md
+++ b/eventing/samples/cronjob-source/README.md
@@ -82,10 +82,9 @@ You should see log lines showing the request headers and body from the source:
 }
 ```
 
-You can also use [`kail`](https://github.com/boz/kail) instead of `kubectl logs` to tail the logs of the subscriber.
+You can also use [`kail`](https://github.com/boz/kail) instead of `kubectl logs`
+to tail the logs of the subscriber.
 
-   ```shell
-   kail -l serving.knative.dev/service=message-dumper -c user-container --since=10m
-   ```
-
-
+```shell
+kail -l serving.knative.dev/service=message-dumper -c user-container --since=10m
+```

--- a/serving/cluster-local-route.md
+++ b/serving/cluster-local-route.md
@@ -10,8 +10,7 @@ You can also set the label `serving.knative.dev/visibility=cluster-local` on
 your Route or KService to achieve the same effect.
 
 For example, if you didn't set a label when you created the Route
-`helloworld-go` and you want to make it local to the cluster,
-run:
+`helloworld-go` and you want to make it local to the cluster, run:
 
 ```shell
 kubectl label route helloworld-go serving.knative.dev/visibility=cluster-local


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`