### PR TITLE
Remove references to Istio yamls attached to releases.

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -83,9 +83,9 @@ service mesh. If you install any of the following options, you must install
 
 † These are the recommended standard install files suitable for most use cases.
 
-[a]: https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml
-[b]: https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
-[c]: https://github.com/knative/serving/releases/download/v0.5.0/istio-lean.yaml
+[a]: https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml
+[b]: https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
+[c]: https://github.com/knative/serving/releases/download/v0.5.2/istio-lean.yaml
 
 ### Installing Istio
 
@@ -113,13 +113,13 @@ service mesh. If you install any of the following options, you must install
 1. Create the Istio CRDs on your cluster:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml
    ```
 
 1. Install Istio by specifying the filename in the `kubectl apply` command:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/[FILENAME].yaml
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/[FILENAME].yaml
    ```
 
    where `[FILENAME]` is the name of the Istio file that you want to install.
@@ -167,12 +167,12 @@ with Knative.
 The following Knative installation files are available:
 
 - **Serving Component and Observability Plugins**:
-  - https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml
-  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
-  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-logs-elasticsearch.yaml
-  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-metrics-prometheus.yaml
-  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
-  - https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.2/monitoring-logs-elasticsearch.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.2/monitoring-metrics-prometheus.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.2/monitoring-tracing-zipkin.yaml
+  - https://github.com/knative/serving/releases/download/v0.5.2/monitoring-tracing-zipkin-in-mem.yaml
 - **Build Component**:
   - https://github.com/knative/build/releases/download/v0.5.0/build.yaml
 - **Eventing Component**:
@@ -187,7 +187,7 @@ The following Knative installation files are available:
   - https://github.com/knative/eventing-sources/releases/download/v0.5.0/kafka.yaml
   - https://github.com/knative/eventing-sources/releases/download/v0.5.0/event-display.yaml
 - **Cluster roles**:
-  - https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+  - https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
 
 #### Install details and options
 
@@ -232,32 +232,32 @@ for details about installing the various supported observability plugins.
 
 <!-- USE ONLY FULLY QUALIFIED URLS -->
 
-[1]: https://github.com/knative/serving/releases/tag/v0.5.0
-[1.1]: https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml
+[1]: https://github.com/knative/serving/releases/tag/v0.5.2
+[1.1]: https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml
 [1.2]:
-  https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
+  https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
 [1.3]:
-  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-logs-elasticsearch.yaml
+  https://github.com/knative/serving/releases/download/v0.5.2/monitoring-logs-elasticsearch.yaml
 [1.4]:
-  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-metrics-prometheus.yaml
+  https://github.com/knative/serving/releases/download/v0.5.2/monitoring-metrics-prometheus.yaml
 [1.5]:
-  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
+  https://github.com/knative/serving/releases/download/v0.5.2/monitoring-tracing-zipkin.yaml
 [1.6]:
-  https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
+  https://github.com/knative/serving/releases/download/v0.5.2/monitoring-tracing-zipkin-in-mem.yaml
 [2]: https://www.elastic.co/elk-stack
 [2.1]: https://prometheus.io
 [2.2]: https://grafana.com
 [2.3]: https://zipkin.io/
-[3]: https://github.com/knative/build/releases/tag/v0.5.0
+[3]: https://github.com/knative/build/releases/tag/v0.5.2
 [3.1]: https://github.com/knative/build/releases/download/v0.5.0/build.yaml
-[4]: https://github.com/knative/eventing/releases/tag/v0.5.0
+[4]: https://github.com/knative/eventing/releases/tag/v0.5.2
 [4.1]: https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml
 [4.2]:
   https://github.com/knative/eventing/releases/download/v0.5.0/eventing.yaml
 [4.3]:
   https://github.com/knative/eventing/releases/download/v0.5.0/in-memory-channel.yaml
 [4.4]: https://github.com/knative/eventing/releases/download/v0.5.0/kafka.yaml
-[5]: https://github.com/knative/eventing-sources/releases/tag/v0.5.0
+[5]: https://github.com/knative/eventing-sources/releases/tag/v0.5.2
 [5.1]:
   https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml
 [5.2]:
@@ -275,7 +275,7 @@ for details about installing the various supported observability plugins.
   https://github.com/knative/eventing-sources/blob/master/samples/cronjob-source/README.md
 [6.3]: https://cloud.google.com/pubsub/
 [7]:
-  https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+  https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
 
 ### Installing Knative
 
