### PR TITLE
Fix broker rolebinding for master

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -136,10 +136,10 @@ Then give it the needed RBAC permissions:
 ```shell
 kubectl -n default create rolebinding eventing-broker-ingress \
   --clusterrole=eventing-broker-ingress \
-  --user=eventing-broker-ingress
+  --serviceaccount=default:eventing-broker-ingress
 kubectl -n default create rolebinding eventing-broker-filter \
   --clusterrole=eventing-broker-filter \
-  --user=eventing-broker-filter
+  --serviceaccount=default:eventing-broker-filter
 ```
 
 Note that the previous commands uses three different objects, all named


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes

It should be `ServiceAccount` instead of `User` for broker `RoleBinding` subject.

## Proposed Changes

-
-
-
