### PR TITLE
Fix up the GRPC sample in preparation for 0.4

### DIFF
--- a/serving/samples/grpc-ping-go/Dockerfile
+++ b/serving/samples/grpc-ping-go/Dockerfile
@@ -21,10 +21,12 @@ WORKDIR /go/src/github.com/knative/docs/
 ADD . /go/src/github.com/knative/docs/
 
 RUN CGO_ENABLED=0 go build -tags=grpcping ./serving/samples/grpc-ping-go/
+RUN CGO_ENABLED=0 go build -tags=grpcping ./serving/samples/grpc-ping-go/client
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/static
 
 EXPOSE 8080
-COPY --from=builder /go/src/github.com/knative/docs/grpc-ping-go /sample
+COPY --from=builder /go/src/github.com/knative/docs/grpc-ping-go /server
+COPY --from=builder /go/src/github.com/knative/docs/client /client
 
-ENTRYPOINT ["/sample"]
+ENTRYPOINT ["/server"]

--- a/serving/samples/grpc-ping-go/README.md
+++ b/serving/samples/grpc-ping-go/README.md
@@ -2,8 +2,7 @@
 
 A simple gRPC server written in Go that you can use for testing.
 
-This sample is dependent on
-[this issue](https://github.com/knative/serving/issues/1047) to be complete.
+This sample requires knative/serving 0.4 or later.
 
 ## Prerequisites
 
@@ -12,22 +11,20 @@ This sample is dependent on
 
 ## Build and run the gRPC server
 
-Build and run the gRPC server. This command will build the server and use
-`kubectl` to apply the configuration.
+First, build and publish the gRPC server to DockerHub (replacing `{username}`):
 
 ```shell
-REPO="gcr.io/<your-project-here>"
-
 # Build and publish the container, run from the root directory.
 docker build \
-  --tag "${REPO}/serving/samples/grpc-ping-go" \
+  --tag "docker.io/{username}/grpc-ping-go" \
   --file=serving/samples/grpc-ping-go/Dockerfile .
 docker push "${REPO}/serving/samples/grpc-ping-go"
+```
 
-# Replace the image reference with our published image.
-perl -pi -e "s@github.com/knative/docs/serving/samples/grpc-ping-go@${REPO}/serving/samples/grpc-ping-go@g" serving/samples/grpc-ping-go/*.yaml
+Next, replace `{username}` in `sample.yaml` with your DockerHub username, and
+apply the yaml.
 
-# Deploy the Knative sample.
+```shell
 kubectl apply --filename serving/samples/grpc-ping-go/sample.yaml
 ```
 
@@ -39,22 +36,15 @@ kubectl apply --filename serving/samples/grpc-ping-go/sample.yaml
 # Put the Host name into an environment variable.
 export SERVICE_HOST=`kubectl get route grpc-ping --output jsonpath="{.status.domain}"`
 
-# In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
-INGRESSGATEWAY=knative-ingressgateway
-
-# The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
-# Use `istio-ingressgateway` instead, since `knative-ingressgateway`
-# will be removed in Knative v0.4.
-if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
-    INGRESSGATEWAY=istio-ingressgateway
-fi
-
 # Put the ingress IP into an environment variable.
-export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+export SERVICE_IP=`kubectl get svc istio-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
-1. Use the client to send message streams to the gRPC server.
+1. Use the client to send message streams to the gRPC server (replacing `{username}`)
 
 ```shell
-go run -tags=grpcping ./serving/samples/grpc-ping-go/client/client.go -server_addr="$SERVICE_IP:80" -server_host_override="$SERVICE_HOST"
+docker run -ti --entrypoint=/client docker.io/{username}/grpc-ping-go \
+  -server_addr="$SERVICE_IP:80" \
+  -server_host_override="$SERVICE_HOST" \
+  -insecure
 ```

--- a/serving/samples/grpc-ping-go/client/client.go
+++ b/serving/samples/grpc-ping-go/client/client.go
@@ -33,10 +33,21 @@ func main() {
 		log.Fatalf("fail to dial: %v", err)
 	}
 	defer conn.Close()
+
 	client := pb.NewPingServiceClient(conn)
 
 	ping(client, "hello")
 	pingStream(client, "hello")
+}
+
+func ping(client pb.PingServiceClient, msg string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	rep, err := client.Ping(ctx, &pb.Request{Msg: msg})
+	if err != nil {
+		log.Fatalf("%v.Ping failed %v: ", client, err)
+	}
+	log.Printf("Ping got %v\n", rep.GetMsg())
 }
 
 func pingStream(client pb.PingServiceClient, msg string) {
@@ -73,14 +84,4 @@ func pingStream(client pb.PingServiceClient, msg string) {
 	stream.CloseSend()
 	<-waitc
 
-}
-
-func ping(client pb.PingServiceClient, msg string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-	rep, err := client.Ping(ctx, &pb.Request{Msg: msg})
-	if err != nil {
-		log.Fatalf("%v.Ping failed %v: ", client, err)
-	}
-	log.Printf("Ping got %v\n", rep.GetMsg())
 }

--- a/serving/samples/grpc-ping-go/sample.yaml
+++ b/serving/samples/grpc-ping-go/sample.yaml
@@ -1,23 +1,17 @@
 apiVersion: serving.knative.dev/v1alpha1
-kind: Configuration
+kind: Service
 metadata:
   name: grpc-ping
   namespace: default
 spec:
-  revisionTemplate:
-    metadata:
-      labels:
-        knative.dev/type: app
-    spec:
-      container:
-        image: github.com/knative/docs/serving/samples/grpc-ping-go
----
-apiVersion: serving.knative.dev/v1alpha1
-kind: Route
-metadata:
-  name: grpc-ping
-  namespace: default
-spec:
-  traffic:
-  - configurationName: grpc-ping
-    percent: 100
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: docker.io/{username}/grpc-ping-go
+            ports:
+              - name: h2c
+                containerPort: 8080
+
+    


### PR DESCRIPTION
User a Service instead of Route/Configuration
Specify the port with `name: h2c`
Build the client into the docker image (due to Go build tags)
User DockerHub, drop perl
Other cosmetic tweaks