### PR TITLE
Format markdown

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -327,7 +327,7 @@ commands below.
      - `https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml`
      - `https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml`
 
-    **Example install commands:**
+     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
        plug-ins:
@@ -340,13 +340,13 @@ commands below.
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin:
 
-      ```bash
-      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-      --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-      --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-      --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-      --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
-      ```
+     ```bash
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+     --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+     --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+     --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+     --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+     ```
 
 1. Depending on what you chose to install, view the status of your installation
    by running one or more of the following commands. It might take a few

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -196,6 +196,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    completed until the upgrade process finishes.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
+
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
@@ -204,6 +205,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+
    > **Note**: If your install fails on the first attempt, try rerunning the
    > commands. They will likely succeed on the second attempt. For background
    > info and to track the upcoming solution to this problem, see issues
@@ -213,6 +215,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each
    > other.
+
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -192,6 +192,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    completed until the upgrade process finishes.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
+
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
@@ -200,6 +201,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+
    > **Note**: If your install fails on the first attempt, try rerunning the
    > commands. They will likely succeed on the second attempt. For background
    > info and to track the upcoming solution to this problem, see issues
@@ -209,6 +211,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each
    > other.
+
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -105,6 +105,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    completed until the upgrade process finishes.
 
 1. Run the `kubectl apply` command to install Knative and its dependencies:
+
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
@@ -113,6 +114,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
    ```
+
    > **Note**: If your install fails on the first attempt, try rerunning the
    > commands. They will likely succeed on the second attempt. For background
    > info and to track the upcoming solution to this problem, see issues
@@ -122,6 +124,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each
    > other.
+
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
    ```bash


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`