### PR TITLE
Add KafkaSource information and link to example

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -256,6 +256,18 @@ The CronJobSource fires events based on given
 
 See the [Cronjob Source](samples/cronjob-source) example.
 
+### KafkaSource
+
+The KafkaSource reads events from an Apache Kafka Cluster, and passes these to a Knative Serving application so that they can be consumed.
+
+**Spec fields**:
+
+- `consumerGroup`: `string` Name of a Kafka consumer group.
+- `bootstrapServers`: `string` Comma separated list of `hostname:port` pairs for the Kafka Broker.
+- `topics`: `string` Name of the Kafka topic to consume messages from.
+
+See the [Kafka Source](https://github.com/knative/eventing-sources/tree/master/contrib/kafka/samples) example.
+
 ## Getting Started
 
 - [Setup Knative Serving](../install/README.md)


### PR DESCRIPTION
Fixes gaps in documentation introduced by https://github.com/knative/eventing-sources/pull/264

## Proposed Changes

- added KafkaSource details using the same template as existing sources to https://github.com/knative/docs/tree/master/docs/eventing#sources
