### PR TITLE
Minor change to our upgrade docs

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -283,6 +283,15 @@ commands below.
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. To install Knative components or plugins, specify the filenames in the
    `kubectl apply` command:
 

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -181,6 +181,15 @@ your Knative installation, see
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -182,6 +182,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -117,6 +117,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -139,6 +139,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the following commands to install Knative:
 
    ```shell

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -178,6 +178,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -106,6 +106,15 @@ kubectl delete svc knative-ingressgateway -n istio-system
 kubectl delete deploy knative-ingressgateway -n istio-system
 ```
 
+If you have the Knative Eventing Sources component installed,
+you will also need to delete the following resource before upgrading:
+```shell
+kubectl delete statefulset/controller-manager -n knative-sources
+```
+While the deletion of this resource during the upgrade process will
+not prevent modifications to Eventing Source resources, those changes will
+not be completed until the upgrade process finishes.
+
 Enter the following command:
 
 ```shell

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -213,6 +213,15 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
    oc delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   oc delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Install Knative serving:
 
    ```shell

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -91,6 +91,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -70,6 +70,15 @@ your Knative installation, see
    kubectl delete deploy knative-ingressgateway -n istio-system
    ```
 
+   If you have the Knative Eventing Sources component installed,
+   you will also need to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
+   While the deletion of this resource during the upgrade process will
+   not prevent modifications to Eventing Source resources, those changes will
+   not be completed until the upgrade process finishes.
+
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash


### PR DESCRIPTION
People need to delete this one Eventing resource before they can apply
the yaml for the upgrade. W/o this they'll see an error like this:
```
The StatefulSet "controller-manager" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```

Once people are ok with this text I'll then apply it to the other md files.

Signed-off-by: Doug Davis <dug@us.ibm.com>