### PR TITLE
golang format tools

### DIFF
--- a/test/e2e/sampleapptestbase.go
+++ b/test/e2e/sampleapptestbase.go
@@ -157,7 +157,7 @@ func checkDeployment(t *testing.T, appName, expectedOutput string) {
 		t.Fatalf("Ingress not found (ingress='%s', host='%s')", ingressAddr, serviceHost)
 	}
 	t.Logf("Curling %s/%s", ingressAddr, serviceHost)
-	
+
 	serviceHost = strings.Replace(serviceHost, "http://", "", 1)
 	outputString := ""
 	timeout = servingTimeout


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
