### PR TITLE
Added toc for all md files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Welcome to Knative](#welcome-to-knative)
+  - [Components](#components)
+  - [Audience](#audience)
+    - [Developers](#developers)
+    - [Operators](#operators)
+    - [Contributors](#contributors)
+  - [Documentation](#documentation)
+    - [Getting started](#getting-started)
+    - [Configuration and networking](#configuration-and-networking)
+    - [Samples and demos](#samples-and-demos)
+    - [Logging and metrics](#logging-and-metrics)
+    - [Debugging](#debugging)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Welcome to Knative
 
 Knative (pronounced kay-nay-tiv) extends Kubernetes to provide a set of

--- a/build/README.md
+++ b/build/README.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Build](#knative-build)
+  - [Key features of Knative Builds](#key-features-of-knative-builds)
+    - [Learn more](#learn-more)
+  - [Install the Knative Build component](#install-the-knative-build-component)
+  - [Configuration syntax example](#configuration-syntax-example)
+  - [Get started with Knative Build samples](#get-started-with-knative-build-samples)
+      - [Simple build samples](#simple-build-samples)
+      - [Build templates](#build-templates)
+      - [Complex samples](#complex-samples)
+  - [Related info](#related-info)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Build
 
 A `Build` is a custom resource in Knative that allows you to define a process

--- a/build/auth.md
+++ b/build/auth.md
@@ -1,3 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Authentication](#authentication)
+    - [Exposing credentials to the build](#exposing-credentials-to-the-build)
+  - [SSH authentication (Git)](#ssh-authentication-git)
+  - [Basic authentication (Git)](#basic-authentication-git)
+  - [Basic authentication (Docker)](#basic-authentication-docker)
+    - [Guiding credential selection](#guiding-credential-selection)
+  - [Implementation detail](#implementation-detail)
+    - [Docker `basic-auth`](#docker-basic-auth)
+    - [Git `basic-auth`](#git-basic-auth)
+    - [Git `ssh-auth`](#git-ssh-auth)
+    - [Least privilege](#least-privilege)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Authentication
 
 This document defines how authentication is provided during execution of a

--- a/build/build-templates.md
+++ b/build/build-templates.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Build Templates](#build-templates)
+  - [What is a Build Template?](#what-is-a-build-template)
+    - [Example template](#example-template)
+    - [Example Builds](#example-builds)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Build Templates
 
 This document defines "Build Templates" and their capabilities.

--- a/build/builder-contract.md
+++ b/build/builder-contract.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Builders](#builders)
+  - [What is a builder?](#what-is-a-builder)
+    - [Typical builders](#typical-builders)
+    - [Atypical builders](#atypical-builders)
+    - [Specialized builders](#specialized-builders)
+  - [What are the builder conventions?](#what-are-the-builder-conventions)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Builders
 
 This document defines builder images and the conventions to which they are

--- a/build/builds.md
+++ b/build/builds.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative `Build` resources](#knative-build-resources)
+    - [Syntax](#syntax)
+      - [Steps](#steps)
+      - [Template](#template)
+      - [Source](#source)
+      - [Service Account](#service-account)
+      - [Volumes](#volumes)
+      - [Timeout](#timeout)
+    - [Examples](#examples)
+      - [Using `git`](#using-git)
+      - [Using `gcs`](#using-gcs)
+      - [Using `custom`](#using-custom)
+      - [Using an extra volume](#using-an-extra-volume)
+      - [Using `steps` to push images](#using-steps-to-push-images)
+      - [Using a `ServiceAccount`](#using-a-serviceaccount)
+      - [Using `timeout`](#using-timeout)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative `Build` resources
 
 Use the `Build` resource object to create and run on-cluster processes to

--- a/build/creating-builds.md
+++ b/build/creating-builds.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Creating a simple Knative Build](#creating-a-simple-knative-build)
+  - [Before you begin](#before-you-begin)
+  - [Creating and running a build](#creating-and-running-a-build)
+    - [Learn more](#learn-more)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Creating a simple Knative Build
 
 Use this page to learn how to create and then run a simple build in Knative. In

--- a/build/installing-build-component.md
+++ b/build/installing-build-component.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installing the Knative Build component](#installing-the-knative-build-component)
+  - [Before you begin](#before-you-begin)
+  - [Adding the Knative Build component](#adding-the-knative-build-component)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Installing the Knative Build component
 
 Before you can run a Knative Build, you must install the Knative Build component

--- a/build/personas.md
+++ b/build/personas.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Personas](#knative-personas)
+  - [Knative Build](#knative-build)
+    - [Developer](#developer)
+    - [Language operator / contributor](#language-operator--contributor)
+  - [Contributors](#contributors)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Personas
 
 When discussing user actions, it is often helpful to

--- a/community/CODE-OF-CONDUCT.md
+++ b/community/CODE-OF-CONDUCT.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributor Covenant Code of Conduct](#contributor-covenant-code-of-conduct)
+  - [Our Pledge](#our-pledge)
+  - [Our Standards](#our-standards)
+  - [Our Responsibilities](#our-responsibilities)
+  - [Scope](#scope)
+  - [Enforcement](#enforcement)
+  - [Attribution](#attribution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/community/CONTRIBUTING.md
+++ b/community/CONTRIBUTING.md
@@ -1,3 +1,24 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributing to Knative](#contributing-to-knative)
+  - [Working groups](#working-groups)
+  - [Code of conduct](#code-of-conduct)
+  - [Team values](#team-values)
+  - [Contributor license agreements](#contributor-license-agreements)
+  - [Design documents](#design-documents)
+  - [Contributing documentation](#contributing-documentation)
+  - [Contributing a feature](#contributing-a-feature)
+  - [Setting up to contribute to Knative](#setting-up-to-contribute-to-knative)
+  - [Pull requests](#pull-requests)
+  - [Issues](#issues)
+  - [Third-party code](#third-party-code)
+    - [Adding a new third-party dependency to `third_party/` folder](#adding-a-new-third-party-dependency-to-third_party-folder)
+    - [LICENSE](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributing to Knative
 
 So, you want to hack on Knative? Yay!

--- a/community/DOCS-CONTRIBUTING.md
+++ b/community/DOCS-CONTRIBUTING.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributing to the Knative Documentation](#contributing-to-the-knative-documentation)
+  - [Before you begin](#before-you-begin)
+    - [Code of conduct](#code-of-conduct)
+    - [Style guide](#style-guide)
+  - [Reporting documentation issues](#reporting-documentation-issues)
+  - [Contributing to the documentation](#contributing-to-the-documentation)
+    - [Working group](#working-group)
+    - [Getting started](#getting-started)
+    - [Submitting documentation PRs - what to expect](#submitting-documentation-prs---what-to-expect)
+    - [Putting your docs in the right place](#putting-your-docs-in-the-right-place)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributing to the Knative Documentation
 
 **First off, thanks for taking the time to contribute!**

--- a/community/README.md
+++ b/community/README.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Community](#knative-community)
+  - [Welcome!](#welcome)
+  - [Introduction](#introduction)
+  - [Knative authors](#knative-authors)
+    - [Authoring samples](#authoring-samples)
+  - [Meetings and work groups](#meetings-and-work-groups)
+  - [How can I help](#how-can-i-help)
+  - [Questions and issues](#questions-and-issues)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Community
 
 _Important_. Before proceeding, please review the Knative community

--- a/community/REVIEWING.md
+++ b/community/REVIEWING.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Reviewing and Merging Pull Requests for Knative](#reviewing-and-merging-pull-requests-for-knative)
+  - [Pull requests welcome](#pull-requests-welcome)
+  - [Code of Conduct](#code-of-conduct)
+  - [Code reviewers](#code-reviewers)
+  - [Reviewing changes](#reviewing-changes)
+    - [Holds](#holds)
+  - [Approvers](#approvers)
+  - [Merging PRs](#merging-prs)
+  - [Prow](#prow)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Reviewing and Merging Pull Requests for Knative
 
 As a community, we believe in the value of code reviews for all contributions.

--- a/community/ROLES.md
+++ b/community/ROLES.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Community Roles](#knative-community-roles)
+  - [Role Summary](#role-summary)
+  - [Collaborator](#collaborator)
+    - [Requirements](#requirements)
+  - [Member](#member)
+    - [Requirements](#requirements-1)
+    - [Responsibilities and privileges](#responsibilities-and-privileges)
+  - [Approver](#approver)
+    - [Requirements](#requirements-2)
+    - [Responsibilities and privileges](#responsibilities-and-privileges-1)
+  - [Lead](#lead)
+    - [Requirements](#requirements-3)
+    - [Responsibilities and privileges](#responsibilities-and-privileges-2)
+  - [Administrator](#administrator)
+    - [Requirements](#requirements-4)
+    - [Responsibilities and privileges](#responsibilities-and-privileges-3)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Community Roles
 
 This document describes the set of roles individuals may have within the Knative

--- a/community/SLACK-GUIDELINES.md
+++ b/community/SLACK-GUIDELINES.md
@@ -1,3 +1,22 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Slack Usage Guidelines](#slack-usage-guidelines)
+  - [Code of Conduct](#code-of-conduct)
+  - [Admins](#admins)
+    - [Admin Expectations and Guidelines](#admin-expectations-and-guidelines)
+  - [Creating Channels](#creating-channels)
+  - [Escalating and/or Reporting a Problem](#escalating-andor-reporting-a-problem)
+    - [What if you have a problem with an admin](#what-if-you-have-a-problem-with-an-admin)
+  - [Bots, Tokens, and Webhooks](#bots-tokens-and-webhooks)
+  - [Admin Moderation](#admin-moderation)
+  - [Inactivating Accounts](#inactivating-accounts)
+  - [Specific Channel Rules](#specific-channel-rules)
+  - [DM (Direct Message) Conversations](#dm-direct-message-conversations)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Slack Usage Guidelines
 
 Slack is the main communication platform for Knative outside of our mailing

--- a/community/STEERING-COMMITTEE.md
+++ b/community/STEERING-COMMITTEE.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Steering Committee](#knative-steering-committee)
+  - [Charter](#charter)
+  - [Committee Mechanics](#committee-mechanics)
+  - [Committee Members](#committee-members)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Steering Committee
 
 The Knative Steering Committee (SC) defines, evolves, and defends the vision,

--- a/community/TECH-OVERSIGHT-COMMITTEE.md
+++ b/community/TECH-OVERSIGHT-COMMITTEE.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Technical Oversight Committee](#knative-technical-oversight-committee)
+  - [Charter](#charter)
+  - [Committee Mechanics](#committee-mechanics)
+  - [Committee Meeting](#committee-meeting)
+  - [Committee Members](#committee-members)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Technical Oversight Committee
 
 The Knative Technical Oversight Committee (TOC) is responsible for cross-cutting

--- a/community/VALUES.md
+++ b/community/VALUES.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Team Values](#knative-team-values)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Team Values
 
 We want to make sure every member has a shared understanding of the goals and

--- a/community/WORKING-GROUP-PROCESSES.md
+++ b/community/WORKING-GROUP-PROCESSES.md
@@ -1,3 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Working Group Processes](#knative-working-group-processes)
+  - [Why working groups?](#why-working-groups)
+  - [Proposing a new working group](#proposing-a-new-working-group)
+  - [Setting up a working group](#setting-up-a-working-group)
+    - [Dissolving a working group](#dissolving-a-working-group)
+  - [Leads](#leads)
+  - [Running a working group](#running-a-working-group)
+    - [Be open](#be-open)
+    - [Making decisions](#making-decisions)
+    - [Subgroups](#subgroups)
+    - [Escalations](#escalations)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Working Group Processes
 
 This document describes the processes we use to manage the Knative working

--- a/community/WORKING-GROUPS.md
+++ b/community/WORKING-GROUPS.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Working Groups](#knative-working-groups)
+  - [API Core](#api-core)
+  - [Build](#build)
+  - [Client](#client)
+  - [Documentation](#documentation)
+  - [Eventing](#eventing)
+  - [Networking](#networking)
+  - [Observability](#observability)
+  - [Scaling](#scaling)
+  - [Productivity](#productivity)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Working Groups
 
 Most community activity is organized into _working groups_.

--- a/community/samples/README.md
+++ b/community/samples/README.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Community Samples](#knative-community-samples)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Community Samples
 
 This directory contains Knative sample applications submitted from the

--- a/community/samples/serving/helloworld-clojure/README.md
+++ b/community/samples/serving/helloworld-clojure/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Clojure sample](#hello-world---clojure-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Clojure sample
 
 A simple web app written in Clojure that you can use for testing. It reads in an

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Dart sample](#hello-world---dart-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Dart sample
 
 A simple web app written in the [Dart](www.dartlang.org) programming language

--- a/community/samples/serving/helloworld-elixir/README.md
+++ b/community/samples/serving/helloworld-elixir/README.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Elixir Sample](#hello-world---elixir-sample)
+- [Set up Elixir and Phoenix Locally](#set-up-elixir-and-phoenix-locally)
+- [Running Locally](#running-locally)
+- [Recreating the sample code](#recreating-the-sample-code)
+- [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Welcome to Knative and Elixir](#welcome-to-knative-and-elixir)
+    - [Environment](#environment)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Elixir Sample
 
 A simple web application written in [Elixir](https://elixir-lang.org/) using the

--- a/community/samples/serving/helloworld-haskell/README.md
+++ b/community/samples/serving/helloworld-haskell/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Haskell sample](#hello-world---haskell-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Build and deploy this sample](#build-and-deploy-this-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Haskell sample
 
 A simple web app written in Haskell that you can use for testing. It reads in an

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Rust sample](#hello-world---rust-sample)
+  - [Prerequisites](#prerequisites)
+  - [Steps to recreate the sample code](#steps-to-recreate-the-sample-code)
+  - [Build and deploy this sample](#build-and-deploy-this-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Rust sample
 
 A simple web app written in Rust that you can use for testing. It reads in an

--- a/community/samples/serving/helloworld-shell/README.md
+++ b/community/samples/serving/helloworld-shell/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Shell sample](#hello-world---shell-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Shell sample
 
 A simple web app that executes a shell script. The shell script reads an env

--- a/community/samples/serving/helloworld-swift/README.md
+++ b/community/samples/serving/helloworld-swift/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Swift sample](#hello-world---swift-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Swift sample
 
 A simple web app written in Swift that you can use for testing. The app reads in

--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Eclipse Vert.x sample](#hello-world---eclipse-vertx-sample)
+  - [Before you begin](#before-you-begin)
+  - [Creating and configuring the sample code](#creating-and-configuring-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Testing the sample app](#testing-the-sample-app)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Eclipse Vert.x sample
 
 Learn how to deploy a simple web app that is written in Java and uses Eclipse

--- a/doc-releases.md
+++ b/doc-releases.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Documentation Releases](#documentation-releases)
+  - [`knative/docs` repositories](#knativedocs-repositories)
+    - [Released versions](#released-versions)
+    - [In development (pre-release) version](#in-development-pre-release-version)
+  - [Documentation website](#documentation-website)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Documentation Releases
 
 The following list shows the available versions of Knative documentation. Select

--- a/eventing/README.md
+++ b/eventing/README.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Eventing](#knative-eventing)
+  - [Design overview](#design-overview)
+    - [Event consumers](#event-consumers)
+    - [Event channels and subscriptions](#event-channels-and-subscriptions)
+    - [Future design goals](#future-design-goals)
+  - [Installation](#installation)
+  - [Architecture](#architecture)
+  - [Sources](#sources)
+    - [KubernetesEventSource](#kuberneteseventsource)
+    - [GitHubSource](#githubsource)
+    - [GcpPubSubSource](#gcppubsubsource)
+    - [AwsSqsSource](#awssqssource)
+    - [ContainerSource](#containersource)
+    - [CronJobSource](#cronjobsource)
+  - [Getting Started](#getting-started)
+  - [Configuration](#configuration)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Eventing
 
 Knative Eventing is a system that is designed to address a common need for cloud

--- a/eventing/channels/README.md
+++ b/eventing/channels/README.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Channels](#knative-channels)
+    - [Inclusion in this list is not an endorsement, nor does it imply any level of support.](#inclusion-in-this-list-is-not-an-endorsement-nor-does-it-imply-any-level-of-support)
+  - [Channels](#channels)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!--
 This is a generated file and should not be changed manually. All changes should follow the
 procedure:

--- a/eventing/channels/default-channels.md
+++ b/eventing/channels/default-channels.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Default Channels](#default-channels)
+  - [Creating a default channel](#creating-a-default-channel)
+    - [Caveats](#caveats)
+      - [Arguments cannot be specified by default channels](#arguments-cannot-be-specified-by-default-channels)
+  - [Setting the default channel configuration](#setting-the-default-channel-configuration)
+    - [Caveats](#caveats-1)
+      - [Defaults only apply on channel creation](#defaults-only-apply-on-channel-creation)
+      - [Default channel arguments cannot be specified](#default-channel-arguments-cannot-be-specified)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Default Channels
 
 The default channel configuration allows channels to be created without

--- a/eventing/debugging/README.md
+++ b/eventing/debugging/README.md
@@ -1,3 +1,39 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Debugging Knative Eventing](#debugging-knative-eventing)
+  - [Audience](#audience)
+  - [Version](#version)
+  - [Prerequisites](#prerequisites)
+  - [Example](#example)
+  - [Triggering Events](#triggering-events)
+  - [Where are my events?](#where-are-my-events)
+    - [Control Plane](#control-plane)
+      - [Resources](#resources)
+        - [`fn`](#fn)
+        - [`svc`](#svc)
+        - [`chan`](#chan)
+          - [`Service`](#service)
+          - [`VirtualService`](#virtualservice)
+        - [`src`](#src)
+        - [ContainerSource](#containersource)
+      - [`sub`](#sub)
+      - [Controllers](#controllers)
+        - [Deployment Controller](#deployment-controller)
+        - [Service Controller](#service-controller)
+        - [Channel Controller](#channel-controller)
+        - [Source Controller](#source-controller)
+          - [ContainerSource Controller](#containersource-controller)
+        - [Subscription Controller](#subscription-controller)
+    - [Data Plane](#data-plane)
+      - [`src`](#src-1)
+      - [Channel Dispatcher](#channel-dispatcher)
+      - [`fn`](#fn-1)
+- [TODO Finish the guide.](#todo-finish-the-guide)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Debugging Knative Eventing
 
 This is an evolving document on how to debug a non-working Knative Eventing

--- a/eventing/samples/cronjob-source/README.md
+++ b/eventing/samples/cronjob-source/README.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Cron Job Source example](#cron-job-source-example)
+  - [Deployment Steps](#deployment-steps)
+    - [Prerequisites](#prerequisites)
+    - [Create a Knative Service](#create-a-knative-service)
+    - [Create Cron Job Event Source](#create-cron-job-event-source)
+    - [Verify](#verify)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Cron Job Source example
 
 Cron Job Source example shows how to configure Cron Job as event source for

--- a/eventing/samples/gcp-pubsub-source/README.md
+++ b/eventing/samples/gcp-pubsub-source/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [GCP Cloud Pub/Sub - Source](#gcp-cloud-pubsub---source)
+  - [Prerequisites](#prerequisites)
+  - [Deployment](#deployment)
+  - [Publish](#publish)
+  - [Verify](#verify)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # GCP Cloud Pub/Sub - Source
 
 This sample shows how to configure the GCP PubSub event source. This event

--- a/eventing/samples/iot-core/README.md
+++ b/eventing/samples/iot-core/README.md
@@ -1,3 +1,26 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Sample: Binding running services to an IoT core](#sample-binding-running-services-to-an-iot-core)
+  - [Deployment Steps](#deployment-steps)
+    - [Environment Variables](#environment-variables)
+      - [Variables you must Change](#variables-you-must-change)
+      - [Variables you may Change](#variables-you-may-change)
+    - [Prerequisites](#prerequisites)
+      - [Local](#local)
+      - [Kubernetes](#kubernetes)
+      - [GCP](#gcp)
+      - [GCP PubSub Source](#gcp-pubsub-source)
+    - [Deploying](#deploying)
+      - [Channel](#channel)
+      - [GCP PubSub Source](#gcp-pubsub-source-1)
+      - [Subscription](#subscription)
+      - [IoT Core](#iot-core)
+    - [Running](#running)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Sample: Binding running services to an IoT core
 
 This sample shows how to bind a running service to an

--- a/eventing/samples/kubernetes-event-source/README.md
+++ b/eventing/samples/kubernetes-event-source/README.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Kubernetes Event Source example](#kubernetes-event-source-example)
+  - [Deployment Steps](#deployment-steps)
+    - [Prerequisites](#prerequisites)
+    - [Channel](#channel)
+    - [Service Account](#service-account)
+    - [Create Event Source for Kubernetes Events](#create-event-source-for-kubernetes-events)
+    - [Subscriber](#subscriber)
+    - [Create Events](#create-events)
+    - [Verify](#verify)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Kubernetes Event Source example
 
 Kubernetes Event Source example shows how to wire kubernetes cluster events for

--- a/eventing/samples/writing-a-source/01-bootstrap.md
+++ b/eventing/samples/writing-a-source/01-bootstrap.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Bootstrap the Project](#bootstrap-the-project)
+  - [Create a git repo](#create-a-git-repo)
+  - [Create a Kubebuilder project](#create-a-kubebuilder-project)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Bootstrap the Project
 
 We'll use Kubebuilder to bootstrap the project and provide common controller

--- a/eventing/samples/writing-a-source/02-define-source.md
+++ b/eventing/samples/writing-a-source/02-define-source.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Define The Source Resource](#define-the-source-resource)
+  - [Create the Source CRD Skeleton](#create-the-source-crd-skeleton)
+  - [Add Fields to Source Type Definition](#add-fields-to-source-type-definition)
+  - [Update type tests](#update-type-tests)
+  - [Enable the Status subresource](#enable-the-status-subresource)
+  - [Update tests to use the Status subresource](#update-tests-to-use-the-status-subresource)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Define The Source Resource
 
 We'll use Kubebuilder to generate a new Kubernetes Custom Resource for our

--- a/eventing/samples/writing-a-source/03-reconcile-sources.md
+++ b/eventing/samples/writing-a-source/03-reconcile-sources.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Reconcile Sources](#reconcile-sources)
+  - [Remove Deployment creation from the Reconcile function](#remove-deployment-creation-from-the-reconcile-function)
+  - [Update Source Status in Reconcile function](#update-source-status-in-reconcile-function)
+  - [Resolve SinkURI from the source's Sink reference](#resolve-sinkuri-from-the-sources-sink-reference)
+  - [Add test to verify SinkURI resolution](#add-test-to-verify-sinkuri-resolution)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Reconcile Sources
 
 Now that we have a Source CRD defined with Sink and SinkURI fields, we'll need

--- a/eventing/samples/writing-a-source/04-publish-to-cluster.md
+++ b/eventing/samples/writing-a-source/04-publish-to-cluster.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Publish to a Kubernetes Cluster](#publish-to-a-kubernetes-cluster)
+  - [Run the controller locally](#run-the-controller-locally)
+  - [Create a sample source](#create-a-sample-source)
+  - [Run the controller in cluster](#run-the-controller-in-cluster)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Publish to a Kubernetes Cluster
 
 So far we've only tested the controller code locally. Now we'd like to deploy it

--- a/eventing/samples/writing-a-source/README.md
+++ b/eventing/samples/writing-a-source/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Writing an Event Source the Hard Way](#writing-an-event-source-the-hard-way)
+  - [Target Audience](#target-audience)
+  - [Before you begin](#before-you-begin)
+  - [Steps](#steps)
+  - [Alternatives](#alternatives)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Writing an Event Source the Hard Way
 
 This tutorial walks you through creating an event source for Knative Eventing

--- a/eventing/sources/README.md
+++ b/eventing/sources/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Event Sources](#knative-event-sources)
+    - [Inclusion in this list is not an endorsement, nor does it imply any level of support.](#inclusion-in-this-list-is-not-an-endorsement-nor-does-it-imply-any-level-of-support)
+  - [Sources](#sources)
+  - [Meta Sources](#meta-sources)
+    - [ContainerSource Containers](#containersource-containers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <!--
 This is a generated file and should not be changed manually. All changes should follow the
 procedure:

--- a/install/Knative-custom-install.md
+++ b/install/Knative-custom-install.md
@@ -1,3 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Performing a Custom Knative Installation](#performing-a-custom-knative-installation)
+  - [Before you begin](#before-you-begin)
+  - [Installing Istio](#installing-istio)
+    - [Choosing an Istio installation](#choosing-an-istio-installation)
+      - [Istio installation options](#istio-installation-options)
+    - [Installing Istio](#installing-istio-1)
+  - [Installing Knative components](#installing-knative-components)
+    - [Choosing Knative installation files](#choosing-knative-installation-files)
+      - [Install details and options](#install-details-and-options)
+    - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Performing a Custom Knative Installation
 
 Use this guide to perform a custom installation of Knative on an existing

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -1,3 +1,24 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on Azure Kubernetes Service (AKS)](#knative-install-on-azure-kubernetes-service-aks)
+  - [Before you begin](#before-you-begin)
+    - [Installing the Azure CLI](#installing-the-azure-cli)
+      - [MacOS](#macos)
+      - [Ubuntu 64-bit](#ubuntu-64-bit)
+    - [Installing kubectl](#installing-kubectl)
+  - [Cluster Setup](#cluster-setup)
+    - [Configure your Azure account](#configure-your-azure-account)
+    - [Create a Resource Group for AKS](#create-a-resource-group-for-aks)
+    - [Create a Kubernetes cluster using AKS](#create-a-kubernetes-cluster-using-aks)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on Azure Kubernetes Service (AKS)
 
 This guide walks you through the installation of the latest version of Knative

--- a/install/Knative-with-Docker-for-Mac.md
+++ b/install/Knative-with-Docker-for-Mac.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on Docker for Mac](#knative-install-on-docker-for-mac)
+  - [Before you begin](#before-you-begin)
+  - [Creating a Kubernetes cluster](#creating-a-kubernetes-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative Serving](#installing-knative-serving)
+  - [Deploying an app](#deploying-an-app)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on Docker for Mac
 
 This guide walks you through the installation of the latest version of

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on Google Kubernetes Engine](#knative-install-on-google-kubernetes-engine)
+  - [Before you begin](#before-you-begin)
+    - [Installing the Google Cloud SDK and `kubectl`](#installing-the-google-cloud-sdk-and-kubectl)
+    - [Setting environment variables](#setting-environment-variables)
+    - [Setting up a Google Cloud Platform project](#setting-up-a-google-cloud-platform-project)
+  - [Creating a Kubernetes cluster](#creating-a-kubernetes-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on Google Kubernetes Engine
 
 This guide walks you through the installation of the latest version of all

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -1,3 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on Gardener](#knative-install-on-gardener)
+  - [Before you begin](#before-you-begin)
+    - [Install and configure kubectl](#install-and-configure-kubectl)
+    - [Access Gardener](#access-gardener)
+    - [Creating a Kubernetes cluster](#creating-a-kubernetes-cluster)
+    - [Configure kubectl for your cluster](#configure-kubectl-for-your-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [Set your custom domain](#set-your-custom-domain)
+  - [What's next](#whats-next)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on [Gardener](https://github.com/gardener)
 
 This guide walks you through the installation of the latest version of Knative

--- a/install/Knative-with-ICP.md
+++ b/install/Knative-with-ICP.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on IBM Cloud Private](#knative-install-on-ibm-cloud-private)
+  - [Before you begin](#before-you-begin)
+    - [Install IBM Cloud Private](#install-ibm-cloud-private)
+    - [Configure IBM Cloud Private security policies](#configure-ibm-cloud-private-security-policies)
+      - [Update the image security policy](#update-the-image-security-policy)
+      - [Update pod security policy](#update-pod-security-policy)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on IBM Cloud Private
 
 This guide walks you through the installation of the latest version of

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on IBM Cloud Kubernetes Service (IKS)](#knative-install-on-ibm-cloud-kubernetes-service-iks)
+  - [Before you begin](#before-you-begin)
+    - [Installing the IBM Cloud developer tools](#installing-the-ibm-cloud-developer-tools)
+    - [Setting environment variables](#setting-environment-variables)
+  - [Creating a Kubernetes cluster](#creating-a-kubernetes-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on IBM Cloud Kubernetes Service (IKS)
 
 This guide walks you through the installation of the latest version of Knative

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on Minikube](#knative-install-on-minikube)
+  - [Before you begin](#before-you-begin)
+    - [Install kubectl and Minikube](#install-kubectl-and-minikube)
+  - [Creating a Kubernetes cluster](#creating-a-kubernetes-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative Serving](#installing-knative-serving)
+  - [Deploying an app](#deploying-an-app)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on Minikube
 
 This guide walks you through the installation of the latest version of

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -1,3 +1,21 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on OpenShift](#knative-install-on-openshift)
+  - [Minishift setup](#minishift-setup)
+  - [Configure and start minishift](#configure-and-start-minishift)
+  - [Configuring `oc` (openshift cli)](#configuring-oc-openshift-cli)
+  - [Preparing Knative Deployment](#preparing-knative-deployment)
+    - [Enable Admission Controller Webhook](#enable-admission-controller-webhook)
+    - [Configuring a OpenShift project](#configuring-a-openshift-project)
+    - [Installing Istio](#installing-istio)
+  - [Install Knative Serving](#install-knative-serving)
+  - [Deploying an app](#deploying-an-app)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on OpenShift
 
 This guide walks you through the installation of the latest version of

--- a/install/Knative-with-OpenShift.md
+++ b/install/Knative-with-OpenShift.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on OpenShift](#knative-install-on-openshift)
+  - [Before you begin](#before-you-begin)
+  - [Install `oc` (openshift cli)](#install-oc-openshift-cli)
+  - [Scripted cluster setup and installation](#scripted-cluster-setup-and-installation)
+  - [Creating a new OpenShift cluster](#creating-a-new-openshift-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative Serving](#installing-knative-serving)
+  - [Deploying an app](#deploying-an-app)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on OpenShift
 
 This guide walks you through the installation of the latest version of

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on Pivotal Container Service](#knative-install-on-pivotal-container-service)
+  - [Before you begin](#before-you-begin)
+    - [Installing Pivotal Container Service](#installing-pivotal-container-service)
+  - [Creating a Kubernetes cluster](#creating-a-kubernetes-cluster)
+  - [Access the cluster](#access-the-cluster)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on Pivotal Container Service
 
 This guide walks you through the installation of the latest version of Knative

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Install on a Kubernetes Cluster](#knative-install-on-a-kubernetes-cluster)
+  - [Before you begin](#before-you-begin)
+  - [Installing Istio](#installing-istio)
+  - [Installing Knative](#installing-knative)
+  - [What's next](#whats-next)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Install on a Kubernetes Cluster
 
 This guide walks you through the installation of the latest version of Knative

--- a/install/README.md
+++ b/install/README.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installing Knative](#installing-knative)
+  - [Choosing a Kubernetes cluster](#choosing-a-kubernetes-cluster)
+  - [Installing Knative](#installing-knative-1)
+    - [Install guides](#install-guides)
+  - [Deploying an app](#deploying-an-app)
+  - [Configuring Knative Serving](#configuring-knative-serving)
+  - [Checking the version of your Knative Serving installation](#checking-the-version-of-your-knative-serving-installation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Installing Knative
 
 Follow this guide to install Knative components on a platform of your choice.

--- a/install/check-install-version.md
+++ b/install/check-install-version.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Checking the Version of Your Knative Serving Installation](#checking-the-version-of-your-knative-serving-installation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Checking the Version of Your Knative Serving Installation
 
 If you want to check what version of Knative serving you have installed, enter

--- a/install/getting-started-knative-app.md
+++ b/install/getting-started-knative-app.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Getting Started with Knative App Deployment](#getting-started-with-knative-app-deployment)
+  - [Before you begin](#before-you-begin)
+  - [Sample application](#sample-application)
+  - [Configuring your deployment](#configuring-your-deployment)
+  - [Deploying your app](#deploying-your-app)
+    - [Interacting with your app](#interacting-with-your-app)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Getting Started with Knative App Deployment
 
 This guide shows you how to deploy an app using Knative, then interact with it

--- a/reference/README.md
+++ b/reference/README.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative API Reference documentation](#knative-api-reference-documentation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative API Reference documentation
 
 - [Serving API](serving.md)

--- a/reference/eventing/eventing-sources.md
+++ b/reference/eventing/eventing-sources.md
@@ -1,3 +1,37 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [sources.eventing.knative.dev](#sourceseventingknativedev)
+  - [ContainerSource
+](#containersource)
+  - [GcpPubSubSource
+](#gcppubsubsource)
+  - [GitHubSource
+](#githubsource)
+  - [KubernetesEventSource
+](#kuberneteseventsource)
+  - [ContainerSourceSpec
+](#containersourcespec)
+  - [ContainerSourceStatus
+](#containersourcestatus)
+  - [GcpPubSubSourceSpec
+](#gcppubsubsourcespec)
+  - [GcpPubSubSourceStatus
+](#gcppubsubsourcestatus)
+  - [GitHubSourceSpec
+](#githubsourcespec)
+  - [GitHubSourceStatus
+](#githubsourcestatus)
+  - [KubernetesEventSourceSpec
+](#kuberneteseventsourcespec)
+  - [KubernetesEventSourceStatus
+](#kuberneteseventsourcestatus)
+  - [SecretValueFromSource
+](#secretvaluefromsource)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <p>Packages:</p>
 <ul>
 <li>

--- a/reference/eventing/eventing.md
+++ b/reference/eventing/eventing.md
@@ -1,3 +1,46 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [duck.knative.dev](#duckknativedev)
+  - [Channel
+](#channel)
+  - [ChannelSpec
+](#channelspec)
+  - [ChannelSubscriberSpec
+](#channelsubscriberspec)
+  - [Subscribable
+](#subscribable)
+- [eventing.knative.dev](#eventingknativedev)
+  - [Channel
+](#channel-1)
+  - [ClusterChannelProvisioner
+](#clusterchannelprovisioner)
+  - [Subscription
+](#subscription)
+  - [ChannelProvisionerDefaulter
+](#channelprovisionerdefaulter)
+  - [ChannelSpec
+](#channelspec-1)
+  - [ChannelStatus
+](#channelstatus)
+  - [ClusterChannelProvisionerSpec
+](#clusterchannelprovisionerspec)
+  - [ClusterChannelProvisionerStatus
+](#clusterchannelprovisionerstatus)
+  - [ReplyStrategy
+](#replystrategy)
+  - [SubscriberSpec
+](#subscriberspec)
+  - [SubscriptionSpec
+](#subscriptionspec)
+  - [SubscriptionStatus
+](#subscriptionstatus)
+  - [SubscriptionStatusPhysicalSubscription
+](#subscriptionstatusphysicalsubscription)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <p>Packages:</p>
 <ul>
 <li>

--- a/resources.md
+++ b/resources.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Resources](#resources)
+  - [Community Resources](#community-resources)
+    - [`knctl`](#knctl)
+  - [Other Resources](#other-resources)
+    - [`go-containerregistry`](#go-containerregistry)
+    - [`jib`](#jib)
+    - [`kaniko`](#kaniko)
+    - [`ko`](#ko)
+    - [`skaffold`](#skaffold)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Resources
 
 This page contains information about various tools and technologies that are

--- a/serving/README.md
+++ b/serving/README.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative Serving](#knative-serving)
+  - [Serving resources](#serving-resources)
+  - [Getting Started](#getting-started)
+  - [More samples and demos](#more-samples-and-demos)
+  - [Setting up Logging and Metrics](#setting-up-logging-and-metrics)
+  - [Debugging Knative Serving issues](#debugging-knative-serving-issues)
+  - [Configuration and Networking](#configuration-and-networking)
+  - [Known Issues](#known-issues)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative Serving
 
 Knative Serving builds on Kubernetes and Istio to support deploying and serving

--- a/serving/accessing-logs.md
+++ b/serving/accessing-logs.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Accessing logs](#accessing-logs)
+  - [Kibana and Elasticsearch](#kibana-and-elasticsearch)
+    - [Accessing stdout/stderr logs](#accessing-stdoutstderr-logs)
+    - [Accessing request logs](#accessing-request-logs)
+    - [Accessing configuration and revision logs](#accessing-configuration-and-revision-logs)
+    - [Accessing build logs](#accessing-build-logs)
+    - [Accessing request logs](#accessing-request-logs-1)
+    - [Accessing end to end request traces](#accessing-end-to-end-request-traces)
+  - [Stackdriver](#stackdriver)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Accessing logs
 
 If you have not yet installed the logging and monitoring components, go through

--- a/serving/accessing-metrics.md
+++ b/serving/accessing-metrics.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Accessing metrics](#accessing-metrics)
+  - [Grafana](#grafana)
+  - [Prometheus](#prometheus)
+    - [Metrics Troubleshooting](#metrics-troubleshooting)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Accessing metrics
 
 You access metrics through the [Grafana](https://grafana.com/) UI. Grafana is

--- a/serving/accessing-traces.md
+++ b/serving/accessing-traces.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Accessing request traces](#accessing-request-traces)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Accessing request traces
 
 If you have not yet installed the logging and monitoring components, go through

--- a/serving/cluster-local-route.md
+++ b/serving/cluster-local-route.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Making your Routes local to the cluster](#making-your-routes-local-to-the-cluster)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Making your Routes local to the cluster
 
 In Knative 0.3.x or later, all Routes with a domain suffix of

--- a/serving/debugging-application-issues.md
+++ b/serving/debugging-application-issues.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Debugging Issues with Your Application](#debugging-issues-with-your-application)
+  - [Check command-line output](#check-command-line-output)
+  - [Check application logs](#check-application-logs)
+  - [Check Route status](#check-route-status)
+    - [Check ClusterIngress/Istio routing](#check-clusteringressistio-routing)
+    - [Check Ingress status](#check-ingress-status)
+  - [Check Revision status](#check-revision-status)
+  - [Check Pod status](#check-pod-status)
+  - [Check Build status](#check-build-status)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Debugging Issues with Your Application
 
 You deployed your app to Knative Serving, but it isn't working as expected. Go

--- a/serving/debugging-performance-issues.md
+++ b/serving/debugging-performance-issues.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Investigating Performance Issues](#investigating-performance-issues)
+  - [Request metrics](#request-metrics)
+  - [Request traces](#request-traces)
+  - [Autoscaler metrics](#autoscaler-metrics)
+  - [CPU and memory usage](#cpu-and-memory-usage)
+  - [Profiling](#profiling)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Investigating Performance Issues
 
 You deployed your application or function to Knative Serving but its performance

--- a/serving/fluentd/README.md
+++ b/serving/fluentd/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Fluentd Docker Image on Knative Serving](#fluentd-docker-image-on-knative-serving)
+  - [Requirements](#requirements)
+  - [Sample images](#sample-images)
+    - [Send logs to Elasticsearch](#send-logs-to-elasticsearch)
+    - [Send logs to Stackdriver](#send-logs-to-stackdriver)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Fluentd Docker Image on Knative Serving
 
 Knative Serving uses a [Fluentd](https://www.fluentd.org/) docker image to

--- a/serving/gke-assigning-static-ip-address.md
+++ b/serving/gke-assigning-static-ip-address.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Assigning a static IP address for Knative on Kubernetes Engine](#assigning-a-static-ip-address-for-knative-on-kubernetes-engine)
+  - [Step 1: Reserve a static IP address](#step-1-reserve-a-static-ip-address)
+  - [Step 2: Update the external IP of `istio-ingressgateway` service](#step-2-update-the-external-ip-of-istio-ingressgateway-service)
+  - [Step 3: Verify the static IP address of `istio-ingressgateway` service](#step-3-verify-the-static-ip-address-of-istio-ingressgateway-service)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Assigning a static IP address for Knative on Kubernetes Engine
 
 If you are running Knative on Google Kubernetes Engine and want to use a

--- a/serving/installing-logging-metrics-traces.md
+++ b/serving/installing-logging-metrics-traces.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installing Logging, Metrics, and Traces](#installing-logging-metrics-and-traces)
+  - [Metrics](#metrics)
+  - [Logs](#logs)
+    - [Elasticsearch and Kibana](#elasticsearch-and-kibana)
+      - [Create Elasticsearch Indices](#create-elasticsearch-indices)
+    - [Stackdriver](#stackdriver)
+  - [End to end traces](#end-to-end-traces)
+  - [Learn More](#learn-more)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Installing Logging, Metrics, and Traces
 
 If you followed one of the

--- a/serving/outbound-network-access.md
+++ b/serving/outbound-network-access.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Configuring outbound network access](#configuring-outbound-network-access)
+  - [Determining the IP scope of your cluster](#determining-the-ip-scope-of-your-cluster)
+  - [Setting the IP scope](#setting-the-ip-scope)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Configuring outbound network access
 
 This guides walks you through enabling outbound network access for a Knative

--- a/serving/samples/README.md
+++ b/serving/samples/README.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Knative serving sample applications](#knative-serving-sample-applications)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Knative serving sample applications
 
 This directory contains sample applications, developed on Knative, to illustrate

--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -1,3 +1,23 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Autoscale Sample](#autoscale-sample)
+  - [Prerequisites](#prerequisites)
+  - [Deploy the Service](#deploy-the-service)
+  - [Load the Service](#load-the-service)
+  - [Analysis](#analysis)
+    - [Algorithm](#algorithm)
+      - [Panic](#panic)
+      - [Customization](#customization)
+      - [Demo](#demo)
+    - [Dashboards](#dashboards)
+    - [Other Experiments](#other-experiments)
+  - [Cleanup](#cleanup)
+  - [Further reading](#further-reading)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Autoscale Sample
 
 A demonstration of the autoscaling capabilities of a Knative Serving Revision.

--- a/serving/samples/blue-green-deployment.md
+++ b/serving/samples/blue-green-deployment.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Routing and managing traffic with blue/green deployment](#routing-and-managing-traffic-with-bluegreen-deployment)
+  - [Before you begin](#before-you-begin)
+  - [Deploying Revision 1 (Blue)](#deploying-revision-1-blue)
+  - [Deploying Revision 2 (Green)](#deploying-revision-2-green)
+  - [Migrating traffic to the new revision](#migrating-traffic-to-the-new-revision)
+  - [Rerouting all traffic to the new version](#rerouting-all-traffic-to-the-new-version)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Routing and managing traffic with blue/green deployment
 
 This sample demonstrates updating an application to a new version using a

--- a/serving/samples/build-private-repo-go/README.md
+++ b/serving/samples/build-private-repo-go/README.md
@@ -1,3 +1,22 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Deploying to Knative from a Private GitHub Repo](#deploying-to-knative-from-a-private-github-repo)
+  - [Before you begin](#before-you-begin)
+  - [Setup](#setup)
+    - [1. Setting up the default service account](#1-setting-up-the-default-service-account)
+    - [2. Configuring the build](#2-configuring-the-build)
+      - [Setting up our Build service account](#setting-up-our-build-service-account)
+      - [Creating a deploy key](#creating-a-deploy-key)
+      - [Creating a DockerHub push credential](#creating-a-dockerhub-push-credential)
+      - [Creating the build bot](#creating-the-build-bot)
+    - [3. Installing a Build template and updating `manifest.yaml`](#3-installing-a-build-template-and-updating-manifestyaml)
+  - [Deploying your application](#deploying-your-application)
+  - [Appendix: Sample Code](#appendix-sample-code)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Deploying to Knative from a Private GitHub Repo
 
 This sample demonstrates:

--- a/serving/samples/buildpack-app-dotnet/README.md
+++ b/serving/samples/buildpack-app-dotnet/README.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Buildpack Sample App](#buildpack-sample-app)
+  - [Prerequisites](#prerequisites)
+  - [Running](#running)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Buildpack Sample App
 
 A sample app that demonstrates using

--- a/serving/samples/buildpack-function-nodejs/README.md
+++ b/serving/samples/buildpack-function-nodejs/README.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Buildpack Sample Function](#buildpack-sample-function)
+  - [Prerequisites](#prerequisites)
+  - [Running](#running)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Buildpack Sample Function
 
 A sample function that demonstrates using

--- a/serving/samples/gitwebhook-go/README.md
+++ b/serving/samples/gitwebhook-go/README.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [GitHub Webhook - Go sample](#github-webhook---go-sample)
+  - [Prerequisites](#prerequisites)
+  - [Build the sample code](#build-the-sample-code)
+  - [Exploring](#exploring)
+  - [Testing the service](#testing-the-service)
+  - [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # GitHub Webhook - Go sample
 
 A handler written in Go that demonstrates interacting with GitHub through a

--- a/serving/samples/grpc-ping-go/README.md
+++ b/serving/samples/grpc-ping-go/README.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [gRPC Ping](#grpc-ping)
+  - [Prerequisites](#prerequisites)
+  - [Build and run the gRPC server](#build-and-run-the-grpc-server)
+  - [Use the client to stream messages to the gRPC server](#use-the-client-to-stream-messages-to-the-grpc-server)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # gRPC Ping
 
 A simple gRPC server written in Go that you can use for testing.

--- a/serving/samples/helloworld-csharp/README.md
+++ b/serving/samples/helloworld-csharp/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - .NET Core sample](#hello-world---net-core-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - .NET Core sample
 
 A simple web app written in C# using .NET Core 2.1 that you can use for testing.

--- a/serving/samples/helloworld-go/README.md
+++ b/serving/samples/helloworld-go/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Go sample](#hello-world---go-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Go sample
 
 A simple web app written in Go that you can use for testing. It reads in an env

--- a/serving/samples/helloworld-java/README.md
+++ b/serving/samples/helloworld-java/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Spring Boot Java sample](#hello-world---spring-boot-java-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Spring Boot Java sample
 
 A simple web app written in Java using Spring Boot 2.0 that you can use for

--- a/serving/samples/helloworld-kotlin/README.md
+++ b/serving/samples/helloworld-kotlin/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Kotlin sample](#hello-world---kotlin-sample)
+  - [Prerequisites](#prerequisites)
+  - [Steps to recreate the sample code](#steps-to-recreate-the-sample-code)
+  - [Build and deploy this sample](#build-and-deploy-this-sample)
+  - [Remove the sample app deployment](#remove-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Kotlin sample
 
 A simple web app written in Kotlin using [Ktor](https://ktor.io/) that you can

--- a/serving/samples/helloworld-nodejs/README.md
+++ b/serving/samples/helloworld-nodejs/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Node.js sample](#hello-world---nodejs-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Node.js sample
 
 A simple web app written in Node.js that you can use for testing. It reads in an

--- a/serving/samples/helloworld-php/README.md
+++ b/serving/samples/helloworld-php/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - PHP sample](#hello-world---php-sample)
+  - [Prerequisites](#prerequisites)
+  - [Recreating the sample code](#recreating-the-sample-code)
+  - [Building and deploying the sample](#building-and-deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - PHP sample
 
 A simple web app written in PHP that you can use for testing. It reads in an env

--- a/serving/samples/helloworld-python/README.md
+++ b/serving/samples/helloworld-python/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Python sample](#hello-world---python-sample)
+  - [Prerequisites](#prerequisites)
+  - [Steps to recreate the sample code](#steps-to-recreate-the-sample-code)
+  - [Build and deploy this sample](#build-and-deploy-this-sample)
+  - [Remove the sample app deployment](#remove-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Python sample
 
 A simple web app written in Python that you can use for testing. It reads in an

--- a/serving/samples/helloworld-ruby/README.md
+++ b/serving/samples/helloworld-ruby/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Ruby sample](#hello-world---ruby-sample)
+  - [Prerequisites](#prerequisites)
+  - [Steps to recreate the sample code](#steps-to-recreate-the-sample-code)
+  - [Build and deploy this sample](#build-and-deploy-this-sample)
+  - [Remove the sample app deployment](#remove-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Ruby sample
 
 A simple web app written in Ruby that you can use for testing. It reads in an

--- a/serving/samples/helloworld-scala/README.md
+++ b/serving/samples/helloworld-scala/README.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Hello World - Scala using Akka HTTP sample](#hello-world---scala-using-akka-http-sample)
+  - [Prerequisites](#prerequisites)
+  - [Configuring the sbt build](#configuring-the-sbt-build)
+  - [Configuring the Service descriptor](#configuring-the-service-descriptor)
+  - [Publishing to Docker](#publishing-to-docker)
+  - [Deploying to Knative Serving](#deploying-to-knative-serving)
+  - [Cleanup](#cleanup)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Hello World - Scala using Akka HTTP sample
 
 A microservice which demonstrates how to get set up and running with Knative

--- a/serving/samples/knative-routing-go/README.md
+++ b/serving/samples/knative-routing-go/README.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Routing across Knative Services](#routing-across-knative-services)
+  - [Prerequisites](#prerequisites)
+  - [Setup](#setup)
+  - [Deploy the Service](#deploy-the-service)
+  - [Exploring the Routes](#exploring-the-routes)
+    - [Access the Services](#access-the-services)
+  - [Apply Custom Routing Rule](#apply-custom-routing-rule)
+  - [How It Works](#how-it-works)
+  - [Clean Up](#clean-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Routing across Knative Services
 
 This example shows how to map multiple Knative services to different paths under

--- a/serving/samples/rest-api-go/README.md
+++ b/serving/samples/rest-api-go/README.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Creating a RESTful Service](#creating-a-restful-service)
+  - [Prerequisites](#prerequisites)
+  - [Setup](#setup)
+  - [Deploy the Service](#deploy-the-service)
+  - [Explore the Service](#explore-the-service)
+  - [Access the Service](#access-the-service)
+  - [Next Steps](#next-steps)
+  - [Clean Up](#clean-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Creating a RESTful Service
 
 This sample demonstrates creating and running a simple RESTful service on Knative Serving.

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Orchestrating a source-to-URL deployment on Kubernetes](#orchestrating-a-source-to-url-deployment-on-kubernetes)
+  - [Prerequisites](#prerequisites)
+  - [Configuring Knative](#configuring-knative)
+    - [Install the kaniko build template](#install-the-kaniko-build-template)
+    - [Register secrets for Docker Hub](#register-secrets-for-docker-hub)
+  - [Deploying the sample](#deploying-the-sample)
+  - [Removing the sample app deployment](#removing-the-sample-app-deployment)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Orchestrating a source-to-URL deployment on Kubernetes
 
 A Go sample that shows how to use Knative to go from source code in a git

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Telemetry Sample](#telemetry-sample)
+  - [Prerequisites](#prerequisites)
+  - [Setup](#setup)
+  - [Deploy the Service](#deploy-the-service)
+  - [Explore the Service](#explore-the-service)
+  - [Access the Service](#access-the-service)
+  - [Access Logs](#access-logs)
+  - [Access per Request Traces](#access-per-request-traces)
+  - [Accessing Custom Metrics](#accessing-custom-metrics)
+  - [Clean up](#clean-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Telemetry Sample
 
 This sample runs a simple web server that makes calls to other in-cluster

--- a/serving/samples/thumbnailer-go/README.md
+++ b/serving/samples/thumbnailer-go/README.md
@@ -1,3 +1,24 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Thumbnailer External Dependencies Demo](#thumbnailer-external-dependencies-demo)
+  - [Before you begin](#before-you-begin)
+  - [Sample code](#sample-code)
+    - [Cloning the sample code](#cloning-the-sample-code)
+    - [Run tests](#run-tests)
+    - [Run the app](#run-the-app)
+    - [Test](#test)
+  - [Deploying the app to Knative](#deploying-the-app-to-knative)
+    - [Deploying a prebuilt image](#deploying-a-prebuilt-image)
+    - [Building and deploying a version of the app](#building-and-deploying-a-version-of-the-app)
+  - [Using the app](#using-the-app)
+    - [Ping](#ping)
+    - [Video Thumbnail](#video-thumbnail)
+  - [Final Thoughts](#final-thoughts)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Thumbnailer External Dependencies Demo
 
 This is a walk-through example that demonstrates deploying a dockerized

--- a/serving/samples/traffic-splitting/README.md
+++ b/serving/samples/traffic-splitting/README.md
@@ -1,3 +1,15 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Simple Traffic Splitting Between Revisions](#simple-traffic-splitting-between-revisions)
+  - [Prerequisites](#prerequisites)
+  - [Updating the Service](#updating-the-service)
+  - [Manual Traffic Splitting](#manual-traffic-splitting)
+  - [Clean Up](#clean-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Simple Traffic Splitting Between Revisions
 
 This samples builds off the [Creating a RESTful Service](../rest-api-go) sample

--- a/serving/setting-up-a-logging-plugin.md
+++ b/serving/setting-up-a-logging-plugin.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setting Up A Logging Plugin](#setting-up-a-logging-plugin)
+  - [Configuring](#configuring)
+    - [Configure the DaemonSet for stdout/stderr logs](#configure-the-daemonset-for-stdoutstderr-logs)
+    - [Configure the Sidecar for log files under /var/log](#configure-the-sidecar-for-log-files-under-varlog)
+  - [Deploying](#deploying)
+  - [Uninstalling](#uninstalling)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Setting Up A Logging Plugin
 
 Knative allows cluster operators to use different backends for their logging

--- a/serving/setting-up-custom-ingress-gateway.md
+++ b/serving/setting-up-custom-ingress-gateway.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setting Up Custom Ingress Gateway](#setting-up-custom-ingress-gateway)
+  - [Step 1: Create Gateway Service and Deployment Instance](#step-1-create-gateway-service-and-deployment-instance)
+  - [Step 2: Update Knative Gateway](#step-2-update-knative-gateway)
+  - [Step 3: Update Gateway Configmap](#step-3-update-gateway-configmap)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Setting Up Custom Ingress Gateway
 
 Knative uses a shared ingress Gateway to serve all incoming traffic within Knative

--- a/serving/using-a-custom-domain.md
+++ b/serving/using-a-custom-domain.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setting up a custom domain](#setting-up-a-custom-domain)
+  - [Edit using kubectl](#edit-using-kubectl)
+  - [Apply from a file](#apply-from-a-file)
+  - [Deploy an application](#deploy-an-application)
+  - [Local DNS setup](#local-dns-setup)
+  - [Publish your Domain](#publish-your-domain)
+    - [Set static IP for Knative Gateway](#set-static-ip-for-knative-gateway)
+    - [Update your DNS records](#update-your-dns-records)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Setting up a custom domain
 
 By default, Knative Serving routes use `example.com` as the default domain. The

--- a/serving/using-an-ssl-cert.md
+++ b/serving/using-an-ssl-cert.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Configuring HTTPS with a custom certificate](#configuring-https-with-a-custom-certificate)
+  - [Add the Certificate and Private Key into a secret](#add-the-certificate-and-private-key-into-a-secret)
+  - [Configure the Knative shared Gateway to use the new secret](#configure-the-knative-shared-gateway-to-use-the-new-secret)
+  - [Obtaining an SSL/TLS certificate using Let’s Encrypt through CertBot](#obtaining-an-ssltls-certificate-using-lets-encrypt-through-certbot)
+  - [Obtaining an SSL/TLS certificate using LetsEncrypt with cert-manager](#obtaining-an-ssltls-certificate-using-letsencrypt-with-cert-manager)
+    - [Install cert-manager](#install-cert-manager)
+    - [Configure cert-manager for your DNS provider](#configure-cert-manager-for-your-dns-provider)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Configuring HTTPS with a custom certificate
 
 If you already have an SSL/TLS certificate for your domain you can follow the

--- a/serving/using-cert-manager-on-gcp.md
+++ b/serving/using-cert-manager-on-gcp.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Configuring Knative and CertManager for Google Cloud DNS](#configuring-knative-and-certmanager-for-google-cloud-dns)
+  - [Creating a Cloud DNS service account](#creating-a-cloud-dns-service-account)
+  - [Configuring CertManager to use your DNS admin service account](#configuring-certmanager-to-use-your-dns-admin-service-account)
+    - [Specifying a certificate issuer](#specifying-a-certificate-issuer)
+    - [Specifying the certificate](#specifying-the-certificate)
+    - [Configuring the gateway](#configuring-the-gateway)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Configuring Knative and CertManager for Google Cloud DNS
 
 These instructions assume you have already setup a Knative cluster and installed

--- a/serving/using-external-dns-on-gcp.md
+++ b/serving/using-external-dns-on-gcp.md
@@ -1,3 +1,22 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Using ExternalDNS on Google Cloud Platform to automate DNS setup](#using-externaldns-on-google-cloud-platform-to-automate-dns-setup)
+  - [Set up environtment variables](#set-up-environtment-variables)
+  - [Set up Kubernetes Engine cluster with CloudDNS read/write permissions](#set-up-kubernetes-engine-cluster-with-clouddns-readwrite-permissions)
+    - [Cluster with Cloud DNS scope](#cluster-with-cloud-dns-scope)
+    - [Cluster with Cloud DNS Admin Service Account credential](#cluster-with-cloud-dns-admin-service-account-credential)
+  - [Set up Knative](#set-up-knative)
+  - [Set up ExternalDNS](#set-up-externaldns)
+    - [Create a DNS zone for managing DNS records](#create-a-dns-zone-for-managing-dns-records)
+    - [Deploy ExternalDNS](#deploy-externaldns)
+    - [Configuring Knative Gateway service](#configuring-knative-gateway-service)
+    - [Verify ExternalDNS works](#verify-externaldns-works)
+    - [Verify domain has been published](#verify-domain-has-been-published)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Using ExternalDNS on Google Cloud Platform to automate DNS setup
 
 [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) is a tool

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Test](#test)
+  - [Running unit tests](#running-unit-tests)
+  - [Running end-to-end tests](#running-end-to-end-tests)
+    - [Dependencies](#dependencies)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Test
 
 This directory contains tests and testing docs.


### PR DESCRIPTION
## Proposed Changes

- Use https://github.com/thlorenz/doctoc#doctoc- to generate the toc for all the md files.

- The command that I used is as follows:

```shell
doctoc $(find . -name '*.md' | grep -v vendor | grep -v .github | grep -v 'reference/build.md' | grep -v 'reference/serving.md')
```
