### PR TITLE
build version of API docs for 0.4

### DIFF
--- a/docs/reference/build.md
+++ b/docs/reference/build.md
@@ -219,6 +219,20 @@ Kubernetes core/v1.Affinity
 <p>If specified, the pod&rsquo;s scheduling constraints</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="#BuildSpecStatus">
+BuildSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a job (and maybe more later on)</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -682,8 +696,31 @@ Kubernetes core/v1.Affinity
 <p>If specified, the pod&rsquo;s scheduling constraints</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="#BuildSpecStatus">
+BuildSpecStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Used for cancelling a job (and maybe more later on)</p>
+</td>
+</tr>
 </tbody>
 </table>
+<h3 id="BuildSpecStatus">BuildSpecStatus
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#BuildSpec">BuildSpec</a>)
+</p>
+<p>
+<p>BuildSpecStatus defines the build spec status the user can provide</p>
+</p>
 <h3 id="BuildStatus">BuildStatus
 </h3>
 <p>
@@ -1315,5 +1352,5 @@ This will override any of the template&rsquo;s steps environment variables.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>695fd25</code>.
+on git commit <code>ee63efc</code>.
 </em></p>

--- a/docs/reference/eventing/eventing-sources.md
+++ b/docs/reference/eventing/eventing-sources.md
@@ -1337,5 +1337,5 @@ Kubernetes core/v1.SecretKeySelector
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>9236f7c</code>.
+on git commit <code>2efe55e1</code>.
 </em></p>

--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -715,7 +715,7 @@ github.com/knative/pkg/apis/duck/v1alpha1.Addressable
 <p>Channel is Addressable. It currently exposes the endpoint as a
 fully-qualified DNS name which will distribute traffic over the
 provided targets from inside the cluster.</p>
-<p>It generally has the form {channel}.{namespace}.svc.cluster.local</p>
+<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 </td>
 </tr>
 <tr>
@@ -730,6 +730,18 @@ github.com/knative/pkg/apis/duck/v1alpha1.Conditions
 <td>
 <em>(Optional)</em>
 <p>Represents the latest available observations of a channel&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>internal</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Internal is status unique to each ClusterChannelProvisioner.</p>
 </td>
 </tr>
 </tbody>
@@ -1123,5 +1135,5 @@ string
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>4712e3a4</code>.
+on git commit <code>c3b25ccd</code>.
 </em></p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -89,10 +89,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -200,10 +201,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -301,6 +303,20 @@ reconciliation processes that bring the &ldquo;spec&rdquo; inline with the obser
 state of the world.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the PodAutoscaler that
+was last processed by the controller. The observed generation is updated
+even if the controller failed to process the spec.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr/>
@@ -387,10 +403,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -906,10 +923,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -1001,6 +1019,20 @@ LoadBalancerStatus
 <td>
 <em>(Optional)</em>
 <p>LoadBalancer contains the current status of the load-balancer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ObservedGeneration is the &lsquo;Generation&rsquo; of the ClusterIngress that
+was last processed by the controller. The observed generation is updated
+even if the controller failed to process the spec.</p>
 </td>
 </tr>
 </tbody>
@@ -1209,10 +1241,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -1339,10 +1372,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -1373,7 +1407,7 @@ RevisionRequestConcurrencyModelType
 </td>
 <td>
 <em>(Optional)</em>
-<p>ConcurrencyModel specifies the desired concurrency model
+<p>DeprecatedConcurrencyModel specifies the desired concurrency model
 (Single or Multi) for the
 Revision. Defaults to Multi.
 Deprecated in favor of ContainerConcurrency.</p>
@@ -1424,7 +1458,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>BuildName optionally holds the name of the Build responsible for
+<p>DeprecatedBuildName optionally holds the name of the Build responsible for
 producing the container image for its Revision.
 DEPRECATED: Use BuildRef instead.</p>
 </td>
@@ -1457,9 +1491,25 @@ Kubernetes core/v1.Container
 <em>(Optional)</em>
 <p>Container defines the unit of execution for this Revision.
 In the context of a Revision, we disallow a number of the fields of
