### PR TITLE
Change the configuration for local Kube cluster in Minikube and Docker desktop

### DIFF
--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -25,7 +25,7 @@ continuing.
 1. After Docker for Mac is installed, configure it with sufficient resources.
    You can do that via the
    [_Advanced_ menu](https://docs.docker.com/docker-for-mac/#advanced) in Docker
-   for Mac's preferences. Set **CPUs** to at least **4** and **Memory** to at
+   for Mac's preferences. Set **CPUs** to at least **6** and **Memory** to at
    least **8.0 GiB**.
 1. Now enable Docker for Mac's
    [Kubernetes capabilities](https://docs.docker.com/docker-for-mac/#kubernetes)

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -39,7 +39,7 @@ greater and your chosen VM driver:
 For Linux use:
 
 ```shell
-minikube start --memory=8192 --cpus=4 \
+minikube start --memory=8192 --cpus=6 \
   --kubernetes-version=v1.12.0 \
   --vm-driver=kvm2 \
   --disk-size=30g \
@@ -49,7 +49,7 @@ minikube start --memory=8192 --cpus=4 \
 For macOS use:
 
 ```shell
-minikube start --memory=8192 --cpus=4 \
+minikube start --memory=8192 --cpus=6 \
   --kubernetes-version=v1.12.0 \
   --vm-driver=hyperkit \
   --disk-size=30g \


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes https://github.com/knative/serving/issues/4057

## Proposed Changes

- Change the configuration of cluster from allocating 4 CPUs to 6 CPUs for local Kubernetes
