### PR TITLE
v0.4 -> v0.5

### DIFF
--- a/docs/build/installing-build-component.md
+++ b/docs/build/installing-build-component.md
@@ -28,7 +28,7 @@ To add only the Knative Build component to an existing installation:
    dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml
+   kubectl apply --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml
    ```
 
 1. Run the

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -83,9 +83,9 @@ service mesh. If you install any of the following options, you must install
 
 † These are the recommended standard install files suitable for most use cases.
 
-[a]: https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml
-[b]: https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
-[c]: https://github.com/knative/serving/releases/download/v0.4.0/istio-lean.yaml
+[a]: https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml
+[b]: https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+[c]: https://github.com/knative/serving/releases/download/v0.5.0/istio-lean.yaml
 
 ### Installing Istio
 
@@ -113,13 +113,13 @@ service mesh. If you install any of the following options, you must install
 1. Create the Istio CRDs on your cluster:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml
    ```
 
 1. Install Istio by specifying the filename in the `kubectl apply` command:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/[FILENAME].yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/[FILENAME].yaml
    ```
 
    where `[FILENAME]` is the name of the Istio file that you want to install.
@@ -167,26 +167,26 @@ with Knative.
 The following Knative installation files are available:
 
 - **Serving Component and Observability Plugins**:
-  - https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml
-  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml
-  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-logs-elasticsearch.yaml
-  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-metrics-prometheus.yaml
-  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin.yaml
-  - https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-logs-elasticsearch.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-metrics-prometheus.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
 - **Build Component**:
-  - https://github.com/knative/build/releases/download/v0.4.0/build.yaml
+  - https://github.com/knative/build/releases/download/v0.5.0/build.yaml
 - **Eventing Component**:
-  - https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml
-  - https://github.com/knative/eventing/releases/download/v0.4.0/eventing.yaml
-  - https://github.com/knative/eventing/releases/download/v0.4.0/in-memory-channel.yaml
-  - https://github.com/knative/eventing/releases/download/v0.4.0/kafka.yaml
+  - https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml
+  - https://github.com/knative/eventing/releases/download/v0.5.0/eventing.yaml
+  - https://github.com/knative/eventing/releases/download/v0.5.0/in-memory-channel.yaml
+  - https://github.com/knative/eventing/releases/download/v0.5.0/kafka.yaml
 - **Eventing sources**:
-  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml
-  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/gcppubsub.yaml
-  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/message-dumper.yaml
-  - https://github.com/knative/eventing-sources/releases/download/v0.4.0/sources.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.5.0/gcppubsub.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.5.0/message-dumper.yaml
+  - https://github.com/knative/eventing-sources/releases/download/v0.5.0/sources.yaml
 - **Cluster roles**:
-  - https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+  - https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
 
 #### Install details and options
 
@@ -229,40 +229,40 @@ for details about installing the various supported observability plug-ins.
 
 <!-- USE ONLY FULLY QUALIFIED URLS -->
 
-[1]: https://github.com/knative/serving/releases/tag/v0.4.0
-[1.1]: https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml
+[1]: https://github.com/knative/serving/releases/tag/v0.5.0
+[1.1]: https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml
 [1.2]:
-  https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml
+  https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
 [1.3]:
-  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-logs-elasticsearch.yaml
+  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-logs-elasticsearch.yaml
 [1.4]:
-  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-metrics-prometheus.yaml
+  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-metrics-prometheus.yaml
 [1.5]:
-  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin.yaml
+  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
 [1.6]:
-  https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin-in-mem.yaml
+  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
 [2]: https://www.elastic.co/elk-stack
 [2.1]: https://prometheus.io
 [2.2]: https://grafana.com
 [2.3]: https://zipkin.io/
-[3]: https://github.com/knative/build/releases/tag/v0.4.0
-[3.1]: https://github.com/knative/build/releases/download/v0.4.0/build.yaml
-[4]: https://github.com/knative/eventing/releases/tag/v0.4.0
-[4.1]: https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml
+[3]: https://github.com/knative/build/releases/tag/v0.5.0
+[3.1]: https://github.com/knative/build/releases/download/v0.5.0/build.yaml
+[4]: https://github.com/knative/eventing/releases/tag/v0.5.0
+[4.1]: https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml
 [4.2]:
-  https://github.com/knative/eventing/releases/download/v0.4.0/eventing.yaml
+  https://github.com/knative/eventing/releases/download/v0.5.0/eventing.yaml
 [4.3]:
-  https://github.com/knative/eventing/releases/download/v0.4.0/in-memory-channel.yaml
-[4.4]: https://github.com/knative/eventing/releases/download/v0.4.0/kafka.yaml
-[5]: https://github.com/knative/eventing-sources/releases/tag/v0.4.0
+  https://github.com/knative/eventing/releases/download/v0.5.0/in-memory-channel.yaml
+[4.4]: https://github.com/knative/eventing/releases/download/v0.5.0/kafka.yaml
+[5]: https://github.com/knative/eventing-sources/releases/tag/v0.5.0
 [5.1]:
-  https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml
 [5.2]:
-  https://github.com/knative/eventing-sources/releases/download/v0.4.0/gcppubsub.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.5.0/gcppubsub.yaml
 [5.3]:
-  https://github.com/knative/eventing-sources/releases/download/v0.4.0/message-dumper.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.5.0/message-dumper.yaml
 [5.4]:
-  https://github.com/knative/eventing-sources/releases/download/v0.4.0/sources.yaml
+  https://github.com/knative/eventing-sources/releases/download/v0.5.0/sources.yaml
 [6]:
   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#event-v1-core
 [6.1]: https://developer.github.com/v3/activity/events/types/
@@ -270,7 +270,7 @@ for details about installing the various supported observability plug-ins.
   https://github.com/knative/eventing-sources/blob/master/samples/cronjob-source/README.md
 [6.3]: https://cloud.google.com/pubsub/
 [7]:
-  https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+  https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
 
 ### Installing Knative
 
@@ -322,10 +322,10 @@ commands below.
      `[COMPONENT]`, `[VERSION]`, and `[FILENAME]` are the Knative component,
      release version, and filename of the Knative component or plugin. Examples:
 
-     - `https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml`
-     - `https://github.com/knative/build/releases/download/v0.4.0/build.yaml`
-     - `https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml`
-     - `https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml`
+     - `https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml`
+     - `https://github.com/knative/build/releases/download/v0.5.0/build.yaml`
+     - `https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml`
+     - `https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml`
 
     **Example install commands:**
 
