### PR TITLE
service/samples: add .dockerignore to samples with local build disruption risk

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-csharp/.dockerignore
+++ b/docs/serving/samples/hello-world/helloworld-csharp/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+**/obj/
+**/bin/

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -87,7 +87,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-csharp
    CMD ["dotnet", "out/helloworld-csharp.dll"]
    ```
 
-1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -87,6 +87,15 @@ cd knative-docs/serving/samples/hello-world/helloworld-csharp
    CMD ["dotnet", "out/helloworld-csharp.dll"]
    ```
 
+1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+
+   ```ignore
+   Dockerfile
+   README.md
+   **/obj/
+   **/bin/
+   ```
+
 1. Create a new file, `service.yaml` and copy the following service definition
    into the file. Make sure to replace `{username}` with your Docker Hub
    username.

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -87,7 +87,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-csharp
    CMD ["dotnet", "out/helloworld-csharp.dll"]
    ```
 
-1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
+1. Create a `.dockerignore` file to ensure that any files related to a local build do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-nodejs/.dockerignore
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+node_modules
+npm-debug.log

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -110,7 +110,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-nodejs
    CMD [ "npm", "start" ]
    ```
 
-1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
+1. Create a `.dockerignore` file to ensure that any files related to a local build do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -110,6 +110,15 @@ cd knative-docs/serving/samples/hello-world/helloworld-nodejs
    CMD [ "npm", "start" ]
    ```
 
+1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+
+   ```ignore
+   Dockerfile
+   README.md
+   node_modules
+   npm-debug.log
+   ```
+
 1. Create a new file, `service.yaml` and copy the following service definition
    into the file. Make sure to replace `{username}` with your Docker Hub
    username.

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -110,7 +110,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-nodejs
    CMD [ "npm", "start" ]
    ```
 
-1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-php/.dockerignore
+++ b/docs/serving/samples/hello-world/helloworld-php/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+README.md
+vendor

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -57,6 +57,14 @@ cd knative-docs/serving/samples/hello-world/helloworld-php
    RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
    ```
 
+1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+
+   ```ignore
+   Dockerfile
+   README.md
+   vendor
+   ```
+
 1. Create a new file, `service.yaml` and copy the following service definition
    into the file. Make sure to replace `{username}` with your Docker Hub
    username.

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -57,7 +57,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-php
    RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
    ```
 
-1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
+1. Create a `.dockerignore` file to ensure that any files related to a local build do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -57,7 +57,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-php
    RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
    ```
 
-1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-python/.dockerignore
+++ b/docs/serving/samples/hello-world/helloworld-python/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+README.md
+*.pyc
+*.pyo
+*.pyd
+__pycache__

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -70,6 +70,17 @@ cd knative-docs/serving/samples/hello-world/helloworld-python
    CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
    ```
 
+1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+
+   ```ignore
+   Dockerfile
+   README.md
+   *.pyc
+   *.pyo
+   *.pyd
+   __pycache__
+   ```
+
 1. Create a new file, `service.yaml` and copy the following service definition
    into the file. Make sure to replace `{username}` with your Docker Hub
    username.

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -70,7 +70,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-python
    CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
    ```
 
-1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
+1. Create a `.dockerignore` file to ensure that any files related to a local build do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -70,7 +70,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-python
    CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
    ```
 
-1. Add a `.dockerignore` file to ensure local builds cannot disrupt container builds.
+1. Create a `.dockerignore` file to ensure that any files related to a local build, do not affect the container that you build for deployment.
 
    ```ignore
    Dockerfile


### PR DESCRIPTION
## Problem

1. If someone runs a local build in these samples, it will generate files that will make their way into the container. Once there, these files can interfere with the build.

2. Files unrelated to the application itself such as the `Dockerfile` or `README.md` can excessively reset the layer cache.

## Proposed Changes

- Add a new `.dockerignore` for serving samples subject to (1), with language-specific exclusions of generated files. This includes: Python, C#, PHP, Nodejs
- Add Dockerfile and README.md for (2)
- Include a new step in the README after the Dockerfile is set up to note creating the .dockerignore.
