### PR TITLE
cherrypick: fix some spelling mistakes of docs (#1188)

### DIFF
--- a/docs/build/auth.md
+++ b/docs/build/auth.md
@@ -257,7 +257,7 @@ credentials are then used to authenticate with the Docker registry.
 
 If both `kubernetes.io/*` and knative flavored basic authentication secret are
 provided, knative will merge the credentials from those two ; knative flavored
-credentials taking precendence over `kubernetes.io/dockerconfigjson` (or
+credentials taking precedence over `kubernetes.io/dockerconfigjson` (or
 `kubernetes.io/dockercfg`) ones.
 
 ### Guiding credential selection

--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -161,7 +161,7 @@ kubectl --namespace knative-debug get channel chan -o jsonpath='{.status.address
 ```
 
 This should return a URI, likely ending in '.cluster.local'. If it doesn't, then
-it implies that something went wrong during reconcilation. See
+it implies that something went wrong during reconciliation. See
 [Channel Controller](#channel-controller).
 
 We will verify that the two resources that the `chan` creates exist and are

--- a/docs/eventing/samples/cronjob-source/README.md
+++ b/docs/eventing/samples/cronjob-source/README.md
@@ -36,7 +36,7 @@ kubectl apply --filename service.yaml
 ### Create Cron Job Event Source
 
 For each set of cron events you want to request, you need to create an Event
-Source in the same namespace as the destiantion. If you need a different
+Source in the same namespace as the destination. If you need a different
 ServiceAccount to create the Deployment, modify the entry accordingly in the
 yaml.
 
@@ -101,7 +101,7 @@ You can remove the Cron Event Source via:
 kubectl delete --filename cronjob-source.yaml
 ```
 
-Similarily, you can remove the Service via:
+Similarly, you can remove the Service via:
 
 ```shell
 kubectl delete --filename service.yaml


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
