### PR TITLE
links and landing pages for all samples

### DIFF
--- a/community/samples/README.md
+++ b/community/samples/README.md
@@ -1,8 +1,24 @@
-## Sample apps
+Get up and running with one of the community code samples. 
+This collection of samples are contributed and maintained by members of the Knative community. 
 
-Note: Community code samples are contributed and maintained by Knative community members. It is possible that these samples are no longer current and the author might not be actively maintaining their contribution. 
+Note: It is possible that these samples are no longer current and the author might not be actively maintaining their contribution. 
 [Learn more about the lifespan of samples](../../contributing/DOCS-CONTRIBUTING.md).  If you find that something is not right, lend a helping hand and fix it in a PR.
 
-| Sample Name | Knative Component | Description                                                | Language(s)                                                                                                                                                                                                                                                                                                                                                                                  |
-| ----------- | ----------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Hello World | Serving           | A quick introduction that highlights how to deploy an app. | [Clojure](./serving/helloworld-clojure/README.md), [Dart](./serving/helloworld-dart/README.md), [Elixir](./serving/helloworld-elixir/README.md), [Haskell](./serving/helloworld-haskell/README.md), [Rust](./serving/helloworld-rust/README.md), [Swift](./serving/helloworld-swift/README.md), [Vertx](./serving/helloworld-vertx/README.md) |
+[**See all Knative code samples**](../../docs/samples/)
+
+### Serving samples
+
+Knative Serving sample apps.
+
+| Sample Name  | Description                                                | Language(s)                                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Hello World | A quick introduction to Knative Serving that highlights how to deploy an app. | [Clojure](./serving/helloworld-clojure/README.md), [Dart](./serving/helloworld-dart/README.md), [Elixir](./serving/helloworld-elixir/README.md), [Haskell](./serving/helloworld-haskell/README.md), [Rust](./serving/helloworld-rust/README.md), [Swift](./serving/helloworld-swift/README.md), [Vertx](./serving/helloworld-vertx/README.md) |
+
+#### Build samples
+
+* *Be the first to contribute a Build code sample to the community collection.*
+
+#### Eventing and Eventing Sources samples
+
+* *Be the first to contribute an Eventing or Eventing Sources code sample to the community collection.*
+

--- a/community/samples/README.md
+++ b/community/samples/README.md
@@ -1,8 +1,9 @@
 Get up and running with one of the community code samples. 
-This collection of samples are contributed and maintained by members of the Knative community. 
+These samples are contributed and maintained by members of the Knative community. 
 
-Note: It is possible that these samples are no longer current and the author might not be actively maintaining their contribution. 
-[Learn more about the lifespan of samples](../../contributing/DOCS-CONTRIBUTING.md).  If you find that something is not right, lend a helping hand and fix it in a PR.
+Note: It is possible that one or more samples might become outdated or the original author is unable to maintain their
+contribution. If you find that something isn't working, lend a helping hand and fix it in a PR.
+[Learn more about the lifespan of samples](../../contributing/DOCS-CONTRIBUTING.md).  
 
 [**See all Knative code samples**](../../docs/samples/)
 

--- a/community/samples/_index.md
+++ b/community/samples/_index.md
@@ -1,14 +1,8 @@
 ---
-title: "Knative Community Sample Apps"
-linkTitle: "Sample Apps"
-weight: 100
+title: "Community code samples"
+linkTitle: "Code samples"
+weight: 40
 type: "docs"
 ---
-
-Get up and running in a language of your choice using one of the community
-contributed and maintained sample apps.
-
-Use the following table to view the instructions and sample code in the
-knative/docs repo.
 
 {{% readfile file="README.md" relative="true" markdown="true" %}}

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -85,23 +85,7 @@ spec:
 
 ## Get started with Knative Build samples
 
