### PR TITLE
Fix a small grammatical error

### DIFF
--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -22,7 +22,7 @@ serverless workload behaves on the cluster:
   update of the service. Service can be defined to always route traffic to the
   latest revision or to a pinned revision.
 - [Route](https://github.com/knative/serving/blob/master/docs/spec/spec.md#route):
-  The `route.serving.knative.dev` resource maps a network endpoint to a one or
+  The `route.serving.knative.dev` resource maps a network endpoint to one or
   more revisions. You can manage the traffic in several ways, including
   fractional traffic and named routes.
 - [Configuration](https://github.com/knative/serving/blob/master/docs/spec/spec.md#configuration):


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Changed
"resource maps a network endpoint to a one or more revisions"
to 
"resource maps a network endpoint to one or more revisions"
