### PR TITLE
Replace knative-ingressgateway service with istio-ingressgateway service

### DIFF
--- a/docs/serving/samples/knative-routing-go/routing.yaml
+++ b/docs/serving/samples/knative-routing-go/routing.yaml
@@ -39,7 +39,7 @@ spec:
       # updated header "search-service.default.example.com" so the request will
       # eventually be directed to Search service.
       - destination:
-          host: knative-ingressgateway.istio-system.svc.cluster.local
+          host: istio-ingressgateway.istio-system.svc.cluster.local
         weight: 100
   - match:
     - uri:
@@ -53,5 +53,5 @@ spec:
       # updated header "login-service.default.example.com" so the request will
       # eventually be directed to LOgin service.
       - destination:
-          host: knative-ingressgateway.istio-system.svc.cluster.local
+          host: istio-ingressgateway.istio-system.svc.cluster.local
         weight: 100


### PR DESCRIPTION

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->


## Proposed Changes

- Replace `knative-ingressgateway` service with `istio-ingressgateway` service as it is the newest ingress service used in Knative 0.3 and above.
