### PR TITLE
Fix 'verion' mispelling in check-install-version

### DIFF
--- a/docs/install/check-install-version.md
+++ b/docs/install/check-install-version.md
@@ -30,12 +30,12 @@ Pod Template:
 Copy the full `gcr.io` link to the container and paste it into your browser. If
 you are already signed in to a Google account, you'll be taken to the Google
 Container Registry page for that container in the Google Cloud Platform console.
-If you aren't already signed in, you'll need to sign in a to a Google account
+If you aren't already signed in, you'll need to sign in to a Google account
 before you can view the container details.
 
 On the container details page, you'll see a section titled "Container
 classification," and in that section is a list of tags. The versions of Knative
-you have installed will appear in the list as `v0.1.1`, or whatever verion you
+you have installed will appear in the list as `v0.1.1`, or whatever version you
 have installed:
 
 ![Shows list of tags on container details page; v0.1.1 is the Knative version and is the first tag.](../../images/knative-version.png)


### PR DESCRIPTION
Relates to [Issue #1119](https://github.com/knative/docs/issues/1119)

Fixes #(1119 )

## Proposed Changes

- 'verion' typo fix
- removed unnecessary article 'a' in line 33
