### PR TITLE
samples/grpc-ping-go: don't provide default -server_host_override

### DIFF
--- a/serving/samples/grpc-ping-go/client/client.go
+++ b/serving/samples/grpc-ping-go/client/client.go
@@ -16,14 +16,17 @@ import (
 
 var (
 	serverAddr         = flag.String("server_addr", "127.0.0.1:8080", "The server address in the format of host:port")
-	serverHostOverride = flag.String("server_host_override", "grpc.knative.dev", "")
+	serverHostOverride = flag.String("server_host_override", "", "")
 	insecure           = flag.Bool("insecure", false, "Set to true to skip SSL validation")
 )
 
 func main() {
 	flag.Parse()
 
-	opts := []grpc.DialOption{grpc.WithAuthority(*serverHostOverride)}
+	var opts []grpc.DialOption
+	if *serverHostOverride != "" {
+		opts = append(opts, grpc.WithAuthority(*serverHostOverride))
+	}
 	if *insecure {
 		opts = append(opts, grpc.WithInsecure())
 	}


### PR DESCRIPTION
I was trying to connect to my grpc service at a custom domain like
`grpc-ping.default.IP.IP.IP.IP.xip.io` while omitting -server_host_override
and it resulted in bug https://github.com/knative/serving/issues/3307 which
took several days to figure out there was a default value for this flag.

Removing the default value as nobody's really owning grpc.knative.dev or
setting it as the custom domain in this sample.