### PR TITLE
Add validation token support to autoscaler-go

### DIFF
--- a/docs/serving/samples/autoscale-go/autoscale.go
+++ b/docs/serving/samples/autoscale-go/autoscale.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"sync"
 	"time"
+	"os"
 )
 
 // Algorithm from https://stackoverflow.com/a/21854246
@@ -153,7 +154,22 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func replyWithToken(token string) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+	  fmt.Fprintln(w, token)
+	}
+  }
+
 func main() {
+	validateToken := os.Getenv("VALIDATION")
+	if validateToken != "" {
+		http.HandleFunc("/" + validateToken + "/", replyWithToken(validateToken))
+	}
+	
+	listenPort := os.Getenv("PORT")
+	if listenPort == "" {
+		listenPort = "8080"
+	}
 	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	http.ListenAndServe(":" + listenPort, nil)
 }


### PR DESCRIPTION
## Proposed Changes

We wanted to use the autoscaler-go sample to do some load testing. However many load testing services require the target to return a specific string to verify that they should be load tested (vs. a DDoS attack).

This update uses the **VALIDATION** env-var to define the string that should be returned from a URL that includes that token, and appears to be a common format for validating a URL from these types of sites.

This PR also fixes that the sample listens only on port 8080, which is not the desired experience in the container runtime contract.