### PR TITLE
Fixing a path to the istio installation docs

### DIFF
--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -122,7 +122,7 @@ the recommended configuration for a cluster is:
 > `--addons` line below.
 
 > Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you need to remove 
-> the `--addons` line below, and follow the [instructions](installing-istio.md) to install Istio
+> the `--addons` line below, and follow the [instructions](../installing-istio.md) to install Istio
 > with Secret Discovery Service.
 
 ```bash


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
