### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -285,8 +285,8 @@ curl -v "http://default-broker.default.svc.cluster.local/" \
 
 #### Knative Source
 
-Provide the Knative Source the `default` `Broker` as its sink
- (note you'll need to use ko apply -f <source_file>.yaml to create it):
+Provide the Knative Source the `default` `Broker` as its sink (note you'll need
+to use ko apply -f <source_file>.yaml to create it):
 
 ```yaml
 apiVersion: sources.eventing.knative.dev/v1alpha1

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -121,9 +121,10 @@ the recommended configuration for a cluster is:
 > [Gloo](./Knative-with-Gloo.md)) will be used, then you can remove the
 > `--addons` line below.
 
-> Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you need to remove 
-> the `--addons` line below, and follow the [instructions](../installing-istio.md) to install Istio
-> with Secret Discovery Service.
+> Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you
+> need to remove the `--addons` line below, and follow the
+> [instructions](../installing-istio.md) to install Istio with Secret Discovery
+> Service.
 
 ```bash
 gcloud beta container clusters create $CLUSTER_NAME \

--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -8,10 +8,10 @@ A simple gRPC server written in Go that you can use for testing.
 
 - Download a copy of the code:
 
-   ```shell
-   git clone -b "release-0.6" https://github.com/knative/docs knative-docs
-   cd knative-docs/docs/serving/samples/grpc-ping-go
-   ```
+  ```shell
+  git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+  cd knative-docs/docs/serving/samples/grpc-ping-go
+  ```
 
 ## Build and run the gRPC server
 


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
