### PR TITLE
Add note to get ingress ip from a cluster that has no external load balancer

### DIFF
--- a/serving/samples/autoscale-go/README.md
+++ b/serving/samples/autoscale-go/README.md
@@ -26,7 +26,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    kubectl apply --filename serving/samples/autoscale-go/service.yaml
    ```
 
-1. Find the ingress hostname and IP and export as an environment variable:
+1. To get the ingress IP for your cluster, use the following command. If your cluster is new, it can take some time for the service to get an external IP address:
 
    ```shell
    # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
@@ -40,6 +40,15 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    fi
 
    export IP_ADDRESS=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+   ```
+
+   > Note: if you use minikube or a baremetal cluster that has no external load
+   > balancer, the `EXTERNAL-IP` field is shown as `<pending>`. You need to use
+   > `NodeIP` and `NodePort` to interact your app instead. To get your app's
+   > `NodeIP` and `NodePort`, enter the following command:
+
+   ```shell
+   export IP_ADDRESS=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
    ```
 
 ## Load the Service

--- a/serving/samples/source-to-url-go/README.md
+++ b/serving/samples/source-to-url-go/README.md
@@ -230,6 +230,23 @@ container for the application.
    xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
    ```
 
+   Take note of the EXTERNAL-IP address.
+
+   You can also export the IP address as a variable with the following command:
+   
+   ```shell
+   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY --namespace istio-system --output 'jsonpath={.status.loadBalancer.ingress[0].ip}')
+   ```    
+
+   > Note: if you use minikube or a baremetal cluster that has no external load
+   > balancer, the `EXTERNAL-IP` field is shown as `<pending>`. You need to use
+   > `NodeIP` and `NodePort` to interact your app instead. To get your app's
+   > `NodeIP` and `NodePort`, enter the following command:
+
+   ```shell
+   export IP_ADDRESS=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+   ```
+
 1. To find the URL for your service, type:
 
    ```shell
@@ -238,8 +255,7 @@ container for the application.
    app-from-source     app-from-source.default.example.com
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address that you got in the previous step:
+1. Now you can make a request to your app to see the result.
 
    ```shell
    curl -H "Host: app-from-source.default.example.com" http://{IP_ADDRESS}

--- a/serving/samples/telemetry-go/README.md
+++ b/serving/samples/telemetry-go/README.md
@@ -175,6 +175,15 @@ fi
 export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
 ```
 
+> Note: if you use minikube or a baremetal cluster that has no external load
+> balancer, the `EXTERNAL-IP` field is shown as `<pending>`. You need to use
+> `NodeIP` and `NodePort` to interact your app instead. To get your app's
+> `NodeIP` and `NodePort`, enter the following command:
+
+```shell
+export SERVICE_IP=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
+```
+
 3. Make a request to the service to see the `Hello World!` message:
 
 ```


### PR DESCRIPTION
Add note for below samples when we get ingress ip from a cluster that has no external load balancer

- [Autoscaling with Knative Serving](https://github.com/knative/docs/blob/master/serving/samples/autoscale-go/README.md)
- [Source-to-URL with Knative Serving](https://github.com/knative/docs/blob/master/serving/samples/source-to-url-go/README.md)
- [Telemetry Sample](https://github.com/knative/docs/blob/master/serving/samples/telemetry-go/README.md)