### PR TITLE
Updating install docs to v0.4

### DIFF
--- a/install/Knative-custom-install.md
+++ b/install/Knative-custom-install.md
@@ -78,9 +78,9 @@ service mesh. If you install any of the following options, you must install
 
 † These are the recommended standard install files suitable for most use cases.
 
-[a]: https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml
-[b]: https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
-[c]: https://github.com/knative/serving/releases/download/v0.3.0/istio-lean.yaml
+[a]: https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml
+[b]: https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+[c]: https://github.com/knative/serving/releases/download/v0.4.0/istio-lean.yaml
 
 ### Installing Istio
 
@@ -108,13 +108,13 @@ service mesh. If you install any of the following options, you must install
 1. Create the Istio CRDs on your cluster:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml
    ```
 
 1. Install Istio by specifying the filename in the `kubectl apply` command:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/[FILENAME].yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/[FILENAME].yaml
    ```
 
    where `[FILENAME]` is the name of the Istio file that you want to install.
@@ -156,23 +156,26 @@ with Knative.
 The following Knative installation files are available:
 
 - **Serving Component and Observability Plugins**:
-  - https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml
-  - https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
-  - https://github.com/knative/serving/releases/download/v0.3.0/monitoring-logs-elasticsearch.yaml
-  - https://github.com/knative/serving/releases/download/v0.3.0/monitoring-metrics-prometheus.yaml
-  - https://github.com/knative/serving/releases/download/v0.3.0/monitoring-tracing-zipkin.yaml
-  - https://github.com/knative/serving/releases/download/v0.3.0/monitoring-tracing-zipkin-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml
+  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml
+  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-logs-elasticsearch.yaml
+  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-metrics-prometheus.yaml
+  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin.yaml
+  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin-in-mem.yaml
 - **Build Component**:
-  - https://github.com/knative/build/releases/download/v0.3.0/release.yaml
+  - https://github.com/knative/build/releases/download/v0.4.0/build.yaml
 - **Eventing Component**:
-  - https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml
-  - https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml
-  - https://github.com/knative/eventing/releases/download/v0.3.0/in-memory-channel.yaml
-  - https://github.com/knative/eventing/releases/download/v0.3.0/kafka.yaml
+  - https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml
+  - https://github.com/knative/eventing/releases/download/v0.4.0/eventing.yaml
+  - https://github.com/knative/eventing/releases/download/v0.4.0/in-memory-channel.yaml
+  - https://github.com/knative/eventing/releases/download/v0.4.0/kafka.yaml
 - **Eventing sources**:
-  - https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
-  - https://github.com/knative/eventing-sources/releases/download/v0.3.0/release-gcppubsub.yaml
-  - https://github.com/knative/eventing-sources/releases/download/v0.3.0/message-dumper.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/gcppubsub.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/message-dumper.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/sources.yaml
+- **Cluster roles**:
+  - https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
 
 #### Install details and options
 
@@ -187,14 +190,14 @@ files from the Knative repositories:
 | Knative Install Filename                       | Notes                                                                                                  | Dependencies                                                      |
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
 | **knative/serving**                            |                                                                                                        |                                                                   |
-| [`serving.yaml`][1.1]†                         | Installs the Serving component.                                                                        |                                                                   |
+| [`serving.yaml`][1.1]†                         | Installs the Serving component.                                                                        | Cluster roles enabled, if interacting with Build                  |
 | [`monitoring.yaml`][1.2]†                      | Installs the [ELK stack][2], [Prometheus][2.1], [Grafana][2.2], and [Zipkin][2.3]**\***                | Serving component                                                 |
 | [`monitoring-logs-elasticsearch.yaml`][1.3]    | Installs only the [ELK stack][2]**\***                                                                 | Serving component                                                 |
 | [`monitoring-metrics-prometheus.yaml`][1.4]    | Installs only [Prometheus][2.1]**\***                                                                  | Serving component                                                 |
 | [`monitoring-tracing-zipkin.yaml`][1.5]        | Installs only [Zipkin][2.3].**\***                                                                     | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml) |
 | [`monitoring-tracing-zipkin-in-mem.yaml`][1.6] | Installs only [Zipkin in-memory][2.3]**\***                                                            | Serving component                                                 |
 | **knative/build**                              |                                                                                                        |                                                                   |
