### PR TITLE
Update README.md to remove dead link

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -4,7 +4,7 @@ Follow this guide to install Knative components on a platform of your choice.
 
 To get started with Knative, you need a Kubernetes cluster. If you aren't sure
 which Kubernetes platform is right for you, see
-[Picking the Right Solution](https://kubernetes.io/docs/setup/pick-right-solution/).
+[Picking the Right Solution]( https://kubernetes.io/docs/setup/).
 
 We provide information for installing Knative on
 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/),


### PR DESCRIPTION
Removed a dead link on "Picking the Right Solution" which was going to a 404 page. Based off feedback from #1382 for which link to use.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1382 

## Proposed Changes

- Replace link for "Picking the Right Solution" with  https://kubernetes.io/docs/setup/ so that it does not go to a 404 page anymore
