### PR TITLE
Add CA certificates

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -75,6 +75,8 @@ recreate the source files from this folder.
    # Use a Docker multi-stage build to create a lean production image.
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
    FROM alpine
+   # Add CA certificates so we can make HTTPS requests.
+   RUN apk --no-cache --update add ca-certificates
 
    # Copy the binary to the production image from the builder stage.
    COPY --from=builder /go/src/github.com/knative/docs/helloworld/helloworld /helloworld


### PR DESCRIPTION
Add CA certificates so we can make HTTPS requests. See https://godoc.org/cloud.google.com/go#hdr-Using_the_Libraries_with_Docker