-| [`release.yaml`][3.1]†                         | Installs the Build component.                                                                          |                                                                   |
+| [`release.yaml`][3.1]†                         | Installs the Build component.                                                                          | Cluster roles enabled, if interacting with Serving                |
 | **knative/eventing**                           |                                                                                                        |                                                                   |
 | [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes the in-memory channel provisioner.                           | Serving component                                                 |
 | [`eventing.yaml`][4.2]                         | Installs the Eventing component. Does not include the in-memory channel provisioner.                   | Serving component                                                 |
@@ -202,8 +205,10 @@ files from the Knative repositories:
 | [`kafka.yaml`][4.4]                            | Installs only the Kafka channel provisioner.                                                           | Serving component, Eventing component                             |
 | **knative/eventing-sources**                   |                                                                                                        |                                                                   |
 | [`release.yaml`][5.1]†                         | Installs the following sources: [Kubernetes][6], [GitHub][6.1], [Container image][6.2], [CronJob][6.3] | Serving component, Eventing component                             |
-| [`release-gcppubsub.yaml`][5.2]                | Installs the following sources: [PubSub][6.4]                                                          | Serving component, Eventing component                             |
+| [`gcppubsub.yaml`][5.2]                        | Installs the following sources: [PubSub][6.4]                                                          | Serving component, Eventing component                             |
 | [`message-dumper.yaml`][5.3]                   | Installs an Event logging service for debugging.                                                       | Serving component, Eventing component                             |
+| **Cluster roles**                              |                                                                                                        |                                                                   |
+| [`clusterrole.yaml`][7]†                       | Enables the Build and Serving components to interact.                                                  | Serving component, Build component                                |
 
 _\*_ See
 [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
@@ -211,38 +216,40 @@ for details about installing the various supported observability plug-ins.
 
 † These are the recommended standard install files suitable for most use cases.
 
-[1]: https://github.com/knative/serving/releases/tag/v0.3.0
-[1.1]: https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml
+[1]: https://github.com/knative/serving/releases/tag/v0.4.0
+[1.1]: https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml
 [1.2]:
-  https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+  https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml
 [1.3]:
-  https://github.com/knative/serving/releases/download/v0.3.0/monitoring-logs-elasticsearch.yaml
+  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-logs-elasticsearch.yaml
 [1.4]:
-  https://github.com/knative/serving/releases/download/v0.3.0/monitoring-metrics-prometheus.yaml
+  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-metrics-prometheus.yaml
 [1.5]:
-  https://github.com/knative/serving/releases/download/v0.3.0/monitoring-tracing-zipkin.yaml
+  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin.yaml
 [1.6]:
-  https://github.com/knative/serving/releases/download/v0.3.0/monitoring-tracing-zipkin-in-mem.yaml
+  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin-in-mem.yaml
 [2]: https://www.elastic.co/elk-stack
 [2.1]: https://prometheus.io
 [2.2]: https://grafana.com
 [2.3]: https://zipkin.io/
-[3]: https://github.com/knative/build/releases/tag/v0.3.0
-[3.1]: https://github.com/knative/build/releases/download/v0.3.0/release.yaml
-[4]: https://github.com/knative/eventing/releases/tag/v0.3.0
-[4.1]: https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml
+[3]: https://github.com/knative/build/releases/tag/v0.4.0
+[3.1]: https://github.com/knative/build/releases/download/v0.4.0/build.yaml
+[4]: https://github.com/knative/eventing/releases/tag/v0.4.0
+[4.1]: https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml
 [4.2]:
-  https://github.com/knative/eventing/releases/download/v0.3.0/eventing.yaml
+  https://github.com/knative/eventing/releases/download/v0.4.0/eventing.yaml
 [4.3]:
-  https://github.com/knative/eventing/releases/download/v0.3.0/in-memory-channel.yaml
-[4.4]: https://github.com/knative/eventing/releases/download/v0.3.0/kafka.yaml
-[5]: https://github.com/knative/eventing-sources/releases/tag/v0.3.0
+  https://github.com/knative/eventing/releases/download/v0.4.0/in-memory-channel.yaml
+[4.4]: https://github.com/knative/eventing/releases/download/v0.4.0/kafka.yaml
+[5]: https://github.com/knative/eventing-sources/releases/tag/v0.4.0
 [5.1]:
-  https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml
 [5.2]:
-  https://github.com/knative/eventing-sources/releases/download/v0.3.0/release-gcppubsub.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.4.0/gcppubsub.yaml
 [5.3]:
-  https://github.com/knative/eventing-sources/releases/download/v0.3.0/message-dumper.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.4.0/message-dumper.yaml
+[5.4]:
+  https://github.com/knative/eventing-sources/releases/download/v0.4.0/sources.yaml
 [6]:
   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#event-v1-core
 [6.1]: https://developer.github.com/v3/activity/events/types/
@@ -250,6 +257,7 @@ for details about installing the various supported observability plug-ins.
 [6.3]:
   https://github.com/knative/eventing-sources/blob/master/samples/cronjob-source/README.md
 [6.4]: https://cloud.google.com/pubsub/
+[7]: https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
 
 ### Installing Knative
 
@@ -280,28 +288,28 @@ commands below.
      `[COMPONENT]`, `[VERSION]`, and `[FILENAME]` are the Knative component,
      release version, and filename of the Knative component or plugin. Examples:
 
-     - `https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml`
-     - `https://github.com/knative/build/releases/download/v0.3.0/release.yaml`
-     - `https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml`
-     - `https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml`
-
+     - `https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml`
+     - `https://github.com/knative/build/releases/download/v0.4.0/build.yaml`
+     - `https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml`
+     - `https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml`
 
     **Example install commands:**
 
      * To install the Knative Serving component with the set of observability plug-ins:
 
        ```bash
-       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-       --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+       --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml
        ```
 
     * To install all three Knative components and the set of Eventing sources without an observability plugin:
 
       ```bash
-      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-      --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-      --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-      --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
+      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+      --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+      --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+      --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+      --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
       ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/install/Knative-with-AKS.md
+++ b/install/Knative-with-AKS.md
@@ -137,8 +137,8 @@ Knative depends on Istio.
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -170,12 +170,15 @@ your Knative installation, see
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/install/Knative-with-Docker-for-Mac.md
+++ b/install/Knative-with-Docker-for-Mac.md
@@ -32,7 +32,7 @@ Knative depends on Istio. Run the following to install Istio. (This changes
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.2.2/istio.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -59,12 +59,11 @@ rerun the command to see the current status.
 Next, install [Knative Serving](https://github.com/knative/serving).
 
 Because you have limited resources available, use the
-`https://github.com/knative/serving/releases/download/v0.2.2/release-lite.yaml`
-file, which omits some of the monitoring components to reduce the memory used by
-the Knative components. To use the provided `release-lite.yaml` release, run:
+`https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml`
+file, which installs only Knative Serving:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.2.2/release-lite.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
   | kubectl apply --filename -
 ```
 

--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -137,8 +137,8 @@ Knative depends on Istio.
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -171,12 +171,15 @@ see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -72,8 +72,8 @@ Knative depends on Istio.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -103,12 +103,15 @@ see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/install/Knative-with-ICP.md
+++ b/install/Knative-with-ICP.md
@@ -129,35 +129,43 @@ see [Performing a Custom Knative Installation](Knative-custom-install.md).
 1. Run the following commands to install Knative:
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+   curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+   curl -L https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
+   curl -L https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
+   curl -L https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml \
+   curl -L https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
+   ```shell
+   curl -L https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml \
+     | sed 's/LoadBalancer/NodePort/' \
+     | kubectl apply --filename -
+   ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
+   
    See
    [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
    for details about installing the various supported observability plug-ins.
@@ -209,31 +217,31 @@ To remove Knative from your IBM Cloud Private cluster, run the following
 commands:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
+curl -L https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
+curl -L https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
+curl -L https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```

--- a/install/Knative-with-IKS.md
+++ b/install/Knative-with-IKS.md
@@ -133,8 +133,8 @@ Knative depends on Istio.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -167,12 +167,15 @@ see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/install/Knative-with-Minikube.md
+++ b/install/Knative-with-Minikube.md
@@ -60,7 +60,7 @@ Knative depends on Istio. Run the following to install Istio. (We are changing
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -93,7 +93,7 @@ and monitoring plugins.
 Enter the following command:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 ```

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -161,8 +161,8 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/is
 1. Run the following to install Istio:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-   oc apply -f https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+   oc apply -f https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -203,10 +203,12 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/kn
 1. Install Knative serving:
 
    ```shell
-   oc apply -f https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   oc apply -f https://github.com/knative/build/releases/download/v0.3.0/release.yaml
+   oc apply -f https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   oc apply -f https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   oc apply -f https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
-
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
 2. Monitor the Knative components until all of the components show a `STATUS` of
    `Running` or `Completed`:
 

--- a/install/Knative-with-PKS.md
+++ b/install/Knative-with-PKS.md
@@ -49,8 +49,8 @@ Containers
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -80,11 +80,15 @@ see [Performing a Custom Knative Installation](Knative-custom-install.md).
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/install/Knative-with-any-k8s.md
+++ b/install/Knative-with-any-k8s.md
@@ -22,8 +22,8 @@ Containers.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -56,12 +56,16 @@ your Knative installation, see
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.3.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.3.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each other.
+
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash


### PR DESCRIPTION
v0.4 release has been cut for all components; updating install files to match.

Adds information about clusterrole.yaml, which is now necessary if using the Build and Serving components together.