### PR TITLE
Fixed Broken Image Links

### DIFF
--- a/install/Knative-with-Gardener.md
+++ b/install/Knative-with-Gardener.md
@@ -35,7 +35,7 @@ Knative requires a Kubernetes cluster v1.11 or newer.
     your project. You can skip this step if you create your cluster using the
     user interface; it is only needed for programmatic access, make sure you set
     `export KUBECONFIG=garden-my-project.yaml` in your shell.
-    ![Download kubeconfig for Gardener](images/gardener_service_account.png "downloading the kubeconfig using a service account")
+    ![Download kubeconfig for Gardener](./images/gardener_service_account.png "downloading the kubeconfig using a service account")
 
 ### Creating a Kubernetes cluster
 
@@ -51,7 +51,7 @@ kubectl apply --filename my-cluster.yaml
 
 The easier alternative is to create the cluster following the cluster creation
 wizard in the Gardener dashboard:
-![shoot creation](images/gardener_shoot_creation.png "shoot creation via the dashboard")
+![shoot creation](./images/gardener_shoot_creation.png "shoot creation via the dashboard")
 
 ### Configure kubectl for your cluster
 


### PR DESCRIPTION
Fixes: 

The website has a couple of  broken image links on this page: 
https://www.knative.dev/docs/install/knative-with-gardener/



Under the following sections: 

1. Access Gardener [Download Kubeconfig for Gardner](https://www.knative.dev/docs/install/knative-with-gardener/images/gardener_service_account.png)
2. Creating a Kubernetes cluster [shoot creation](https://www.knative.dev/docs/install/knative-with-gardener/images/gardener_shoot_creation.png)

## Proposed Changes

- Fixed the dead links on this page. 