### PR TITLE
[RELEASE 0.7] Revert the use of Serving v1beta1.

### DIFF
--- a/community/samples/serving/helloworld-clojure/README.md
+++ b/community/samples/serving/helloworld-clojure/README.md
@@ -82,7 +82,7 @@ recreate the source files from this folder.
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-clojure

--- a/community/samples/serving/helloworld-clojure/service.yaml
+++ b/community/samples/serving/helloworld-clojure/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-clojure

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -81,7 +81,7 @@ be created using the following instructions.
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-dart

--- a/community/samples/serving/helloworld-dart/service.yaml
+++ b/community/samples/serving/helloworld-dart/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-dart

--- a/community/samples/serving/helloworld-elixir/README.md
+++ b/community/samples/serving/helloworld-elixir/README.md
@@ -93,7 +93,7 @@ When asked, if you want to `Fetch and install dependencies? [Yn]` select `y`
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-elixir

--- a/community/samples/serving/helloworld-elixir/service.yaml
+++ b/community/samples/serving/helloworld-elixir/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-elixir

--- a/community/samples/serving/helloworld-haskell/README.md
+++ b/community/samples/serving/helloworld-haskell/README.md
@@ -108,7 +108,7 @@ recreate the source files from this folder.
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-haskell

--- a/community/samples/serving/helloworld-haskell/service.yaml
+++ b/community/samples/serving/helloworld-haskell/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-haskell

--- a/community/samples/serving/helloworld-java-micronaut/README.md
+++ b/community/samples/serving/helloworld-java-micronaut/README.md
@@ -189,7 +189,7 @@ To create and configure the source files in the root of your working directory:
    the `Micronaut Sample v1` value.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-java-micronaut

--- a/community/samples/serving/helloworld-java-micronaut/service.yaml
+++ b/community/samples/serving/helloworld-java-micronaut/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-java-micronaut

--- a/community/samples/serving/helloworld-java-quarkus/README.md
+++ b/community/samples/serving/helloworld-java-quarkus/README.md
@@ -181,7 +181,7 @@ which you update and create the necessary build and configuration files:
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-java-quarkus

--- a/community/samples/serving/helloworld-java-quarkus/service.yaml
+++ b/community/samples/serving/helloworld-java-quarkus/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-java-quarkus

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -106,7 +106,7 @@ recreate the source files from this folder.
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-rust

--- a/community/samples/serving/helloworld-rust/service.yaml
+++ b/community/samples/serving/helloworld-rust/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-rust

--- a/community/samples/serving/helloworld-swift/README.md
+++ b/community/samples/serving/helloworld-swift/README.md
@@ -89,7 +89,7 @@ source files from this folder.
    into the file. Replace `{username}` with your Docker Hub username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-swift

--- a/community/samples/serving/helloworld-swift/service.yaml
+++ b/community/samples/serving/helloworld-swift/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-swift

--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -156,7 +156,7 @@ To create and configure the source files in the root of your working directory:
    the `Eclipse Vert.x Sample v1` value.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-vertx

--- a/community/samples/serving/helloworld-vertx/service.yaml
+++ b/community/samples/serving/helloworld-vertx/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-vertx

--- a/docs/eventing/samples/apache-camel-source/display_resources.yaml
+++ b/docs/eventing/samples/apache-camel-source/display_resources.yaml
@@ -25,7 +25,7 @@ spec:
     name: camel-test
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: camel-event-display
 
@@ -33,7 +33,7 @@ spec:
 
 # This is a very simple Knative Service that prints the input event to its log.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: camel-event-display

--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -39,7 +39,7 @@ In order to verify `ContainerSource` is working, we will create a Event Display
 Service that dumps incoming messages to its log.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display
