### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -125,9 +125,11 @@ gcloud pubsub topics publish testing --message="Hello world"
 ## Verify
 
 We will verify that the published message was sent into the Knative eventing
-system by looking at the logs of the function subscribed to the `pubsub-test` channel.
+system by looking at the logs of the function subscribed to the `pubsub-test`
+channel.
 
-The function and the subscription were created by applying the `subscriber.yaml` manifest in the [deployment](#deployment) section above.
+The function and the subscription were created by applying the `subscriber.yaml`
+manifest in the [deployment](#deployment) section above.
 
 1. We need to wait for the downstream pods to get started and receive our event,
    wait 60 seconds.

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -10,64 +10,58 @@ procedure:
     ```
 -->
 
-Event Sources are Kubernetes Custom Resources which provide a mechanism for registering interest in
-a class of events from a particular software system. Since different event sources may be described
-by different Custom Resources, this page provides an index of the available source resource types as
-well as links to installation instructions.
+Event Sources are Kubernetes Custom Resources which provide a mechanism for
+registering interest in a class of events from a particular software system.
+Since different event sources may be described by different Custom Resources,
+this page provides an index of the available source resource types as well as
+links to installation instructions.
 
 This is a non-exhaustive list of Event sources for Knative.
 
-
 ### Inclusion in this list is not an endorsement, nor does it imply any level of support.
-
 
 ## Sources
 
 These are sources that are installed as `CRD`s.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[AWS SQS](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/aws_sqs_types.go) | Proof of Concept | None | Brings [AWS Simple Queue Service](https://aws.amazon.com/sqs/) messages into Knative.
-[Apache Camel](https://github.com/knative/eventing-sources/blob/master/contrib/camel/pkg/apis/sources/v1alpha1/camelsource_types.go) | Proof of Concept | None | Allows to use [Apache Camel](https://github.com/apache/camel) components for pushing events into Knative.
-[Apache Kafka](https://github.com/knative/eventing-sources/blob/master/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go) | Proof of Concept | None | Brings [Apache Kafka](https://kafka.apache.org/) messages into Knative.
-[BitBucket](https://github.com/nachocano/bitbucket-source) | Proof of Concept | None | Registers for events of the specified types on the specified BitBucket organization/repository. Brings those events into Knative.
-[Cron Job](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go) | Proof of Concept | None | Uses an in-memory timer to produce events on the specified Cron schedule.
-[GCP PubSub](https://github.com/knative/eventing-sources/blob/master/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go) | Proof of Concept | None | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.
-[GitHub](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
-[GitLab](https://gitlab.com/triggermesh/gitlabsource) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
-[Google Cloud Scheduler](https://github.com/vaikas-google/csr) | Active Development | None | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative.
-[Google Cloud Storage](https://github.com/vaikas-google/gcs) | Active Development | None | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.
-[Kubernetes](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go) | Active Development | Knative | Brings Kubernetes cluster events into Knative. Uses ContainerSource for underlying infrastructure.
-
-
+| Name                                                                                                                                  | Status             | Support | Description                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [AWS SQS](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/aws_sqs_types.go)                         | Proof of Concept   | None    | Brings [AWS Simple Queue Service](https://aws.amazon.com/sqs/) messages into Knative.                                                                           |
+| [Apache Camel](https://github.com/knative/eventing-sources/blob/master/contrib/camel/pkg/apis/sources/v1alpha1/camelsource_types.go)  | Proof of Concept   | None    | Allows to use [Apache Camel](https://github.com/apache/camel) components for pushing events into Knative.                                                       |
+| [Apache Kafka](https://github.com/knative/eventing-sources/blob/master/contrib/kafka/pkg/apis/sources/v1alpha1/kafka_types.go)        | Proof of Concept   | None    | Brings [Apache Kafka](https://kafka.apache.org/) messages into Knative.                                                                                         |
+| [BitBucket](https://github.com/nachocano/bitbucket-source)                                                                            | Proof of Concept   | None    | Registers for events of the specified types on the specified BitBucket organization/repository. Brings those events into Knative.                               |
+| [Cron Job](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go)                       | Proof of Concept   | None    | Uses an in-memory timer to produce events on the specified Cron schedule.                                                                                       |
+| [GCP PubSub](https://github.com/knative/eventing-sources/blob/master/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go) | Proof of Concept   | None    | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.                                                                                    |
+| [GitHub](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/githubsource_types.go)                     | Proof of Concept   | None    | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.                                  |
+| [GitLab](https://gitlab.com/triggermesh/gitlabsource)                                                                                 | Proof of Concept   | None    | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.                                               |
+| [Google Cloud Scheduler](https://github.com/vaikas-google/csr)                                                                        | Active Development | None    | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative. |
+| [Google Cloud Storage](https://github.com/vaikas-google/gcs)                                                                          | Active Development | None    | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.          |
+| [Kubernetes](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/kuberneteseventsource_types.go)        | Active Development | Knative | Brings Kubernetes cluster events into Knative. Uses ContainerSource for underlying infrastructure.                                                              |
 
 ## Meta Sources
 
 These are not directly usable, but make writing a Source much easier.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[Auto Container Source](https://github.com/Harwayne/auto-container-source) | Proof of Concept | None | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure.
-[Container Source](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.
-[Sample Source](https://github.com/grantr/sample-source) | Proof of Concept | None | SampleSource is a reference implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).
-
-
+| Name                                                                                                                           | Status             | Support | Description                                                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------ | ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Auto Container Source](https://github.com/Harwayne/auto-container-source)                                                     | Proof of Concept   | None    | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure. |
+| [Container Source](https://github.com/knative/eventing-sources/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.                      |
+| [Sample Source](https://github.com/grantr/sample-source)                                                                       | Proof of Concept   | None    | SampleSource is a reference implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).                                                                                                         |
 
 ### ContainerSource Containers
 
 These are containers intended to be used with `ContainerSource`.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Active Development | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
-[AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito) | Active Development | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.
-[AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb) | Active Development | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
-[AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis) | Active Development | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
-[AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns) | Active Development | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.
-[AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs) | Active Development | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.
-[FTP / SFTP](https://github.com/vaikas-google/ftp) | Proof of concept | None | Watches for files being uploaded into a FTP/SFTP and generates events for those.
-[Heartbeat](https://github.com/knative/eventing-sources/tree/master/cmd/heartbeats) | Proof of Concept | None | Uses an in-memory timer to produce events at the specified interval.
-[Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source) | Proof of Concept | None | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure.
-[K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source) | Proof of Concept | None | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.
-[WebSocket](https://github.com/knative/eventing-sources/tree/master/cmd/websocketsource) | Active Development | None | Opens a WebSocket to the specified source and packages each received message as a Knative event.
-
+| Name                                                                                              | Status             | Support     | Description                                                                                                                  |
+| ------------------------------------------------------------------------------------------------- | ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Active Development | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.    |
+| [AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito)       | Active Development | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.                                                          |
+| [AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb)     | Active Development | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.                               |
+| [AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis)       | Active Development | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.                                  |
+| [AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns)               | Active Development | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.                                    |
+| [AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs)               | Active Development | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.                                       |
+| [FTP / SFTP](https://github.com/vaikas-google/ftp)                                                | Proof of concept   | None        | Watches for files being uploaded into a FTP/SFTP and generates events for those.                                             |
+| [Heartbeat](https://github.com/knative/eventing-sources/tree/master/cmd/heartbeats)               | Proof of Concept   | None        | Uses an in-memory timer to produce events at the specified interval.                                                         |
+| [Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source)       | Proof of Concept   | None        | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure. |
+| [K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source)             | Proof of Concept   | None        | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.                       |
+| [WebSocket](https://github.com/knative/eventing-sources/tree/master/cmd/websocketsource)          | Active Development | None        | Opens a WebSocket to the specified source and packages each received message as a Knative event.                             |

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -327,7 +327,7 @@ commands below.
      - `https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml`
      - `https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml`
 
-    **Example install commands:**
+     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
        plug-ins:
@@ -340,13 +340,13 @@ commands below.
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin:
 
-      ```bash
-      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-      --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
-      --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
-      --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-      --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
-      ```
+     ```bash
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+     --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+     --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+     --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+     --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+     ```
 
 1. Depending on what you chose to install, view the status of your installation
    by running one or more of the following commands. It might take a few

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -27,23 +27,26 @@ minishift version
 
 ## Automatic Set Up
 
-Once you have `minishift` present on your machine and in your `PATH`,
-you can either follow the manual set up steps below,  or you can run the convenient
-scripts from [the openshift-cloud-functions/knative-operators project](https://github.com/openshift-cloud-functions/knative-operators),
+Once you have `minishift` present on your machine and in your `PATH`, you can
+either follow the manual set up steps below, or you can run the convenient
+scripts from
+[the openshift-cloud-functions/knative-operators project](https://github.com/openshift-cloud-functions/knative-operators),
 which do something similiar, like this:
 
     git clone https://github.com/openshift-cloud-functions/knative-operators
     cd knative-operators
     ./etc/scripts/install-on-minishift.sh
 
-The `myproject` this created is now ready for Knative!  (If you use `oc new-project yourproject`
-to create additional projects, make sure that you apply the two `oc adm policy ...` commands from below.)
+The `myproject` this created is now ready for Knative! (If you use
+`oc new-project yourproject` to create additional projects, make sure that you
+apply the two `oc adm policy ...` commands from below.)
 
 ## Manually Set Up
 
 ### Manually configure and start minishift
 
-Here are the manual steps which the above script automates for you in case you prefer doing this yourself:
+Here are the manual steps which the above script automates for you in case you
+prefer doing this yourself:
 
 The following details the bare minimum configuration required to setup minishift
 for running Knative:


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`