### PR TITLE
Update using-cert-manager-on-gcp.md

### DIFF
--- a/docs/serving/using-cert-manager-on-gcp.md
+++ b/docs/serving/using-cert-manager-on-gcp.md
@@ -215,7 +215,7 @@ metadata:
   namespace: knative-serving
 spec:
   selector:
-    knative: ingressgateway
+    istio: ingressgateway
   servers:
   - port:
       number: 80


### PR DESCRIPTION
When I did
kubectl edit gateway knative-ingress-gateway -n knative-serving
It was 
```
spec:
  selector:
    istio: ingressgateway
```
not
```
spec:
  selector:
    knatvie: ingressgateway
```

and     knatvie: ingressgateway doesn't work
but      istio: ingressgateway 
tls works

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
