### PR TITLE
Fix syntax error in yaml

### DIFF
--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -134,7 +134,7 @@ container for the application.
                arguments:
                  - name: IMAGE
                    value: docker.io/{DOCKER_USERNAME}/app-from-source:latest
-              timeout: 10m
+             timeout: 10m
          revisionTemplate:
            spec:
              container:


### PR DESCRIPTION
Lined up `timeout` key correctly