### PR TITLE
Format markdown

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -83,8 +83,10 @@ service mesh. If you install any of the following options, you must install
 
 † These are the recommended standard install files suitable for most use cases.
 
-[a]: https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml
-[b]: https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
+[a]:
+  https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml
+[b]:
+  https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml
 [c]: https://github.com/knative/serving/releases/download/v0.5.2/istio-lean.yaml
 
 ### Installing Istio
@@ -346,7 +348,7 @@ commands below.
      - `https://github.com/knative/eventing/releases/download/v0.5.0/release.yaml`
      - `https://github.com/knative/eventing-sources/releases/download/v0.5.0/eventing-sources.yaml`
 
-    **Example install commands:**
+     **Example install commands:**
 
      - To install the Knative Serving component with the set of observability
        plugins, enter the following command. The `--selector` flag installs the

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -117,20 +117,20 @@ the recommended configuration for a cluster is:
 
 1. Create a Kubernetes cluster on GKE with the required specifications:
 
-> Note: If this setup is for development, or a non-Istio networking layer
-> (e.g. [Gloo](./Knative-with-Gloo.md)) will be used, then you can remove
-> the `--addons` line below.
+> Note: If this setup is for development, or a non-Istio networking layer (e.g.
+> [Gloo](./Knative-with-Gloo.md)) will be used, then you can remove the
+> `--addons` line below.
 
-   ```bash
-   gcloud beta container clusters create $CLUSTER_NAME \
-     --addons=HorizontalPodAutoscaling,HttpLoadBalancing,Istio \
-     --machine-type=n1-standard-4 \
-     --cluster-version=latest --zone=$CLUSTER_ZONE \
-     --enable-stackdriver-kubernetes --enable-ip-alias \
-     --enable-autoscaling --min-nodes=1 --max-nodes=10 \
-     --enable-autorepair \
-     --scopes cloud-platform
-   ```
+```bash
+gcloud beta container clusters create $CLUSTER_NAME \
+  --addons=HorizontalPodAutoscaling,HttpLoadBalancing,Istio \
+  --machine-type=n1-standard-4 \
+  --cluster-version=latest --zone=$CLUSTER_ZONE \
+  --enable-stackdriver-kubernetes --enable-ip-alias \
+  --enable-autoscaling --min-nodes=1 --max-nodes=10 \
+  --enable-autorepair \
+  --scopes cloud-platform
+```
 
 1. Grant cluster-admin permissions to the current user:
 

--- a/docs/serving/accessing-traces.md
+++ b/docs/serving/accessing-traces.md
@@ -5,7 +5,9 @@ weight: 15
 type: "docs"
 ---
 
-Depending on the request tracing tool that you have installed on your Knative Serving cluster, see the corresponding section for details about how to visualize and trace your requests.
+Depending on the request tracing tool that you have installed on your Knative
+Serving cluster, see the corresponding section for details about how to
+visualize and trace your requests.
 
 If you have not yet installed the logging and monitoring components, go through
 the [installation instructions](./installing-logging-metrics-traces.md) to set
@@ -49,8 +51,8 @@ In order to access request traces, you use the Jaeger visualization tool.
 1.  Navigate to the
     [Jaeger UI](http://localhost:8001/api/v1/namespaces/istio-system/services/jaeger-query:16686/proxy/search/).
 
-1.  Select the service of interest and click "Find Traces" to see the latest traces. Click on a trace to see a
-    detailed view of a specific call.
+1.  Select the service of interest and click "Find Traces" to see the latest
+    traces. Click on a trace to see a detailed view of a specific call.
 
 <!--TODO: Consider adding a video here. -->
 

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -228,9 +228,12 @@ Knative.
 
 ## End to end request tracing
 
-You can choose from one of the following options to enable request tracing in your Knative Serving cluster.
+You can choose from one of the following options to enable request tracing in
+your Knative Serving cluster.
 
-**Important**: Your cluster supports only a single request trace tool. If you want to replace a currently installed request trace tool, you must first uninstall that tool before installing the new tool.
+**Important**: Your cluster supports only a single request trace tool. If you
+want to replace a currently installed request trace tool, you must first
+uninstall that tool before installing the new tool.
 
 ### Zipkin
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`