### PR TITLE
update sample.yaml to fix the build-template name to buildpacks-cnb

### DIFF
--- a/docs/serving/samples/buildpack-app-dotnet/sample.yaml
+++ b/docs/serving/samples/buildpack-app-dotnet/sample.yaml
@@ -10,7 +10,7 @@ spec:
         url: https://github.com/cloudfoundry-samples/dotnet-core-hello-world
         revision: master
     template:
-      name: buildpack
+      name: buildpacks-cnb
       arguments:
       - name: IMAGE
         value: DOCKER_REPO_OVERRIDE/buildpack-sample-app

--- a/docs/serving/samples/buildpack-function-nodejs/sample.yaml
+++ b/docs/serving/samples/buildpack-function-nodejs/sample.yaml
@@ -10,7 +10,7 @@ spec:
         url: https://github.com/projectriff-samples/node-square
         revision: master
     template:
-      name: buildpack
+      name: buildpacks-cnb
       arguments:
       - name: IMAGE
         value: DOCKER_REPO_OVERRIDE/buildpack-function


### PR DESCRIPTION

Fixes #issue-number

according the buildpacks build-templates name in cnb.yaml updated to 'buildpacks-cnb', the build-template name in buildpacks sample.yaml should update to 'buildpacks-cnb' as well

## Proposed Changes
sample.yaml
-
-
-
