### PR TITLE
Add note on build pod timeout in Serving source-to-url sample

### DIFF
--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -134,6 +134,7 @@ container for the application.
                arguments:
                  - name: IMAGE
                    value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
+              timeout: 10m
          revisionTemplate:
            spec:
              container:
@@ -165,6 +166,8 @@ container for the application.
    app-from-source-00001-deployment-6d6ff665f9-xfhm5   2/3       Running   0         6s
    app-from-source-00001-deployment-6d6ff665f9-xfhm5   3/3       Running   0         11s
    ```
+
+  > **Note:** If the build pod never reaches Completed status and terminates after 10 minutes, Kaniko probably didn't finish pulling the build image within the default timeout period. Try increasing the `timeout` value in `service.yaml`.
 
 1. Once you see the deployment pod switch to the running state, press Ctrl+C to
    escape the watch. Your container is now built and deployed!

--- a/serving/samples/source-to-url-go/service.yaml
+++ b/serving/samples/source-to-url-go/service.yaml
@@ -20,6 +20,7 @@ spec:
             arguments:
             - name: IMAGE
               value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
+          timeout: 10m
       revisionTemplate:
         spec:
           container:


### PR DESCRIPTION
## Proposed Changes

Users trying out the source-to-url sample might experience Kaniko build pod time-outs in slow network conditions. This is hard to troubleshoot as Kaniko offers no pull progress logs. The existence of a timeout and setting should thus be made explicit for new users to avoid getting stuck at this point.

- note in doc
- timeout parameter explicit in yaml