@@ -332,7 +332,7 @@ commands below.
      `[COMPONENT]`, `[VERSION]`, and `[FILENAME]` are the Knative component,
      release version, and filename of the Knative component or plugin. Examples:
 
-     - `https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml`
+     - `https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml`
      - `https://github.com/knative/build/releases/download/v0.5.0/build.yaml`
      - `https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml`
      - `https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml`
@@ -345,16 +345,16 @@ commands below.
 
        ```bash
        kubectl apply --selector knative.dev/crd-install=true \
-         --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-         --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
+         --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
+         --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
        ```
 
        Then complete the install by running the command again, this time without
        `--selector knative.dev/crd-install=true`:
 
        ```bash
-       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-         --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml
+       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
+         --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
        ```
 
    * To install all three Knative components and the set of Eventing sources
@@ -363,22 +363,22 @@ commands below.
 
      ```bash
      kubectl apply --selector knative.dev/crd-install=true \
-     --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-     --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
-     --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
-     --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-     --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+       --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
+       --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+       --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+       --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+       --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
      ```
 
      Then complete the install by running the command again, this time without
      `--selector knative.dev/crd-install=true`:
 
      ```bash
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
-     --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
-     --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
-     --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-     --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
+       --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
+       --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
+       --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
+       --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
      ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -142,8 +142,8 @@ Knative depends on Istio.
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml && \
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -200,12 +200,12 @@ your Knative installation, see
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -213,12 +213,12 @@ your Knative installation, see
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -37,7 +37,7 @@ Knative depends on Istio. Run the following to install Istio. (This changes
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml \
+curl -L https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -64,11 +64,11 @@ rerun the command to see the current status.
 Next, install [Knative Serving](https://github.com/knative/serving).
 
 Because you have limited resources available, use the
-`https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml` file,
+`https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml` file,
 which installs only Knative Serving:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 ```

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -12,6 +12,9 @@ You can find [guides for other platforms here](./README.md).
 
 ## Before you begin
 
