### PR TITLE
Set pilot memory request lower for lean install

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -109,6 +109,7 @@ helm template --namespace=istio-system \
   --set mixer.telemetry.enabled=false \
   `# Pilot doesn't need a sidecar.` \
   --set pilot.sidecar=false \
+  --set pilot.resources.requests.memory=128Mi \
   `# Disable galley (and things requiring galley).` \
   --set galley.enabled=false \
   --set global.useMCP=false \


### PR DESCRIPTION
Since `istio-lean` should not be used for production deployment, this PR sets the Istio pilot memory request to 128Mi from 2Gi ...

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
