### PR TITLE
Fix broken links to knative install instruction

### DIFF
--- a/community/samples/serving/helloworld-clojure/README.md
+++ b/community/samples/serving/helloworld-clojure/README.md
@@ -7,7 +7,7 @@ specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -8,7 +8,7 @@ that you can use for testing. It reads in the env variable `TARGET` and prints
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/community/samples/serving/helloworld-haskell/README.md
+++ b/community/samples/serving/helloworld-haskell/README.md
@@ -7,7 +7,7 @@ specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -8,7 +8,7 @@ TARGET is not specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/community/samples/serving/helloworld-shell/README.md
+++ b/community/samples/serving/helloworld-shell/README.md
@@ -7,7 +7,7 @@ variable is not specified, the script uses `World`.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/community/samples/serving/helloworld-swift/README.md
+++ b/community/samples/serving/helloworld-swift/README.md
@@ -8,7 +8,7 @@ specified, the app uses "World" as the TARGET.
 
 - You must have a Kubernetes cluster with Knative installed. If you need to
   create a cluster, follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md).
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md).
 - You must have [Docker](https://www.docker.com) installed and running on your
   local machine, and a Docker Hub account configured (used for container
   registry).

--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -15,7 +15,7 @@ You must meet the following requirements to complete this sample:
 
 - A version of the Knative Serving component installed and running on your
   Kubernetes cluster. Follow the
-  [Knative installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [Knative installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create a Knative cluster.
 - The following software downloaded and install on your loacal machine:
   - [Java SE 8 or later JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html).

--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -16,7 +16,7 @@ source is most useful as a bridge from other GCP services, such as
    project id, and also set your project ID as default using
    `gcloud config set project $PROJECT_ID`.
 
-1. Setup [Knative Serving](https://github.com/knative/docs/blob/master/install)
+1. Setup [Knative Serving](https://github.com/knative/docs/blob/master/docs/install)
 
 1. Setup
    [Knative Eventing](https://github.com/knative/docs/tree/master/eventing). In

--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -11,7 +11,7 @@ You will need:
 
 1. An internet-accessible Kubernetes cluster with Knative Serving
    installed. Follow the [installation
-   instructions](https://github.com/knative/docs/blob/master/install/README.md)
+   instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
    if you need to create one.
 1. Ensure Knative Serving is [configured with a domain
    name](https://github.com/knative/docs/blob/master/serving/using-a-custom-domain.md)

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -155,7 +155,7 @@ required commands to configure necessary
 to the service accounts used by Istio.
 
 ```shell
-curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/istio-openshift-policies.sh | bash
+curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scripts/istio-openshift-policies.sh | bash
 ```
 
 1. Run the following to install Istio:
@@ -190,7 +190,7 @@ the required commands to configure necessary privileges to the service accounts
 used by Knative.
 
 ```shell
-curl -s https://raw.githubusercontent.com/knative/docs/master/install/scripts/knative-openshift-policies.sh | bash
+curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scripts/knative-openshift-policies.sh | bash
 ```
 
 > You can safely ignore the warnings:

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -5,7 +5,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 ## Prerequisites
 
 1. A Kubernetes cluster with
-   [Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)
+   [Knative Serving](https://github.com/knative/docs/blob/master/docs/install/README.md)
    installed.
 1. A
    [metrics installation](https://github.com/knative/docs/blob/master/serving/installing-logging-metrics-traces.md)

--- a/docs/serving/samples/gitwebhook-go/README.md
+++ b/docs/serving/samples/gitwebhook-go/README.md
@@ -6,7 +6,7 @@ webhook.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -6,7 +6,7 @@ This sample requires knative/serving 0.4 or later.
 
 ## Prerequisites
 
-1. [Install Knative](https://github.com/knative/docs/blob/master/install/README.md)
+1. [Install Knative](https://github.com/knative/docs/blob/master/docs/install/README.md)
 1. Install [docker](https://www.docker.com/)
 
 ## Build and run the gRPC server

--- a/docs/serving/samples/helloworld-csharp/README.md
+++ b/docs/serving/samples/helloworld-csharp/README.md
@@ -7,7 +7,7 @@ is not specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-go/README.md
+++ b/docs/serving/samples/helloworld-go/README.md
@@ -7,7 +7,7 @@ it will use `World` as the `TARGET`.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-java/README.md
+++ b/docs/serving/samples/helloworld-java/README.md
@@ -7,7 +7,7 @@ TARGET is not specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-kotlin/README.md
+++ b/docs/serving/samples/helloworld-kotlin/README.md
@@ -7,7 +7,7 @@ use for testing. It reads in an env variable `TARGET` and prints "Hello
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-nodejs/README.md
+++ b/docs/serving/samples/helloworld-nodejs/README.md
@@ -7,7 +7,7 @@ specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-php/README.md
+++ b/docs/serving/samples/helloworld-php/README.md
@@ -7,7 +7,7 @@ will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-python/README.md
+++ b/docs/serving/samples/helloworld-python/README.md
@@ -7,7 +7,7 @@ specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-ruby/README.md
+++ b/docs/serving/samples/helloworld-ruby/README.md
@@ -7,7 +7,7 @@ specified, it will use "World" as the TARGET.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/helloworld-scala/README.md
+++ b/docs/serving/samples/helloworld-scala/README.md
@@ -9,7 +9,7 @@ to `"Hello World!"`.
 ## Prerequisites
 
 - A Kubernetes cluster
-  [installation](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation](https://github.com/knative/docs/blob/master/docs/install/README.md)
   with Knative Serving up and running.
 - [Docker](https://www.docker.com) installed locally, and running, optionally a
   Docker Hub account configured or some other Docker Repository installed

--- a/docs/serving/samples/knative-routing-go/README.md
+++ b/docs/serving/samples/knative-routing-go/README.md
@@ -16,7 +16,7 @@ the Login service.
 ## Prerequisites
 
 1. A Kubernetes cluster with
-   [Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)
+   [Knative Serving](https://github.com/knative/docs/blob/master/docs/install/README.md)
    installed.
 2. Install
    [Docker](https://docs.docker.com/get-started/#prepare-your-docker-environment).

--- a/docs/serving/samples/rest-api-go/README.md
+++ b/docs/serving/samples/rest-api-go/README.md
@@ -7,7 +7,7 @@ then outputs the stock price.
 ## Prerequisites
 
 1. A Kubernetes cluster with
-   [Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)
+   [Knative Serving](https://github.com/knative/docs/blob/master/docs/install/README.md)
    v0.3 or higher installed.
 1. [Docker](https://docs.docker.com/get-started/#prepare-your-docker-environment)
    installed locally.

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -8,7 +8,7 @@ into a container as a Volume.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/source-to-url-go/README.md
+++ b/docs/serving/samples/source-to-url-go/README.md
@@ -12,7 +12,7 @@ deployment.
 You need:
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
+  [installation instructions](https://github.com/knative/docs/blob/master/docs/install/README.md)
   if you need to create one.
 - Go installed and configured. This is optional, and only required if you want
   to run the sample app locally.

--- a/docs/serving/samples/telemetry-go/README.md
+++ b/docs/serving/samples/telemetry-go/README.md
@@ -10,7 +10,7 @@ dedicated Prometheus instance rather than using the default installation.
 ## Prerequisites
 
 1. A Kubernetes cluster with
-   [Knative Serving](https://github.com/knative/docs/blob/master/install/README.md)
+   [Knative Serving](https://github.com/knative/docs/blob/master/docs/install/README.md)
    installed.
 2. Check if Knative monitoring components are installed:
 

--- a/docs/serving/using-external-dns-on-gcp.md
+++ b/docs/serving/using-external-dns-on-gcp.md
@@ -112,7 +112,7 @@ permission to get the credential secret can access your Cloud DNS.
 ## Set up Knative
 
 1. Follow the
-   [instruction](https://github.com/knative/docs/blob/master/install/README.md)
+   [instruction](https://github.com/knative/docs/blob/master/docs/install/README.md)
    to install Knative on your cluster.
 1. Configure Knative to use your custom domain.
 


### PR DESCRIPTION
all links to knative installation instruction still thinks `install` is on top level, and broke a bunch of them