### PR TITLE
Fix the helloworld-go sample.

### DIFF
--- a/docs/install/getting-started-knative-app.md
+++ b/docs/install/getting-started-knative-app.md
@@ -53,13 +53,22 @@ metadata:
   name: helloworld-go # The name of the app
   namespace: default # The namespace the app will use
 spec:
-  template:
-    spec:
-      containers:
-        - image: gcr.io/knative-samples/helloworld-go # The URL to the image of the app
-          env:
+apiVersion: serving.knative.dev/v1alpha1 # Current version of Knative
+kind: Service
+metadata:
+  name: helloworld-go # The name of the app
+  namespace: default # The namespace the app will use
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: gcr.io/knative-samples/helloworld-go # The URL to the image of the app
+            env:
             - name: TARGET # The environment variable printed out by the sample app
               value: "Go Sample v1"
+
 ```
 
 If you want to deploy the sample app, leave the config file as-is. If you're

--- a/docs/install/getting-started-knative-app.md
+++ b/docs/install/getting-started-knative-app.md
@@ -53,12 +53,6 @@ metadata:
   name: helloworld-go # The name of the app
   namespace: default # The namespace the app will use
 spec:
-apiVersion: serving.knative.dev/v1alpha1 # Current version of Knative
-kind: Service
-metadata:
-  name: helloworld-go # The name of the app
-  namespace: default # The namespace the app will use
-spec:
   runLatest:
     configuration:
       revisionTemplate:

--- a/docs/serving/samples/hello-world/helloworld-go/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-go/service.yaml
@@ -4,10 +4,13 @@ metadata:
   name: helloworld-go
   namespace: default
 spec:
-  template:
-    spec:
-      containers:
-      - image: docker.io/{username}/helloworld-go
-        env:
-        - name: TARGET
-          value: "Go Sample v1"
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: docker.io/{username}/helloworld-go
+            env:
+            - name: TARGET
+              value: "Go Sample v1"
+


### PR DESCRIPTION
On running the sample service.yaml 
Following error is produced.
```
Error from server (InternalError): error when creating "service.yaml": Internal error occurred: admission webhook "webhook.serving.knative.dev" denied the request: mutation failed: cannot decode incoming new object: json: unknown field "template"

```

## Proposed Changes

- Fixed the sample service.yaml.
- Fixed the doc to reflect the correct service.yaml contents.

