### PR TITLE
Fix broker rolebinding for 0.6.0

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -32,8 +32,8 @@ spec:
 
 ## Trigger
 
-A Trigger represents a desire to subscribe to events from a specific Broker. Basic
-filtering on the type and source of events is provided.
+A Trigger represents a desire to subscribe to events from a specific Broker.
+Basic filtering on the type and source of events is provided.
 
 Example:
 
@@ -95,8 +95,8 @@ If `spec.channelTemplate` is not specified:
 
 There are two ways to create a Broker:
 
-* [namespace annotation](#annotation)
-* [manual setup](#manual-setup)
+- [namespace annotation](#annotation)
+- [manual setup](#manual-setup)
 
 Normally the [namespace annotation](#annotation) is used to do this setup.
 
@@ -134,7 +134,7 @@ Then give it the needed RBAC permissions:
 ```shell
 kubectl -n default create rolebinding eventing-broker-filter \
   --clusterrole=eventing-broker-filter \
-  --user=eventing-broker-filter
+  --serviceaccount=default:eventing-broker-filter
 ```
 
 Note that the previous commands uses three different objects, all named
@@ -157,9 +157,9 @@ EOF
 
 ### Subscriber
 
-Now create a function to receive those events. This document will
-assume the following manifest describing a Knative Service is created, but it
-could be anything that is `Addressable`.
+Now create a function to receive those events. This document will assume the
+following manifest describing a Knative Service is created, but it could be
+anything that is `Addressable`.
 
 ```yaml
 apiVersion: serving.knative.dev/v1alpha1


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes 

Broker `RoleBinding` subject should use `ServiceAccount` instead of `User`

-
-
-
