### PR TITLE
Remove note about Gloo incompatibility with Eventing

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -36,7 +36,6 @@ to run multiple installation commands.
 ## Installing Istio
 
 > Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
-> Gloo is not currently compatible with the Knative Eventing component.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on [Istio](https://istio.io/docs/concepts/what-is-istio/) for

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -134,7 +134,6 @@ recommended configuration for a cluster is:
 ## Installing Istio
 
 > Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
-> Gloo is not currently compatible with the Knative Eventing component.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on Istio. If your cloud platform offers a managed Istio

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -59,7 +59,6 @@ minikube start --memory=8192 --cpus=6 \
 ## Installing Istio
 
 > Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
-> Gloo is not currently compatible with the Knative Eventing component.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on Istio. Run the following to install Istio. (We are changing

--- a/docs/install/Knative-with-OpenShift.md
+++ b/docs/install/Knative-with-OpenShift.md
@@ -106,7 +106,6 @@ oc label namespace default istio-injection=enabled
 ## Installing Istio
 
 > Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
-> Gloo is not currently compatible with the Knative Eventing component.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on Istio. First, run the following to grant the necessary


### PR DESCRIPTION
## Proposed Changes

- Eventing now uses standard Kubernetes Services, so it should be compatible
with both Gloo and Istio.