@@ -84,7 +84,7 @@ spec:
             - name: POD_NAMESPACE
               value: "event-test"
   sink:
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: event-display
 ```

--- a/docs/eventing/samples/container-source/heartbeats-source.yaml
+++ b/docs/eventing/samples/container-source/heartbeats-source.yaml
@@ -18,6 +18,6 @@ spec:
             - name: POD_NAMESPACE
               value: "event-test"
   sink:
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: event-display

--- a/docs/eventing/samples/container-source/service.yaml
+++ b/docs/eventing/samples/container-source/service.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/cronjob-source/README.md
+++ b/docs/eventing/samples/cronjob-source/README.md
@@ -14,7 +14,7 @@ In order to verify `CronJobSource` is working, we will create a simple Knative
 Service that dumps incoming messages to its log.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display
@@ -47,7 +47,7 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: event-display
 ```

--- a/docs/eventing/samples/cronjob-source/cronjob-source.yaml
+++ b/docs/eventing/samples/cronjob-source/cronjob-source.yaml
@@ -6,6 +6,6 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: event-display

--- a/docs/eventing/samples/cronjob-source/service.yaml
+++ b/docs/eventing/samples/cronjob-source/service.yaml
@@ -1,6 +1,6 @@
 # This is a very simple Knative Service that writes the input request to its log.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/gcp-pubsub-source/trigger.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/trigger.yaml
@@ -1,6 +1,6 @@
 # This is a very simple Knative Service that writes the input request to its log.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display
@@ -24,7 +24,7 @@ metadata:
 spec:
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: event-display
 

--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -27,7 +27,7 @@ To verify the `GitHubSource` is working, we will create a simple Knative
 defines this basic service.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: github-event-display
@@ -118,7 +118,7 @@ spec:
       name: githubsecret
       key: secretToken
   sink:
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: github-event-display
 ```

--- a/docs/eventing/samples/github-source/github-source.yaml
+++ b/docs/eventing/samples/github-source/github-source.yaml
@@ -15,7 +15,7 @@ spec:
       name: githubsecret
       key: secretToken
   sink:
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     kind: Service
     name: github-message-dumper
 # To use GitHub Enterprise you would need to add an entry for your githubAPIURL similar to the example below

--- a/docs/eventing/samples/github-source/service.yaml
+++ b/docs/eventing/samples/github-source/service.yaml
@@ -1,5 +1,5 @@
 # This is a very simple Knative Service that writes the input request to its log.
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: github-message-dumper

--- a/docs/eventing/samples/iot-core/trigger.yaml
+++ b/docs/eventing/samples/iot-core/trigger.yaml
@@ -6,14 +6,14 @@ metadata:
 spec:
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: event-display
 
 ---
 # This is a very simple Knative Service that writes the input request to its log.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -126,14 +126,14 @@ metadata:
 spec:
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: event-display
 
 ---
 # This is a very simple Knative Service that writes the input request to its log.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/kubernetes-event-source/trigger.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/trigger.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: event-display
 
@@ -14,7 +14,7 @@ spec:
 
 # This is a very simple Knative Service that writes the input request to its log.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -32,7 +32,7 @@ Change `default` below to create the steps in the Namespace where you want
 resources created.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -46,7 +46,7 @@ spec:
               value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -59,7 +59,7 @@ spec:
             - name: STEP
               value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third
@@ -96,20 +96,20 @@ spec:
     kind: InMemoryChannel
   steps:
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: first
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: second
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: third
   reply:
     kind: Service
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     name: event-display
 ```
 
@@ -123,7 +123,7 @@ kubectl -n default create -f ./sequence.yaml
 ### Create the Service displaying the events created by Sequence
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/event-display.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/event-display.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/sequence.yaml
@@ -8,18 +8,18 @@ spec:
     kind: InMemoryChannel
   steps:
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: first
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: second
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: third
   reply:
     kind: Service
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -33,7 +33,7 @@ Change `default` below to create the steps in the Namespace where you want
 resources created.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -47,7 +47,7 @@ spec:
               value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -60,7 +60,7 @@ spec:
             - name: STEP
               value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third
@@ -73,7 +73,7 @@ spec:
             - name: STEP
               value: "2"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: fourth
