### PR TITLE
There is no longer a eventing-sources release.

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -85,7 +85,7 @@ The following Knative installation files are available:
   - https://github.com/knative/eventing/releases/download/v0.7.0/in-memory-channel.yaml
   - https://github.com/knative/eventing/releases/download/v0.7.0/kafka.yaml
 - **Eventing sources**:
-  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/github.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/camel.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
   - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
@@ -121,7 +121,7 @@ files from the Knative repositories:
 | [`natss.yaml`][4.5]                            | Installs only the NATSS channel provisioner.                                                                                                                           | Eventing component                                                                        |
 | [`gcp-pubsub.yaml`][4.6]                       | Installs only the GCP PubSub channel provisioner.                                                                                                                      | Eventing component                                                                        |
 | **knative/eventing-contrib**                   |                                                                                                                                                                        |                                                                                           |
-| [`eventing-sources.yaml`][5.1]†                | Installs the [GitHub][6.1] source.                                                                                                                                     | Eventing component                                                                        |
+| [`github.yaml`][5.1]†                          | Installs the [GitHub][6.1] source.                                                                                                                                     | Eventing component                                                                        |
 | [`camel.yaml`][5.4]                            | Installs the Apache Camel source.                                                                                                                                      | Eventing component                                                                        |
 | [`gcppubsub.yaml`][5.2]                        | Installs the [GCP PubSub source][6.3]                                                                                                                                  | Eventing component                                                                        |
 | [`kafka.yaml`][5.5]                            | Installs the Apache Kafka source.                                                                                                                                      | Eventing component                                                                        |
@@ -172,7 +172,7 @@ for details about installing the various supported observability plugins.
   https://github.com/knative/eventing/releases/download/v0.7.0/gcp-pubsub.yaml
 [5]: https://github.com/knative/eventing-contrib/releases/tag/v0.7.0
 [5.1]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
+  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/github.yaml
 [5.2]:
   https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
 [5.3]:
@@ -256,7 +256,6 @@ commands below.
       - `https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
       - `https://github.com/knative/build/releases/download/v0.7.0/build.yaml`
       - `https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml`
-      - `https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml`
       - `https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml`
 
       **Note**: By default, the Knative Serving component installation
@@ -303,8 +302,7 @@ commands below.
         kubectl apply --selector knative.dev/crd-install=true \
           --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
           --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
-          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
+          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and the run
@@ -314,8 +312,7 @@ commands below.
         ```bash
         kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
           --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
-          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-          --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml
+          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
         ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -184,7 +184,6 @@ your Knative installation, see
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -197,7 +196,6 @@ your Knative installation, see
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -163,7 +163,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -175,7 +174,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -118,7 +118,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -130,7 +129,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -189,12 +189,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```
 
    ```shell
-   curl -L https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
-     | sed 's/LoadBalancer/NodePort/' \
-     | kubectl apply --filename -
-   ```
-
-   ```shell
    curl -L https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
@@ -270,12 +264,6 @@ curl -L https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
 
 ```shell
 curl -L https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
- | sed 's/LoadBalancer/NodePort/' \
- | kubectl delete --filename -
-```
-
-```shell
-curl -L https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -202,7 +202,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -214,7 +213,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -124,7 +124,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -136,7 +135,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -104,7 +104,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -116,7 +115,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -71,7 +71,6 @@ your Knative installation, see
    --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
@@ -83,7 +82,6 @@ your Knative installation, see
    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
    --filename https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
    --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml \
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 


### PR DESCRIPTION
Eventing sources: https://github.com/knative/eventing-contrib/releases/download/v0.7.0/eventing-sources.yaml has been removed in lieu of all individual releases of the contrib projects.