### PR TITLE
Format markdown

### DIFF
--- a/community/samples/serving/helloworld-java-micronaut/README.md
+++ b/community/samples/serving/helloworld-java-micronaut/README.md
@@ -198,10 +198,10 @@ To create and configure the source files in the root of your working directory:
      template:
        spec:
          containers:
-         - image: docker.io/{username}/helloworld-java-micronaut
-           env:
-             - name: TARGET
-               value: "Micronaut Sample v1"
+           - image: docker.io/{username}/helloworld-java-micronaut
+             env:
+               - name: TARGET
+                 value: "Micronaut Sample v1"
    ```
 
 ## Building and deploying the sample

--- a/community/samples/serving/helloworld-java-quarkus/README.md
+++ b/community/samples/serving/helloworld-java-quarkus/README.md
@@ -189,10 +189,10 @@ which you update and create the necessary build and configuration files:
      template:
        spec:
          containers:
-         - image: docker.io/{username}/helloworld-java-quarkus
-           env:
-             - name: TARGET
-               value: "Quarkus Sample v1"
+           - image: docker.io/{username}/helloworld-java-quarkus
+             env:
+               - name: TARGET
+                 value: "Quarkus Sample v1"
    ```
 
 ## Locally testing your sample

--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -47,7 +47,7 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
 ```
 
 Use following command to create the service from `service.yaml`:

--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -43,10 +43,10 @@ spec:
         knative.dev/type: container
     spec:
       containers:
-      - image: gcr.io/knative-samples/knative-route-demo:blue # The URL to the sample app docker image
-        env:
-          - name: T_VERSION
-            value: "blue"
+        - image: gcr.io/knative-samples/knative-route-demo:blue # The URL to the sample app docker image
+          env:
+            - name: T_VERSION
+              value: "blue"
 ```
 
 Save the file, then deploy the configuration to your cluster:
@@ -132,10 +132,10 @@ spec:
         knative.dev/type: container
     spec:
       containers:
-      - image: gcr.io/knative-samples/knative-route-demo:green # URL to the new version of the sample app docker image
-        env:
-          - name: T_VERSION
-            value: "green" # Updated value for the T_VERSION environment variable
+        - image: gcr.io/knative-samples/knative-route-demo:green # URL to the new version of the sample app docker image
+          env:
+            - name: T_VERSION
+              value: "green" # Updated value for the T_VERSION environment variable
 ```
 
 Save the file, then apply the updated configuration to your cluster:

--- a/docs/serving/samples/hello-world/helloworld-java-spark/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/README.md
@@ -82,7 +82,7 @@ recreate the source files from this folder.
      template:
        spec:
          containers:
-         - image: docker.io/{username}/helloworld-java
+           - image: docker.io/{username}/helloworld-java
    ```
 
 ## Building and deploying the sample


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
