### PR TITLE
add initial version of knative-with-minishift.sh

### DIFF
--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -20,7 +20,14 @@ You can find [guides for other platforms here](README.md).
 minishift version
 ```
 
-## Configure and start minishift
+## Run automated set-up script
+
+Once you have `minishift` present on your machine and in your `PATH`,
+you can [run a script](scripts/knative-with-minishift.sh) that automates the steps on this page.
+
+## Manually configure and start minishift
+
+Here are the manual steps which the above script automates for you in case you prefer doing this yourself:
 
 The following details the bare minimum configuration required to setup minishift
 for running Knative:

--- a/install/Knative-with-Minishift.md
+++ b/install/Knative-with-Minishift.md
@@ -20,12 +20,14 @@ You can find [guides for other platforms here](README.md).
 minishift version
 ```
 
-## Run automated set-up script
+## Automatic Set Up
 
 Once you have `minishift` present on your machine and in your `PATH`,
 you can [run a script](scripts/knative-with-minishift.sh) that automates the steps on this page.
 
-## Manually configure and start minishift
+## Manually Set Up
+
+### Manually configure and start minishift
 
 Here are the manual steps which the above script automates for you in case you prefer doing this yourself:
 
@@ -74,7 +76,7 @@ minishift start
   and stop minishift to make sure that you are on right `knative` minishift
   profile that was configured above.
 
-## Configuring `oc` (openshift cli)
+### Configuring `oc` (openshift cli)
 
 Running the following command make sure that you have right version of `oc` and
 have configured the DOCKER daemon to be connected to minishift docker.
@@ -86,9 +88,9 @@ minishift docker-env
 minishift oc-env
 ```
 
-## Preparing Knative Deployment
+### Preparing Knative Deployment
 
-### Enable Admission Controller Webhook
+#### Enable Admission Controller Webhook
 
 To be able to deploy and run serverless Knative applications, its required that
 you must enable the
@@ -127,7 +129,7 @@ minishift openshift config set --target=kube --patch '{
 until oc login -u admin -p admin; do sleep 5; done;
 ```
 
-### Configuring a OpenShift project
+#### Configuring a OpenShift project
 
 1. Set up the project **myproject** for use with Knative applications.
 
@@ -153,7 +155,7 @@ until oc login -u admin -p admin; do sleep 5; done;
 > applications in `default` project, it's safer not to touch it to avoid any
 > instabilities in OpenShift.
 
-### Installing Istio
+#### Installing Istio
 
 Knative depends on Istio. The
 [istio-openshift-policies.sh](scripts/istio-openshift-policies.sh) does run the
@@ -187,7 +189,7 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/is
    > **NOTE:** It will take a few minutes for all the components to be up and
    > running.
 
-## Install Knative Serving
+### Install Knative Serving
 
 The following section details on deploying
 [Knative Serving](https://github.com/knative/serving) to OpenShift.

--- a/install/scripts/knative-with-minishift.sh
+++ b/install/scripts/knative-with-minishift.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Originally stolen almost literally from
+# https://github.com/openshift-cloud-functions/knative-operators/blob/master/etc/scripts/install-on-minishift.sh
+# just added 'anyuid' add-on, as per manual steps documentation.
+
+# WARNING: this totally destroys and recreates your `knative` profile,
+# thereby guaranteeing (hopefully) a clean environment upon successful
+# completion.
+
+if minishift status | head -1 | grep "Running" >/dev/null; then
+  echo "Please stop your running minishift to acknowledge this script will destroy it."
+  exit 1
+fi
+
+set -ex
+
+OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-v3.11.0}
+MEMORY=${MEMORY:-10GB}
+CPUS=${CPUS:-4}
+DISK_SIZE=${DISK_SIZE:-50g}
+
+# blow away everything in the knative profile
+minishift profile delete knative --force || true
+
+# configure knative profile
+minishift profile set knative
+minishift config set openshift-version ${OPENSHIFT_VERSION}
+minishift config set memory ${MEMORY}
+minishift config set cpus ${CPUS}
+minishift config set disk-size ${DISK_SIZE}
+minishift config set image-caching true
+minishift addons enable admin-user
+minishift addons enable anyuid
+
+# Start minishift
+minishift start
+
+eval "$(minishift oc-env)"
+
+oc login -u admin -p admin
+
+# DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+# "$DIR/install.sh" -q


### PR DESCRIPTION
The idea is to further fully automate the steps from the install/Knative-with-Minishift.md documentation,
by integrating with [the other scripts here](https://github.com/knative/docs/tree/master/install/scripts) to fully automate [the steps documented here](https://github.com/knative/docs/blob/master/install/Knative-with-Minishift.md).

@jcrossley3 hope it's OK with you if I more or less just copy/pasted your https://github.com/openshift-cloud-functions/knative-operators/blob/master/etc/scripts/install-on-minishift.sh here!

@kameshsampath @gyliu513 @vdemeester @RichieEscarez @pmorie 