### PR TITLE
Format markdown

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -332,7 +332,7 @@ commands below.
      - `https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml`
      - `https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml`
 
-    **Example install commands:**
+     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
        plug-ins:
@@ -345,13 +345,13 @@ commands below.
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin:
 
-      ```bash
-      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-      --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
-      --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
-      --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-      --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
-      ```
+     ```bash
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+     --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+     --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+     --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+     --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+     ```
 
 1. Depending on what you chose to install, view the status of your installation
    by running one or more of the following commands. It might take a few


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`