### PR TITLE
Add label install to guides, update Minikube

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -311,7 +311,7 @@ commands below.
    prevents race conditions, which cause intermittent install errors.) 
 
      ```bash
-     kubectl apply -l knative.dev/crd-install=true \
+     kubectl apply --selector knative.dev/crd-install=true \
      --filename [FILE_URL] \
      --filename [FILE_URL]
      ```
@@ -344,7 +344,7 @@ commands below.
        plug-ins:
 
        ```bash
-       kubectl apply -l knative.dev/crd-install=true \
+       kubectl apply --selector knative.dev/crd-install=true \
        --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
        --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
        ```
@@ -359,7 +359,7 @@ commands below.
      without an observability plugin:
 
       ```bash
-      kubectl apply -l knative.dev/crd-install=true \
+      kubectl apply --selector knative.dev/crd-install=true \
       --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
       --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
       --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -304,23 +304,29 @@ commands below.
    completed until the upgrade process finishes.
 
 1. To install Knative components or plugins, specify the filenames in the
-   `kubectl apply` command:
+   `kubectl apply` command.
 
-   - To install an individual component or plgugin
-
-     ```bash
-     kubectl apply --filename [FILE_URL]
-     ```
-
-   - To install multiple components or plugins, append additional
-     `--filename [FILENAME]` flags to the `kubectl apply` command:
+   - Run the `kubectl apply` command once with the
+   `-l knative.dev/crd-install=true` flag to install the CRDs first. (This
+   prevents race conditions, which cause intermittent install errors.) 
 
      ```bash
-     kubectl apply --filename [FILE_URL] --filename [FILE_URL] \
-       --filename [FILE_URL]
+     kubectl apply -l knative.dev/crd-install=true \
+     --filename [FILE_URL] \
+     --filename [FILE_URL]
      ```
 
-     where [`FILE_URL`] is the URL path of the desired Knative release:
+   - Then run the `kubectl apply` command without the `-l` flag to complete the
+   install:
+
+     ```bash
+     kubectl apply --filename [FILE_URL] \
+     --filename [FILE_URL]
+     ```
+
+     You can add as many `--filename [FILE_URL]` as needed.
+
+     [`FILE_URL`] is the URL path of the desired Knative release:
 
      `https://github.com/knative/[COMPONENT]/releases/download/[VERSION]/[FILENAME].yaml`
 
@@ -338,12 +344,30 @@ commands below.
        plug-ins:
 
        ```bash
+       kubectl apply -l knative.dev/crd-install=true \
+       --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+       --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
+       ```
+       Then:
+
+       ```bash
        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
        --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
        ```
 
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin:
+
+      ```bash
+      kubectl apply -l knative.dev/crd-install=true \
+      --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+      --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+      --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+      --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+      --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+      ```
+
+     Then:
 
       ```bash
       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -226,7 +226,7 @@ files from the Knative repositories:
 
 _\*_ See
 [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
-for details about installing the various supported observability plug-ins.
+for details about installing the various supported observability plugins.
 
 † These are the recommended standard install files suitable for most use cases.
 
@@ -339,7 +339,7 @@ commands below.
     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
-       plug-ins, enter the following command. The `--selector` flag
+       plugins, enter the following command. The `--selector` flag
        installs the CRDs first:
 
        ```bash
