### PR TITLE
cherrypick: explicit template types (#1061)

### DIFF
--- a/blog/_index.md
+++ b/blog/_index.md
@@ -4,6 +4,7 @@ linkTitle: "Blog"
 menu:
   main:
     weight: 30
+type: "blog"
 ---
 
 

--- a/blog/articles/Build--deploy--manage-modern-serverless-workloads-using-Knative-on-Kubernetes.html
+++ b/blog/articles/Build--deploy--manage-modern-serverless-workloads-using-Knative-on-Kubernetes.html
@@ -3,6 +3,7 @@ title: "Build, deploy, manage modern serverless workloads using Knative on Kuber
 linkTitle: "Serverless workloads using Knative"
 date: 2018-11-14
 description: "Learn how to build, deploy, and manage modern serverless workloads using Knative on Kubernetes."
+type: "blog"
 ---
 
 <!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><article class="h-entry">

--- a/blog/articles/_index.md
+++ b/blog/articles/_index.md
@@ -2,5 +2,6 @@
 title: "Knative articles"
 linkTitle: "Articles"
 weight: 30
+type: "blog"
 ---
 

--- a/blog/events/Knative-at-KubeCon-Seattle.html
+++ b/blog/events/Knative-at-KubeCon-Seattle.html
@@ -3,6 +3,7 @@ title: "Knative at KubeCon Seattle"
 linkTitle: "KubeCon 2018"
 date: 2018-12-04
 description: "Knative sessions at KubeCon"
+type: "blog"
 ---
 
 <!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><article class="h-entry">

--- a/blog/events/_index.md
+++ b/blog/events/_index.md
@@ -2,4 +2,5 @@
 title: "Knative social events"
 linkTitle: "Events"
 weight: 20
+type: "blog"
 ---

--- a/blog/releases/Announcing-Knative-v0-2-Release.html
+++ b/blog/releases/Announcing-Knative-v0-2-Release.html
@@ -3,6 +3,7 @@ title: "Announcing the Knative v0.2 release"
 linkTitle: "Version 0.2 release"
 date: 2018-11-14
 description: "The Knative v0.2 release announcement"
+type: "blog"
 ---
 
 <!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><article class="h-entry">

--- a/blog/releases/Announcing-Knative-v0-3-Release.html
+++ b/blog/releases/Announcing-Knative-v0-3-Release.html
@@ -3,6 +3,7 @@ title: "Announcing the Knative v0.3 release"
 linkTitle: "Version 0.3 release"
 date: 2019-01-15
 description: "The Knative v0.3 release announcement"
+type: "blog"
 ---
 
 <!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body><article class="h-entry">

--- a/blog/releases/_index.md
+++ b/blog/releases/_index.md
@@ -2,4 +2,5 @@
 title: "Knative releases"
 linkTitle: "Releases"
 weight: 20
+type: "blog"
 ---

--- a/community/_index.md
+++ b/community/_index.md
@@ -3,6 +3,7 @@ title: Community
 menu:
   main:
     weight: 40
+type: "community"
 ---
 
 <!--add blocks of content here to add more sections to the community page -->

--- a/docs/build/auth.md
+++ b/docs/build/auth.md
@@ -2,6 +2,7 @@
 title: "Authentication"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 25
+type: "docs"
 ---
 
 This document defines how authentication is provided during execution of a

--- a/docs/build/build-templates.md
+++ b/docs/build/build-templates.md
@@ -2,6 +2,7 @@
 title: "Build templates"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 35
+type: "docs"
 ---
 
 This document defines "Build Templates" and their capabilities.

--- a/docs/build/builder-contract.md
+++ b/docs/build/builder-contract.md
@@ -2,6 +2,7 @@
 title: "Builders"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 15
+type: "docs"
 ---
 
 This document defines builder images and the conventions to which they are

--- a/docs/build/builds.md
+++ b/docs/build/builds.md
@@ -1,7 +1,8 @@
 ---
-title: "Knative `Build` resources"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+title: "Knative Build resources"
+linkTitle: "Build resources"
 weight: 5
+type: "docs"
 ---
 
 Use the `Build` resource object to create and run on-cluster processes to

--- a/docs/build/creating-builds.md
+++ b/docs/build/creating-builds.md
@@ -1,7 +1,8 @@
 ---
 title: "Creating a simple Knative build"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Creating a build"
 weight: 30
+type: "docs"
 ---
 
 Use this page to learn how to create and then run a simple build in Knative. In

--- a/docs/build/installing-build-component.md
+++ b/docs/build/installing-build-component.md
@@ -2,6 +2,7 @@
 title: "Installing the Knative Build component"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 10
+type: "docs"
 ---
 
 Before you can run a Knative Build, you must install the Knative Build component

--- a/docs/build/personas.md
+++ b/docs/build/personas.md
@@ -2,6 +2,7 @@
 title: "Knative personas"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 20
+type: "docs"
 ---
 
 When discussing user actions, it is often helpful to

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -2,6 +2,7 @@
 title: "Knative Concepts"
 linkTitle: "Concepts"
 weight: 89
+type: "docs"
 ---
 
 Learn about Knative.

--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -1,6 +1,7 @@
 ---
 title: "Resources"
 weight: 10
+type: "docs"
 ---
 
 This page contains information about various tools and technologies that are

--- a/docs/eventing/channels/default-channels.md
+++ b/docs/eventing/channels/default-channels.md
@@ -1,6 +1,8 @@
 ---
 title: "Default channels"
+#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 2
+type: "docs"
 ---
 
 The default channel configuration allows channels to be created without

--- a/docs/eventing/samples/writing-a-source/01-bootstrap.md
+++ b/docs/eventing/samples/writing-a-source/01-bootstrap.md
@@ -1,10 +1,12 @@
 ---
-title: "Bootstrap the project"
+title: "Creating a Kubebuilder project"
+linkTitle: "Creating a project"
 weight: 10
+type: "docs"
 ---
 
-We'll use Kubebuilder to bootstrap the project and provide common controller
-boilerplate and scaffolding. Check out the
+We'll use Kubebuilder to create a Kubebuilder project and provide common
+controller for your cluster and Kubernetes API. Check out the
 [Kubebuilder book](https://book.kubebuilder.io/) to learn more about
 Kubebuilder.
 

--- a/docs/eventing/samples/writing-a-source/02-define-source.md
+++ b/docs/eventing/samples/writing-a-source/02-define-source.md
@@ -1,11 +1,14 @@
 ---
-title: "Define the source resource"
+title: "Defining a custom resource definition as the source"
+linkTitle: "Defining a CRD source"
 weight: 20
+type: "docs"
 ---
 
-We'll use Kubebuilder to generate a new Kubernetes Custom Resource for our
-source. Check out the [Kubebuilder book](https://book.kubebuilder.io/) to learn
-more about Kubebuilder.
+We'll use Kubebuilder to generate a new
+[Kubernetes Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+for our source. Check out the [Kubebuilder book](https://book.kubebuilder.io/)
+to learn more about Kubebuilder.
 
 ## Create the Source CRD Skeleton
 

--- a/docs/eventing/samples/writing-a-source/03-reconcile-sources.md
+++ b/docs/eventing/samples/writing-a-source/03-reconcile-sources.md
@@ -1,6 +1,8 @@
 ---
 title: "Reconcile sources"
+linkTitle: ""
 weight: 30
+type: "docs"
 ---
 
 Now that we have a Source CRD defined with Sink and SinkURI fields, we'll need

--- a/docs/eventing/samples/writing-a-source/04-publish-to-cluster.md
+++ b/docs/eventing/samples/writing-a-source/04-publish-to-cluster.md
@@ -1,6 +1,8 @@
 ---
-title: "Publish to a Kubernetes cluster"
+title: "Publishing to your Kubernetes cluster"
+linkTitle: "Publishing to your cluster"
 weight: 40
+type: "docs"
 ---
 
 So far we've only tested the controller code locally. Now we'd like to deploy it

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -1,7 +1,8 @@
 ---
 title: "Performing a Custom Knative Installation"
-linkTitle: "Custom Install"
-weight: 10
+linkTitle: "Customizing your install"
+weight: 15
+type: "docs"
 ---
 
 Use this guide to perform a custom installation of Knative on an existing

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -1,7 +1,8 @@
 ---
 title: "Install on Azure Kubernetes Service (AKS)"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Azure Kubernetes Service"
 weight: 15
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of Knative

--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -1,7 +1,8 @@
 ---
-title: "Install on Docker for Mac"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+title: "Install on Docker for Mac OS"
+linkTitle: "Docker - Mac OS"
 weight: 15
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -1,7 +1,8 @@
 ---
 title: "Install on Google Kubernetes Engine"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Google Kubernetes Engine"
 weight: 15
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of all

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -1,7 +1,8 @@
 ---
 title: "Install on Gardener"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Gardener"
 weight: 10
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of Knative

--- a/docs/install/Knative-with-Gloo.md
+++ b/docs/install/Knative-with-Gloo.md
@@ -1,7 +1,8 @@
 ---
 title: "Knative Install using Gloo on a Kubernetes Cluster"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Gloo on a Cluster"
 weight: 10
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of Knative
@@ -257,7 +258,7 @@ Hello Go Sample v1!
 
 > Note: Add `-v` option to get more detail if the `curl` command failed.
 
-Removing the sample app deployment  
+Removing the sample app deployment
 To remove the sample app from your cluster, delete the service record:
 
 ```bash

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -1,7 +1,8 @@
 ---
 title: "Install on IBM Cloud Private"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "IBM Cloud Private"
 weight: 15
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -1,13 +1,14 @@
 ---
 title: "Install on IBM Cloud Kubernetes Service (IKS)"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "IBM Cloud Kubernetes Service"
 weight: 10
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of Knative
 using pre-built images.
 
-You may also have it all installed for you by clicking the button below:  
+You may also have it all installed for you by clicking the button below:
 [![Deploy to IBM Cloud](https://bluemix.net/deploy/button_x2.png)](https://console.bluemix.net/devops/setup/deploy?repository=https://git.ng.bluemix.net/start-with-knative/toolchain.git)
 
 More

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -1,7 +1,8 @@
 ---
 title: "Install on Minikube"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Minikube"
 weight: 10
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -2,6 +2,7 @@
 title: "Install on Minishift"
 linkTitle: "Minishift"
 weight: 10
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of

--- a/docs/install/Knative-with-OpenShift.md
+++ b/docs/install/Knative-with-OpenShift.md
@@ -2,6 +2,7 @@
 title: "Install on OpenShift"
 linkTitle: "OpenShift"
 weight: 15
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -1,7 +1,8 @@
 ---
 title: "Install on Pivotal Container Service"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Pivotal Container Service"
 weight: 10
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of Knative

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -2,6 +2,7 @@
 title: "Install on a Kubernetes cluster"
 linkTitle: "On existing cluster"
 weight: 15
+type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of Knative
@@ -94,7 +95,7 @@ your Knative installation, see
      track the upcoming solution to this problem, see issues
      [#968](https://github.com/knative/docs/issues/968) and
      [#1036](https://github.com/knative/docs/issues/1036).
-     
+
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each other.
 

--- a/docs/install/_index.md
+++ b/docs/install/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Installing Knative"
-#linkTitle: "Installing"
-weight: 20
+linkTitle: ""
+weight: 05
 type: "docs"
 ---
 

--- a/docs/install/check-install-version.md
+++ b/docs/install/check-install-version.md
@@ -1,7 +1,8 @@
 ---
-title: "Checking the Version of Your Knative Serving Installation"
-#linkTitle: "Checking your install version"
+title: "Checking the version of your Knative Serving installation"
+linkTitle: "Checking your install version"
 weight: 20
+type: "docs"
 ---
 
 If you want to check what version of Knative serving you have installed, enter

--- a/docs/install/getting-started-knative-app.md
+++ b/docs/install/getting-started-knative-app.md
@@ -2,6 +2,7 @@
 title: "Getting Started with App Deployment"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 05
+type: "docs"
 ---
 
 This guide shows you how to deploy an app using Knative, then interact with it

--- a/docs/serving/accessing-logs.md
+++ b/docs/serving/accessing-logs.md
@@ -2,6 +2,7 @@
 title: "Accessing logs"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 5
+type: "docs"
 ---
 
 If you have not yet installed the logging and monitoring components, go through

--- a/docs/serving/accessing-metrics.md
+++ b/docs/serving/accessing-metrics.md
@@ -2,6 +2,7 @@
 title: "Accessing metrics"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 10
+type: "docs"
 ---
 
 You access metrics through the [Grafana](https://grafana.com/) UI. Grafana is

--- a/docs/serving/accessing-traces.md
+++ b/docs/serving/accessing-traces.md
@@ -2,6 +2,7 @@
 title: "Accessing request traces"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 15
+type: "docs"
 ---
 
 If you have not yet installed the logging and monitoring components, go through

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -1,7 +1,8 @@
 ---
 title: "Making your Routes local to the cluster"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Configuring local routes"
 weight: 20
+type: "docs"
 ---
 
 In Knative 0.3.x or later, all Routes with a domain suffix of

--- a/docs/serving/debugging-application-issues.md
+++ b/docs/serving/debugging-application-issues.md
@@ -2,6 +2,7 @@
 title: "Debugging issues with your application"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 25
+type: "docs"
 ---
 
 You deployed your app to Knative Serving, but it isn't working as expected. Go

--- a/docs/serving/debugging-performance-issues.md
+++ b/docs/serving/debugging-performance-issues.md
@@ -2,6 +2,7 @@
 title: "Investigating performance issues"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 30
+type: "docs"
 ---
 
 You deployed your application or function to Knative Serving but its performance

--- a/docs/serving/deploying-with-private-registry.md
+++ b/docs/serving/deploying-with-private-registry.md
@@ -1,8 +1,12 @@
 ---
 title: "Deploying to Knative using a private container registry"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Deploying from private registries"
 weight: 10
+type: "docs"
 ---
+
+This guide walks you through deploying an application to Knative from source code in a git repository using a private container registry for the container image. The source code should contain a dockerfile. For this guide, we'll use this [helloworld app](./samples/hello-world/helloworld-go), but you could use your own.
+>>>>>>> fe15327... explicit template types (#1061)
 
 This guide walks you through deploying an application to Knative from source
 code in a git repository using a private container registry for the container

--- a/docs/serving/gke-assigning-static-ip-address.md
+++ b/docs/serving/gke-assigning-static-ip-address.md
@@ -1,7 +1,8 @@
 ---
 title: "Assigning a static IP address for Knative on Kubernetes Engine"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+linkTitle: "Assigning static IPs - GKE"
 weight: 35
+type: "docs"
 ---
 
 If you are running Knative on Google Kubernetes Engine and want to use a
@@ -30,6 +31,7 @@ Using the Google Cloud SDK:
 1.  Enter the following command, replacing IP_NAME and REGION with appropriate
     values. For example, select the `us-west1` region if you deployed your
     cluster to the `us-west1-c` zone:
+
     ```shell
     gcloud beta compute addresses create IP_NAME --region=REGION
     ```
@@ -37,6 +39,7 @@ Using the Google Cloud SDK:
     ```shell
     gcloud beta compute addresses create knative-ip --region=us-west1
     ```
+
 1.  Enter the following command to get the newly created static IP address:
     ```shell
     gcloud beta compute addresses list

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -2,6 +2,7 @@
 title: "Installing logging, metrics, and traces"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 40
+type: "docs"
 ---
 
 If you followed one of the

--- a/docs/serving/outbound-network-access.md
+++ b/docs/serving/outbound-network-access.md
@@ -2,6 +2,7 @@
 title: "Configuring outbound network access"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 45
+type: "docs"
 ---
 
 This guides walks you through enabling outbound network access for a Knative

--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -2,6 +2,7 @@
 title: "Routing and managing traffic with blue/green deployment"
 linkTitle: "Routing and managing traffic"
 weight:
+type: "docs"
 ---
 
 This sample demonstrates updating an application to a new version using a

--- a/docs/serving/samples/hello-world/_index.md
+++ b/docs/serving/samples/hello-world/_index.md
@@ -2,5 +2,6 @@
 title: "Knative 'Hello World' samples"
 linkTitle: "Hello world apps"
 weight: 1
+type: "docs"
 ---
 

--- a/docs/serving/setting-up-a-logging-plugin.md
+++ b/docs/serving/setting-up-a-logging-plugin.md
@@ -2,6 +2,7 @@
 title: "Setting up a logging plugin"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 50
+type: "docs"
 ---
 
 Knative allows cluster operators to use different backends for their logging

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -1,4 +1,9 @@
-# Setting Up Custom Ingress Gateway
+---
+title: "Setting up custom ingress gateway"
+linkTitle: "Configuring the ingress gateway"
+weight: 55
+type: "docs"
+---
 
 Knative uses a shared ingress Gateway to serve all incoming traffic within
 Knative service mesh, which is the `knative-ingress-gateway` Gateway under

--- a/docs/serving/using-a-custom-domain.md
+++ b/docs/serving/using-a-custom-domain.md
@@ -2,6 +2,7 @@
 title: "Setting up a custom domain"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 55
+type: "docs"
 ---
 
 By default, Knative Serving routes use `example.com` as the default domain. The

--- a/docs/serving/using-an-ssl-cert.md
+++ b/docs/serving/using-an-ssl-cert.md
@@ -2,6 +2,7 @@
 title: "Configuring HTTPS with a custom certificate"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 60
+type: "docs"
 ---
 
 If you already have an SSL/TLS certificate for your domain you can follow the

--- a/docs/serving/using-cert-manager-on-gcp.md
+++ b/docs/serving/using-cert-manager-on-gcp.md
@@ -2,6 +2,7 @@
 title: "Configuring Knative and CertManager for Google Cloud DNS"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 65
+type: "docs"
 ---
 
 These instructions assume you have already setup a Knative cluster and installed

--- a/docs/serving/using-external-dns-on-gcp.md
+++ b/docs/serving/using-external-dns-on-gcp.md
@@ -2,6 +2,7 @@
 title: "Using ExternalDNS on Google Cloud Platform to automate DNS setup"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 70
+type: "docs"
 ---
 
 [ExternalDNS](https://github.com/kubernetes-incubator/external-dns) is a tool


### PR DESCRIPTION
cherry pick changes to master to ensure future doc sets work when versioned into different folders:

define the Hugo template type for each file so that "versioned" content (which is placed outside of the default /docs/ folder), knows to use the Docsy "docs" content type.