### PR TITLE
Update Dockerfile

### DIFF
--- a/serving/samples/helloworld-go/Dockerfile
+++ b/serving/samples/helloworld-go/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.12 as builder
 WORKDIR /go/src/github.com/knative/docs/helloworld
 COPY . .
 
-# Build the outyet command inside the container.
+# Build the command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld


### PR DESCRIPTION
The instructions use the binary name "outyet" which doesn't reflect the helloworld binary actually used. I believe this is a copy-paste from:
https://blog.golang.org/docker

Fixes #(issue-number)

## Proposed Changes

-
-
-
