### PR TITLE
serving/samples/helloworld-nodejs: specifically require package.json

### DIFF
--- a/serving/samples/helloworld-nodejs/Dockerfile
+++ b/serving/samples/helloworld-nodejs/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/app
 # Copy application dependency manifests to the container image.
 # A wildcard is used to ensure both package.json AND package-lock.json are copied.
 # Copying this separately prevents re-running npm install on every code change.
-COPY package*.json ./
+COPY package.json package*.json ./
 
 # Install production dependencies.
 RUN npm install --only=production


### PR DESCRIPTION
By specifying the package.json separately from the wildcard argument, we get a more specific error. In general there is no error if missing `package-lock.json`, but missing `package.json`:

### Before

```
COPY failed: no source files were specified
```

### After

```
COPY failed: stat /var/lib/docker/tmp/docker-builder239774917/package.json: no such file or directory
```