### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -137,13 +137,16 @@ format, but may be expressed as simple lists, etc in YAML. All Sources should be
 part of the `sources` category, so you can list all existing Sources with
 `kubectl get sources`. The currently-implemented Sources are described below.
 
-In addition to the core sources (explained below), there are [other sources](./sources/README.md)
-that you can install.
+In addition to the core sources (explained below), there are
+[other sources](./sources/README.md) that you can install.
 
-If you need a Source not covered by the [available Source implementations](./sources/README.md), there is a [tutorial on writing your own Source](./samples/writing-a-source/README.md).
+If you need a Source not covered by the
+[available Source implementations](./sources/README.md), there is a
+[tutorial on writing your own Source](./samples/writing-a-source/README.md).
 
-If your code needs to send events as part of its business logic and doesn't fit the model of a Source, consider [feeding events directly to a Broker](https://knative.dev/docs/eventing/broker-trigger/#manual).
-
+If your code needs to send events as part of its business logic and doesn't fit
+the model of a Source, consider
+[feeding events directly to a Broker](https://knative.dev/docs/eventing/broker-trigger/#manual).
 
 ### KubernetesEventSource
 


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