-this Container, including: name, resources, ports, and volumeMounts.
-TODO(mattmoor): Link to the runtime contract tracked by:
-<a href="https://github.com/knative/serving/issues/627">https://github.com/knative/serving/issues/627</a></p>
+this Container, including: name and lifecycle.
+See also the runtime contract for more information about the execution
+environment:
+<a href="https://github.com/knative/serving/blob/master/docs/runtime-contract.md">https://github.com/knative/serving/blob/master/docs/runtime-contract.md</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes defines a set of Kubernetes volumes to be mounted into the
+specified Container.  Currently only ConfigMap and Secret volumes are
+supported.</p>
 </td>
 </tr>
 <tr>
@@ -1567,10 +1617,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -1683,10 +1734,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -1716,9 +1768,7 @@ PinnedType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Pins this service to a specific revision name. The revision must
-be owned by the configuration provided.
-PinnedType is DEPRECATED in favor of ReleaseType</p>
+<p>DeprecatedPinned is DEPRECATED in favor of ReleaseType</p>
 </td>
 </tr>
 <tr>
@@ -1799,10 +1849,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -2107,6 +2158,12 @@ come from a single configuration.</p>
 <p>RevisionContainerConcurrencyType is an integer expressing a number of
 in-flight (concurrent) requests.</p>
 </p>
+<h3 id="RevisionProtocolType">RevisionProtocolType
+(<code>string</code> alias)</p></h3>
+<p>
+<p>RevisionProtocolType is an enumeration of the supported application-layer protocols
+See also: <a href="https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports">https://github.com/knative/serving/blob/master/docs/runtime-contract.md#protocols-and-ports</a></p>
+</p>
 <h3 id="RevisionRequestConcurrencyModelType">RevisionRequestConcurrencyModelType
 (<code>string</code> alias)</p></h3>
 <p>
@@ -2146,10 +2203,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -2180,7 +2238,7 @@ RevisionRequestConcurrencyModelType
 </td>
 <td>
 <em>(Optional)</em>
-<p>ConcurrencyModel specifies the desired concurrency model
+<p>DeprecatedConcurrencyModel specifies the desired concurrency model
 (Single or Multi) for the
 Revision. Defaults to Multi.
 Deprecated in favor of ContainerConcurrency.</p>
@@ -2231,7 +2289,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>BuildName optionally holds the name of the Build responsible for
+<p>DeprecatedBuildName optionally holds the name of the Build responsible for
 producing the container image for its Revision.
 DEPRECATED: Use BuildRef instead.</p>
 </td>
@@ -2264,9 +2322,25 @@ Kubernetes core/v1.Container
 <em>(Optional)</em>
 <p>Container defines the unit of execution for this Revision.
 In the context of a Revision, we disallow a number of the fields of
-this Container, including: name, resources, ports, and volumeMounts.
-TODO(mattmoor): Link to the runtime contract tracked by:
-<a href="https://github.com/knative/serving/issues/627">https://github.com/knative/serving/issues/627</a></p>
+this Container, including: name and lifecycle.
+See also the runtime contract for more information about the execution
+environment:
+<a href="https://github.com/knative/serving/blob/master/docs/runtime-contract.md">https://github.com/knative/serving/blob/master/docs/runtime-contract.md</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes defines a set of Kubernetes volumes to be mounted into the
+specified Container.  Currently only ConfigMap and Secret volumes are
+supported.</p>
 </td>
 </tr>
 <tr>
@@ -2432,10 +2506,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -2466,7 +2541,7 @@ RevisionRequestConcurrencyModelType
 </td>
 <td>
 <em>(Optional)</em>
-<p>ConcurrencyModel specifies the desired concurrency model
+<p>DeprecatedConcurrencyModel specifies the desired concurrency model
 (Single or Multi) for the
 Revision. Defaults to Multi.
 Deprecated in favor of ContainerConcurrency.</p>
