### PR TITLE
Doc changes to githubsource for specifying API URL

### DIFF
--- a/eventing/README.md
+++ b/eventing/README.md
@@ -175,7 +175,7 @@ The GitHubSource fires a new event for selected
 - `sink`:
   [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core)
   A reference to the object that should receive events.
-- `githubAPIURL`: `string` Optional field to specify the base URL for API requests. Defaults to the public GitHub API if not specified, but can be set to a domain endpoint to use with GitHub Enterprise, for example, https://github.mycompany.com/api/v3/. This base URL should always be specified with a trailing slash.
+- `githubAPIURL`: `string` Optional field to specify the base URL for API requests. Defaults to the public GitHub API if not specified, but can be set to a domain endpoint to use with GitHub Enterprise, for example, `https://github.mycompany.com/api/v3/`. This base URL should always be specified with a trailing slash.
 
 ### GcpPubSubSource
 

--- a/eventing/README.md
+++ b/eventing/README.md
@@ -175,6 +175,7 @@ The GitHubSource fires a new event for selected
 - `sink`:
   [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#objectreference-v1-core)
   A reference to the object that should receive events.
+- `githubAPIURL`: `string` Optional field to specify the base URL for API requests. Defaults to the public GitHub API if not specified, but can be set to a domain endpoint to use with GitHub Enterprise, for example, https://github.mycompany.com/api/v3/. This base URL should always be specified with a trailing slash.
 
 ### GcpPubSubSource
 

--- a/eventing/samples/github-source/README.md
+++ b/eventing/samples/github-source/README.md
@@ -102,7 +102,7 @@ by your GitHub user.
 
 If using GitHub enterprise you will need to add an additional githubAPIURL
 field to the spec specifying your GitHub enterprise API endpoint, see 
-[here](https://github.com/knative/docs/tree/master/eventing#githubsource)
+[here](../../README.md#githubsource)
 
 ```yaml
 apiVersion: sources.eventing.knative.dev/v1alpha1

--- a/eventing/samples/github-source/README.md
+++ b/eventing/samples/github-source/README.md
@@ -100,6 +100,10 @@ Source for a specific namespace. Be sure to replace the
 `ownerAndRepository` value with a valid GitHub public repository owned
 by your GitHub user.
 
+If using GitHub enterprise you will need to add an additional githubAPIURL
+field to the spec specifying your GitHub enterprise API endpoint, see 
+[here](https://github.com/knative/docs/tree/master/eventing#githubsource)
+
 ```yaml
 apiVersion: sources.eventing.knative.dev/v1alpha1
 kind: GitHubSource

--- a/eventing/samples/github-source/github-source.yaml
+++ b/eventing/samples/github-source/github-source.yaml
@@ -18,3 +18,5 @@ spec:
     apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: github-message-dumper
+# To use GitHub Enterprise you would need to add an entry for your githubAPIURL similar to the example below
+# githubAPIURL: "https://github.mycompany.com/api/v3/"


### PR DESCRIPTION
This commit introduces extra documentation to support the new
functionality on githubsource where you can optionally specify
the baseURL of the github api server - thus enabling the existing
githubsource to be used against both public github and github
enterprise.  

New function added under https://github.com/knative/eventing-sources/pull/219

## Proposed Changes

- Update sample code to highlight new optional githubAPIURL spec value
- Update main doc to highlight new optional githubAPIURL spec value

