### PR TITLE
Fix #1239 - add a note on how docs are built

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ release of the Knative docs are
 [branched](https://github.com/knative/docs/branches). If you are looking for an
 archived doc set, see the list of available versions in
 [Knative doc releases](./doc-releases.md).
+
+## Building the docs
+
+Docs here are built by <https://github.com/knative/website> and pushed to <https://knative.dev>.


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1239 

## Proposed Changes
- Note how the docs in this repo are built and then published to <https://knative.dev>
