### PR TITLE
Update community samples to use v1beta1 APIs

### DIFF
--- a/community/samples/serving/helloworld-clojure/README.md
+++ b/community/samples/serving/helloworld-clojure/README.md
@@ -88,15 +88,13 @@ recreate the source files from this folder.
      name: helloworld-clojure
      namespace: default
    spec:
-     runLatest:
-       configuration:
-         revisionTemplate:
-           spec:
-             container:
-               image: docker.io/{username}/helloworld-clojure
-               env:
-                 - name: TARGET
-                   value: "Clojure Sample v1"
+     template:
+       spec:
+         containers:
+           - image: docker.io/{username}/helloworld-clojure
+             env:
+               - name: TARGET
+                 value: "Clojure Sample v1"
    ```
 
 ## Building and deploying the sample

--- a/community/samples/serving/helloworld-clojure/service.yaml
+++ b/community/samples/serving/helloworld-clojure/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-clojure
   namespace: default
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-clojure
-            env:
-              - name: TARGET
-                value: "Clojure Sample v1"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-clojure
+          env:
+            - name: TARGET
+              value: "Clojure Sample v1"

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -87,15 +87,13 @@ be created using the following instructions.
      name: helloworld-dart
      namespace: default
    spec:
-     runLatest:
-       configuration:
-         revisionTemplate:
-           spec:
-             container:
-               image: docker.io/{username}/helloworld-dart
-               env:
-                 - name: TARGET
-                   value: "Dart Sample v1"
+     template:
+       spec:
+         containers:
+           - image: docker.io/{username}/helloworld-dart
+             env:
+               - name: TARGET
+                 value: "Dart Sample v1"
    ```
 
 ## Building and deploying the sample

--- a/community/samples/serving/helloworld-dart/service.yaml
+++ b/community/samples/serving/helloworld-dart/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-dart
   namespace: default
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-dart
-            env:
-            - name: TARGET
-              value: "Dart Sample v1"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-dart
+          env:
+          - name: TARGET
+            value: "Dart Sample v1"

--- a/community/samples/serving/helloworld-elixir/README.md
+++ b/community/samples/serving/helloworld-elixir/README.md
@@ -99,15 +99,13 @@ When asked, if you want to `Fetch and install dependencies? [Yn]` select `y`
      name: helloworld-elixir
      namespace: default
    spec:
-     runLatest:
-       configuration:
-         revisionTemplate:
-           spec:
-             container:
-               image: docker.io/{username}/helloworld-elixir
-               env:
-                 - name: TARGET
-                   value: "elixir Sample v1"
+     template:
+       spec:
+         containers:
+           - image: docker.io/{username}/helloworld-elixir
+             env:
+               - name: TARGET
+                 value: "elixir Sample v1"
    ```
 
 # Building and deploying the sample

--- a/community/samples/serving/helloworld-elixir/service.yaml
+++ b/community/samples/serving/helloworld-elixir/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-elixir
   namespace: default
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-elixir
-            env:
-            - name: TARGET
-              value: "elixir Sample v1"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-elixir
+          env:
+          - name: TARGET
+            value: "elixir Sample v1"

--- a/community/samples/serving/helloworld-haskell/README.md
+++ b/community/samples/serving/helloworld-haskell/README.md
@@ -114,15 +114,13 @@ recreate the source files from this folder.
      name: helloworld-haskell
      namespace: default
    spec:
-     runLatest:
-       configuration:
-         revisionTemplate:
-           spec:
-             container:
-               image: docker.io/{username}/helloworld-haskell
-               env:
-                 - name: TARGET
-                   value: "Haskell Sample v1"
+     template:
+       spec:
+         containers:
+           - image: docker.io/{username}/helloworld-haskell
+             env:
+               - name: TARGET
+                 value: "Haskell Sample v1"
    ```
 
 ## Build and deploy this sample

--- a/community/samples/serving/helloworld-haskell/service.yaml
+++ b/community/samples/serving/helloworld-haskell/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-haskell
   namespace: default
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-haskell
-            env:
-            - name: TARGET
-              value: "Haskell Sample v1"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-haskell
+          env:
+          - name: TARGET
+            value: "Haskell Sample v1"

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -109,18 +109,16 @@ recreate the source files from this folder.
    apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
-   name: helloworld-rust
-   namespace: default
+     name: helloworld-rust
+     namespace: default
    spec:
-   runLatest:
-     configuration:
-     revisionTemplate:
+     template:
        spec:
-       container:
-         image: docker.io/{username}/helloworld-rust
-         env:
-           - name: TARGET
-         value: "Rust Sample v1"
+       containers:
+         - image: docker.io/{username}/helloworld-rust
+           env:
+             - name: TARGET
+           value: "Rust Sample v1"
    ```
 
 ## Build and deploy this sample

--- a/community/samples/serving/helloworld-rust/service.yaml
+++ b/community/samples/serving/helloworld-rust/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-rust
   namespace: default
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-rust
-            env:
-            - name: TARGET
-              value: "Rust Sample v1"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-rust
+          env:
+          - name: TARGET
+            value: "Rust Sample v1"

--- a/community/samples/serving/helloworld-swift/README.md
+++ b/community/samples/serving/helloworld-swift/README.md
@@ -92,18 +92,16 @@ source files from this folder.
    apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
-   name: helloworld-swift
-   namespace: default
+     name: helloworld-swift
+     namespace: default
    spec:
-   runLatest:
-     configuration:
-     revisionTemplate:
+     template:
        spec:
-       container:
-         image: docker.io/{username}/helloworld-swift
-         env:
-           - name: TARGET
-         value: "Swift"
+       containers:
+         - image: docker.io/{username}/helloworld-swift
+           env:
+             - name: TARGET
+           value: "Swift"
    ```
 
 ## Building and deploying the sample

--- a/community/samples/serving/helloworld-swift/service.yaml
+++ b/community/samples/serving/helloworld-swift/service.yaml
@@ -4,12 +4,10 @@ metadata:
   name: helloworld-swift
   namespace: default
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-swift
-            env:
-            - name: TARGET
-              value: "Swift"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-swift
+          env:
+          - name: TARGET
+            value: "Swift"

--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -162,15 +162,13 @@ To create and configure the source files in the root of your working directory:
      name: helloworld-vertx
      namespace: default
    spec:
-     runLatest:
-       configuration:
-         revisionTemplate:
-           spec:
-             container:
-               image: docker.io/{username}/helloworld-vertx
-               env:
-                 - name: TARGET
-                   value: "Eclipse Vert.x Sample v1"
+     template:
+       spec:
+         containers:
+           - image: docker.io/{username}/helloworld-vertx
+             env:
+               - name: TARGET
+                 value: "Eclipse Vert.x Sample v1"
    ```
 
 ## Building and deploying the sample

--- a/community/samples/serving/helloworld-vertx/service.yaml
+++ b/community/samples/serving/helloworld-vertx/service.yaml
@@ -3,12 +3,10 @@ kind: Service
 metadata:
   name: helloworld-vertx
 spec:
-  runLatest:
-    configuration:
-      revisionTemplate:
-        spec:
-          container:
-            image: docker.io/{username}/helloworld-vertx
-            env:
-            - name: TARGET
-              value: "Eclipse Vert.x Sample v1"
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-vertx
+          env:
+          - name: TARGET
+            value: "Eclipse Vert.x Sample v1"


### PR DESCRIPTION
Replace the use of `runLatest` with `template`.

/label cherrypick-0.6

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1330 