### PR TITLE
Install updates -- v0.7.0

### DIFF
--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -17,7 +17,7 @@ Knative [event-sources](https://github.com/knative/eventing-contrib) has a
 sample of heartbeats event source. You could clone the source codes by
 
 ```
-git clone -b "release-0.6" https://github.com/knative/eventing-contrib.git
+git clone -b "release-0.7" https://github.com/knative/eventing-contrib.git
 ```
 
 And then build a heartbeats image and publish to your image repo with

--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -20,7 +20,7 @@ source is most useful as a bridge from other GCP services, such as
    PubSub event source from `release-gcppubsub.yaml`:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/gcppubsub.yaml
+   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
    ```
 
 1. Enable the `Cloud Pub/Sub API` on your project:

--- a/docs/eventing/samples/iot-core/README.md
+++ b/docs/eventing/samples/iot-core/README.md
@@ -80,7 +80,7 @@ export IOTCORE_TOPIC_DEVICE="iot-demo-device-pubsub-topic"
     controller.
 
     ```shell
-    kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/gcppubsub.yaml
+    kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
     ```
 
 ### Deploying
@@ -207,5 +207,5 @@ To cleanup the knative resources:
 1.  Remove the `GcpPubSubSource` controller:
 
     ```shell
-    kubectl delete --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/gcppubsub.yaml
+    kubectl delete --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
     ```

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -89,8 +89,6 @@ The following Knative installation files are available:
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/camel.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
-- **Cluster roles**:
-  - https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
 
 #### Install details and options
 
@@ -105,7 +103,7 @@ files from the Knative repositories:
 | Knative Install Filename                       | Notes                                                                                                                                                                  | Dependencies                                                                              |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | **knative/serving**                            |                                                                                                                                                                        |                                                                                           |
-| [`serving.yaml`][1.1]†                         | Installs the Serving component.                                                                                                                                        | Cluster roles enabled, if interacting with Build                                          |
+| [`serving.yaml`][1.1]†                         | Installs the Serving component.                                                                                                                                        |                      |
 | [`monitoring.yaml`][1.2]†                      | Installs the [ELK stack][2], [Prometheus][2.1], [Grafana][2.2], and [Zipkin][2.3]**\***                                                                                | Serving component                                                                         |
 | [`monitoring-logs-elasticsearch.yaml`][1.3]    | Installs only the [ELK stack][2]**\***                                                                                                                                 | Serving component                                                                         |
 | [`monitoring-metrics-prometheus.yaml`][1.4]    | Installs only [Prometheus][2.1]**\***                                                                                                                                  | Serving component                                                                         |
@@ -114,7 +112,7 @@ files from the Knative repositories:
 | [`monitoring-tracing-zipkin.yaml`][1.7]        | Installs only [Zipkin][2.3].**\***                                                                                                                                     | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml)                         |
 | [`monitoring-tracing-zipkin-in-mem.yaml`][1.8] | Installs only [Zipkin in-memory][2.3]**\***                                                                                                                            | Serving component                                                                         |
 | **knative/build**                              |                                                                                                                                                                        |                                                                                           |
-| [`build.yaml`][3.1]†                           | Installs the Build component.                                                                                                                                          | Cluster roles enabled, if interacting with Serving                                        |
+| [`build.yaml`][3.1]†                           | Installs the Build component.                                                                                                                                          |                                       |
 | **knative/eventing**                           |                                                                                                                                                                        |                                                                                           |
 | [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource), [CronJobSource][6.2], the in-memory channel provisioner.                     |                                                                                           |
 | [`eventing.yaml`][4.2]                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource) and [CronJobSource][6.2]. Does not include the in-memory channel provisioner. |                                                                                           |
@@ -129,8 +127,6 @@ files from the Knative repositories:
 | [`kafka.yaml`][5.5]                            | Installs the Apache Kafka source.                                                                                                                                      | Eventing component                                                                        |
 | [`awssqs.yaml`][5.6]                           | Installs the AWS SQS source.                                                                                                                                           | Eventing component                                                                        |
 | [`event-display.yaml`][5.3]                    | Installs a Knative Service that logs events received for use in samples and debugging.                                                                                 | Serving component, Eventing component                                                     |
-| **Cluster roles**                              |                                                                                                                                                                        |                                                                                           |
-| [`clusterrole.yaml`][7]†                       | Enables the Build and Serving components to interact.                                                                                                                  | Serving component, Build component                                                        |
 
 _\*_ See
 [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
@@ -193,8 +189,6 @@ for details about installing the various supported observability plugins.
 [6.2]:
   https://github.com/knative/eventing-contrib/blob/master/samples/cronjob-source/README.md
 [6.3]: https://cloud.google.com/pubsub/
-[7]:
-  https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
 
 ### Installing Knative
 
@@ -310,8 +304,7 @@ commands below.
           --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
           --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
           --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-          --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and the run
@@ -322,8 +315,7 @@ commands below.
         kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
           --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
           --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-          --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
         ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -69,26 +69,26 @@ with Knative.
 The following Knative installation files are available:
 
 - **Serving Component and Observability Plugins**:
-  - https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring-logs-elasticsearch.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring-metrics-prometheus.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-jaeger.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-jaeger-in-mem.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-zipkin.yaml
-  - https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-zipkin-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-logs-elasticsearch.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-metrics-prometheus.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
+  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
 - **Build Component**:
   - https://github.com/knative/build/releases/download/v0.6.0/build.yaml
 - **Eventing Component**:
-  - https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml
-  - https://github.com/knative/eventing/releases/download/v0.6.0/eventing.yaml
-  - https://github.com/knative/eventing/releases/download/v0.6.0/in-memory-channel.yaml
-  - https://github.com/knative/eventing/releases/download/v0.6.0/kafka.yaml
+  - https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
+  - https://github.com/knative/eventing/releases/download/v0.7.0/eventing.yaml
+  - https://github.com/knative/eventing/releases/download/v0.7.0/in-memory-channel.yaml
+  - https://github.com/knative/eventing/releases/download/v0.7.0/kafka.yaml
 - **Eventing sources**:
-  - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/camel.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/gcppubsub.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.6.0/kafka.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/camel.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
 - **Cluster roles**:
   - https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
 
@@ -141,21 +141,21 @@ for details about installing the various supported observability plugins.
 <!-- USE ONLY FULLY QUALIFIED URLS -->
 
 [1]: https://github.com/knative/serving/releases/tag/v0.6.0
-[1.1]: https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml
+[1.1]: https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml
 [1.2]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
 [1.3]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring-logs-elasticsearch.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-logs-elasticsearch.yaml
 [1.4]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring-metrics-prometheus.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-metrics-prometheus.yaml
 [1.5]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-jaeger.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger.yaml
 [1.6]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-jaeger-in-mem.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger-in-mem.yaml
 [1.7]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-zipkin.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
 [1.8]:
-  https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-zipkin-in-mem.yaml
+  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
 [2]: https://www.elastic.co/elk-stack
 [2.1]: https://prometheus.io
 [2.2]: https://grafana.com
@@ -165,28 +165,28 @@ for details about installing the various supported observability plugins.
 [3]: https://github.com/knative/build/releases/tag/v0.6.0
 [3.1]: https://github.com/knative/build/releases/download/v0.6.0/build.yaml
 [4]: https://github.com/knative/eventing/releases/tag/v0.6.0
-[4.1]: https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml
+[4.1]: https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
 [4.2]:
-  https://github.com/knative/eventing/releases/download/v0.6.0/eventing.yaml
+  https://github.com/knative/eventing/releases/download/v0.7.0/eventing.yaml
 [4.3]:
-  https://github.com/knative/eventing/releases/download/v0.6.0/in-memory-channel.yaml
-[4.4]: https://github.com/knative/eventing/releases/download/v0.6.0/kafka.yaml
-[4.5]: https://github.com/knative/eventing/releases/download/v0.6.0/natss.yaml
+  https://github.com/knative/eventing/releases/download/v0.7.0/in-memory-channel.yaml
+[4.4]: https://github.com/knative/eventing/releases/download/v0.7.0/kafka.yaml
+[4.5]: https://github.com/knative/eventing/releases/download/v0.7.0/natss.yaml
 [4.6]:
-  https://github.com/knative/eventing/releases/download/v0.6.0/gcp-pubsub.yaml
+  https://github.com/knative/eventing/releases/download/v0.7.0/gcp-pubsub.yaml
 [5]: https://github.com/knative/eventing-contrib/releases/tag/v0.6.0
 [5.1]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
 [5.2]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.6.0/gcppubsub.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
 [5.3]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.6.0/event-display.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/event-display.yaml
 [5.4]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.6.0/camel.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/camel.yaml
 [5.5]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.6.0/kafka.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
 [5.6]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.6.0/awssqs.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/awssqs.yaml
 [6]:
   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#event-v1-core
 [6.1]: https://developer.github.com/v3/activity/events/types/
@@ -259,11 +259,11 @@ commands below.
 
       `[FILE_URL]`Examples:
 
-      - `https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
+      - `https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
       - `https://github.com/knative/build/releases/download/v0.6.0/build.yaml`
-      - `https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml`
-      - `https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml`
-      - `https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml`
+      - `https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml`
+      - `https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml`
+      - `https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml`
 
       **Note**: By default, the Knative Serving component installation
       (`serving.yaml`) includes a controller for
@@ -284,16 +284,16 @@ commands below.
 
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
-          --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
-          --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml
+          --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
+          --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and the run
         the command to install the Serving component and observability plugins:
 
         ```bash
-        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
-          --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml
+        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
+          --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
         ```
 
    - To install all three Knative components and the set of Eventing sources
@@ -307,10 +307,10 @@ commands below.
 
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
-          --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+          --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
           --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-          --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-          --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
+          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
           --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
         ```
 
@@ -319,10 +319,10 @@ commands below.
         Eventing sources and auto certificate controller:
 
         ```bash
-        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
           --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-          --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-          --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
+          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
           --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
         ```
 

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -90,7 +90,7 @@ The following Knative installation files are available:
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
 - **Cluster roles**:
-  - https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+  - https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
 
 #### Install details and options
 
@@ -140,7 +140,7 @@ for details about installing the various supported observability plugins.
 
 <!-- USE ONLY FULLY QUALIFIED URLS -->
 
-[1]: https://github.com/knative/serving/releases/tag/v0.6.0
+[1]: https://github.com/knative/serving/releases/tag/v0.7.0
 [1.1]: https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml
 [1.2]:
   https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
@@ -162,9 +162,9 @@ for details about installing the various supported observability plugins.
 [2.3]: https://zipkin.io/
 [2.4]: https://jaegertracing.io/
 [2.5]: https://github.com/jaegertracing/jaeger-operator#installing-the-operator
-[3]: https://github.com/knative/build/releases/tag/v0.6.0
+[3]: https://github.com/knative/build/releases/tag/v0.7.0
 [3.1]: https://github.com/knative/build/releases/download/v0.6.0/build.yaml
-[4]: https://github.com/knative/eventing/releases/tag/v0.6.0
+[4]: https://github.com/knative/eventing/releases/tag/v0.7.0
 [4.1]: https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
 [4.2]:
   https://github.com/knative/eventing/releases/download/v0.7.0/eventing.yaml
@@ -174,7 +174,7 @@ for details about installing the various supported observability plugins.
 [4.5]: https://github.com/knative/eventing/releases/download/v0.7.0/natss.yaml
 [4.6]:
   https://github.com/knative/eventing/releases/download/v0.7.0/gcp-pubsub.yaml
-[5]: https://github.com/knative/eventing-contrib/releases/tag/v0.6.0
+[5]: https://github.com/knative/eventing-contrib/releases/tag/v0.7.0
 [5.1]:
   https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
 [5.2]:
@@ -194,7 +194,7 @@ for details about installing the various supported observability plugins.
   https://github.com/knative/eventing-contrib/blob/master/samples/cronjob-source/README.md
 [6.3]: https://cloud.google.com/pubsub/
 [7]:
-  https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+  https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
 
 ### Installing Knative
 
@@ -311,7 +311,7 @@ commands below.
           --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
           --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
           --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-          --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+          --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and the run
@@ -323,7 +323,7 @@ commands below.
           --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
           --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
           --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-          --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+          --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
         ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -78,7 +78,7 @@ The following Knative installation files are available:
   - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
   - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
 - **Build Component**:
-  - https://github.com/knative/build/releases/download/v0.6.0/build.yaml
+  - https://github.com/knative/build/releases/download/v0.7.0/build.yaml
 - **Eventing Component**:
   - https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
   - https://github.com/knative/eventing/releases/download/v0.7.0/eventing.yaml
@@ -163,7 +163,7 @@ for details about installing the various supported observability plugins.
 [2.4]: https://jaegertracing.io/
 [2.5]: https://github.com/jaegertracing/jaeger-operator#installing-the-operator
 [3]: https://github.com/knative/build/releases/tag/v0.7.0
-[3.1]: https://github.com/knative/build/releases/download/v0.6.0/build.yaml
+[3.1]: https://github.com/knative/build/releases/download/v0.7.0/build.yaml
 [4]: https://github.com/knative/eventing/releases/tag/v0.7.0
 [4.1]: https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
 [4.2]:
@@ -260,7 +260,7 @@ commands below.
       `[FILE_URL]`Examples:
 
       - `https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
-      - `https://github.com/knative/build/releases/download/v0.6.0/build.yaml`
+      - `https://github.com/knative/build/releases/download/v0.7.0/build.yaml`
       - `https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml`
       - `https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml`
       - `https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml`
@@ -308,7 +308,7 @@ commands below.
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
           --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-          --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+          --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
           --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
           --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
           --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
@@ -320,7 +320,7 @@ commands below.
 
         ```bash
         kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-          --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+          --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
           --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
           --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
           --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -182,7 +182,7 @@ your Knative installation, see
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -196,7 +196,7 @@ your Knative installation, see
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -186,7 +186,7 @@ your Knative installation, see
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -200,7 +200,7 @@ your Knative installation, see
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -181,11 +181,11 @@ your Knative installation, see
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -195,11 +195,11 @@ your Knative installation, see
    Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -185,8 +185,7 @@ your Knative installation, see
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -199,8 +198,7 @@ your Knative installation, see
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -213,9 +211,6 @@ your Knative installation, see
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -68,7 +68,7 @@ Because you have limited resources available, use the
 which installs only Knative Serving:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --selector networking.knative.dev/certificate-provider!=cert-manager --filename -
 ```

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -165,7 +165,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -178,7 +178,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -160,11 +160,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -173,11 +173,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -161,7 +161,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -174,7 +174,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -164,8 +164,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -177,8 +176,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -191,9 +189,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -116,7 +116,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -129,7 +129,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -119,8 +119,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -132,8 +131,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -146,9 +144,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -120,7 +120,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -133,7 +133,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -115,11 +115,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -128,11 +128,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -201,7 +201,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```
 
    ```shell
-   curl -L https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml \
+   curl -L https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -200,21 +200,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
      | kubectl apply --filename -
    ```
 
-   ```shell
-   curl -L https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml \
-     | sed 's/LoadBalancer/NodePort/' \
-     | kubectl apply --filename -
-   ```
-
    > **Note**: If your install fails on the first attempt, try rerunning the
    > commands. They will likely succeed on the second attempt. For background
    > info and to track the upcoming solution to this problem, see issues
    > [#968](https://github.com/knative/docs/issues/968) and
    > [#1036](https://github.com/knative/docs/issues/1036).
-
-   > **Note**: For the v0.4.0 release and newer, the `clusterrole.yaml` file is
-   > required to enable the Build and Serving components to interact with each
-   > other.
 
    See
    [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -161,7 +161,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the following commands to install Knative:
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --selector networking.knative.dev/certificate-provider!=cert-manager --filename -
    ```
@@ -183,19 +183,19 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
+   curl -L https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
+   curl -L https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   curl -L https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
@@ -267,7 +267,7 @@ To remove Knative from your IBM Cloud Private cluster, run the following
 commands:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
@@ -279,19 +279,19 @@ curl -L https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
+curl -L https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
+curl -L https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+curl -L https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -177,7 +177,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   statement to install the controller.
 
    ```shell
-   curl -L https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   curl -L https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
@@ -273,7 +273,7 @@ curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml
 ```
 
 ```shell
-curl -L https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+curl -L https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -199,11 +199,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -212,11 +212,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -203,8 +203,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -216,8 +215,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -230,9 +228,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -204,7 +204,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -217,7 +217,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -200,7 +200,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -213,7 +213,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -125,8 +125,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -138,8 +137,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -152,9 +150,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -122,7 +122,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```shell
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -135,7 +135,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```shell
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -126,7 +126,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -139,7 +139,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -121,11 +121,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```shell
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -134,11 +134,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -105,8 +105,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -118,8 +117,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -132,9 +130,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -102,7 +102,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -115,7 +115,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -106,7 +106,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -119,7 +119,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -101,11 +101,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -114,11 +114,11 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -73,7 +73,7 @@ your Knative installation, see
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -86,7 +86,7 @@ your Knative installation, see
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
+   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -69,7 +69,7 @@ your Knative installation, see
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
@@ -82,7 +82,7 @@ your Knative installation, see
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
+   --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -72,8 +72,7 @@ your Knative installation, see
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -85,8 +84,7 @@ your Knative installation, see
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
    --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
-   --filename https://raw.githubusercontent.com/knative/serving/v0.7.0/third_party/config/build/clusterrole.yaml
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
    > **Notes**:
@@ -99,9 +97,6 @@ your Knative installation, see
    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
-   >
-   > - For the v0.4.0 release and newer, the `clusterrole.yaml` file is required
-   >   to enable the Build and Serving components to interact with each other.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -68,11 +68,11 @@ your Knative installation, see
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 
@@ -81,11 +81,11 @@ your Knative installation, see
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.6.0/build.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.6.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.6.0/eventing-sources.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring.yaml \
+   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
+   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
    --filename https://raw.githubusercontent.com/knative/serving/v0.6.0/third_party/config/build/clusterrole.yaml
    ```
 

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -20,7 +20,7 @@ sections to do so now.
 1. Run the following command to install Prometheus and Grafana:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring-metrics-prometheus.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-metrics-prometheus.yaml
    ```
 
 1. Ensure that the `grafana-*`, `kibana-logging-*`, `kube-state-metrics-*`,
@@ -64,7 +64,7 @@ install:
 1. Run the following command to install an ELK stack:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring-logs-elasticsearch.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-logs-elasticsearch.yaml
    ```
 
 1. Ensure that the `elasticsearch-logging-*`, `fluentd-ds-*`, and
@@ -243,14 +243,14 @@ uninstall that tool before installing the new tool.
      end traces, run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-zipkin-in-mem.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
      ```
 
    - If Elasticsearch is installed and you want to persist end to end traces,
      first run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-zipkin.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
      ```
 
 1. Create an Elasticsearch index for end to end traces:
@@ -278,14 +278,14 @@ end traces.
      end traces, run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-jaeger-in-mem.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger-in-mem.yaml
      ```
 
    - If Elasticsearch is installed and you want to persist end to end traces,
      first run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.6.0/monitoring-tracing-jaeger.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger.yaml
      ```
 
 1. Create an Elasticsearch index for end to end traces:

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -10,7 +10,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 1. Clone this repository, and move into the sample directory:
 
    ```shell
-   git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
    cd knative-docs
    ```
 

--- a/docs/serving/samples/gitwebhook-go/README.md
+++ b/docs/serving/samples/gitwebhook-go/README.md
@@ -26,7 +26,7 @@ You must meet the following requirements to run this sample:
 1. Download a copy of the code:
 
    ```shell
-   git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
    cd knative-docs/serving/samples/gitwebhook-go
    ```
 

--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -9,7 +9,7 @@ A simple gRPC server written in Go that you can use for testing.
 - Download a copy of the code:
 
   ```shell
-  git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+  git clone -b "release-0.7" https://github.com/knative/docs knative-docs
   cd knative-docs/docs/serving/samples/grpc-ping-go
   ```
 

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-csharp
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-go
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs cd
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs cd
 knative-docs/serving/samples/hello-world/helloworld-java-spring
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-kotlin
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-nodejs
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-php
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-python
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-ruby/README.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-ruby
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-scala/README.md
+++ b/docs/serving/samples/hello-world/helloworld-scala/README.md
@@ -9,7 +9,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-scala
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-shell/README.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/README.md
@@ -7,7 +7,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/hello-world/helloworld-shell
 ```
 

--- a/docs/serving/samples/rest-api-go/README.md
+++ b/docs/serving/samples/rest-api-go/README.md
@@ -17,7 +17,7 @@ like `AAPL`,`AMZN`, `GOOG`, `MSFT`, etc.
 1. Download a copy of the code:
 
    ```shell
-   git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
    cd knative-docs/serving/samples/rest-api-go
    ```
 

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -8,7 +8,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.6" https://github.com/knative/docs knative-docs
+git clone -b "release-0.7" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/secrets-go
 ```
 


### PR DESCRIPTION
- Updates locations for install resources and `git clone` commands to the 0.7 release. 
- Removes references to clusterrole.yaml, since that is not necessary with Build being spun out to Tekton Pipelines