### PR TITLE
Cherry-pick batch release-0.6 --> master

### DIFF
--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -121,10 +121,9 @@ the recommended configuration for a cluster is:
 > [Gloo](./Knative-with-Gloo.md)) will be used, then you can remove the
 > `--addons` line below.
 
-> Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you
-> need to remove the `--addons` line below, and follow the
-> [instructions](installing-istio.md) to install Istio with Secret Discovery
-> Service.
+> Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you need to remove 
+> the `--addons` line below, and follow the [instructions](../installing-istio.md) to install Istio
+> with Secret Discovery Service.
 
 ```bash
 gcloud beta container clusters create $CLUSTER_NAME \

--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -174,7 +174,7 @@ spec:
       percent: 100 # All traffic still going to the first revision
     - revisionName: blue-green-demo-m9548
       percent: 0 # 0% of traffic routed to the second revision
-      name: v2 # A named route
+      tag: v2 # A named route
 ```
 
 Save the file, then apply the updated route to your cluster:
@@ -216,7 +216,7 @@ spec:
       percent: 50 # Updating the percentage from 100 to 50
     - revisionName: blue-green-demo-m9548
       percent: 50 # Updating the percentage from 0 to 50
-      name: v2
+      tag: v2
 ```
 
 Save the file, then apply the updated route to your cluster:
@@ -250,7 +250,7 @@ spec:
   traffic:
     - revisionName: blue-green-demo-lcfrd
       percent: 0
-      name: v1 # Adding a new named route for v1
+      tag: v1 # Adding a new named route for v1
     - revisionName: blue-green-demo-m9548
       percent: 100
       # Named route for v2 has been removed, since we don't need it anymore

--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -8,10 +8,10 @@ A simple gRPC server written in Go that you can use for testing.
 
 - Download a copy of the code:
 
-  ```shell
-  git clone -b "release-0.6" https://github.com/knative/docs knative-docs
-  cd knative-docs/serving/samples/grpc-ping-go
-  ```
+   ```shell
+   git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+   cd knative-docs/docs/serving/samples/grpc-ping-go
+   ```
 
 ## Build and run the gRPC server
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->
Original PRs:

#1404 
#1453 
#1493 

