### PR TITLE
Add the instruction on how to get IP_ADDRESS for autoscaling for other Kube environments

### DIFF
--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -22,39 +22,43 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    kubectl apply --filename docs/serving/samples/autoscale-go/service.yaml
    ```
 
-1. Find the ingress hostname and IP and export as an environment variable. The variable IP_ADDRESS is configured
-   differently, based on which platform you use as the Kubernetes environment.
+1. Obtain both the hostname and IP address of the `istio-ingressgateway` service in the `istio-system` namespace,
+   and then `export` them into the `IP_ADDRESS` environment variable.
+   
+   Note that each platform where you run your Kubernetes cluster is configured differently. Details about the 
+   various ways that you can obatin your ingress hostname and IP address is available in the Istio documentation
+   under the [Control Ingress Traffic](https://istio.io/docs/tasks/traffic-management/ingress/) topic.
 
-   If you use GKE as the Kubernetes environment, run the commands as below:
+   **Examples**:
+   
+   * For GKE, you run the following commands:
 
-   ```shell
-   # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
-   INGRESSGATEWAY=knative-ingressgateway
+      ```shell
+      # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
+      INGRESSGATEWAY=knative-ingressgateway
 
-   # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
-   # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
-   # will be removed in Knative v0.4.
-   if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
-       INGRESSGATEWAY=istio-ingressgateway
-   fi
+      # The use of `knative-ingressgateway` is deprecated in Knative v0.3.x.
+      # Use `istio-ingressgateway` instead, since `knative-ingressgateway`
+      # will be removed in Knative v0.4.
+      if kubectl get configmap config-istio -n knative-serving &> /dev/null; then
+          INGRESSGATEWAY=istio-ingressgateway
+      fi
 
-   export IP_ADDRESS=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
-   ```
+      export IP_ADDRESS=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+      ```
    
-   If you use Minikube as the Kubernetes environment, run the command as below:
+   * For Minikube, you run the following command:
    
-   ```shell
-   export IP_ADDRESS=$(minikube ip)
-   ```
+      ```shell
+      export IP_ADDRESS=$(minikube ip)
+      ```
    
-   If you use Docker Desktop as the Kubernetes environment, run the command as below:
+   * For Docker Desktop, you run the following command:
    
-   ```shell
-   # The value can be 127.0.0.1 as well
-   export IP_ADDRESS=localhost
-   ```     
-   
-   If you use other cloud platform for Kubernetes service, please refer to document about [Control Ingress Traffic](https://istio.io/docs/tasks/traffic-management/ingress/) to get the hostname or IP.
+      ```shell
+      # The value can be 127.0.0.1 as well
+      export IP_ADDRESS=localhost
+      ```   
 
 ## Load the Service
 

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -22,7 +22,10 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    kubectl apply --filename docs/serving/samples/autoscale-go/service.yaml
    ```
 
-1. Find the ingress hostname and IP and export as an environment variable:
+1. Find the ingress hostname and IP and export as an environment variable. The variable IP_ADDRESS is configured
+   differently, based on which platform you use as the Kubernetes environment.
+
+   If you use GKE as the Kubernetes environment, run the commands as below:
 
    ```shell
    # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
@@ -37,6 +40,21 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
    export IP_ADDRESS=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
    ```
+   
+   If you use Minikube as the Kubernetes environment, run the command as below:
+   
+   ```shell
+   export IP_ADDRESS=$(minikube ip)
+   ```
+   
+   If you use Docker Desktop as the Kubernetes environment, run the command as below:
+   
+   ```shell
+   # The value can be 127.0.0.1 as well
+   export IP_ADDRESS=localhost
+   ```     
+   
+   If you use other cloud platform for Kubernetes service, please refer to document about [Control Ingress Traffic](https://istio.io/docs/tasks/traffic-management/ingress/) to get the hostname or IP.
 
 ## Load the Service
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1300

## Proposed Changes

- Instruction is added for Minikube and docker desktop to get the IP address for autoscaling
- A reference link is added for other platforms
