### PR TITLE
Fix bash syntax error

### DIFF
--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -229,8 +229,8 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
 1. Install Knative serving:
 
    ```shell
-   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-   oc apply --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml && \
+   oc apply --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml && \
    oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 


### PR DESCRIPTION
Adds missing chaining in bash command resulting in invalid command error: Unexpected args: [oc apply oc apply]

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

No Issue created

## Proposed Changes

- Fix bash syntax in docs/install/Knative-with-Minishift.md snipped on line 231
