### PR TITLE
Format markdown

### DIFF
--- a/contributing/STEERING-COMMITTEE.md
+++ b/contributing/STEERING-COMMITTEE.md
@@ -93,7 +93,6 @@ first name):
 | <img width="30px" src="https://github.com/rgregg.png">    | Ryan Gregg       | Google       | [@rgregg](https://github.com/rgregg)       |
 | <img width="30px" src="https://github.com/isdal.png">     | Tomas Isdal      | Google       | [@isdal](https://github.com/isdal)         |
 
-
 ### Allocation of seats
 
 Seats on the steering committee are allocated based upon contribution to the

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -350,23 +350,23 @@ commands below.
 
    **Example install commands:**
 
-     - To install the Knative Serving component with the set of observability
-       plugins, enter the following command. The `--selector` flag installs the
-       CRDs first:
+   - To install the Knative Serving component with the set of observability
+     plugins, enter the following command. The `--selector` flag installs the
+     CRDs first:
 
-       ```bash
-       kubectl apply --selector knative.dev/crd-install=true \
-         --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
-         --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
-       ```
+     ```bash
+     kubectl apply --selector knative.dev/crd-install=true \
+       --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
+       --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
+     ```
 
-       Then complete the install by running the command again, this time without
-       `--selector knative.dev/crd-install=true`:
+     Then complete the install by running the command again, this time without
+     `--selector knative.dev/crd-install=true`:
 
-       ```bash
-       kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
-         --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
-       ```
+     ```bash
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml \
+       --filename https://github.com/knative/serving/releases/download/v0.5.2/monitoring.yaml
+     ```
 
    * To install all three Knative components and the set of Eventing sources
      without an observability plugin, enter the following command. The


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`