### PR TITLE
Update issue templates -- separate feature request from new/changing functionality

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/docs-feature-request.md
@@ -1,0 +1,14 @@
+---
+name: Docs feature request
+about: Suggest an improvement/change to the docs
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the change you'd like to see**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/docs-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/docs-feature-request.md
@@ -6,6 +6,7 @@ labels: ''
 assignees: ''
 
 ---
+<!-- For a feature request about a change to Knative, please open the issue in the corresponding repo. -->
 
 **Describe the change you'd like to see**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/new-changing-functionality-in-knative.md
+++ b/.github/ISSUE_TEMPLATE/new-changing-functionality-in-knative.md
@@ -1,0 +1,24 @@
+---
+name: New/changing functionality in Knative
+about: For new features in Knative, or updates to existing functionality
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## What is changing? (Please include as many details as possible.)
+
+## How will this impact our users?
+
+## In what release will this take happen (to the best of your knowledge)?
+Ex. v0.2-v0.3
+
+## Context
+Link to associated PRs or issues from other repos here.
+
+1.
+1.
+1.
+
+## Additional info


### PR DESCRIPTION
- We needed a template specifically for user's feature requests; we only had one for bugs and one for upcoming changes to Knative