### PR TITLE
Add commands to clean up `knative-ingressgateway` before upgrade from 0.3.x to 0.4

### DIFF
--- a/install/Knative-custom-install.md
+++ b/install/Knative-custom-install.md
@@ -252,6 +252,15 @@ for details about installing the various supported observability plug-ins.
 **Tip**: From the table above, copy and paste the URL and filename into the
 commands below.
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. To install Knative components or plugins, specify the filenames in the
    `kubectl apply` command:
 

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -164,6 +164,15 @@ The following commands install all available Knative components. To customize
 your Knative installation, see
 [Performing a Custom Knative Installation](Knative-custom-install.md).
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -165,6 +165,15 @@ The following commands install all available Knative components as well as the
 standard set of observability plugins. To customize your Knative installation,
 see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -101,6 +101,15 @@ The following commands install all available Knative components as well as the
 standard set of observability plugins. To customize your Knative installation,
 see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \

--- a/install/Knative-with-ICP.md
+++ b/install/Knative-with-ICP.md
@@ -126,6 +126,15 @@ The following commands install all available Knative components as well as the
 standard set of observability plugins. To customize your Knative installation,
 see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Run the following commands to install Knative:
 
    ```shell

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -3,7 +3,7 @@
 This guide walks you through the installation of the latest version of Knative
 using pre-built images.
 
-You may also have it all installed for you by clicking the button below:  
+You may also have it all installed for you by clicking the button below:
 [![Deploy to IBM Cloud](https://bluemix.net/deploy/button_x2.png)](https://console.bluemix.net/devops/setup/deploy?repository=https://git.ng.bluemix.net/start-with-knative/toolchain.git)
 
 More
@@ -164,6 +164,15 @@ rerun the command to see the current status.
 The following commands install all available Knative components as well as the
 standard set of observability plugins. To customize your Knative installation,
 see [Performing a Custom Knative Installation](Knative-custom-install.md).
+
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -86,6 +86,16 @@ Because you have limited resources available, install only the Knative Serving
 component, omitting the other Knative components as well as the observability
 and monitoring plugins.
 
+If you are upgrading from Knative 0.3.x: Update your domain and static IP
+address to be associated with the LoadBalancer `istio-ingressgateway` instead
+of `knative-ingressgateway`.  Then run the following to clean up leftover
+resources:
+
+```shell
+kubectl delete svc knative-ingressgateway -n istio-system
+kubectl delete deploy knative-ingressgateway -n istio-system
+```
+
 Enter the following command:
 
 ```shell

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -200,6 +200,15 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/kn
 - Warning: ServiceAccount 'controller' not found cluster role "cluster-admin"
   added: "controller"
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   oc delete svc knative-ingressgateway -n istio-system
+   oc delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Install Knative serving:
 
    ```shell
@@ -207,7 +216,7 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/kn
    oc apply -f https://github.com/knative/build/releases/download/v0.3.0/release.yaml
    ```
 
-2. Monitor the Knative components until all of the components show a `STATUS` of
+1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running` or `Completed`:
 
    ```shell
@@ -221,7 +230,7 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/kn
    > **NOTE:** It will take a few minutes for all the components to be up and
    > running.
 
-3. Set route to access the OpenShift ingress CIDR, so that services can be
+1. Set route to access the OpenShift ingress CIDR, so that services can be
    accessed via LoadBalancerIP
    ```shell
    # Only for macOS

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -78,6 +78,15 @@ The following commands install all available Knative components as well as the
 standard set of observability plugins. To customize your Knative installation,
 see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -54,6 +54,15 @@ The following commands install all available Knative components. To customize
 your Knative installation, see
 [Performing a Custom Knative Installation](Knative-custom-install.md).
 
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`.  Then run the following to clean up leftover
+   resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \


### PR DESCRIPTION
0.4 isn't cut yet but I'd like to send this PR out to get feedback first to be ready when it is.

/hold
(until 0.4.0 is cut)