### PR TITLE
Fix some spelling mistakes of doc

### DIFF
--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -28,7 +28,7 @@ You must meet the following requirements to complete this sample:
 
 **Tip**: You can clone the [Knative/docs repo](https://github.com/knative/docs)
 and then modify the source files. Alternatively, learn more by manually creating
-the files youself.
+the files yourself.
 
 ## Creating and configuring the sample code
 

--- a/contributing/DOCS-CONTRIBUTING.md
+++ b/contributing/DOCS-CONTRIBUTING.md
@@ -287,7 +287,7 @@ If you want to notify and include other stakeholders in your PR review, use the
 
 Because contributing to the documentation requires a different skill set than
 contributing to the Knative code base, we've defined the roles of documentation
-contributors seperately from the roles of code contributors.
+contributors separately from the roles of code contributors.
 
 If you're looking for code contributor roles, see [ROLES](./ROLES.md).
 


### PR DESCRIPTION
Fix some minor problems while reading.
Some spelling mistakes:
- youself -> yourself
- seperately -> separately 