### PR TITLE
golang format tools

### DIFF
--- a/docs/serving/samples/autoscale-go/autoscale.go
+++ b/docs/serving/samples/autoscale-go/autoscale.go
@@ -19,10 +19,10 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"time"
-	"os"
 )
 
 // Algorithm from https://stackoverflow.com/a/21854246
@@ -156,20 +156,20 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func replyWithToken(token string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-	  fmt.Fprintln(w, token)
+		fmt.Fprintln(w, token)
 	}
-  }
+}
 
 func main() {
 	validateToken := os.Getenv("VALIDATION")
 	if validateToken != "" {
-		http.HandleFunc("/" + validateToken + "/", replyWithToken(validateToken))
+		http.HandleFunc("/"+validateToken+"/", replyWithToken(validateToken))
 	}
-	
+
 	listenPort := os.Getenv("PORT")
 	if listenPort == "" {
 		listenPort = "8080"
 	}
 	http.HandleFunc("/", handler)
-	http.ListenAndServe(":" + listenPort, nil)
+	http.ListenAndServe(":"+listenPort, nil)
 }


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
