### PR TITLE
Clarify "event sources" NOT "Knative eventing sources"

### DIFF
--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -19,7 +19,7 @@ This document works with
 
 ## Example
 
-This guide uses an example consisting of an Eventing-contrib resource that sends
+This guide uses an example consisting of an event source that sends
 events to a function.
 
 ![src -> chan -> sub -> svc -> fn](ExampleModel.png)

--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -11,16 +11,16 @@ know roughly how things fit together.
 
 This document works with
 [Eventing 0.3](https://github.com/knative/eventing/releases/tag/v0.3.0) and
-[Eventing Sources 0.3](https://github.com/knative/eventing-contrib/releases/tag/v0.3.0).
+[Eventing-contrib resources 0.3](https://github.com/knative/eventing-contrib/releases/tag/v0.3.0).
 
 ## Prerequisites
 
-1. Setup [Knative Eventing and Eventing-Sources](../README.md).
+1. Setup [Knative Eventing and an Eventing-contrib resource](../README.md).
 
 ## Example
 
-This guide uses an example consisting of an Event Source sending events to a
-function.
+This guide uses an example consisting of an Eventing-contrib resource that sends
+events to a function.
 
 ![src -> chan -> sub -> svc -> fn](ExampleModel.png)
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -12,7 +12,7 @@ The API source files are located at:
 - [Serving API](./serving.md)
 - [Build API](./build.md)
 - [Eventing API](./eventing/eventing.md)
-- [Event Sources API](./eventing/eventing-sources.md)
+- [Eventing-contrib resources API](./eventing/eventing-resources.md)
 
 ## Updating API Reference docs (for Knative maintainers)
 
@@ -60,7 +60,7 @@ To generate a version of the API:
 
    - [Build](https://github.com/knative/build/releases/)
    - [Eventing](https://github.com/knative/eventing/releases/)
-   - [Eventing Sources](https://github.com/knative/eventing-contrib/releases/)
+   - [Eventing-contrib resources](https://github.com/knative/eventing-contrib/releases/)
    - [Serving](https://github.com/knative/serving/releases/)
 
 1. To run the `gen-api-reference-docs.sh` command from the `hack` directory, you

--- a/docs/reference/eventing/eventing-contrib-api.md
+++ b/docs/reference/eventing/eventing-contrib-api.md
@@ -1,9 +1,20 @@
 ---
-title: "Knative Eventing Contrib"
+title: "Eventing-contrib Resources"
 linkTitle: "Eventing-contrib API"
 weight: 50
 type: "docs"
+aliases:
+  - /docs/reference/eventing/eventing-contrib-resources/
 ---
 
 
-The API content for the source implementations that integrate with Knative Eventing are located in the [Knative/eventing-contrib](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib) repo.
+The API definitions for the Eventing resources that conform to
+Knative Eventing are located in the
+[`knative/eventing-contrib`](https://github.com/knative/eventing-contrib/tree/release-0.7/)
+repo:
+
+- [`awssqs` source](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib/awssqs/pkg/apis/sources/v1alpha1)
+- [`camel` source](https://github.com/knative/eventing-contrib/tree/release-0.7/camel/source/pkg/apis/sources/v1alpha1)
+- [`gcppubsub` source](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib/gcppubsub/pkg/apis/sources/v1alpha1)
+- [`github` source](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib/github/pkg/apis/sources/v1alpha1)
+- [`kafka` source](https://github.com/knative/eventing-contrib/tree/release-0.7/kafka/source/pkg/apis/sources/v1alpha1)

--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -39,7 +39,7 @@ KNATIVE_EVENTING_OUT_FILE="eventing/eventing.md"
 
 KNATIVE_EVENTING_SOURCES_REPO="github.com/knative/eventing-contrib"
 KNATIVE_EVENTING_SOURCES_COMMIT="${KNATIVE_EVENTING_SOURCES_COMMIT:?specify the \$KNATIVE_EVENTING_SOURCES_COMMIT variable}"
-KNATIVE_EVENTING_SOURCES_OUT_FILE="eventing/eventing-sources.md"
+KNATIVE_EVENTING_SOURCES_OUT_FILE="eventing/eventing-contrib-resources.md"
 
 cleanup_refdocs_root=
 cleanup_repo_clone_root=


### PR DESCRIPTION
updating a few terms and file names to better align with the change from "knative eventing sources" to 
"eventing resources that conform to Knative Eventing"