@@ -87,7 +87,7 @@ spec:
               value: "3"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: fifth
@@ -100,7 +100,7 @@ spec:
             - name: STEP
               value: "4"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: sixth
@@ -137,15 +137,15 @@ spec:
     kind: InMemoryChannel
   steps:
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: first
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: second
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: third
   reply:
@@ -178,27 +178,27 @@ spec:
     kind: InMemoryChannel
   steps:
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: fourth
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: fifth
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: sixth
   reply:
     kind: Service
-    apiVersion: serving.knative.dev/v1beta1
+    apiVersion: serving.knative.dev/v1alpha1
     name: event-display
 ```
 
 ### Create the Service displaying the events created by Sequence
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/event-display.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/event-display.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence1.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence1.yaml
@@ -8,15 +8,15 @@ spec:
     kind: InMemoryChannel
   steps:
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: first
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: second
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: third
   reply:

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence2.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence2.yaml
@@ -8,15 +8,15 @@ spec:
     kind: InMemoryChannel
   steps:
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: fourth
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: fifth
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: sixth
   reply:

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/steps.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -12,7 +12,7 @@ spec:
           value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -25,7 +25,7 @@ spec:
         - name: STEP
           value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third
@@ -39,7 +39,7 @@ spec:
           value: "2"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: fourth
@@ -52,7 +52,7 @@ spec:
         - name: STEP
           value: "3"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: fifth
@@ -65,7 +65,7 @@ spec:
         - name: STEP
           value: "4"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: sixth

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -29,7 +29,7 @@ If you want to use different type of `Channel`, you will have to modify the
 First create the 3 steps that will be referenced in the Steps.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -43,7 +43,7 @@ spec:
               value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -56,7 +56,7 @@ spec:
             - name: STEP
               value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third
@@ -93,15 +93,15 @@ spec:
     kind: InMemoryChannel
   steps:
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: first
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: second
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: third
 ```

--- a/docs/eventing/samples/sequence/sequence-terminal/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/sequence.yaml
@@ -8,14 +8,14 @@ spec:
     kind: InMemoryChannel
   steps:
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: first
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: second
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: third

--- a/docs/eventing/samples/sequence/sequence-terminal/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/steps.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -12,7 +12,7 @@ spec:
           value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -25,7 +25,7 @@ spec:
         - name: STEP
           value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -38,7 +38,7 @@ Change `default` below to create the steps in the Namespace where you have
 configured your `Broker`
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -52,7 +52,7 @@ spec:
               value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -65,7 +65,7 @@ spec:
             - name: STEP
               value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third
@@ -104,15 +104,15 @@ spec:
     kind: InMemoryChannel
   steps:
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: first
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: second
     - ref:
-        apiVersion: serving.knative.dev/v1beta1
+        apiVersion: serving.knative.dev/v1alpha1
         kind: Service
         name: third
   reply:
