### PR TITLE
Update path in prerequisites command for grpc example

### DIFF
--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -10,7 +10,7 @@ A simple gRPC server written in Go that you can use for testing.
 
    ```shell
    git clone -b "release-0.6" https://github.com/knative/docs knative-docs
-   cd knative-docs/serving/samples/grpc-ping-go
+   cd knative-docs/docs/serving/samples/grpc-ping-go
    ```
 
 ## Build and run the gRPC server


### PR DESCRIPTION


<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes
Was trying to run through the Prerequisite commands and noticed that the `cd` command had the incorrect path.

```
❯ git clone -b "release-0.6" https://github.com/knative/docs knative-docs
   cd knative-docs/serving/samples/grpc-ping-go
Cloning into 'knative-docs'...
remote: Enumerating objects: 27, done.
remote: Counting objects: 100% (27/27), done.
remote: Compressing objects: 100% (22/22), done.
remote: Total 10590 (delta 9), reused 12 (delta 5), pack-reused 10563
Receiving objects: 100% (10590/10590), 25.08 MiB | 14.92 MiB/s, done.
Resolving deltas: 100% (6409/6409), done.
cd: no such file or directory: knative-docs/serving/samples/grpc-ping-go
```

This PR updates that command to the correct path.
