### PR TITLE
Improve the documents for the knative routing example

### DIFF
--- a/docs/serving/samples/knative-routing-go/README.md
+++ b/docs/serving/samples/knative-routing-go/README.md
@@ -21,6 +21,8 @@ the Login service.
    - In this example, we use `example.com`. If you don't have a domain name, you
      can modify your hosts file (on Mac or Linux) to map `example.com` to your
      cluster's ingress IP.
+   - If you have configured a custom domain for your Knative installation, we will
+     refer to it as <YOUR_DOMAIN_NAME> in the rest of this document
 4. Check out the code:
 
 ```
@@ -28,6 +30,13 @@ go get -d github.com/knative/docs/docs/serving/samples/knative-routing-go
 ```
 
 ## Setup
+
+To check the domain name, run the following command:
+```
+kubectl get cm  -n knative-serving config-domain -o yaml
+```
+Then, check the value for `data`. The domain name should be in the format of `<YOUR_DOMAIN_NAME>: ""`,
+if it is available.
 
 Build the application container and publish it to a container registry:
 
@@ -39,26 +48,31 @@ cd $GOPATH/src/github.com/knative/docs
 
 2. Set your preferred container registry:
 
+If you use Google Container Registry (GCR), uou will need to enable the [GCR API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com) in your GCP project.
+
 ```shell
 export REPO="gcr.io/<YOUR_PROJECT_ID>"
 ```
 
-This example shows how to use Google Container Registry (GCR). You will need a
-Google Cloud Project and to enable the
-[Google Container Registry API](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).
+If you use Docker Hub as your docker image registry, replace <username> with your dockerhub username and
+run the following command:
+
+```shell
+export REPO="docker.io/<username>"
+```
 
 3. Use Docker to build your application container:
 
 ```
 docker build \
-  --tag "${REPO}/docs/serving/samples/knative-routing-go" \
+  --tag "${REPO}/knative-routing-go" \
   --file=docs/serving/samples/knative-routing-go/Dockerfile .
 ```
 
 4. Push your container to a container registry:
 
 ```
-docker push "${REPO}/docs/serving/samples/knative-routing-go"
+docker push "${REPO}/knative-routing-go"
 ```
 
 5. Replace the image reference path with our published image path in the
@@ -67,14 +81,15 @@ docker push "${REPO}/docs/serving/samples/knative-routing-go"
    - Manually replace:
      `image: github.com/knative/docs/docs/serving/samples/knative-routing-go`
      with
-     `image: <YOUR_CONTAINER_REGISTRY>docs/serving/samples/knative-routing-go`
+     `image: ${REPO}/knative-routing-go`
+     If you manually changed the .yaml file, you must replace ${REPO} with the correct path on your local machine.
 
    Or
 
    - Run this command:
 
    ```
-   perl -pi -e "s@github.com/knative/docs@${REPO}@g" docs/serving/samples/knative-routing-go/sample.yaml
+   perl -pi -e "s@github.com/knative/docs/docs/serving/samples@${REPO}@g" docs/serving/samples/knative-routing-go/sample.yaml
    ```
 
 ## Deploy the Service
@@ -172,8 +187,26 @@ You should see: `Login Service is called !`
 kubectl apply --filename docs/serving/samples/knative-routing-go/routing.yaml
 ```
 
+If you have configured a custom domain name for your service, please replace all
+mentions of "example.com" in `routing.yaml` with "<YOUR_DOMAIN_NAME>" for
+spec.hosts and spec.http.rewrite.authority.
+
+In addition, you need to verify how your domain template is defined. By default, we
+use the format of {{.Name}}.{{.Namespace}}, like search-service.default and
+login-service.default. However, some Knative environments may use other format like
+{{.Name}}-{{.Namespace}}. You can find out the format by running the command:
+
+```
+kubectl get cm  -n knative-serving config-network -o yaml
+```
+
+Then look for the value for `domainTemplate`. If it is `{{.Name}}-{{.Namespace}}.{{.Domain}}`,
+you need to change `search-service.default` into `search-service-default` and
+`login-service.default` into `login-service-default` as well in `routing.yaml`.
+
+
 2. The `routing.yaml` file will generate a new VirtualService `entry-route` for
-   domain `example.com`. View the VirtualService:
+   domain `example.com` or your own domain name. View the VirtualService:
 
 ```
 kubectl get VirtualService entry-route --output yaml
@@ -195,22 +228,32 @@ kubectl get VirtualService entry-route --output yaml
     fi
 
     export GATEWAY_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system \
-        --output jsonpath="{.status.loadBalancer.ingress[_]['ip']}"`
+        --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
     ```
 
         * Send a request to the Search service:
         ```shell
-        curl http://${GATEWAY_IP}/search --header "Host:example.com"
+        curl http://${GATEWAY_IP}/search --header "Host: example.com"
         ```
+        or
+        ```shell
+        curl http://${GATEWAY_IP}/search --header "Host: <YOUR_DOMAIN_NAME>"
+        ```
+        for the case using your own domain.
 
         * Send a request to the Login service:
         ```shell
-        curl http://${GATEWAY_IP}/login --header "Host:example.com"
+        curl http://${GATEWAY_IP}/login --header "Host: example.com"
         ```
+        or
+        ```shell
+        curl http://${GATEWAY_IP}/login --header "Host: <YOUR_DOMAIN_NAME>"
+        ```
+        for the case using your own domain.
 
 ## How It Works
 
-When an external request with host `example.com` reaches
+When an external request with host `example.com` or your own domain name reaches
 `knative-ingress-gateway` Gateway, the `entry-route` VirtualService will check
 if it has `/search` or `/login` URI. If the URI matches, then the host of
 request will be rewritten into the host of `Search` service or `Login` service


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1384

## Proposed Changes

- Fixes the typo in the command to get the gateway ip.
- Adds the information regarding using existing domain name.
- Adds the information on how to use dockerhub.
- Adds the information on different domain templates.
