### PR TITLE
Fix the broker trigger demo in release-0.6 docs

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -269,7 +269,18 @@ kind: ContainerSource
 metadata:
   name: heartbeats-sender
 spec:
-  image: github.com/knative/eventing-sources/cmd/heartbeats/
+  image: github.com/knative/eventing-contrib/cmd/heartbeats/
+  args:
+    - --eventType=dev.knative.foo.bar
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Broker

--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -261,7 +261,8 @@ curl -v "http://default-broker.default.svc.cluster.local/" \
 
 #### Knative Source
 
-Provide the Knative Source the `default` `Broker` as its sink:
+Provide the Knative Source the `default` `Broker` as its sink
+(note you'll need to use `ko apply -f <source_file>.yaml` to create it):
 
 ```yaml
 apiVersion: sources.eventing.knative.dev/v1alpha1


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes
As part of fix for https://github.com/knative/eventing/issues/1395.
This change needs to be merged after https://github.com/knative/eventing-contrib/pull/469

/hold