### PR TITLE
Update docs to define jaeger-operator as a dependency

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -210,8 +210,8 @@ files from the Knative repositories:
 | [`monitoring.yaml`][1.2]†                      | Installs the [ELK stack][2], [Prometheus][2.1], [Grafana][2.2], and [Zipkin][2.3]**\***                                                            | Serving component                                                 |
 | [`monitoring-logs-elasticsearch.yaml`][1.3]    | Installs only the [ELK stack][2]**\***                                                                                                             | Serving component                                                 |
 | [`monitoring-metrics-prometheus.yaml`][1.4]    | Installs only [Prometheus][2.1]**\***                                                                                                              | Serving component                                                 |
-| [`monitoring-tracing-jaeger.yaml`][1.5]        | Installs only [Jaeger][2.4].**\***                                                                                                                 | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml) |
-| [`monitoring-tracing-jaeger-in-mem.yaml`][1.6] | Installs only [Jaeger in-memory][2.4]**\***                                                                                                        | Serving component                                                 |
+| [`monitoring-tracing-jaeger.yaml`][1.5]        | Installs only [Jaeger][2.4]**\***                                                                                                                 | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml), [Jaeger Operator][2.5] |
+| [`monitoring-tracing-jaeger-in-mem.yaml`][1.6] | Installs only [Jaeger in-memory][2.4]**\***                                                                                                       | Serving component, [Jaeger Operator][2.5]                                                  |
 | [`monitoring-tracing-zipkin.yaml`][1.7]        | Installs only [Zipkin][2.3].**\***                                                                                                                 | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml) |
 | [`monitoring-tracing-zipkin-in-mem.yaml`][1.8] | Installs only [Zipkin in-memory][2.3]**\***                                                                                                        | Serving component                                                 |
 | **knative/build**                              |                                                                                                                                                    |                                                                   |
@@ -259,6 +259,7 @@ for details about installing the various supported observability plugins.
 [2.2]: https://grafana.com
 [2.3]: https://zipkin.io/
 [2.4]: https://jaegertracing.io/
+[2.5]: https://github.com/jaegertracing/jaeger-operator#installing-the-operator
 [3]: https://github.com/knative/build/releases/tag/v0.5.2
 [3.1]: https://github.com/knative/build/releases/download/v0.5.0/build.yaml
 [4]: https://github.com/knative/eventing/releases/tag/v0.5.2

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -237,56 +237,66 @@ uninstall that tool before installing the new tool.
 
 ### Zipkin
 
-- If Elasticsearch is not installed or if you don't want to persist end to end
-  traces, run:
 
-  ```shell
-  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
-  ```
+1. Install support for Zipkin:
 
-- If Elasticsearch is installed and you want to persist end to end traces, first
-  run:
+   - If Elasticsearch is not installed or if you don't want to persist end to end
+     traces, run:
 
-  ```shell
-  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
-  ```
+     ```shell
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin-in-mem.yaml
+     ```
 
-  Next, create an Elasticsearch index for end to end traces:
+   - If Elasticsearch is installed and you want to persist end to end traces, first
+     run:
 
-  - Open Kibana UI as described in
-    [Create Elasticsearch Indices](#create-elasticsearch-indices) section.
-  - Select `Create Index Pattern` button on top left of the page. Enter
-    `zipkin*` to `Index pattern` and select `timestamp_millis` from
-    `Time Filter field name` and click on `Create` button.
+     ```shell
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-zipkin.yaml
+     ```
+
+1. Create an Elasticsearch index for end to end traces:
+
+   1. Open Kibana UI as described in
+      [Create Elasticsearch Indices](#create-elasticsearch-indices) section.
+
+   1. Select `Create Index Pattern` button on top left of the page. Enter
+      `zipkin*` to `Index pattern` and select `timestamp_millis` from
+      `Time Filter field name` and click on `Create` button.
 
 Visit [Accessing Traces](./accessing-traces.md) for more information on end to
 end traces.
 
 ### Jaeger
 
-**Important**: Before proceeding with the steps below, you will need to install the Jaeger operator (if not already installed). Follow the instructions in the [Installing the operator](https://github.com/jaegertracing/jaeger-operator#installing-the-operator) section only.
+1. Install the Jaeger operator. Use the instructions in jaegertracing/jaeger-operator
+   repository and follow only the steps in the 
+   [Installing the operator](https://github.com/jaegertracing/jaeger-operator#installing-the-operator) 
+   section.
 
-- If Elasticsearch is not installed or if you don't want to persist end to end
-  traces, run:
+1. Install support for Jaeger:
 
-  ```shell
-  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-jaeger-in-mem.yaml
-  ```
+   - If Elasticsearch is not installed or if you don't want to persist end to end
+     traces, run:
 
-- If Elasticsearch is installed and you want to persist end to end traces, first
-  run:
+     ```shell
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-jaeger-in-mem.yaml
+     ```
 
-  ```shell
-  kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-jaeger.yaml
-  ```
+   - If Elasticsearch is installed and you want to persist end to end traces, first
+     run:
 
-  Next, create an Elasticsearch index for end to end traces:
+     ```shell
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.0/monitoring-tracing-jaeger.yaml
+     ```
 
-  - Open Kibana UI as described in
-    [Create Elasticsearch Indices](#create-elasticsearch-indices) section.
-  - Select `Create Index Pattern` button on top left of the page. Enter
-    `jaeger*` to `Index pattern` and select `timestamp_millis` from
-    `Time Filter field name` and click on `Create` button.
+1. Create an Elasticsearch index for end to end traces:
+
+   1. Open Kibana UI as described in
+      [Create Elasticsearch Indices](#create-elasticsearch-indices) section.
+      
+   1. Select `Create Index Pattern` button on top left of the page. Enter
+      `jaeger*` to `Index pattern` and select `timestamp_millis` from
+      `Time Filter field name` and click on `Create` button.
 
 Visit [Accessing Traces](./accessing-traces.md) for more information on end to
 end traces.

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -264,6 +264,8 @@ end traces.
 
 ### Jaeger
 
+**Important**: Before proceeding with the steps below, you will need to install the Jaeger operator (if not already installed). Follow the instructions in the [Installing the operator](https://github.com/jaegertracing/jaeger-operator#installing-the-operator) section only.
+
 - If Elasticsearch is not installed or if you don't want to persist end to end
   traces, run:
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- Documentation changes to accompany serving PR https://github.com/knative/serving/pull/3938
- Jaeger operator is changed from being embedded (and managed by Knative) to being a dependency that needs to be pre-installed