@@ -403,7 +403,7 @@ commands below.
 
    See
    [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
-   for details about setting up the various supported observability plug-ins.
+   for details about setting up the various supported observability plugins.
 
 You are now ready to deploy an app, run a build, or start sending and receiving
 events in your Knative cluster.

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -304,11 +304,9 @@ commands below.
    completed until the upgrade process finishes.
 
 1. To install Knative components or plugins, specify the filenames in the
-   `kubectl apply` command.
-
-   - Run the `kubectl apply` command once with the
-   `-l knative.dev/crd-install=true` flag to install the CRDs first. (This
-   prevents race conditions, which cause intermittent install errors.) 
+   `kubectl apply` command. To prevent install failures due to race conditions,
+   run the install command first with the `-l knative.dev/crd-install=true` flag,
+   then a second time without the selector flag. This installs the CRDs first:
 
      ```bash
      kubectl apply --selector knative.dev/crd-install=true \
@@ -316,8 +314,8 @@ commands below.
      --filename [FILE_URL]
      ```
 
-   - Then run the `kubectl apply` command without the `-l` flag to complete the
-   install:
+   - Then run the `kubectl apply` command again without the `-l` flag to
+   complete the install:
 
      ```bash
      kubectl apply --filename [FILE_URL] \
@@ -341,14 +339,16 @@ commands below.
     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
-       plug-ins:
+       plug-ins, enter the following command. The `--selector` flag
+       installs the CRDs first:
 
        ```bash
        kubectl apply --selector knative.dev/crd-install=true \
        --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
        --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
        ```
-       Then:
+       Then complete the install by running the command again, this time without
+       `--selector knative.dev/crd-install=true`:
 
        ```bash
        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -356,7 +356,8 @@ commands below.
        ```
 
    * To install all three Knative components and the set of Eventing sources
-     without an observability plugin:
+     without an observability plugin, enter the following command. The
+    `--selector` flag installs the CRDs first:
 
       ```bash
       kubectl apply --selector knative.dev/crd-install=true \
@@ -367,7 +368,8 @@ commands below.
       --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
       ```
 
-     Then:
+     Then complete the install by running the command again, this time without
+     `--selector knative.dev/crd-install=true`:
 
       ```bash
       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -194,9 +194,9 @@ your Knative installation, see
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -208,8 +208,9 @@ your Knative installation, see
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -194,7 +194,22 @@ your Knative installation, see
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command to install Knative and its dependencies:
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
+
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
+
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -204,12 +219,6 @@ your Knative installation, see
    --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
-
-   > **Note**: If your install fails on the first attempt, try rerunning the
-   > commands. They will likely succeed on the second attempt. For background
-   > info and to track the upcoming solution to this problem, see issues
-   > [#968](https://github.com/knative/docs/issues/968) and
-   > [#1036](https://github.com/knative/docs/issues/1036).
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -199,7 +199,7 @@ your Knative installation, see
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -204,7 +204,22 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command to install Knative and its dependencies:
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
+
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
+
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -214,12 +229,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
-
-   > **Note**: If your install fails on the first attempt, try rerunning the
-   > commands. They will likely succeed on the second attempt. For background
-   > info and to track the upcoming solution to this problem, see issues
-   > [#968](https://github.com/knative/docs/issues/968) and
-   > [#1036](https://github.com/knative/docs/issues/1036).
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -209,7 +209,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -204,9 +204,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -218,8 +218,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -130,9 +130,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -144,8 +144,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -135,7 +135,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -130,7 +130,22 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command to install Knative and its dependencies:
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
+
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
+
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -140,12 +155,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
-
-   > **Note**: If your install fails on the first attempt, try rerunning the
-   > commands. They will likely succeed on the second attempt. For background
-   > info and to track the upcoming solution to this problem, see issues
-   > [#968](https://github.com/knative/docs/issues/968) and
-   > [#1036](https://github.com/knative/docs/issues/1036).
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -211,9 +211,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -225,8 +225,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -211,7 +211,22 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command to install Knative and its dependencies:
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
+
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
+
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -221,12 +236,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
-
-   > **Note**: If your install fails on the first attempt, try rerunning the
-   > commands. They will likely succeed on the second attempt. For background
-   > info and to track the upcoming solution to this problem, see issues
-   > [#968](https://github.com/knative/docs/issues/968) and
-   > [#1036](https://github.com/knative/docs/issues/1036).
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -216,7 +216,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -121,7 +121,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -116,9 +116,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -130,8 +130,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -89,58 +89,72 @@ rerun the command to see the current status.
 > command to view the component's status updates in real time. Use CTRL+C to
 > exit watch mode.
 
-## Installing Knative Serving
+## Installing Knative
 
-Next, install [Knative Serving](https://github.com/knative/serving):
+The following commands install all available Knative components as well as the
+standard set of observability plugins. To customize your Knative installation,
+see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
-Because you have limited resources available, install only the Knative Serving
-component, omitting the other Knative components as well as the observability
-and monitoring plugins.
+1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
+   address to be associated with the LoadBalancer `istio-ingressgateway` instead
+   of `knative-ingressgateway`. Then run the following to clean up leftover
+   resources:
 
-If you are upgrading from Knative 0.3.x: Update your domain and static IP
-address to be associated with the LoadBalancer `istio-ingressgateway` instead of
-`knative-ingressgateway`. Then run the following to clean up leftover resources:
+   ```
+   kubectl delete svc knative-ingressgateway -n istio-system
+   kubectl delete deploy knative-ingressgateway -n istio-system
+   ```
 
-```shell
-kubectl delete svc knative-ingressgateway -n istio-system
-kubectl delete deploy knative-ingressgateway -n istio-system
-```
+   If you have the Knative Eventing Sources component installed, you will also
+   need to delete the following resource before upgrading:
 
-If you have the Knative Eventing Sources component installed, you will also need
-to delete the following resource before upgrading:
+   ```
+   kubectl delete statefulset/controller-manager -n knative-sources
+   ```
 
-```shell
-kubectl delete statefulset/controller-manager -n knative-sources
-```
+   While the deletion of this resource during the upgrade process will not
+   prevent modifications to Eventing Source resources, those changes will not be
+   completed until the upgrade process finishes.
 
-While the deletion of this resource during the upgrade process will not prevent
-modifications to Eventing Source resources, those changes will not be completed
-until the upgrade process finishes.
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
 
-Enter the following command:
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
 
-```shell
-curl -L https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-  | sed 's/LoadBalancer/NodePort/' \
-  | kubectl apply --filename -
-```
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
-Monitor the Knative components until all of the components show a `STATUS` of
-`Running`:
+   ```bash
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
 
-```shell
-kubectl get pods --namespace knative-serving
-```
+   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
+   > required to enable the Build and Serving components to interact with each
+   > other.
 
-Just as with the Istio components, it will take a few seconds for the Knative
-components to be up and running; you can rerun the command to see the current
-status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL+C to
-> exit watch mode.
-
-Now you can deploy an app to your newly created Knative cluster.
+1. Monitor the Knative components until all of the components show a `STATUS` of
+   `Running`:
+   ```bash
+   kubectl get pods --namespace knative-serving
+   kubectl get pods --namespace knative-build
+   kubectl get pods --namespace knative-eventing
+   kubectl get pods --namespace knative-sources
+   kubectl get pods --namespace knative-monitoring
+   ```
 
 ## Deploying an app
 

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -172,10 +172,11 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
    > **NOTE:** It will take a few minutes for all the components to be up and
    > running.
 
-### Install Knative Serving
+### Install Knative
 
-The following section details on deploying
-[Knative Serving](https://github.com/knative/serving) to OpenShift.
+The following commands install the Knative Serving and Build components on
+OpenShift. To customize your Knative installation, see
+[Performing a Custom Knative Installation](./Knative-custom-install.md).
 
 The [knative-openshift-policies.sh](./scripts/knative-openshift-policies.sh)
 runs the required commands to configure necessary privileges to the service
@@ -213,7 +214,7 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Install Knative serving:
+1. Install Knative Serving and Build:
 
    ```shell
    oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml && \

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -104,9 +104,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -118,8 +118,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -104,7 +104,22 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command to install Knative and its dependencies:
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
+
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
+
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -114,12 +129,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
-
-   > **Note**: If your install fails on the first attempt, try rerunning the
-   > commands. They will likely succeed on the second attempt. For background
-   > info and to track the upcoming solution to this problem, see issues
-   > [#968](https://github.com/knative/docs/issues/968) and
-   > [#1036](https://github.com/knative/docs/issues/1036).
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -109,7 +109,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -83,7 +83,22 @@ your Knative installation, see
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command to install Knative and its dependencies:
+1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
+   flag to install the CRDs first. (This prevents race conditions, which
+   cause intermittent install errors.)
+
+   ```bash
+   kubectl apply -l knative.dev/crd-install=true \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+   --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   ```
+
+1. Then run the `kubectl apply` command without the `-l` flag to complete the
+   install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
@@ -93,12 +108,6 @@ your Knative installation, see
    --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
-
-   > **Note**: If your install fails on the first attempt, try rerunning the
-   > commands. They will likely succeed on the second attempt. For background
-   > info and to track the upcoming solution to this problem, see issues
-   > [#968](https://github.com/knative/docs/issues/968) and
-   > [#1036](https://github.com/knative/docs/issues/1036).
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
    > required to enable the Build and Serving components to interact with each

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -88,7 +88,7 @@ your Knative installation, see
    cause intermittent install errors.)
 
    ```bash
-   kubectl apply -l knative.dev/crd-install=true \
+   kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -83,9 +83,9 @@ your Knative installation, see
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. Run the `kubectl apply` command once with the `-l knative.dev/crd-install=true`
-   flag to install the CRDs first. (This prevents race conditions, which
-   cause intermittent install errors.)
+1. To install Knative, first install the CRDs by running the `kubectl apply`
+   command once with the `-l knative.dev/crd-install=true` flag. This prevents
+   race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
@@ -97,8 +97,9 @@ your Knative installation, see
    --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
    ```
 
-1. Then run the `kubectl apply` command without the `-l` flag to complete the
-   install of Knative and its dependencies:
+1. To complete the install of Knative and its dependencies, run the
+   `kubectl apply` command again, this time without the `--selector`
+   flag, to complete the install of Knative and its dependencies:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -69,6 +69,7 @@ available Knative components and a set of observability plugins.
 - [Knative Install on Google Kubernetes Engine](./Knative-with-GKE.md)
 - [Knative Install on IBM Cloud Kubernetes Service](./Knative-with-IKS.md)
 - [Knative Install on IBM Cloud Private](./Knative-with-ICP.md)
+- [Knative Install on Minikube](./Knative-with-Minikube.md)
 - [Knative Install on Pivotal Container Service](./Knative-with-PKS.md)
 
 If you already have a Kubernetes cluster you're comfortable installing _alpha_
@@ -82,10 +83,9 @@ The guides below install some of the available Knative components, without all
 available observability plugins, to minimize the disk space used for install.
 
 - [Knative Install on Docker for Mac](./Knative-with-Docker-for-Mac.md)
-- [Knative Install on Minikube](./Knative-with-Minikube.md)
 - [Knative Install on Minishift](./Knative-with-Minishift.md)
 - [Knative Install on OpenShift](./Knative-with-OpenShift.md)
-- [Knative Install via Operator](https://github.com/openshift-cloud-functions/Documentation/blob/master/knative-OCP-4x.md)
+- [Knative Install on OpenShift via Operator](https://github.com/openshift-cloud-functions/Documentation/blob/master/knative-OCP-4x.md)
 
 **Custom install guide**
 


### PR DESCRIPTION
Fixes #1190  and #1194 

## Proposed Changes

- Updates install guides to first install only the labeled sections of the install files, to avoid race conditions and unpredictable install errors as described in #1036 

- Updates Minikube install to include all components, not just Serving
