### PR TITLE
Format markdown

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -209,7 +209,7 @@ files from the Knative repositories:
 | [`monitoring-tracing-zipkin.yaml`][1.5]        | Installs only [Zipkin][2.3].**\***                                                                                             | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml) |
 | [`monitoring-tracing-zipkin-in-mem.yaml`][1.6] | Installs only [Zipkin in-memory][2.3]**\***                                                                                    | Serving component                                                 |
 | **knative/build**                              |                                                                                                                                |                                                                   |
-| [`build.yaml`][3.1]†                         | Installs the Build component.                                                                                                  | Cluster roles enabled, if interacting with Serving                |
+| [`build.yaml`][3.1]†                           | Installs the Build component.                                                                                                  | Cluster roles enabled, if interacting with Serving                |
 | **knative/eventing**                           |                                                                                                                                |                                                                   |
 | [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes the in-memory channel provisioner.                                                   | Serving component                                                 |
 | [`eventing.yaml`][4.2]                         | Installs the Eventing component. Does not include the in-memory channel provisioner.                                           | Serving component                                                 |
@@ -332,7 +332,7 @@ commands below.
      - `https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml`
      - `https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml`
 
-    **Example install commands:**
+     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
        plug-ins:
@@ -345,13 +345,13 @@ commands below.
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin:
 
-      ```bash
-      kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-      --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
-      --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
-      --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-      --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
-      ```
+     ```bash
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+     --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+     --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+     --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+     --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+     ```
 
 1. Depending on what you chose to install, view the status of your installation
    by running one or more of the following commands. It might take a few

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -91,8 +91,8 @@ minishift start
   that is usually after successful start of Minishift
 - The [addon](https://docs.okd.io/latest/minishift/using/addons.html) **anyuid**
   allows the `default` service account to run the application with uid `0`
-- The [addon](https://docs.okd.io/latest/minishift/using/addons.html) **admissions-webhook**
-  allows cluster to register admissions webhooks
+- The [addon](https://docs.okd.io/latest/minishift/using/addons.html)
+  **admissions-webhook** allows cluster to register admissions webhooks
 
 - The command `minishift profile set knative` is required every time you start
   and stop minishift to make sure that you are on right `knative` minishift


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`