### PR TITLE
Update eventing install for v0.4.0

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -80,8 +80,8 @@ ChannelProvisioner) and the core sources (which provides the Kubernetes Events,
 GitHub, and "Container" Sources) with the following commands:
 
 ```bash
-kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.3.0/release.yaml
-kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release.yaml
+kubectl apply --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml
+kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml
 ```
 
 In addition to the core sources, there are [other sources](./sources/README.md)


### PR DESCRIPTION
Fixes N/A (Follow up https://github.com/knative/docs/pull/915)

## Proposed Changes
- Install v0.4.0 release of eventing and eventing-sources instead of v0.3.0.
