### PR TITLE
Update cert manager on GCP example to upgrade to http by default

### DIFF
--- a/docs/serving/using-cert-manager-on-gcp.md
+++ b/docs/serving/using-cert-manager-on-gcp.md
@@ -259,6 +259,10 @@ spec:
       protocol: HTTP
     hosts:
     - "*"
+    tls:
+      # Sends 301 redirect for all http requests.
+      # Omit to allow http and https.
+      httpsRedirect: true
   - port:
       number: 443
       name: https
@@ -266,7 +270,6 @@ spec:
     hosts:
     - "*"
     tls:
-      httpsRedirect: true # sends 301 redirect for http requests.
       mode: SIMPLE
       privateKey: /etc/istio/ingressgateway-certs/tls.key
       serverCertificate: /etc/istio/ingressgateway-certs/tls.crt


### PR DESCRIPTION
## Proposed Changes

The current documentation only has httpsRedirect set on the https endpoint itself. In order for the ingress to redirect all traffic to use https, the tls section with httpsRedirect: true needs to be on the http section as well.