### PR TITLE
Fix the wrong information in grpc example

### DIFF
--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -2,7 +2,7 @@ A simple gRPC server written in Go that you can use for testing.
 
 ## Prerequisites
 
-- [Install the Knative Serving version 0.4 or later](../../../install/README.md).
+- [Install the latest version of Knative Serving](../../../install/README.md).
 
 - Install [docker](https://www.docker.com/).
 
@@ -22,7 +22,7 @@ First, build and publish the gRPC server to DockerHub (replacing `{username}`):
 docker build \
   --tag "docker.io/{username}/grpc-ping-go" \
   --file=docs/serving/samples/grpc-ping-go/Dockerfile .
-docker push "${REPO}/docs/serving/samples/grpc-ping-go"
+docker push "docker.io/{username}/grpc-ping-go"
 ```
 
 Next, replace `{username}` in `sample.yaml` with your DockerHub username, and


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1381

## Proposed Changes

- Based on the syntax in sample.yaml, it should be version 0.6 or later.
- The command "docker push" uses a wrong tag name for the image. This PR corrects it.
