### PR TITLE
Update order of files in example

### DIFF
--- a/docs/serving/using-a-tls-cert.md
+++ b/docs/serving/using-a-tls-cert.md
@@ -147,7 +147,7 @@ To manually add a TLS certificate to your Knative cluster, you create a
 Kubernetes secret and then configure the `knative-ingress-gateway`:
 
 1. Run the following command to create a Kubernetes secret to hold your TLS
-   certificate, `cert.pk`, and the private key, `cert.pem`:
+   certificate, `cert.pem`, and the private key, `cert.pk`:
 
    ```shell
    kubectl create --namespace istio-system secret tls istio-ingressgateway-certs \


### PR DESCRIPTION
Updating kubernetes secret creation instruction to correctly show which file should hold which data, ie. certificate on `cert.pem` and private key on `cert.pk`.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