-Use the following samples to learn how to configure your Knative Builds to
-perform simple tasks.
-
-Tip: Review and reference multiple samples to piece together more complex
-builds.
-
-#### Simple build samples
-
-- [Collection of simple test builds](https://github.com/knative/build/tree/master/test).
-
-#### Build templates
-
-- [Repository of sample build templates](https://github.com/knative/build-templates).
-
-#### Complex samples
-
-- [Use Knative to build apps from source code and then run those containers](../serving/samples/source-to-url-go).
+[See Knative Build code samples](./samples.md) 
 
 ## Related info
 

--- a/docs/build/samples.md
+++ b/docs/build/samples.md
@@ -1,0 +1,31 @@
+---
+title: "Knative Build code samples"
+linkTitle: "Code samples"
+weight: 90
+type: "docs"
+---
+
+Use the following code samples to help you understand the various use cases for Knative
+Build. [Learn more about Knative Build](../index.html).
+
+[**See all Knative code samples**](../../samples/)
+
+Use the following code samples to learn about configuring and createing your Knative Builds.
+
+Tip: Review and reference multiple samples to piece together more complex
+builds.
+
+#### Simple build samples
+
+- View the collection of code samples in the `knative/build` repo: 
+  [Simple test builds](https://github.com/knative/build/tree/master/test).
+
+#### Build template samples
+
+
+- View the collection of build templates in the `knative/build-template` repo: 
+  [Sample build templates](https://github.com/knative/build-templates).
+
+#### Complex code samples
+
+- [Learn how to use Knative to build apps from source code and then run those containers](../serving/samples/source-to-url-go).

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Knative Concepts"
 linkTitle: "Concepts"
-weight: 89
+weight: 90
 type: "docs"
 ---
 

--- a/docs/eventing/debugging/_index.md
+++ b/docs/eventing/debugging/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Debugging Knative Eventing"
 linkTitle: "Debugging"
-weight: 80
+weight: 100
 type: "docs"
 ---
 

--- a/docs/eventing/samples/_index.md
+++ b/docs/eventing/samples/_index.md
@@ -1,6 +1,11 @@
 ---
-title: "Knative Eventing samples"
-linkTitle: "Sample apps"
-weight: 60
+title: "Knative Eventing code samples"
+linkTitle: "Code samples"
+weight: 90
 type: "docs"
 ---
+
+Use the following code samples to help you understand the various use cases for Knative
+Eventing and Event Sources. [Learn more about Knative Eventing and Eventing Sources](../index.html).
+
+[**See all Knative code samples**](../../samples/)

--- a/docs/samples.md
+++ b/docs/samples.md
@@ -1,0 +1,29 @@
+---
+title: "Knative code samples"
+linkTitle: "Code samples"
+weight: 90
+type: "docs"
+---
+
+Find and use Knative code samples to help you get up and running with common use cases.
+Code samples include content from the Knative team and community members.
+
+Browse all code samples to find other languages and use cases that might align closer with your goals.
+
+### Knative owned and maintained
+
+View the set of Knative code samples that are actively tested and maintained:
+
+* [Build code samples](./build/samples.md)
+* [Eventing and Eventing Sources code samples](./eventing/samples/)
+* [Serving code samples](./serving/samples/README.md)
+
+### Community owned and maintained
+
+[View code samples that are contributed and maintained by the community](../community/samples/README.md).
+
+### External code samples
+
+A list of links to Knative code samples that live outside of [https://knative.dev](https://knative.dev):
+
+* *Be the first to link your externally hosted Knative code sample.*

--- a/docs/serving/samples/README.md
+++ b/docs/serving/samples/README.md
@@ -1,8 +1,8 @@
-Use the following sample applications to help you understand the various Knative
+Use the following code samples to help you understand the various Knative
 Serving resources and how they can be applied across common use cases.
 [Learn more about Knative Serving resources](../README.md).
 
-Additional samples provided by the community are available in the [Community Samples](../../../community/samples/serving) folder.
+[**See all Knative code samples**](../../samples/)
 
 | Name                       | Description                                                                                                                                                                                                              |                                                                                                                                                                                                                            Languages                                                                                                                                                                                                                             |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |

--- a/docs/serving/samples/_index.md
+++ b/docs/serving/samples/_index.md
@@ -1,7 +1,7 @@
 ---
-title: "Knative Serving sample applications"
-linkTitle: "Sample apps"
-weight: 1
+title: "Knative Serving code samples"
+linkTitle: "Code samples"
+weight: 100
 type: "docs"
 ---
 


### PR DESCRIPTION
Add crossing link for all samples, create a main code samples page, and add some consistency:

- Add "Code samples" landing pages:
   - "all code samples" at top level in nav (new)
   - community (edit)
   - serving (edit)
   - build (new)
   - eventing (edit)

- Ensure "Code samples" shows toward the bottom of each section in the nav tree

- Shallow pass at consistent use of "code sample" (vs sample app)

Issue: #1213