### PR TITLE
Add label kservice instead of route

### DIFF
--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -18,5 +18,5 @@ For example, if you didn't set a label when you created the Route
 `helloworld-go` and you want to make it local to the cluster, run:
 
 ```shell
-kubectl label route helloworld-go serving.knative.dev/visibility=cluster-local
+kubectl label kservice helloworld-go serving.knative.dev/visibility=cluster-local
 ```


### PR DESCRIPTION
`kubectl label route` does not makes sense, as change for `route` is
reconciled.

This patch changes to add label to kservice instead of route.


## Proposed Changes

- Add label kservice instead of route