### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -269,8 +269,7 @@ the next topic: How do we actually populate the registry in the first place?
   When you `kubectl apply` this yaml, the KafkaSource `kafka-source-sample` will
   be instantiated, and two EventTypes will be added to the registry (as there
   are two topics). You can see that in the registry example output from the
-  previous sections.  
-
+  previous sections.
 
 ## What's next
 

--- a/docs/serving/using-a-tls-cert.md
+++ b/docs/serving/using-a-tls-cert.md
@@ -179,7 +179,6 @@ Kubernetes secret and then configure the `knative-ingress-gateway`:
       configuration:
 
       ```yaml
-
       ---
       tls:
         mode: SIMPLE


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`