### PR TITLE
Add in-memory-channel to enable eventing release

### DIFF
--- a/install/Knative-with-GKE.md
+++ b/install/Knative-with-GKE.md
@@ -182,6 +182,7 @@ see [Performing a Custom Knative Installation](Knative-custom-install.md).
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.4.0/in-memory-channel.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \


### PR DESCRIPTION

Eventing release was failing for me due to missing `ClusterChannelProvisioner`
```
unable to recognize "https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml": no matches for kind "ClusterChannelProvisioner" in version "eventing.knative.dev/v1alpha1"
```
Adding `https://github.com/knative/eventing/releases/download/v0.4.0/in-memory-channel.yaml` fixes this

Fixes #(issue-number)

## Proposed Changes

-
-
-
