### PR TITLE
Don't show event-display as a source

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -89,7 +89,6 @@ The following Knative installation files are available:
   - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/camel.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/gcppubsub.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/kafka.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/event-display.yaml
 - **Cluster roles**:
   - https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
 


### PR DESCRIPTION
It's not a source, it's a sample Sink. And since it's just a sample
Sink we shouldn't include it in the docs as something people should install
as part of a default install process for core Knative.

Signed-off-by: Doug Davis <dug@us.ibm.com>

