### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -145,8 +145,9 @@ kubectl -n default create rolebinding eventing-broker-filter \
 Note that these commands each use three different objects, all named
 `eventing-broker-ingress` or `eventing-broker-filter`. The `ClusterRole` is
 installed with Knative Eventing
-[here](https://github.com/knative/eventing/blob/master/config/200-broker-clusterrole.yaml). The `ServiceAccount` was
-created two commands prior. The `RoleBinding` is created with this command.
+[here](https://github.com/knative/eventing/blob/master/config/200-broker-clusterrole.yaml).
+The `ServiceAccount` was created two commands prior. The `RoleBinding` is
+created with this command.
 
 Create RBAC permissions granting access to shared configmaps for logging,
 tracing, and metrics configuration.

--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -19,8 +19,8 @@ This document works with
 
 ## Example
 
-This guide uses an example consisting of an event source that sends
-events to a function.
+This guide uses an example consisting of an event source that sends events to a
+function.
 
 ![src -> chan -> sub -> svc -> fn](ExampleModel.png)
 

--- a/docs/eventing/samples/sequence/_index.md
+++ b/docs/eventing/samples/sequence/_index.md
@@ -4,4 +4,3 @@ linkTitle: "Sequences"
 weight: 10
 type: "docs"
 ---
-

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -1,4 +1,3 @@
-
 ## Overview
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -1,4 +1,3 @@
-
 ## Overview
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -1,4 +1,3 @@
-
 ## Overview
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -1,4 +1,3 @@
-
 ## Overview
 
 We are going to create the following logical configuration. We create a

--- a/docs/reference/eventing/eventing-contrib-api.md
+++ b/docs/reference/eventing/eventing-contrib-api.md
@@ -7,9 +7,8 @@ aliases:
   - /docs/reference/eventing/eventing-contrib-resources/
 ---
 
-
-The API definitions for the Eventing resources that conform to
-Knative Eventing are located in the
+The API definitions for the Eventing resources that conform to Knative Eventing
+are located in the
 [`knative/eventing-contrib`](https://github.com/knative/eventing-contrib/tree/release-0.7/)
 repo:
 


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
