### PR TITLE
Update the GcpPubSubSource example to use Broker, rather than Channel.

### DIFF
--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -22,7 +22,7 @@ source is most useful as a bridge from other GCP services, such as
    addition, install the GCP PubSub event source from `release-gcppubsub.yaml`:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.3.0/release-gcppubsub.yaml
+   kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.4.1/gcppubsub.yaml
    ```
 
 1. Enable the `Cloud Pub/Sub API` on your project:
@@ -96,8 +96,8 @@ source is most useful as a bridge from other GCP services, such as
    apply in one command:
 
    ```shell
-    sed "s/MY_GCP_PROJECT/$PROJECT_ID/g" gcp-pubsub-source.yaml | \
-        kubectl apply --filename -
+   sed "s/MY_GCP_PROJECT/$PROJECT_ID/g" gcp-pubsub-source.yaml | \
+       kubectl apply --filename -
    ```
 
    If you are replacing `MY_GCP_PROJECT` manually, then make sure you apply the
@@ -110,7 +110,7 @@ source is most useful as a bridge from other GCP services, such as
 1. Create a function and create a Trigger that will send all events from the Broker to the function:
 
    ```shell
-   kubectl apply --filename subscriber.yaml
+   kubectl apply --filename trigger.yaml
    ```
 
 ## Publish

--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -22,13 +22,7 @@ source is most useful as a bridge from other GCP services, such as
    addition, install the GCP PubSub event source from `release-gcppubsub.yaml`:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.4.1/gcppubsub.yaml
-   ```
-
-   Until 0.5.0 is released (and the previous URL is updated to point at it), you will need to have a copy of the `knative/eventing-sources` repo locally and from its root:
-
-   ```shell
-   kubectl apply --filename contrib/gcppubsub/config/201-clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/gcppubsub.yaml
    ```
 
 1. Enable the `Cloud Pub/Sub API` on your project:

--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -74,26 +74,11 @@ source is most useful as a bridge from other GCP services, such as
 
 ## Deployment
 
-1. Create a Channel. This example creates a Channel called `pubsub-test` which
-   uses the in-memory provisioner, with the following definition:
+1. Create the `default` Broker in your namespace. These instructions assume the namespace `default`, feel free to change to any other namespace you would like to use instead:
 
-   ```yaml
-   apiVersion: eventing.knative.dev/v1alpha1
-   kind: Channel
-   metadata:
-     name: pubsub-test
-   spec:
-     provisioner:
-       apiVersion: eventing.knative.dev/v1alpha1
-       kind: ClusterChannelProvisioner
-       name: in-memory-channel
-   ```
-
-   If you're in the samples directory, you can apply the `channel.yaml` file:
-
-   ```shell
-   kubectl apply --filename channel.yaml
-   ```
+  ```shell
+  kubectl label namespace default knative-eventing-injection=enabled
+  ```
 
 1. Create a GCP PubSub Topic. If you change its name (`testing`), you also need
    to update the `topic` in the
@@ -122,7 +107,7 @@ source is most useful as a bridge from other GCP services, such as
    kubectl apply --filename gcp-pubsub-source.yaml
    ```
 
-1. Create a function and subscribe it to the `pubsub-test` channel:
+1. Create a function and create a Trigger that will send all events from the Broker to the function:
 
    ```shell
    kubectl apply --filename subscriber.yaml

--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -25,6 +25,12 @@ source is most useful as a bridge from other GCP services, such as
    kubectl apply --filename https://github.com/knative/eventing-sources/releases/download/v0.4.1/gcppubsub.yaml
    ```
 
+   Until 0.5.0 is released (and the previous URL is updated to point at it), you will need to have a copy of the `knative/eventing-sources` repo locally and from its root:
+
+   ```shell
+   kubectl apply --filename contrib/gcppubsub/config/201-clusterrole.yaml
+   ```
+
 1. Enable the `Cloud Pub/Sub API` on your project:
 
    ```shell

--- a/docs/eventing/samples/gcp-pubsub-source/channel.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/channel.yaml
@@ -1,9 +1,0 @@
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Channel
-metadata:
-  name: pubsub-test
-spec:
-  provisioner:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: ClusterChannelProvisioner
-    name: in-memory-channel

--- a/docs/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
@@ -13,5 +13,5 @@ spec:
   topic: testing
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    name: pubsub-test
+    kind: Broker
+    name: default

--- a/docs/eventing/samples/gcp-pubsub-source/trigger.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/trigger.yaml
@@ -16,17 +16,14 @@ spec:
 
 ---
 
-# Subscription from the GcpPubSubSource's output Channel to the Knative Service below.
+# The GcpPubSubSource's output goes to the default Broker. This Trigger subscribes to events in the
+# default Broker.
 
 apiVersion: eventing.knative.dev/v1alpha1
-kind: Subscription
+kind: Trigger
 metadata:
   name: gcppubsub-source-sample
 spec:
-  channel:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    name: pubsub-test
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1alpha1


### PR DESCRIPTION
Part of #1021

## Proposed Changes

- Switches the sample from using `Channel` to use `Broker`.
