### PR TITLE
Add resource cleanup instructions for several event-source examples

### DIFF
--- a/docs/eventing/samples/cronjob-source/README.md
+++ b/docs/eventing/samples/cronjob-source/README.md
@@ -95,3 +95,16 @@ to tail the logs of the subscriber.
 ```shell
 kail -l serving.knative.dev/service=message-dumper -c user-container --since=10m
 ```
+
+### Cleanup
+
+You can remove the Cron Event Source via:
+```shell
+kubectl delete --filename cronjob-source.yaml
+```
+
+Similarily, you can remove the Service via:
+
+```shell
+kubectl delete --filename service.yaml
+```

--- a/docs/eventing/samples/iot-core/README.md
+++ b/docs/eventing/samples/iot-core/README.md
@@ -201,3 +201,35 @@ see them in the subscriber.
         -src "iot-core demo" \
         -events 10
     ```
+
+### Cleanup
+
+To cleanup the knative resources:
+
+1.  Remove the gcppubsub controller:
+    ```shell
+    pushd $HOME/go/src/github.com/knative/eventing-sources
+    kubectl delete --filename config/default-gcppubsub.yaml
+    popd
+    ```
+
+2.  Remove the channel:
+    ```shell
+    sed "s/CHANNEL_NAME/$CHANNEL_NAME/" channel.yaml |
+    kubectl --namespace default delete --filename -
+    ```
+
+3.  Remove the gcppubsub source:
+    ```shell
+    sed -e "s/MY_GCP_PROJECT/$IOTCORE_PROJECT/" \
+        -e "s/TOPIC_NAME/$IOTCORE_TOPIC_DATA/" \
+        -e "s/CHANNEL_NAME/$CHANNEL_NAME/" \
+        gcp-pubsub-source.yaml |
+    kubectl delete --filename -
+    ```
+
+4.  Remove the subscription:
+    ```shell
+    sed "s/CHANNEL_NAME/$CHANNEL_NAME/" subscription.yaml |
+    kubectl delete --filename -
+    ```

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -95,3 +95,14 @@ Ce-Source: /apis/v1/namespaces/default/pods/busybox
 {"metadata":{"name":"busybox.15644359f59f72f2","namespace":"default","selfLink":"/api/v1/namespaces/default/events/busybox.15644359f59f72f2","uid":"db14ff23-e10d-11e8-bf3c-42010a8a017d","resourceVersion":"7841","creationTimestamp":"2018-11-05T15:17:06Z"},"involvedObject":{"kind":"Pod","namespace":"default","name":"busybox","uid":"daf645df-e10d-11e8-bf3c-42010a8a017d","apiVersion":"v1","resourceVersion":"681389"},"reason":"SuccessfulMountVolume","message":"MountVolume.SetUp succeeded for volume \"default-token-pzr6x\" ","source":{"component":"kubelet","host":"gke-knative-eventing-e2e-default-pool-575bcad9-vz55"},"firstTimestamp":"2018-11-05T15:17:06Z","lastTimestamp":"2018-11-05T15:17:06Z","count":1,"type":"Normal","eventTime":null,"reportingComponent":"","reportingInstance":""}
 Ce-Source: /apis/v1/namespaces/default/pods/busybox
 ```
+
+### Cleanup
+
+You can remove the `Channel`, `Service Account`, `Event Sources`, and `Subscriber` via:
+```shell
+kubectl --namespace default delete --filename channel.yaml
+kubectl --namespace default delete --filename serviceaccount.yaml
+kubectl --namespace default delete --filename k8s-events.yaml
+kubectl --namespace default delete --filename subscription.yaml
+
+```


### PR DESCRIPTION
### Proposed Changes

- cronjob-source: cleanup event source, service
- iot-core: cleanup gcpubsub, channel, gcpubsub-source and subscription
- kubernetes-event-source: cleanup channel, service account, k8s event, and subscription