### PR TITLE
knative with gardener: fix markdown syntax

### DIFF
--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -86,7 +86,10 @@ Knative depends on Istio.
     kubectl label namespace default istio-injection=enabled
     ```
 3.  Monitor the Istio components until all of the components show a `STATUS` of
-    `Running` or `Completed`: `bash kubectl get pods --namespace istio-system`
+    `Running` or `Completed`: 
+    ```bash 
+    kubectl get pods --namespace istio-system`
+    ```
 
 It will take a few minutes for all the components to be up and running; you can
 rerun the command to see the current status.


### PR DESCRIPTION
## Proposed Changes

- Fix issue with markdown syntax in `install/knative-with-gardener.md`
