### PR TITLE
Correct traffic splitting in version 0.5

### DIFF
--- a/docs/serving/samples/traffic-splitting/README.md
+++ b/docs/serving/samples/traffic-splitting/README.md
@@ -47,7 +47,7 @@ echo ${REVISIONS[*]}
 ```shell
 CURRENT=${REVISIONS[0]} \
 envsubst < serving/samples/traffic-splitting/release_sample.yaml \
-| kubectl apply --filename -
+| kubectl replace --filename -
 ```
 
 3. The `spec` of the Service should now show `release` with the Revision name


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes
To update the original ksvc from `runLatest` to `release` should use `kubectl replace` rather than `kubectl apply`, if not, the command will raise exception: `expected exactly one, got both: runLatest release`
