### PR TITLE
Fix 401 exception when push image to repository with Kaniko

### DIFF
--- a/docs/build/builds.md
+++ b/docs/build/builds.md
@@ -283,6 +283,9 @@ spec:
       args:
         - --dockerfile=${DOCKERFILE}
         - --destination=${IMAGE}
+      env:
+        - name: "DOCKER_CONFIG"
+          value: "/builder/home/.docker/"
 ```
 
 #### Using a `ServiceAccount`


### PR DESCRIPTION
Fixes #(issue-number)
I try to create "builder" make "kaniko" as a step to push image to docker.hub,
then hit exception 401, seems there is no authority to do that.
As we know, the "builder" will launch a "init container" to do that for us after set the "service account".

After some search, I find in "kaniko", it use a env parameter: DOCKER_CONFIG which point to ".docker/config.json". by default, the value is "/kaniko/.docker/".
As we know, the "build" will put the docker authentication file at "/builder/home/.docker/"

So, to make the example work, need add additional config to rewrite the " DOCKER_CONFIG"
## Proposed Changes
/docs/docs/build/builds.md
-
-
-