@@ -333,19 +333,19 @@ commands below.
        plug-ins:
 
        ```bash
-       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-       --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml
+       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+       --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
        ```
 
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin:
 
       ```bash
-      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-      --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-      --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-      --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-      --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+      --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+      --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+      --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+      --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
       ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -142,8 +142,8 @@ Knative depends on Istio.
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -197,12 +197,12 @@ your Knative installation, see
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: If your install fails on the first attempt, try rerunning the

--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -37,7 +37,7 @@ Knative depends on Istio. Run the following to install Istio. (This changes
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -64,11 +64,11 @@ rerun the command to see the current status.
 Next, install [Knative Serving](https://github.com/knative/serving).
 
 Because you have limited resources available, use the
-`https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml` file,
+`https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml` file,
 which installs only Knative Serving:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 ```

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -148,8 +148,8 @@ Knative depends on Istio.
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -207,12 +207,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: If your install fails on the first attempt, try rerunning the

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -77,8 +77,8 @@ Knative depends on Istio.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -133,12 +133,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: If your install fails on the first attempt, try rerunning the

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -155,37 +155,37 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the following commands to install Knative:
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+   curl -L https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+   curl -L https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+   curl -L https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+   curl -L https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+   curl -L https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml \
+   curl -L https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
@@ -251,31 +251,31 @@ To remove Knative from your IBM Cloud Private cluster, run the following
 commands:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
+curl -L https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
+curl -L https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
+curl -L https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -138,8 +138,8 @@ Knative depends on Istio.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -194,12 +194,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: If your install fails on the first attempt, try rerunning the

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -66,8 +66,8 @@ Knative depends on Istio. Run the following to install Istio. (We are changing
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml &&
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml \
+kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml &&
+curl -L https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -120,7 +120,7 @@ until the upgrade process finishes.
 Enter the following command:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 ```

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -166,8 +166,8 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
 1. Run the following to install Istio:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-   oc apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -229,9 +229,9 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
 1. Install Knative serving:
 
    ```shell
-   oc apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   oc apply --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   oc apply --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -54,8 +54,8 @@ Containers
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -107,12 +107,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: If your install fails on the first attempt, try rerunning the

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -27,8 +27,8 @@ Containers.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/istio.yaml
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -86,12 +86,12 @@ your Knative installation, see
 1. Run the `kubectl apply` command to install Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.4.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.4.0/third_party/config/build/clusterrole.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: If your install fails on the first attempt, try rerunning the

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -20,7 +20,7 @@ sections to do so now.
 1. Run the following command to install Prometheus and Grafana:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring-metrics-prometheus.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-metrics-prometheus.yaml
    ```
 
 1. Ensure that the `grafana-*`, `kibana-logging-*`, `kube-state-metrics-*`,
@@ -64,7 +64,7 @@ install:
 1. Run the following command to install an ELK stack:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring-logs-elasticsearch.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-logs-elasticsearch.yaml
    ```
 
 1. Ensure that the `elasticsearch-logging-*`, `fluentd-ds-*`, and
@@ -232,14 +232,14 @@ Knative.
   traces, run:
 
   ```shell
-  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin-in-mem.yaml
+  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
   ```
 
 - If Elasticsearch is installed and you want to persist end to end traces, first
   run:
 
   ```shell
-  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.4.0/monitoring-tracing-zipkin.yaml
+  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
   ```
 
   Next, create an Elasticsearch index for end to end traces:


### PR DESCRIPTION
Fixes #994 

## Proposed Changes

- Release name changed for one of the [eventing-sources resources
](https://github.com/knative/eventing-sources/releases) https://github.com/knative/eventing-sources/releases/download/v0.4.0/release.yaml --> https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml
- /releases/download/v0.4.0/ --> /releases/download/v0.5.0/