@@ -191,7 +191,7 @@ the last step are filtered.
 [TODO: Fix this](https://github.com/knative/eventing/issues/1421)
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: sequence-display
@@ -211,7 +211,7 @@ spec:
       type: samples.http.mod3
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: sequence-display
 ---

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/sequence.yaml
@@ -8,15 +8,15 @@ spec:
     kind: InMemoryChannel
   steps:
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: first
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: second
   - ref:
-      apiVersion: serving.knative.dev/v1beta1
+      apiVersion: serving.knative.dev/v1alpha1
       kind: Service
       name: third
   reply:

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/steps.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: first
@@ -12,7 +12,7 @@ spec:
           value: "0"
 
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: second
@@ -25,7 +25,7 @@ spec:
         - name: STEP
           value: "1"
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: third

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -3964,7 +3964,7 @@ See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/over
 string</td>
 <td>
 <code>
-serving.knative.dev/v1beta1
+serving.knative.dev/v1alpha1
 </code>
 </td>
 </tr>
@@ -4058,7 +4058,7 @@ Configuration.</p>
 string</td>
 <td>
 <code>
-serving.knative.dev/v1beta1
+serving.knative.dev/v1alpha1
 </code>
 </td>
 </tr>
@@ -4185,7 +4185,7 @@ See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/over
 string</td>
 <td>
 <code>
-serving.knative.dev/v1beta1
+serving.knative.dev/v1alpha1
 </code>
 </td>
 </tr>
@@ -4288,7 +4288,7 @@ and Route, reflecting their statuses and conditions as its own.</p>
 string</td>
 <td>
 <code>
-serving.knative.dev/v1beta1
+serving.knative.dev/v1alpha1
 </code>
 </td>
 </tr>

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -188,7 +188,7 @@ autoscaler classes built into Knative:
    Example of a Service scaled on CPU:
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: autoscale-go
@@ -209,7 +209,7 @@ autoscaler classes built into Knative:
    annotations. Example of a Service with custom targets and scale bounds:
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: autoscale-go

--- a/docs/serving/samples/autoscale-go/service.yaml
+++ b/docs/serving/samples/autoscale-go/service.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: autoscale-go

--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -31,7 +31,7 @@ First, create a new file called `blue-green-demo-config.yaml`and copy this into
 it:
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: blue-green-demo
@@ -75,7 +75,7 @@ called `blue-green-demo-route.yaml` and copy the following YAML manifest into it
 (do not forget to edit the revision name):
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: blue-green-demo # The name of our route; appears in the URL to access the app
@@ -120,7 +120,7 @@ background. To create the new revision, we'll edit our existing configuration in
 `blue-green-demo-config.yaml` with an updated image and environment variables:
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: blue-green-demo # Configuration name is unchanged, since we're updating an existing Configuration
@@ -163,7 +163,7 @@ revision while still sending all other traffic to the first revision. Edit
 `blue-green-demo-route.yaml`:
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: blue-green-demo # Route name is unchanged, since we're updating an existing Route
@@ -205,7 +205,7 @@ We'll once again update our existing route to begin shifting traffic away from
 the first revision and toward the second. Edit `blue-green-demo-route.yaml`:
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: blue-green-demo # Updating our existing route
@@ -241,7 +241,7 @@ Lastly, we'll update our existing route to finally shift all traffic to the
 second revision. Edit `blue-green-demo-route.yaml`:
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: blue-green-demo # Updating our existing route

--- a/docs/serving/samples/gitwebhook-go/README.md
+++ b/docs/serving/samples/gitwebhook-go/README.md
@@ -83,7 +83,7 @@ You must meet the following requirements to run this sample:
    image from step 1.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: gitwebhook

--- a/docs/serving/samples/gitwebhook-go/service.yaml
+++ b/docs/serving/samples/gitwebhook-go/service.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: gitwebhook

--- a/docs/serving/samples/grpc-ping-go/sample.yaml
+++ b/docs/serving/samples/grpc-ping-go/sample.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: grpc-ping

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -102,7 +102,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-csharp
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-csharp

--- a/docs/serving/samples/hello-world/helloworld-csharp/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-csharp/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-csharp

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -93,7 +93,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-go

--- a/docs/serving/samples/hello-world/helloworld-go/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-go/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-go

--- a/docs/serving/samples/hello-world/helloworld-java-spark/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/README.md
@@ -73,7 +73,7 @@ recreate the source files from this folder.
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-java

--- a/docs/serving/samples/hello-world/helloworld-java-spark/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-java

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -120,7 +120,7 @@ knative-docs/serving/samples/hello-world/helloworld-java-spring
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-java-spring

--- a/docs/serving/samples/hello-world/helloworld-java-spring/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-java-spring

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -141,7 +141,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-kotlin
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-kotlin

--- a/docs/serving/samples/hello-world/helloworld-kotlin/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-kotlin

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -125,7 +125,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-nodejs
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-nodejs

--- a/docs/serving/samples/hello-world/helloworld-nodejs/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-nodejs

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -71,7 +71,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-php
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-php

--- a/docs/serving/samples/hello-world/helloworld-php/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-php/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-php

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -87,7 +87,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-python
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-python

--- a/docs/serving/samples/hello-world/helloworld-python/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-python/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-python

--- a/docs/serving/samples/hello-world/helloworld-ruby/README.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/README.md
@@ -84,7 +84,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-ruby
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-ruby

--- a/docs/serving/samples/hello-world/helloworld-ruby/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-ruby/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-ruby

--- a/docs/serving/samples/hello-world/helloworld-scala/README.md
+++ b/docs/serving/samples/hello-world/helloworld-scala/README.md
@@ -63,7 +63,7 @@ image reference to match up with the repository**, name, and version specified
 in the [build.sbt](./build.sbt) in the previous section.
 
 ```yaml
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-scala

--- a/docs/serving/samples/hello-world/helloworld-scala/helloworld-scala.yaml
+++ b/docs/serving/samples/hello-world/helloworld-scala/helloworld-scala.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-scala

--- a/docs/serving/samples/hello-world/helloworld-shell/README.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/README.md
@@ -84,7 +84,7 @@ cd knative-docs/serving/samples/hello-world/helloworld-shell
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: helloworld-shell

--- a/docs/serving/samples/hello-world/helloworld-shell/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-shell/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: helloworld-shell

--- a/docs/serving/samples/hello-world/rest-api-go/sample-template.yaml
+++ b/docs/serving/samples/hello-world/rest-api-go/sample-template.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/hello-world/traffic-splitting/release_sample.yaml
+++ b/docs/serving/samples/hello-world/traffic-splitting/release_sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/hello-world/traffic-splitting/split_sample.yaml
+++ b/docs/serving/samples/hello-world/traffic-splitting/split_sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/hello-world/traffic-splitting/updated_sample.yaml
+++ b/docs/serving/samples/hello-world/traffic-splitting/updated_sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/knative-routing-go/sample.yaml
+++ b/docs/serving/samples/knative-routing-go/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: search-service
@@ -33,7 +33,7 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 3
 ---
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: login-service

--- a/docs/serving/samples/rest-api-go/sample-template.yaml
+++ b/docs/serving/samples/rest-api-go/sample-template.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/rest-api-go/sample.yaml
+++ b/docs/serving/samples/rest-api-go/sample.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -156,7 +156,7 @@ cd knative-docs/serving/samples/secrets-go
    username.
 
    ```yaml
-   apiVersion: serving.knative.dev/v1beta1
+   apiVersion: serving.knative.dev/v1alpha1
    kind: Service
    metadata:
      name: secrets-go

--- a/docs/serving/samples/secrets-go/service.yaml
+++ b/docs/serving/samples/secrets-go/service.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: secrets-go

--- a/docs/serving/samples/telemetry-go/route.yaml
+++ b/docs/serving/samples/telemetry-go/route.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Route
 metadata:
   name: telemetrysample-route

--- a/docs/serving/samples/telemetry-go/sample.yaml
+++ b/docs/serving/samples/telemetry-go/sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Configuration
 metadata:
   name: telemetrysample-configuration

--- a/docs/serving/samples/traffic-splitting/README.md
+++ b/docs/serving/samples/traffic-splitting/README.md
@@ -32,7 +32,7 @@ us in the previous sample:
 
 ```shell
 $ kubectl get ksvc -oyaml stock-service-example
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/traffic-splitting/release_sample.yaml
+++ b/docs/serving/samples/traffic-splitting/release_sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/traffic-splitting/split_sample.yaml
+++ b/docs/serving/samples/traffic-splitting/split_sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example

--- a/docs/serving/samples/traffic-splitting/updated_sample.yaml
+++ b/docs/serving/samples/traffic-splitting/updated_sample.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: serving.knative.dev/v1beta1
+apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: stock-service-example


### PR DESCRIPTION
This reverts the direct use of v1beta1 throughout our samples due to https://github.com/knative/serving/issues/4533.

/hold