### PR TITLE
Fixing Broker manual event emit curl example

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -250,10 +250,10 @@ While SSHed into a `Pod` and run:
 curl -v "http://default-broker.default.svc.cluster.local/" \
   -X POST \
   -H "X-B3-Flags: 1" \
-  -H "CE-CloudEventsVersion: 0.1" \
-  -H "CE-EventType: dev.knative.foo.bar" \
-  -H "CE-EventTime: 2018-04-05T03:56:24Z" \
-  -H "CE-EventID: 45a8b444-3213-4758-be3f-540bf93f85ff" \
+  -H 'CE-SpecVersion: 0.2' \
+  -H "CE-Type: dev.knative.foo.bar" \
+  -H "CE-Time: 2018-04-05T03:56:24Z" \
+  -H "CE-ID: 45a8b444-3213-4758-be3f-540bf93f85ff" \
   -H "CE-Source: dev.knative.example" \
   -H 'Content-Type: application/json' \
   -d '{ "much": "wow" }'


### PR DESCRIPTION
Upgrading the `curl` example in Broker's manual event emit example as the CloudEvents v0.1 format and no longer works, v0.2 does.

Tested with Knative Eventing 0.6

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

