### PR TITLE
Add missing command chaining at "Install serving"

### DIFF
--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -212,8 +212,8 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/kn
 1. Install Knative serving:
 
    ```shell
-   oc apply -f https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   oc apply -f https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   oc apply -f https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml && \
+   oc apply -f https://github.com/knative/build/releases/download/v0.4.0/build.yaml && \
    oc apply -f https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is


### PR DESCRIPTION
No issue created 

## Proposed Changes

- Adds missing chaining in bash command resulting in invalid command `error: Unexpected args: [oc apply oc apply]`
