### PR TITLE
removed unnecessary H1 from autoscaling docs

### DIFF
--- a/docs/serving/configuring-the-autoscaler.md
+++ b/docs/serving/configuring-the-autoscaler.md
@@ -1,4 +1,3 @@
-# Configuring the Autoscaler
 ---
 title: "Configuring the Autoscaler"
 weight: 10


### PR DESCRIPTION
Fixes #1405 

## Proposed Changes

- removes H1 that wasn't required at the start of the configuring-the-autoscaler.md doc
