### PR TITLE
README: fix broken links to "help wanted" label

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -83,10 +83,10 @@ overall project.
 If you're looking for something to do to get your feet wet working on Knative,
 look for GitHub issues marked with the Help Wanted label:
 
-- [Build issues](https://github.com/knative/build/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
-- [Eventing issues](https://github.com/knative/eventing/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
-- [Serving issues](https://github.com/knative/serving/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
-- [Documentation repo](https://github.com/knative/docs/issues?q=is%3Aopen+is%3Aissue+label%3A%22community%2Fhelp+wanted%22)
+- [Build issues](https://github.com/knative/build/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
+- [Eventing issues](https://github.com/knative/eventing/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
+- [Serving issues](https://github.com/knative/serving/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
+- [Documentation repo](https://github.com/knative/docs/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
 
 Even if there's not an issue opened for it, we can always use more testing
 throughout the platform. Similarly, we can always use more docs, richer docs,

--- a/contributing/README.md
+++ b/contributing/README.md
@@ -83,10 +83,10 @@ overall project.
 If you're looking for something to do to get your feet wet working on Knative,
 look for GitHub issues marked with the Help Wanted label:
 
-- [Build issues](https://github.com/knative/build/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
-- [Eventing issues](https://github.com/knative/eventing/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
-- [Serving issues](https://github.com/knative/serving/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
-- [Documentation repo](https://github.com/knative/docs/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A"help+wanted")
+- [Build issues](https://github.com/knative/build/labels/kind%2Fgood-first-issue)
+- [Eventing issues](https://github.com/knative/eventing/labels/kind%2Fgood-first-issue)
+- [Serving issues](https://github.com/knative/serving/labels/kind%2Fgood-first-issue)
+- [Documentation repo](https://github.com/knative/docs/labels/kind%2Fgood-first-issue)
 
 Even if there's not an issue opened for it, we can always use more testing
 throughout the platform. Similarly, we can always use more docs, richer docs,


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Fix the links that go to issues labelled "help wanted", current links are querying for labels named "community/help wanted"