+> [Cloud Run on GKE](https://cloud.google.com/run/docs/gke/setup) is a hosted
+> offering on top of GKE that builds around Istio and Knative Serving.
+
 Knative requires a Kubernetes cluster v1.11 or newer. `kubectl` v1.10 is also
 required. This guide walks you through creating a cluster with the correct
 specifications for Knative on Google Cloud Platform (GCP).
@@ -104,78 +107,41 @@ Engine cluster.
 
 ## Creating a Kubernetes cluster
 
-To make sure the cluster is large enough to host all the Knative and Istio
-components, the recommended configuration for a cluster is:
+To make sure the cluster is large enough to host Knative and its dependencies,
+the recommended configuration for a cluster is:
 
 - Kubernetes version 1.11 or later
 - 4 vCPU nodes (`n1-standard-4`)
 - Node autoscaling, up to 10 nodes
-- API scopes for `cloud-platform`, `logging-write`, `monitoring-write`, and
-  `pubsub` (if those features will be used)
+- API scopes for `cloud-platform`
 
 1. Create a Kubernetes cluster on GKE with the required specifications:
 
+> Note: If this setup is for development, or a non-Istio networking layer
+> (e.g. [Gloo](./Knative-with-Gloo.md)) will be used, then you can remove
+> the `--addons` line below.
+
    ```bash
-   gcloud container clusters create $CLUSTER_NAME \
-     --zone=$CLUSTER_ZONE \
-     --cluster-version=latest \
+   gcloud beta container clusters create $CLUSTER_NAME \
+     --addons=HorizontalPodAutoscaling,HttpLoadBalancing,Istio \
      --machine-type=n1-standard-4 \
+     --cluster-version=latest --zone=$CLUSTER_ZONE \
+     --enable-stackdriver-kubernetes --enable-ip-alias \
      --enable-autoscaling --min-nodes=1 --max-nodes=10 \
      --enable-autorepair \
-     --scopes=service-control,service-management,compute-rw,storage-ro,cloud-platform,logging-write,monitoring-write,pubsub,datastore \
-     --num-nodes=3
+     --scopes cloud-platform
    ```
 
 1. Grant cluster-admin permissions to the current user:
 
    ```bash
    kubectl create clusterrolebinding cluster-admin-binding \
-   --clusterrole=cluster-admin \
-   --user=$(gcloud config get-value core/account)
+     --clusterrole=cluster-admin \
+     --user=$(gcloud config get-value core/account)
    ```
 
 Admin permissions are required to create the necessary
-[RBAC rules for Istio](https://istio.io/docs/concepts/security/rbac/).
-
-## Installing Istio
-
-> Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
-> Gloo is not currently compatible with the Knative Eventing component.
-> [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
-
-Knative depends on Istio.
-
-1. Install Istio:
-
-   ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
-   ```
-
-   Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
-   included in the `istio.yaml` file, but they are pulled out so that the CRD
-   definitions are created first. If you see an error when creating resources
-   about an unknown type, run the second `kubectl apply` command again.
-
-1. Label the default namespace with `istio-injection=enabled`:
-
-   ```bash
-   kubectl label namespace default istio-injection=enabled
-   ```
-
-1. Monitor the Istio components until all of the components show a `STATUS` of
-   `Running` or `Completed`:
-
-   ```bash
-   kubectl get pods --namespace istio-system
-   ```
-
-It will take a few minutes for all the components to be up and running; you can
-rerun the command to see the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL + C to
-> exit watch mode.
+[RBAC rules for Knative](https://istio.io/docs/concepts/security/rbac/).
 
 ## Installing Knative
 
@@ -183,39 +149,18 @@ The following commands install all available Knative components as well as the
 standard set of observability plugins. To customize your Knative installation,
 see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
-1. If you are upgrading from Knative 0.3.x: Update your domain and static IP
-   address to be associated with the LoadBalancer `istio-ingressgateway` instead
-   of `knative-ingressgateway`. Then run the following to clean up leftover
-   resources:
-
-   ```
-   kubectl delete svc knative-ingressgateway -n istio-system
-   kubectl delete deploy knative-ingressgateway -n istio-system
-   ```
-
-   If you have the Knative Eventing Sources component installed, you will also
-   need to delete the following resource before upgrading:
-
-   ```
-   kubectl delete statefulset/controller-manager -n knative-sources
-   ```
-
-   While the deletion of this resource during the upgrade process will not
-   prevent modifications to Eventing Source resources, those changes will not be
-   completed until the upgrade process finishes.
-
 1. To install Knative, first install the CRDs by running the `kubectl apply`
    command once with the `-l knative.dev/crd-install=true` flag. This prevents
    race conditions during the install, which cause intermittent errors:
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -223,12 +168,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -77,8 +77,8 @@ Knative depends on Istio.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml && \
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -136,12 +136,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -149,12 +149,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -159,8 +159,8 @@ Knative depends on Istio.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml && \
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -218,12 +218,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -231,12 +231,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -66,8 +66,8 @@ Knative depends on Istio. Run the following to install Istio. (We are changing
 `LoadBalancer` to `NodePort` for the `istio-ingress` service).
 
 ```shell
-kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml &&
-curl -L https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml \
+kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml &&
+curl -L https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --filename -
 
@@ -122,12 +122,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -135,12 +135,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-Minishift.md
+++ b/docs/install/Knative-with-Minishift.md
@@ -153,8 +153,8 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
 1. Run the following to install Istio:
 
    ```shell
-   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+   oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml && \
+   oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -217,9 +217,9 @@ curl -s https://raw.githubusercontent.com/knative/docs/master/docs/install/scrip
 1. Install Knative Serving and Build:
 
    ```shell
-   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml && \
+   oc apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml && \
    oc apply --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml && \
-   oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   oc apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -54,8 +54,8 @@ Containers
 1. Install Istio:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml && \
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
    ```
 
    Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -110,12 +110,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -123,12 +123,12 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -27,8 +27,8 @@ Containers.
 1.  Install Istio:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio-crds.yaml && \
-    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/istio.yaml
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml && \
+    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
     ```
 
     Note: the resources (CRDs) defined in the `istio-crds.yaml`file are also
@@ -89,12 +89,12 @@ your Knative installation, see
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -102,12 +102,12 @@ your Knative installation, see
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.5.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml \
    --filename https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.5.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml \
+   --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/config/build/clusterrole.yaml
    ```
 
    > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is


### PR DESCRIPTION
In 0.6 we will stop shipping Istio yamls, as we are not in the business of
redistributing Istio (incl. supporting these yamls).  In preparation for that,
this change makes a few changes:
1. Update things to point to the 0.5.2 release
1. Point to our in-tree Istio files (which is what we were attaching)
1. For GKE, direct users to the Istio addon instead.
1. For GKE, add a pointer to CR-GKE (if folks wanted hosted).

This is a half-measure to avoid things breaking.  We need a page that points
folks to the Istio docs, and calls out any specialized instructions for
what Knative needs.

Fixes: https://github.com/knative/serving/issues/3670