@@ -2517,7 +2592,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>BuildName optionally holds the name of the Build responsible for
+<p>DeprecatedBuildName optionally holds the name of the Build responsible for
 producing the container image for its Revision.
 DEPRECATED: Use BuildRef instead.</p>
 </td>
@@ -2550,9 +2625,25 @@ Kubernetes core/v1.Container
 <em>(Optional)</em>
 <p>Container defines the unit of execution for this Revision.
 In the context of a Revision, we disallow a number of the fields of
-this Container, including: name, resources, ports, and volumeMounts.
-TODO(mattmoor): Link to the runtime contract tracked by:
-<a href="https://github.com/knative/serving/issues/627">https://github.com/knative/serving/issues/627</a></p>
+this Container, including: name and lifecycle.
+See also the runtime contract for more information about the execution
+environment:
+<a href="https://github.com/knative/serving/blob/master/docs/runtime-contract.md">https://github.com/knative/serving/blob/master/docs/runtime-contract.md</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>volumes</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#volume-v1-core">
+[]Kubernetes core/v1.Volume
+</a>
+</em>
+</td>
+<td>
+<p>Volumes defines a set of Kubernetes volumes to be mounted into the
+specified Container.  Currently only ConfigMap and Secret volumes are
+supported.</p>
 </td>
 </tr>
 <tr>
@@ -2598,10 +2689,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -2659,9 +2751,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>DomainInternal holds the top-level domain that will distribute traffic over the provided
+<p>DeprecatedDomainInternal holds the top-level domain that will distribute traffic over the provided
 targets from inside the cluster. It generally has the form
-{route-name}.{route-namespace}.svc.cluster.local
+{route-name}.{route-namespace}.svc.{cluster-domain-name}
 DEPRECATED: Use Address instead.</p>
 </td>
 </tr>
@@ -2791,10 +2883,11 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>TODO: Generation does not work correctly with CRD. They are scrubbed
-by the APIserver (<a href="https://github.com/kubernetes/kubernetes/issues/58778">https://github.com/kubernetes/kubernetes/issues/58778</a>)
-So, we add Generation here. Once that gets fixed, remove this and use
-ObjectMeta.Generation instead.</p>
+<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
+when metadata.generation was not being incremented by the api server</p>
+<p>This property will be dropped in future Knative releases and should
+not be used - use metadata.generation</p>
+<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
 </td>
 </tr>
 <tr>
@@ -2824,9 +2917,7 @@ PinnedType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Pins this service to a specific revision name. The revision must
-be owned by the configuration provided.
-PinnedType is DEPRECATED in favor of ReleaseType</p>
+<p>DeprecatedPinned is DEPRECATED in favor of ReleaseType</p>
 </td>
 </tr>
 <tr>
@@ -2869,6 +2960,7 @@ to be split between two revisions. This type replaces the deprecated Pinned type
 <a href="#Service">Service</a>)
 </p>
 <p>
+<p>ServiceStatus represents the Status stanza of the Service resource.</p>
 </p>
 <table>
 <thead>
@@ -2915,9 +3007,9 @@ string
 <td>
 <em>(Optional)</em>
 <p>From RouteStatus.
-DomainInternal holds the top-level domain that will distribute traffic over the provided
+DeprecatedDomainInternal holds the top-level domain that will distribute traffic over the provided
 targets from inside the cluster. It generally has the form
-{route-name}.{route-namespace}.svc.cluster.local
+{route-name}.{route-namespace}.svc.{cluster-domain-name}
 DEPRECATED: Use Address instead.</p>
 </td>
 </tr>
@@ -3075,5 +3167,5 @@ This defaults to zero if unspecified.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>4d198db8</code>.
+on git commit <code>b3c82dc7</code>.
 </em></p>


### PR DESCRIPTION
Built an 0.4 version of the API docs using the 0.4.0 releases of knative components:

KNATIVE_BUILD_COMMIT=v0.4.0 \
KNATIVE_EVENTING_COMMIT=v0.4.0 \
KNATIVE_EVENTING_SOURCES_COMMIT=v0.4.0 \
KNATIVE_SERVING_COMMIT=v0.4.0 \
./gen-api-reference-docs.sh

