### PR TITLE
Correct the path in the Dockerfile

### DIFF
--- a/docs/serving/samples/telemetry-go/Dockerfile
+++ b/docs/serving/samples/telemetry-go/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang AS builder
 
-WORKDIR /go/src/github.com/knative/docs/
+WORKDIR /go/src/github.com/knative/docs/docs/
 ADD . /go/src/github.com/knative/docs/
 
 RUN CGO_ENABLED=0 go build ./serving/samples/telemetry-go/
@@ -22,6 +22,6 @@ RUN CGO_ENABLED=0 go build ./serving/samples/telemetry-go/
 FROM gcr.io/distroless/base
 
 EXPOSE 8080
-COPY --from=builder /go/src/github.com/knative/docs/telemetry-go /sample
+COPY --from=builder /go/src/github.com/knative/docs/docs/telemetry-go /sample
 
 ENTRYPOINT ["/sample"]


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->
## Proposed Changes
Cannot build the image follow the doc: 
https://github.com/knative/docs/tree/master/docs/serving/samples/telemetry-go
will hit $GOPATH exception, it's caused by a incorrect path in the Dockfile

