### PR TITLE
IKS: move addon enable -y flag to the end

### DIFF
--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -139,7 +139,7 @@ You can get the add-on via the "Add-ons" tab of your Kubernetes cluster's
 console page, or via the command line:
 
 ```bash
-ibmcloud ks cluster-addon-enable -y knative $CLUSTER_NAME
+ibmcloud ks cluster-addon-enable knative -y $CLUSTER_NAME
 ```
 
 For more information about the add-on see


### PR DESCRIPTION
cluster-addon-enable knative -y $CLUSTER_NAME
or 
cluster-addon-enable knative $CLUSTER_NAME -y

works but the currently documented

cluster-addon-enable -y knative $CLUSTER_NAME

doesn't.

Note: If this creates a CLA warning, it's because
I made the PR from the GitHub web editor.