### PR TITLE
increase e2e timeout

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -24,6 +24,6 @@ function knative_setup() {
 
 initialize $@
 
-go_test_e2e ./test/e2e || fail_test
+go_test_e2e -timeout=20m ./test/e2e || fail_test
 
 success


### PR DESCRIPTION
e2e tests are failing running out of time with no error message, increase to 20 minutes to see how it goes

Part of: #1435 
/hold