### PR TITLE
Correct the command for build auth.

### DIFF
--- a/build/auth.md
+++ b/build/auth.md
@@ -80,7 +80,7 @@ into their respective files in `$HOME`.
 1.  Execute the build:
 
     ```shell
-    kubectl apply --filename secret.yaml serviceaccount.yaml build.yaml
+    kubectl apply --filename secret.yaml --filename serviceaccount.yaml --filename build.yaml
     ```
 
 When the build executes, before steps execute, a `~/.ssh/config` will be
@@ -137,7 +137,7 @@ to authenticate with the Git service.
 1.  Execute the build:
 
     ```shell
-    kubectl apply --filename secret.yaml serviceaccount.yaml build.yaml
+    kubectl apply --filename secret.yaml --filename serviceaccount.yaml --filename build.yaml
     ```
 
 When this build executes, before steps execute, a `~/.gitconfig` will be
@@ -194,7 +194,7 @@ credentials are then used to authenticate with the Git repository.
 1.  Execute the build:
 
     ```shell
-    kubectl apply --filename secret.yaml serviceaccount.yaml build.yaml
+    kubectl apply --filename secret.yaml --filename serviceaccount.yaml --filename build.yaml
     ```
 
 When this build executes, before steps execute, a `~/.docker/config.json` will


### PR DESCRIPTION
If there are multiple YAML files for kubectl, all files should be
specified by -f option.