### PR TITLE
Update the kubernetes-event-source example to use Broker, rather than Channel.

### DIFF
--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -10,22 +10,19 @@ consumption by a function that has been implemented as a Knative Service.
 1. Setup
    [Knative Eventing](../../../eventing).
 
-### Channel
+### Broker
 
-1. Create a `Channel`. You can use your own `Channel` or use the provided
-   sample, which creates a channel called `testchannel`. If you use your own
-   `Channel` with a different name, then you will need to alter other commands
-   later.
+1. Create the `default` Broker in your namespace. These instructions assume the namespace `default`, feel free to change to any other namespace you would like to use instead. If you use a different namespace, you will need to modify all the YAML files deployed in this sample to point at that namespace.
 
 ```shell
-kubectl --namespace default apply --filename channel.yaml
+kubectl label namespace default knative-eventing-injection=enabled
 ```
 
 ### Service Account
 
 1. Create a Service Account that the `Receive Adapter` runs as. The
    `Receive Adapater` watches for Kubernetes events and forwards them to the
-   Knative Eventing Framework. If you want to re-use an existing Service Account
+   Knative Eventing Broker. If you want to re-use an existing Service Account
    with the appropriate permissions, you need to modify the
    `serviceaccount.yaml`.
 
@@ -36,27 +33,27 @@ kubectl apply --filename serviceaccount.yaml
 ### Create Event Source for Kubernetes Events
 
 1. In order to receive events, you have to create a concrete Event Source for a
-   specific namespace. If you are wanting to consume events from a different
-   namespace or using a different `Service Account`, you need to modify the yaml
+   specific namespace. If you want to consume events from a different
+   namespace or use a different `Service Account`, you need to modify the yaml
    accordingly.
 
 ```shell
 kubectl apply --filename k8s-events.yaml
 ```
 
-### Subscriber
+### Trigger
 
 In order to check the `KubernetesEventSource` is fully working, we will create a
 simple Knative Service that dumps incoming messages to its log and create a
-`Subscription` from the `Channel` to that Knative Service.
+`Trigger` from the `Broker` to that Knative Service.
 
-1. If the deployed `KubernetesEventSource` is pointing at a `Channel` other than
-   `testchannel`, modify `subscription.yaml` by replacing `testchannel` with
-   that `Channel`'s name.
-1. Deploy `subscription.yaml`.
+1. If the deployed `KubernetesEventSource` is pointing at a `Broker` other than
+   `default`, modify `trigger.yaml` by adding `spec.broker` with the `Broker`'s name.
+
+1. Deploy `trigger.yaml`.
 
 ```shell
-kubectl apply --filename subscription.yaml
+kubectl apply --filename trigger.yaml
 ```
 
 ### Create Events
@@ -78,7 +75,7 @@ kubectl delete pod busybox
 
 We will verify that the kubernetes events were sent into the Knative eventing
 system by looking at our message dumper function logs. If you deployed the
-[Subscriber](#subscriber), then continue using this section. If not, then you
+[Trigger](#trigger), then continue using this section. If not, then you
 will need to look downstream yourself.
 
 ```shell

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -44,7 +44,7 @@ kubectl apply --filename k8s-events.yaml
 ### Trigger
 
 In order to check the `KubernetesEventSource` is fully working, we will create a
-simple Knative Service that dumps incoming messages to its log and create a
+simple Knative Service that dumps incoming messages to its log and creates a
 `Trigger` from the `Broker` to that Knative Service.
 
 1. If the deployed `KubernetesEventSource` is pointing at a `Broker` other than

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -68,7 +68,7 @@ kubectl delete pod busybox
 
 ### Verify
 
-We will verify that the kubernetes events were sent into the Knative eventing
+We will verify that the Kubernetes events were sent into the Knative eventing
 system by looking at our message dumper function logs. If you deployed the
 [Trigger](#trigger), then continue using this section. If not, then you
 will need to look downstream yourself.

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -34,8 +34,8 @@ kubectl apply --filename serviceaccount.yaml
 
 1. In order to receive events, you have to create a concrete Event Source for a
    specific namespace. If you want to consume events from a different
-   namespace or use a different `Service Account`, you need to modify the yaml
-   accordingly.
+   namespace or use a different `Service Account`, you need to modify
+   `k8s-events.yaml` accordingly.
 
 ```shell
 kubectl apply --filename k8s-events.yaml

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -59,15 +59,10 @@ kubectl apply --filename trigger.yaml
 ### Create Events
 
 Create events by launching a pod in the default namespace. Create a busybox
-container
+container and immediately delete it.
 
 ```shell
-kubectl run -i --tty busybox --image=busybox --restart=Never -- sh
-```
-
-Once the shell comes up, just exit it and kill the pod.
-
-```shell
+kubectl run busybox --image=busybox --restart=Never -- ls
 kubectl delete pod busybox
 ```
 

--- a/docs/eventing/samples/kubernetes-event-source/channel.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/channel.yaml
@@ -1,9 +1,0 @@
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Channel
-metadata:
-  name: testchannel
-spec:
-  provisioner:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: ClusterChannelProvisioner
-    name: in-memory-channel

--- a/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
@@ -7,5 +7,5 @@ spec:
   serviceAccountName: events-sa
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    name: testchannel
+    kind: Broker
+    name: default

--- a/docs/eventing/samples/kubernetes-event-source/serviceaccount.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/serviceaccount.yaml
@@ -3,7 +3,9 @@ kind: ServiceAccount
 metadata:
   name: events-sa
   namespace: default
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -18,7 +20,9 @@ rules:
   - get
   - list
   - watch
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/docs/eventing/samples/kubernetes-event-source/trigger.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Trigger
 metadata:
-  name: testevents-subscription
+  name: testevents-trigger
   namespace: default
 spec:
   subscriber:

--- a/docs/eventing/samples/kubernetes-event-source/trigger.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/trigger.yaml
@@ -1,13 +1,9 @@
 apiVersion: eventing.knative.dev/v1alpha1
-kind: Subscription
+kind: Trigger
 metadata:
   name: testevents-subscription
   namespace: default
 spec:
-  channel:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Channel
-    name: testchannel
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1alpha1
@@ -28,4 +24,6 @@ spec:
       revisionTemplate:
         spec:
           container:
-            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper@sha256:73a95b05b5b937544af7c514c3116479fa5b6acf7771604b313cfc1587bf0940
+            # This corresponds to
+            # https://github.com/knative/eventing-sources/blob/release-0.3/cmd/message_dumper/dumper.go
+            image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper@sha256:8423232db7a7b4010c0cfbfaef95745efe962631af9b7456903825801a7893f7


### PR DESCRIPTION
Part of #1021 

## Proposed Changes

- Switches the sample from using `Channel` to use `Broker`.