### PR TITLE
Update container source documentation with `template` field

### DIFF
--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -71,18 +71,22 @@ kind: ContainerSource
 metadata:
   name: test-heartbeats
 spec:
-  image: <heartbeats_image_uri>
+  template:
+    spec:
+      containers:
+        - image: <heartbeats_image_uri>
+          name: heartbeats
+          args:
+            - --period=1
+          env:
+            - name: POD_NAME
+              value: "mypod"
+            - name: POD_NAMESPACE
+              value: "event-test"
   sink:
     apiVersion: serving.knative.dev/v1beta1
     kind: Service
     name: event-display
-  args:
-    - --period=1
-  env:
-    - name: POD_NAME
-      value: "mypod"
-    - name: POD_NAMESPACE
-      value: "event-test"
 ```
 
 Use the following command to create the event source from

--- a/docs/eventing/samples/container-source/heartbeats-source.yaml
+++ b/docs/eventing/samples/container-source/heartbeats-source.yaml
@@ -3,17 +3,21 @@ kind: ContainerSource
 metadata:
   name: test-heartbeats
 spec:
-  # This corresponds to a heartbeats image uri you build and publish,
-  # e.g. gcr.io/[gcloud-project]/github.com/knative/eventing-contrib/cmd/heartbeats
-  image: index.docker.io/daisyycguo/heartbeats-6790335e994243a8d3f53b967cdd6398
-  args: 
-    - --period=1
+  template:
+    spec:
+      containers:
+        # This corresponds to a heartbeats image uri you build and publish,
+        # e.g. gcr.io/[gcloud-project]/github.com/knative/eventing-contrib/cmd/heartbeats
+        - image: github.com/knative/eventing-contrib/cmd/heartbeats
+          name: heartbeats
+          args:
+            - --period=1
+          env:
+            - name: POD_NAME
+              value: "mypod"
+            - name: POD_NAMESPACE
+              value: "event-test"
   sink:
     apiVersion: serving.knative.dev/v1beta1
     kind: Service
     name: event-display
-  env:
-    - name: POD_NAME
-      value: "mypod"
-    - name: POD_NAMESPACE
-      value: "event-test"


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/1348

## Proposed Changes

https://github.com/knative/eventing/pull/1321 introduces `PodTemplateSpec` to `ContainerSourceSpec`. This feature will be out in 0.7.x. Updating documentation to reflect the `template` field.
