### PR TITLE
Fix e2e test breakage by using url instead of domain

### DIFF
--- a/test/e2e/sampleapptestbase.go
+++ b/test/e2e/sampleapptestbase.go
@@ -69,7 +69,7 @@ func cleanup(yamlFilePath, workDir string) {
 }
 
 func serviceHostname(appName string) string {
-	return noStderrShell("kubectl", "get", "rt", appName, "-o", "jsonpath={.status.domain}", "-n", servingNamespace)
+	return noStderrShell("kubectl", "get", "rt", appName, "-o", "jsonpath={.status.url}", "-n", servingNamespace)
 }
 
 func ingressAddress(gateway string, addressType string) string {
@@ -157,7 +157,8 @@ func checkDeployment(t *testing.T, appName, expectedOutput string) {
 		t.Fatalf("Ingress not found (ingress='%s', host='%s')", ingressAddr, serviceHost)
 	}
 	t.Logf("Curling %s/%s", ingressAddr, serviceHost)
-
+	
+	serviceHost = strings.Replace(serviceHost, "http://", "", 1)
 	outputString := ""
 	timeout = servingTimeout
 	for outputString != expectedOutput && timeout >= 0 {


### PR DESCRIPTION
This PR fixes e2e test error by using url instead of domain for finding domain URL. This PR unblocks PR from being merged in docs, but will makes e2e tests diverge from instructions. subsequent update is needed from #1438 