### PR TITLE
Add Build and Eventing to "How can I help" (#193)

### DIFF
--- a/community/README.md
+++ b/community/README.md
@@ -81,6 +81,8 @@ overall project.
 If you're looking for something to do to get your feet wet working on Knative,
 look for GitHub issues marked with the Help Wanted label:
 
+- [Build issues](https://github.com/knative/build/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
+- [Eventing issues](https://github.com/knative/eventing/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
 - [Serving issues](https://github.com/knative/serving/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
 - [Documentation repo](https://github.com/knative/docs/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
 


### PR DESCRIPTION
Fixes #193 

## Proposed Changes
- Add the links of Build and Eventing to "How can I help"