### PR TITLE
Fix command line to extract LATEST_HOSTNAME

### DIFF
--- a/docs/serving/samples/traffic-splitting/README.md
+++ b/docs/serving/samples/traffic-splitting/README.md
@@ -107,7 +107,7 @@ kubectl get ksvc stock-service-example --output yaml
 
 ```shell
 # Replace "latest" with whichever tag for which we want the hostname.
-export LATEST_HOSTNAME=`kubectl get ksvc autoscale-go --output jsonpath="{.status.traffic[?(@.tag=='latest')].url}" | cut -d'/' -f 3`
+export LATEST_HOSTNAME=`kubectl get ksvc stock-service-example --output jsonpath="{.status.traffic[?(@.name=='latest')].url}" | cut -d'/' -f 3`
 curl --header "Host: ${LATEST_HOSTNAME}" http://${INGRESS_IP}
 ```
 


### PR DESCRIPTION
<!-- General PR guidelines:


New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->
Update the command in README to correctly extract latest_hostname from target Knative Service json output.

## Proposed Changes

- pick the right k service ("stock-service-example")
- look up with right field ("name")

