### PR TITLE
New07api

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -88,6 +88,12 @@ To generate a version of the API:
 1. Copy the generated API files into the `docs/reference` directory of your
    knative/docs clone.
 
+1. IMPORTANT: There are some limitations to the build script that require
+   manual changes to the HTML. For the `serving.md` and
+   `eventing-contrib-resources.md`, you must manually fix the `Packages` lists.
+   Details for the required manual changes are in
+   [PR 1552](https://github.com/knative/docs/pull/1552#issuecomment-506891983).
+
 You can now perform the necessary steps to open a PR, complete a review, and
 merge the new API files into the appropriate branch of the `knative/docs` repo.
 See the [contributor flow](../../contributing/DOCS-CONTRIBUTING.md) for details

--- a/docs/reference/build.md
+++ b/docs/reference/build.md
@@ -10,13 +10,13 @@
 </p>
 Resource Types:
 <ul><li>
-<a href="#Build">Build</a>
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.Build">Build</a>
 </li><li>
-<a href="#BuildTemplate">BuildTemplate</a>
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildTemplate">BuildTemplate</a>
 </li><li>
-<a href="#ClusterBuildTemplate">ClusterBuildTemplate</a>
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.ClusterBuildTemplate">ClusterBuildTemplate</a>
 </li></ul>
-<h3 id="Build">Build
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.Build">Build
 </h3>
 <p>
 <p>Build represents a build of a container image. A Build is made up of a
@@ -66,7 +66,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#BuildSpec">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildSpec">
 BuildSpec
 </a>
 </em>
@@ -93,8 +93,8 @@ to migrate</p>
 <td>
 <code>source</code></br>
 <em>
-<a href="#SourceSpec">
-SourceSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec
 </a>
 </em>
 </td>
@@ -107,8 +107,8 @@ SourceSpec
 <td>
 <code>sources</code></br>
 <em>
-<a href="#SourceSpec">
-[]SourceSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec">
+[][]github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec
 </a>
 </em>
 </td>
@@ -163,8 +163,8 @@ string
 <td>
 <code>template</code></br>
 <em>
-<a href="#TemplateInstantiationSpec">
-TemplateInstantiationSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.TemplateInstantiationSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.TemplateInstantiationSpec
 </a>
 </em>
 </td>
@@ -223,7 +223,7 @@ Kubernetes core/v1.Affinity
 <td>
 <code>Status</code></br>
 <em>
-<a href="#BuildSpecStatus">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildSpecStatus">
 BuildSpecStatus
 </a>
 </em>
@@ -240,7 +240,7 @@ BuildSpecStatus
 <td>
 <code>status</code></br>
 <em>
-<a href="#BuildStatus">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildStatus">
 BuildStatus
 </a>
 </em>
@@ -250,7 +250,7 @@ BuildStatus
 </tr>
 </tbody>
 </table>
-<h3 id="BuildTemplate">BuildTemplate
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildTemplate">BuildTemplate
 </h3>
 <p>
 <p>BuildTemplate is a template that can used to easily create Builds.</p>
@@ -298,7 +298,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#BuildTemplateSpec">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildTemplateSpec">
 BuildTemplateSpec
 </a>
 </em>
@@ -325,8 +325,8 @@ to migrate</p>
 <td>
 <code>parameters</code></br>
 <em>
-<a href="#ParameterSpec">
-[]ParameterSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec">
+[][]github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec
 </a>
 </em>
 </td>
@@ -367,7 +367,7 @@ steps of the build.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterBuildTemplate">ClusterBuildTemplate
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.ClusterBuildTemplate">ClusterBuildTemplate
 </h3>
 <p>
 <p>ClusterBuildTemplate is a template that can used to easily create Builds.</p>
@@ -415,7 +415,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#BuildTemplateSpec">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildTemplateSpec">
 BuildTemplateSpec
 </a>
 </em>
@@ -442,8 +442,8 @@ to migrate</p>
 <td>
 <code>parameters</code></br>
 <em>
-<a href="#ParameterSpec">
-[]ParameterSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec">
+[][]github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec
 </a>
 </em>
 </td>
@@ -484,11 +484,11 @@ steps of the build.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ArgumentSpec">ArgumentSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.ArgumentSpec">ArgumentSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#TemplateInstantiationSpec">TemplateInstantiationSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.TemplateInstantiationSpec">TemplateInstantiationSpec</a>)
 </p>
 <p>
 <p>ArgumentSpec defines the actual values to use to populate a template&rsquo;s
@@ -526,20 +526,20 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="BuildProvider">BuildProvider
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildProvider">BuildProvider
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildStatus">BuildStatus</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildStatus">BuildStatus</a>)
 </p>
 <p>
 <p>BuildProvider defines a build execution implementation.</p>
 </p>
-<h3 id="BuildSpec">BuildSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildSpec">BuildSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Build">Build</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.Build">Build</a>)
 </p>
 <p>
 <p>BuildSpec is the spec for a Build resource.</p>
@@ -570,8 +570,8 @@ to migrate</p>
 <td>
 <code>source</code></br>
 <em>
-<a href="#SourceSpec">
-SourceSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec
 </a>
 </em>
 </td>
@@ -584,8 +584,8 @@ SourceSpec
 <td>
 <code>sources</code></br>
 <em>
-<a href="#SourceSpec">
-[]SourceSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec">
+[][]github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec
 </a>
 </em>
 </td>
@@ -640,8 +640,8 @@ string
 <td>
 <code>template</code></br>
 <em>
-<a href="#TemplateInstantiationSpec">
-TemplateInstantiationSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.TemplateInstantiationSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.TemplateInstantiationSpec
 </a>
 </em>
 </td>
@@ -700,7 +700,7 @@ Kubernetes core/v1.Affinity
 <td>
 <code>Status</code></br>
 <em>
-<a href="#BuildSpecStatus">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildSpecStatus">
 BuildSpecStatus
 </a>
 </em>
@@ -712,20 +712,20 @@ BuildSpecStatus
 </tr>
 </tbody>
 </table>
-<h3 id="BuildSpecStatus">BuildSpecStatus
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildSpecStatus">BuildSpecStatus
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildSpec">BuildSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildSpec">BuildSpec</a>)
 </p>
 <p>
 <p>BuildSpecStatus defines the build spec status the user can provide</p>
 </p>
-<h3 id="BuildStatus">BuildStatus
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildStatus">BuildStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Build">Build</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.Build">Build</a>)
 </p>
 <p>
 <p>BuildStatus is the status for a Build resource</p>
@@ -757,7 +757,7 @@ github.com/knative/pkg/apis/duck/v1alpha1.Status
 <td>
 <code>builder</code></br>
 <em>
-<a href="#BuildProvider">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.BuildProvider">
 BuildProvider
 </a>
 </em>
@@ -770,8 +770,8 @@ BuildProvider
 <td>
 <code>cluster</code></br>
 <em>
-<a href="#ClusterSpec">
-ClusterSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.ClusterSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.ClusterSpec
 </a>
 </em>
 </td>
@@ -784,8 +784,8 @@ ClusterSpec
 <td>
 <code>google</code></br>
 <em>
-<a href="#GoogleSpec">
-GoogleSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.GoogleSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.GoogleSpec
 </a>
 </em>
 </td>
@@ -850,17 +850,17 @@ Kubernetes meta/v1.Time
 </tr>
 </tbody>
 </table>
-<h3 id="BuildTemplateInterface">BuildTemplateInterface
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildTemplateInterface">BuildTemplateInterface
 </h3>
 <p>
 <p>BuildTemplateInterface is implemented by BuildTemplate and ClusterBuildTemplate</p>
 </p>
-<h3 id="BuildTemplateSpec">BuildTemplateSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.BuildTemplateSpec">BuildTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildTemplate">BuildTemplate</a>, 
-<a href="#ClusterBuildTemplate">ClusterBuildTemplate</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildTemplate">BuildTemplate</a>, 
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.ClusterBuildTemplate">ClusterBuildTemplate</a>)
 </p>
 <p>
 <p>BuildTemplateSpec is the spec for a BuildTemplate.</p>
@@ -891,8 +891,8 @@ to migrate</p>
 <td>
 <code>parameters</code></br>
 <em>
-<a href="#ParameterSpec">
-[]ParameterSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec">
+[][]github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec
 </a>
 </em>
 </td>
@@ -930,11 +930,11 @@ steps of the build.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterSpec">ClusterSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.ClusterSpec">ClusterSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildStatus">BuildStatus</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildStatus">BuildStatus</a>)
 </p>
 <p>
 <p>ClusterSpec provides information about the on-cluster build, if applicable.</p>
@@ -971,11 +971,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="GCSSourceSpec">GCSSourceSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.GCSSourceSpec">GCSSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SourceSpec">SourceSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.SourceSpec">SourceSpec</a>)
 </p>
 <p>
 <p>GCSSourceSpec describes source input to the Build in the form of an archive,
@@ -993,7 +993,7 @@ or a source manifest describing files to fetch.</p>
 <td>
 <code>type</code></br>
 <em>
-<a href="#GCSSourceType">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.GCSSourceType">
 GCSSourceType
 </a>
 </em>
@@ -1015,20 +1015,20 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="GCSSourceType">GCSSourceType
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.GCSSourceType">GCSSourceType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#GCSSourceSpec">GCSSourceSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.GCSSourceSpec">GCSSourceSpec</a>)
 </p>
 <p>
 <p>GCSSourceType defines a type of GCS source fetch.</p>
 </p>
-<h3 id="GitSourceSpec">GitSourceSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.GitSourceSpec">GitSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SourceSpec">SourceSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.SourceSpec">SourceSpec</a>)
 </p>
 <p>
 <p>GitSourceSpec describes a Git repo source input to the Build.</p>
@@ -1067,11 +1067,11 @@ information.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="GoogleSpec">GoogleSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.GoogleSpec">GoogleSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildStatus">BuildStatus</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildStatus">BuildStatus</a>)
 </p>
 <p>
 <p>GoogleSpec provides information about the GCB build, if applicable.</p>
@@ -1097,11 +1097,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="ParameterSpec">ParameterSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.ParameterSpec">ParameterSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildTemplateSpec">BuildTemplateSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildTemplateSpec">BuildTemplateSpec</a>)
 </p>
 <p>
 <p>ParameterSpec defines the possible parameters that can be populated in a
@@ -1151,11 +1151,11 @@ the build does not specify the value for this parameter.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SourceSpec">SourceSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.SourceSpec">SourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildSpec">BuildSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildSpec">BuildSpec</a>)
 </p>
 <p>
 <p>SourceSpec defines the input to the Build</p>
@@ -1172,8 +1172,8 @@ the build does not specify the value for this parameter.</p>
 <td>
 <code>git</code></br>
 <em>
-<a href="#GitSourceSpec">
-GitSourceSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.GitSourceSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.GitSourceSpec
 </a>
 </em>
 </td>
@@ -1186,8 +1186,8 @@ GitSourceSpec
 <td>
 <code>gcs</code></br>
 <em>
-<a href="#GCSSourceSpec">
-GCSSourceSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.GCSSourceSpec">
+github.com/knative/build/pkg/apis/build/v1alpha1.GCSSourceSpec
 </a>
 </em>
 </td>
@@ -1258,17 +1258,17 @@ TargetPath should not be set for custom source.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="Template">Template
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.Template">Template
 </h3>
 <p>
 <p>Template is an interface for accessing the BuildTemplateSpec
 from various forms of template (namespace-/cluster-scoped).</p>
 </p>
-<h3 id="TemplateInstantiationSpec">TemplateInstantiationSpec
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.TemplateInstantiationSpec">TemplateInstantiationSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BuildSpec">BuildSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.BuildSpec">BuildSpec</a>)
 </p>
 <p>
 <p>TemplateInstantiationSpec specifies how a BuildTemplate is instantiated into
@@ -1298,7 +1298,7 @@ The template is assumed to exist in the Build&rsquo;s namespace.</p>
 <td>
 <code>kind</code></br>
 <em>
-<a href="#TemplateKind">
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.TemplateKind">
 TemplateKind
 </a>
 </em>
@@ -1313,8 +1313,8 @@ or ClusterBuildTemplate. If nothing is specified, the default if is BuildTemplat
 <td>
 <code>arguments</code></br>
 <em>
-<a href="#ArgumentSpec">
-[]ArgumentSpec
+<a href="#github.com/knative/build/pkg/apis/build/v1alpha1.ArgumentSpec">
+[][]github.com/knative/build/pkg/apis/build/v1alpha1.ArgumentSpec
 </a>
 </em>
 </td>
@@ -1341,11 +1341,11 @@ This will override any of the template&rsquo;s steps environment variables.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="TemplateKind">TemplateKind
+<h3 id="github.com/knative/build/pkg/apis/build/v1alpha1.TemplateKind">TemplateKind
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#TemplateInstantiationSpec">TemplateInstantiationSpec</a>)
+<a href="#github.com%2fknative%2fbuild%2fpkg%2fapis%2fbuild%2fv1alpha1.TemplateInstantiationSpec">TemplateInstantiationSpec</a>)
 </p>
 <p>
 <p>TemplateKind defines the type of BuildTemplate used by the build.</p>

--- a/docs/reference/eventing/eventing-contrib-api.md
+++ b/docs/reference/eventing/eventing-contrib-api.md
@@ -3,17 +3,6 @@ title: "Eventing-contrib Resources"
 linkTitle: "Eventing-contrib API"
 weight: 50
 type: "docs"
-aliases:
-  - /docs/reference/eventing/eventing-contrib-resources/
 ---
 
-The API definitions for the Eventing resources that conform to Knative Eventing
-are located in the
-[`knative/eventing-contrib`](https://github.com/knative/eventing-contrib/tree/release-0.7/)
-repo:
-
-- [`awssqs` source](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib/awssqs/pkg/apis/sources/v1alpha1)
-- [`camel` source](https://github.com/knative/eventing-contrib/tree/release-0.7/camel/source/pkg/apis/sources/v1alpha1)
-- [`gcppubsub` source](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib/gcppubsub/pkg/apis/sources/v1alpha1)
-- [`github` source](https://github.com/knative/eventing-contrib/tree/release-0.7/contrib/github/pkg/apis/sources/v1alpha1)
-- [`kafka` source](https://github.com/knative/eventing-contrib/tree/release-0.7/kafka/source/pkg/apis/sources/v1alpha1)
+{{% readfile file="eventing-contrib-resources.md" relative="true" %}}

--- a/docs/reference/eventing/eventing-contrib-resources.md
+++ b/docs/reference/eventing/eventing-contrib-resources.md
@@ -1,0 +1,2020 @@
+<p>Packages:</p>
+<ul>
+<li>
+<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
+</li>
+<li>
+<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
+</li>
+<li>
+<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
+</li>
+<li>
+<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
+</li>
+<li>
+<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
+</li>
+</ul>
+<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcamel%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.CamelSource">CamelSource</a>
+</li></ul>
+<h3 id="github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSource">CamelSource
+</h3>
+<p>
+<p>CamelSource is the Schema for the camelsources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>CamelSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceSpec">
+CamelSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceOriginSpec">
+CamelSourceOriginSpec
+</a>
+</em>
+</td>
+<td>
+<p>Source is the reference to the integration flow to run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DEPRECATED: moved inside the specific CamelSourceOriginSpec
+ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DEPRECATED: use the context field in CamelSourceOriginSpec
+Image is an optional base image used to run the source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceStatus">
+CamelSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceOriginComponentSpec">CamelSourceOriginComponentSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcamel%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.CamelSourceOriginSpec">CamelSourceOriginSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>URI is a Camel component URI to use as starting point (e.g. &ldquo;timer:tick?period=2s&rdquo;)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code></br>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>context</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The Camel K context to use when running the source</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceOriginSpec">CamelSourceOriginSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcamel%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.CamelSourceSpec">CamelSourceSpec</a>)
+</p>
+<p>
+<p>CamelSourceOriginSpec is the integration flow to run</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>component</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceOriginComponentSpec">
+github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceOriginComponentSpec
+</a>
+</em>
+</td>
+<td>
+<p>Component is a kind of source that directly references a Camel component</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>integration</code></br>
+<em>
+github.com/apache/camel-k/pkg/apis/camel/v1alpha1.IntegrationSpec
+</em>
+</td>
+<td>
+<p>Integration is a kind of source that contains a Camel K integration</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceSpec">CamelSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcamel%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.CamelSource">CamelSource</a>)
+</p>
+<p>
+<p>CamelSourceSpec defines the desired state of CamelSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceOriginSpec">
+CamelSourceOriginSpec
+</a>
+</em>
+</td>
+<td>
+<p>Source is the reference to the integration flow to run.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DEPRECATED: moved inside the specific CamelSourceOriginSpec
+ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>image</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DEPRECATED: use the context field in CamelSourceOriginSpec
+Image is an optional base image used to run the source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSourceStatus">CamelSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcamel%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.CamelSource">CamelSource</a>)
+</p>
+<p>
+<p>CamelSourceStatus defines the observed state of CamelSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
+github.com/knative/pkg/apis/duck/v1alpha1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the CamelSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fawssqs%2fpkg%2fapis%2fsources%2fv1alpha1.AwsSqsSource">AwsSqsSource</a>
+</li></ul>
+<h3 id="github.com/knative/eventing-contrib/contrib/awssqs/pkg/apis/sources/v1alpha1.AwsSqsSource">AwsSqsSource
+</h3>
+<p>
+<p>AwsSqsSource is the Schema for the AWS SQS API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>AwsSqsSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/awssqs/pkg/apis/sources/v1alpha1.AwsSqsSourceSpec">
+AwsSqsSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>queueUrl</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>QueueURL of the SQS queue that we will poll from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>awsCredsSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>AwsCredsSecret is the credential to use to poll the AWS SQS</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to
+use as the sink.  This is where events will be received.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to
+run the Receive Adapter Deployment.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/awssqs/pkg/apis/sources/v1alpha1.AwsSqsSourceStatus">
+AwsSqsSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/awssqs/pkg/apis/sources/v1alpha1.AwsSqsSourceSpec">AwsSqsSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fawssqs%2fpkg%2fapis%2fsources%2fv1alpha1.AwsSqsSource">AwsSqsSource</a>)
+</p>
+<p>
+<p>AwsSqsSourceSpec defines the desired state of the source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>queueUrl</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>QueueURL of the SQS queue that we will poll from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>awsCredsSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>AwsCredsSecret is the credential to use to poll the AWS SQS</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to
+use as the sink.  This is where events will be received.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to
+run the Receive Adapter Deployment.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/awssqs/pkg/apis/sources/v1alpha1.AwsSqsSourceStatus">AwsSqsSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fawssqs%2fpkg%2fapis%2fsources%2fv1alpha1.AwsSqsSource">AwsSqsSource</a>)
+</p>
+<p>
+<p>AwsSqsSourceStatus defines the observed state of the source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
+github.com/knative/pkg/apis/duck/v1alpha1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgcppubsub%2fpkg%2fapis%2fsources%2fv1alpha1.GcpPubSubSource">GcpPubSubSource</a>
+</li></ul>
+<h3 id="github.com/knative/eventing-contrib/contrib/gcppubsub/pkg/apis/sources/v1alpha1.GcpPubSubSource">GcpPubSubSource
+</h3>
+<p>
+<p>GcpPubSubSource is the Schema for the gcppubsubsources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GcpPubSubSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/gcppubsub/pkg/apis/sources/v1alpha1.GcpPubSubSourceSpec">
+GcpPubSubSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>gcpCredsSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
+to create or delete the Subscription, only to poll it. The value of the secret entry must be
+a service account key in the JSON format (see
+<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>googleCloudProject</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>GoogleCloudProject is the ID of the Google Cloud Project that the PubSub Topic exists in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topic</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Topic is the ID of the GCP PubSub Topic to Subscribe to. It must be in the form of the
+unique identifier within the project, not the entire name. E.g. it must be &lsquo;laconia&rsquo;, not
+&lsquo;projects/my-gcp-project/topics/laconia&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>transformer</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Transformer is a reference to an object that will resolve to a domain name to use as the transformer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
+Adapter Deployment.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/gcppubsub/pkg/apis/sources/v1alpha1.GcpPubSubSourceStatus">
+GcpPubSubSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/gcppubsub/pkg/apis/sources/v1alpha1.GcpPubSubSourceSpec">GcpPubSubSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgcppubsub%2fpkg%2fapis%2fsources%2fv1alpha1.GcpPubSubSource">GcpPubSubSource</a>)
+</p>
+<p>
+<p>GcpPubSubSourceSpec defines the desired state of the GcpPubSubSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>gcpCredsSecret</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
+to create or delete the Subscription, only to poll it. The value of the secret entry must be
+a service account key in the JSON format (see
+<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>googleCloudProject</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>GoogleCloudProject is the ID of the Google Cloud Project that the PubSub Topic exists in.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topic</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Topic is the ID of the GCP PubSub Topic to Subscribe to. It must be in the form of the
+unique identifier within the project, not the entire name. E.g. it must be &lsquo;laconia&rsquo;, not
+&lsquo;projects/my-gcp-project/topics/laconia&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>transformer</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Transformer is a reference to an object that will resolve to a domain name to use as the transformer.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
+Adapter Deployment.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/gcppubsub/pkg/apis/sources/v1alpha1.GcpPubSubSourceStatus">GcpPubSubSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgcppubsub%2fpkg%2fapis%2fsources%2fv1alpha1.GcpPubSubSource">GcpPubSubSource</a>)
+</p>
+<p>
+<p>GcpPubSubSourceStatus defines the observed state of GcpPubSubSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
+github.com/knative/pkg/apis/duck/v1alpha1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the GcpPubSubSource.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>transformerUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TransformerURI is the current active transformer URI that has been configured for the GcpPubSubSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgithub%2fpkg%2fapis%2fsources%2fv1alpha1.GitHubSource">GitHubSource</a>
+</li></ul>
+<h3 id="github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.GitHubSource">GitHubSource
+</h3>
+<p>
+<p>GitHubSource is the Schema for the githubsources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>GitHubSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.GitHubSourceSpec">
+GitHubSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the GitHubSource exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ownerAndRepository</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OwnerAndRepository is the GitHub owner/org and repository to
+receive events from. The repository may be left off to receive
+events from an entire organization.
+Examples:
+myuser/project
+myorganization</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eventTypes</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>EventType is the type of event to receive from GitHub. These
+correspond to the &ldquo;Webhook event name&rdquo; values listed at
+<a href="https://developer.github.com/v3/activity/events/types/">https://developer.github.com/v3/activity/events/types/</a> - ie
+&ldquo;pull_request&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accessToken</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>AccessToken is the Kubernetes secret containing the GitHub
+access token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretToken</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>SecretToken is the Kubernetes secret containing the GitHub
+secret token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain
+name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>githubAPIURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API URL if using github enterprise (default <a href="https://api.github.com">https://api.github.com</a>)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secure</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Secure can be set to true to configure the webhook to use https.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.GitHubSourceStatus">
+GitHubSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.GitHubSourceSpec">GitHubSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgithub%2fpkg%2fapis%2fsources%2fv1alpha1.GitHubSource">GitHubSource</a>)
+</p>
+<p>
+<p>GitHubSourceSpec defines the desired state of GitHubSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName holds the name of the Kubernetes service account
+as which the underlying K8s resources should be run. If unspecified
+this will default to the &ldquo;default&rdquo; service account for the namespace
+in which the GitHubSource exists.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ownerAndRepository</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OwnerAndRepository is the GitHub owner/org and repository to
+receive events from. The repository may be left off to receive
+events from an entire organization.
+Examples:
+myuser/project
+myorganization</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>eventTypes</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>EventType is the type of event to receive from GitHub. These
+correspond to the &ldquo;Webhook event name&rdquo; values listed at
+<a href="https://developer.github.com/v3/activity/events/types/">https://developer.github.com/v3/activity/events/types/</a> - ie
+&ldquo;pull_request&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>accessToken</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>AccessToken is the Kubernetes secret containing the GitHub
+access token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secretToken</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<p>SecretToken is the Kubernetes secret containing the GitHub
+secret token</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain
+name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>githubAPIURL</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>API URL if using github enterprise (default <a href="https://api.github.com">https://api.github.com</a>)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>secure</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Secure can be set to true to configure the webhook to use https.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.GitHubSourceStatus">GitHubSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgithub%2fpkg%2fapis%2fsources%2fv1alpha1.GitHubSource">GitHubSource</a>)
+</p>
+<p>
+<p>GitHubSourceStatus defines the observed state of GitHubSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
+github.com/knative/pkg/apis/duck/v1alpha1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>webhookIDKey</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>WebhookIDKey is the ID of the webhook registered with GitHub</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured
+for the GitHubSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgithub%2fpkg%2fapis%2fsources%2fv1alpha1.GitHubSourceSpec">GitHubSourceSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSource">KafkaSource</a>
+</li></ul>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSource">KafkaSource
+</h3>
+<p>
+<p>KafkaSource is the Schema for the kafkasources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>KafkaSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceSpec">
+KafkaSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>bootstrapServers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Bootstrap servers are the Kafka servers the consumer will connect to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topics</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Topic topics to consume messages from</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumerGroup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ConsumerGroupID is the consumer group ID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>net</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceNetSpec">
+KafkaSourceNetSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
+Adapter Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaResourceSpec">
+KafkaResourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Resource limits and Request specifications of the Receive Adapter Deployment</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceStatus">
+KafkaSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaLimitsSpec">KafkaLimitsSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaResourceSpec">KafkaResourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cpu</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>memory</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaRequestsSpec">KafkaRequestsSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaResourceSpec">KafkaResourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cpu</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>memory</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaResourceSpec">KafkaResourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceSpec">KafkaSourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>requests</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaRequestsSpec">
+KafkaRequestsSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>limits</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaLimitsSpec">
+KafkaLimitsSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceNetSpec">KafkaSourceNetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceSpec">KafkaSourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>sasl</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceSASLSpec">
+KafkaSourceSASLSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>tls</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceTLSSpec">
+KafkaSourceTLSSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceSASLSpec">KafkaSourceSASLSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceNetSpec">KafkaSourceNetSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>user</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>User is the Kubernetes secret containing the SASL username.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>password</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Password is the Kubernetes secret containing the SASL password.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceSpec">KafkaSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSource">KafkaSource</a>)
+</p>
+<p>
+<p>KafkaSourceSpec defines the desired state of the KafkaSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>bootstrapServers</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Bootstrap servers are the Kafka servers the consumer will connect to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topics</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Topic topics to consume messages from</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumerGroup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ConsumerGroupID is the consumer group ID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>net</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceNetSpec">
+KafkaSourceNetSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
+Adapter Deployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaResourceSpec">
+KafkaResourceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Resource limits and Request specifications of the Receive Adapter Deployment</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceStatus">KafkaSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSource">KafkaSource</a>)
+</p>
+<p>
+<p>KafkaSourceStatus defines the observed state of KafkaSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
+github.com/knative/pkg/apis/duck/v1alpha1.Status
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sinkUri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SinkURI is the current active sink URI that has been configured for the KafkaSource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSourceTLSSpec">KafkaSourceTLSSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceNetSpec">KafkaSourceNetSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>cert</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Cert is the Kubernetes secret containing the client certificate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Key is the Kubernetes secret containing the client key.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caCert</code></br>
+<em>
+<a href="#github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CACert is the Kubernetes secret containing the server CA cert.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceSASLSpec">KafkaSourceSASLSpec</a>, 
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceTLSSpec">KafkaSourceTLSSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<p><em>
+Generated with <code>gen-crd-api-reference-docs</code>
+on git commit <code>641f98fe</code>.
+</em></p>

--- a/docs/reference/eventing/eventing-contrib-resources.md
+++ b/docs/reference/eventing/eventing-contrib-resources.md
@@ -3,18 +3,6 @@
 <li>
 <a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
 </li>
-<li>
-<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
-</li>
-<li>
-<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
-</li>
-<li>
-<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
-</li>
-<li>
-<a href="#sources.eventing.knative.dev">sources.eventing.knative.dev</a>
-</li>
 </ul>
 <h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
 <p>
@@ -23,6 +11,18 @@
 Resource Types:
 <ul><li>
 <a href="#github.com%2fknative%2feventing-contrib%2fcamel%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.CamelSource">CamelSource</a>
+</li>
+<li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fawssqs%2fpkg%2fapis%2fsources%2fv1alpha1.AwsSqsSource">AwsSqsSource</a>
+</li>
+<li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgcppubsub%2fpkg%2fapis%2fsources%2fv1alpha1.GcpPubSubSource">GcpPubSubSource</a>
+</li>
+<li>
+<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgithub%2fpkg%2fapis%2fsources%2fv1alpha1.GitHubSource">GitHubSource</a>
+</li>
+<li>
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSource">KafkaSource</a>
 </li></ul>
 <h3 id="github.com/knative/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1.CamelSource">CamelSource
 </h3>
@@ -381,14 +381,6 @@ string
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fawssqs%2fpkg%2fapis%2fsources%2fv1alpha1.AwsSqsSource">AwsSqsSource</a>
-</li></ul>
 <h3 id="github.com/knative/eventing-contrib/contrib/awssqs/pkg/apis/sources/v1alpha1.AwsSqsSource">AwsSqsSource
 </h3>
 <p>
@@ -634,14 +626,6 @@ string
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgcppubsub%2fpkg%2fapis%2fsources%2fv1alpha1.GcpPubSubSource">GcpPubSubSource</a>
-</li></ul>
 <h3 id="github.com/knative/eventing-contrib/contrib/gcppubsub/pkg/apis/sources/v1alpha1.GcpPubSubSource">GcpPubSubSource
 </h3>
 <p>
@@ -712,7 +696,7 @@ Kubernetes core/v1.SecretKeySelector
 <p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
 to create or delete the Subscription, only to poll it. The value of the secret entry must be
 a service account key in the JSON format (see
-<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys">https://cloud.google.com/iam/docs/creating-managing-service-account-keys</a>.</p>
 </td>
 </tr>
 <tr>
@@ -826,7 +810,7 @@ Kubernetes core/v1.SecretKeySelector
 <p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
 to create or delete the Subscription, only to poll it. The value of the secret entry must be
 a service account key in the JSON format (see
-<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys">https://cloud.google.com/iam/docs/creating-managing-service-account-keys</a>.</p>
 </td>
 </tr>
 <tr>
@@ -957,14 +941,6 @@ string
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#github.com%2fknative%2feventing-contrib%2fcontrib%2fgithub%2fpkg%2fapis%2fsources%2fv1alpha1.GitHubSource">GitHubSource</a>
-</li></ul>
 <h3 id="github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1.GitHubSource">GitHubSource
 </h3>
 <p>
@@ -1376,14 +1352,6 @@ Kubernetes core/v1.SecretKeySelector
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.eventing.knative.dev">sources.eventing.knative.dev</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSource">KafkaSource</a>
-</li></ul>
 <h3 id="github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1.KafkaSource">KafkaSource
 </h3>
 <p>
@@ -1984,7 +1952,7 @@ SecretValueFromSource
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceSASLSpec">KafkaSourceSASLSpec</a>, 
+<a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceSASLSpec">KafkaSourceSASLSpec</a>,
 <a href="#github.com%2fknative%2feventing-contrib%2fkafka%2fsource%2fpkg%2fapis%2fsources%2fv1alpha1.KafkaSourceTLSSpec">KafkaSourceTLSSpec</a>)
 </p>
 <p>

--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -19,11 +19,11 @@
 </p>
 Resource Types:
 <ul><li>
-<a href="#Channelable">Channelable</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.Channelable">Channelable</a>
 </li><li>
-<a href="#SubscribableType">SubscribableType</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.SubscribableType">SubscribableType</a>
 </li></ul>
-<h3 id="Channelable">Channelable
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.Channelable">Channelable
 </h3>
 <p>
 <p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
@@ -73,7 +73,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ChannelableSpec">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.ChannelableSpec">
 ChannelableSpec
 </a>
 </em>
@@ -87,7 +87,7 @@ ChannelableSpec
 <td>
 <code>SubscribableTypeSpec</code></br>
 <em>
-<a href="#SubscribableTypeSpec">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
 </a>
 </em>
@@ -105,7 +105,7 @@ SubscribableTypeSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#ChannelableStatus">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.ChannelableStatus">
 ChannelableStatus
 </a>
 </em>
@@ -115,7 +115,7 @@ ChannelableStatus
 </tr>
 </tbody>
 </table>
-<h3 id="SubscribableType">SubscribableType
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableType">SubscribableType
 </h3>
 <p>
 <p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
@@ -165,7 +165,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#SubscribableTypeSpec">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
 </a>
 </em>
@@ -180,8 +180,8 @@ configured as to be compatible with Subscribable contract.</p>
 <td>
 <code>subscribable</code></br>
 <em>
-<a href="#Subscribable">
-Subscribable
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
 </a>
 </em>
 </td>
@@ -195,7 +195,7 @@ Subscribable
 <td>
 <code>status</code></br>
 <em>
-<a href="#SubscribableTypeStatus">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
 </a>
 </em>
@@ -207,11 +207,11 @@ configured as to be compatible with Subscribable contract.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelableSpec">ChannelableSpec
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.ChannelableSpec">ChannelableSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Channelable">Channelable</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.Channelable">Channelable</a>)
 </p>
 <p>
 <p>ChannelableSpec contains Spec of the Channelable object</p>
@@ -228,7 +228,7 @@ configured as to be compatible with Subscribable contract.</p>
 <td>
 <code>SubscribableTypeSpec</code></br>
 <em>
-<a href="#SubscribableTypeSpec">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
 </a>
 </em>
@@ -241,11 +241,11 @@ SubscribableTypeSpec
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelableStatus">ChannelableStatus
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.ChannelableStatus">ChannelableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Channelable">Channelable</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.Channelable">Channelable</a>)
 </p>
 <p>
 <p>ChannelableStatus contains the Status of a Channelable object.</p>
@@ -296,7 +296,7 @@ github.com/knative/pkg/apis/duck/v1alpha1.AddressStatus
 <td>
 <code>SubscribableTypeStatus</code></br>
 <em>
-<a href="#SubscribableTypeStatus">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
 </a>
 </em>
@@ -310,13 +310,13 @@ SubscribableTypeStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Subscribable">Subscribable
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">Subscribable
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ChannelSpec">ChannelSpec</a>, 
-<a href="#InMemoryChannelSpec">InMemoryChannelSpec</a>, 
-<a href="#SubscribableTypeSpec">SubscribableTypeSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.ChannelSpec">ChannelSpec</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.InMemoryChannelSpec">InMemoryChannelSpec</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
 </p>
 <p>
 <p>Subscribable is the schema for the subscribable portion of the spec
@@ -334,8 +334,8 @@ section of the resource.</p>
 <td>
 <code>subscribers</code></br>
 <em>
-<a href="#SubscriberSpec">
-[]SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscriberSpec">
+[][]github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -345,11 +345,11 @@ section of the resource.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SubscribableStatus">SubscribableStatus
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableStatus">SubscribableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SubscribableTypeStatus">SubscribableTypeStatus</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
 </p>
 <p>
 <p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
@@ -367,8 +367,8 @@ section of the resource.</p>
 <td>
 <code>subscribers</code></br>
 <em>
-<a href="#SubscriberStatus">
-[]SubscriberStatus
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscriberStatus">
+[][]github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscriberStatus
 </a>
 </em>
 </td>
@@ -378,12 +378,12 @@ section of the resource.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SubscribableTypeSpec">SubscribableTypeSpec
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SubscribableType">SubscribableType</a>, 
-<a href="#ChannelableSpec">ChannelableSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.SubscribableType">SubscribableType</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.ChannelableSpec">ChannelableSpec</a>)
 </p>
 <p>
 <p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
@@ -400,8 +400,8 @@ section of the resource.</p>
 <td>
 <code>subscribable</code></br>
 <em>
-<a href="#Subscribable">
-Subscribable
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
 </a>
 </em>
 </td>
@@ -410,14 +410,14 @@ Subscribable
 </tr>
 </tbody>
 </table>
-<h3 id="SubscribableTypeStatus">SubscribableTypeStatus
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SubscribableType">SubscribableType</a>, 
-<a href="#ChannelStatus">ChannelStatus</a>, 
-<a href="#ChannelableStatus">ChannelableStatus</a>, 
-<a href="#InMemoryChannelStatus">InMemoryChannelStatus</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.SubscribableType">SubscribableType</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.ChannelStatus">ChannelStatus</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
 </p>
 <p>
 <p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
@@ -434,8 +434,8 @@ Subscribable
 <td>
 <code>subscribablestatus</code></br>
 <em>
-<a href="#SubscribableStatus">
-SubscribableStatus
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableStatus">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableStatus
 </a>
 </em>
 </td>
@@ -444,11 +444,11 @@ SubscribableStatus
 </tr>
 </tbody>
 </table>
-<h3 id="SubscriberSpec">SubscriberSpec
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscriberSpec">SubscriberSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Subscribable">Subscribable</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.Subscribable">Subscribable</a>)
 </p>
 <p>
 <p>SubscriberSpec defines a single subscriber to a Subscribable.
@@ -527,11 +527,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="SubscriberStatus">SubscriberStatus
+<h3 id="github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscriberStatus">SubscriberStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SubscribableStatus">SubscribableStatus</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fduck%2fv1alpha1.SubscribableStatus">SubscribableStatus</a>)
 </p>
 <p>
 <p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
@@ -603,19 +603,19 @@ string
 </p>
 Resource Types:
 <ul><li>
-<a href="#Broker">Broker</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Broker">Broker</a>
 </li><li>
-<a href="#Channel">Channel</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Channel">Channel</a>
 </li><li>
-<a href="#ClusterChannelProvisioner">ClusterChannelProvisioner</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>
 </li><li>
-<a href="#EventType">EventType</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.EventType">EventType</a>
 </li><li>
-<a href="#Subscription">Subscription</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Subscription">Subscription</a>
 </li><li>
-<a href="#Trigger">Trigger</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Trigger">Trigger</a>
 </li></ul>
-<h3 id="Broker">Broker
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.Broker">Broker
 </h3>
 <p>
 <p>Broker collects a pool of events that are consumable using Triggers. Brokers
@@ -668,7 +668,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#BrokerSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.BrokerSpec">
 BrokerSpec
 </a>
 </em>
@@ -682,8 +682,8 @@ BrokerSpec
 <td>
 <code>channelTemplate</code></br>
 <em>
-<a href="#ChannelSpec">
-ChannelSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelSpec">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelSpec
 </a>
 </em>
 </td>
@@ -698,7 +698,7 @@ Channel for the namespace will be used.</p>
 <td>
 <code>channelTemplateSpec</code></br>
 <em>
-<a href="#ChannelTemplateSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelTemplateSpec">
 ChannelTemplateSpec
 </a>
 </em>
@@ -715,7 +715,7 @@ Broker.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#BrokerStatus">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.BrokerStatus">
 BrokerStatus
 </a>
 </em>
@@ -728,7 +728,7 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="Channel">Channel
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.Channel">Channel
 </h3>
 <p>
 <p>Channel is an abstract resource that implements the Addressable contract.
@@ -779,7 +779,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ChannelSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelSpec">
 ChannelSpec
 </a>
 </em>
@@ -834,8 +834,8 @@ provisions this Channel.</p>
 <td>
 <code>subscribable</code></br>
 <em>
-<a href="#Subscribable">
-Subscribable
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
 </a>
 </em>
 </td>
@@ -850,7 +850,7 @@ Subscribable
 <td>
 <code>status</code></br>
 <em>
-<a href="#ChannelStatus">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelStatus">
 ChannelStatus
 </a>
 </em>
@@ -863,7 +863,7 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterChannelProvisioner">ClusterChannelProvisioner
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner
 </h3>
 <p>
 <p>ClusterChannelProvisioner encapsulates a provisioning strategy for the
@@ -913,7 +913,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ClusterChannelProvisionerSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ClusterChannelProvisionerSpec">
 ClusterChannelProvisionerSpec
 </a>
 </em>
@@ -945,7 +945,7 @@ in the future</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#ClusterChannelProvisionerStatus">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ClusterChannelProvisionerStatus">
 ClusterChannelProvisionerStatus
 </a>
 </em>
@@ -957,7 +957,7 @@ ClusterChannelProvisionerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="EventType">EventType
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.EventType">EventType
 </h3>
 <p>
 </p>
@@ -1005,7 +1005,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#EventTypeSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.EventTypeSpec">
 EventTypeSpec
 </a>
 </em>
@@ -1080,7 +1080,7 @@ string
 <td>
 <code>status</code></br>
 <em>
-<a href="#EventTypeStatus">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.EventTypeStatus">
 EventTypeStatus
 </a>
 </em>
@@ -1093,7 +1093,7 @@ This data may be out of date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="Subscription">Subscription
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.Subscription">Subscription
 </h3>
 <p>
 <p>Subscription routes events received on a Channel to a DNS name and
@@ -1142,7 +1142,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#SubscriptionSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriptionSpec">
 SubscriptionSpec
 </a>
 </em>
@@ -1189,8 +1189,8 @@ etc.)</p>
 <td>
 <code>subscriber</code></br>
 <em>
-<a href="#SubscriberSpec">
-SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -1205,8 +1205,8 @@ sent to a channel as specified by the Reply.</p>
 <td>
 <code>reply</code></br>
 <em>
-<a href="#ReplyStrategy">
-ReplyStrategy
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ReplyStrategy">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ReplyStrategy
 </a>
 </em>
 </td>
@@ -1223,7 +1223,7 @@ the Subscriber target.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#SubscriptionStatus">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriptionStatus">
 SubscriptionStatus
 </a>
 </em>
@@ -1233,7 +1233,7 @@ SubscriptionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Trigger">Trigger
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.Trigger">Trigger
 </h3>
 <p>
 <p>Trigger represents a request to have events delivered to a consumer from a
@@ -1283,7 +1283,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#TriggerSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerSpec">
 TriggerSpec
 </a>
 </em>
@@ -1309,8 +1309,8 @@ to &lsquo;default&rsquo;.</p>
 <td>
 <code>filter</code></br>
 <em>
-<a href="#TriggerFilter">
-TriggerFilter
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilter">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilter
 </a>
 </em>
 </td>
@@ -1324,8 +1324,8 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 <td>
 <code>subscriber</code></br>
 <em>
-<a href="#SubscriberSpec">
-SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -1341,7 +1341,7 @@ is required.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#TriggerStatus">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerStatus">
 TriggerStatus
 </a>
 </em>
@@ -1354,11 +1354,11 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="BrokerSpec">BrokerSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.BrokerSpec">BrokerSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Broker">Broker</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Broker">Broker</a>)
 </p>
 <p>
 </p>
@@ -1374,8 +1374,8 @@ date.</p>
 <td>
 <code>channelTemplate</code></br>
 <em>
-<a href="#ChannelSpec">
-ChannelSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelSpec">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelSpec
 </a>
 </em>
 </td>
@@ -1390,7 +1390,7 @@ Channel for the namespace will be used.</p>
 <td>
 <code>channelTemplateSpec</code></br>
 <em>
-<a href="#ChannelTemplateSpec">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelTemplateSpec">
 ChannelTemplateSpec
 </a>
 </em>
@@ -1402,11 +1402,11 @@ Broker.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="BrokerStatus">BrokerStatus
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.BrokerStatus">BrokerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Broker">Broker</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Broker">Broker</a>)
 </p>
 <p>
 <p>BrokerStatus represents the current state of a Broker.</p>
@@ -1481,18 +1481,18 @@ Kubernetes core/v1.ObjectReference
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelProvisionerDefaulter">ChannelProvisionerDefaulter
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelProvisionerDefaulter">ChannelProvisionerDefaulter
 </h3>
 <p>
 <p>ChannelProvisionerDefaulter sets the default Provisioner and Arguments on Channels that do not
 specify any Provisioner.</p>
 </p>
-<h3 id="ChannelSpec">ChannelSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelSpec">ChannelSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Channel">Channel</a>, 
-<a href="#BrokerSpec">BrokerSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Channel">Channel</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.BrokerSpec">BrokerSpec</a>)
 </p>
 <p>
 <p>ChannelSpec specifies the Provisioner backing a channel and the configuration
@@ -1551,8 +1551,8 @@ provisions this Channel.</p>
 <td>
 <code>subscribable</code></br>
 <em>
-<a href="#Subscribable">
-Subscribable
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
 </a>
 </em>
 </td>
@@ -1562,11 +1562,11 @@ Subscribable
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelStatus">ChannelStatus
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelStatus">ChannelStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Channel">Channel</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Channel">Channel</a>)
 </p>
 <p>
 <p>ChannelStatus represents the current state of a Channel.</p>
@@ -1629,7 +1629,7 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>SubscribableTypeStatus</code></br>
 <em>
-<a href="#SubscribableTypeStatus">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
 </a>
 </em>
@@ -1642,11 +1642,11 @@ SubscribableTypeStatus
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelTemplateSpec">ChannelTemplateSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelTemplateSpec">ChannelTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#BrokerSpec">BrokerSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.BrokerSpec">BrokerSpec</a>)
 </p>
 <p>
 <p>This should be duck so that Broker can also use this</p>
@@ -1702,7 +1702,7 @@ structs.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
 </h3>
 <p>
 <p>Internal version of ChannelTemplateSpec that includes ObjectMeta so that
@@ -1774,11 +1774,11 @@ structs.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterChannelProvisionerSpec">ClusterChannelProvisionerSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ClusterChannelProvisionerSpec">ClusterChannelProvisionerSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
 </p>
 <p>
 <p>ClusterChannelProvisionerSpec is the spec for a ClusterChannelProvisioner resource.</p>
@@ -1808,11 +1808,11 @@ in the future</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterChannelProvisionerStatus">ClusterChannelProvisionerStatus
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ClusterChannelProvisionerStatus">ClusterChannelProvisionerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
 </p>
 <p>
 <p>ClusterChannelProvisionerStatus is the status for a ClusterChannelProvisioner resource</p>
@@ -1845,11 +1845,11 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 </tr>
 </tbody>
 </table>
-<h3 id="EventTypeSpec">EventTypeSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.EventTypeSpec">EventTypeSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#EventType">EventType</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.EventType">EventType</a>)
 </p>
 <p>
 </p>
@@ -1921,11 +1921,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="EventTypeStatus">EventTypeStatus
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.EventTypeStatus">EventTypeStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#EventType">EventType</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.EventType">EventType</a>)
 </p>
 <p>
 <p>EventTypeStatus represents the current state of a EventType.</p>
@@ -1958,15 +1958,15 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 </tr>
 </tbody>
 </table>
-<h3 id="HasSpec">HasSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.HasSpec">HasSpec
 </h3>
 <p>
 </p>
-<h3 id="ReplyStrategy">ReplyStrategy
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ReplyStrategy">ReplyStrategy
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SubscriptionSpec">SubscriptionSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
 <p>
 <p>ReplyStrategy specifies the handling of the SubscriberSpec&rsquo;s returned replies.
@@ -2002,13 +2002,13 @@ it will be reflected in the Subscription&rsquo;s status.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SubscriberSpec">SubscriberSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">SubscriberSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SequenceSpec">SequenceSpec</a>, 
-<a href="#SubscriptionSpec">SubscriptionSpec</a>, 
-<a href="#TriggerSpec">TriggerSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.SequenceSpec">SequenceSpec</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.SubscriptionSpec">SubscriptionSpec</a>, 
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.TriggerSpec">TriggerSpec</a>)
 </p>
 <p>
 <p>SubscriberSpec specifies the reference to an object that&rsquo;s expected to
@@ -2093,11 +2093,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="SubscriptionSpec">SubscriptionSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriptionSpec">SubscriptionSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Subscription">Subscription</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Subscription">Subscription</a>)
 </p>
 <p>
 <p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
@@ -2159,8 +2159,8 @@ etc.)</p>
 <td>
 <code>subscriber</code></br>
 <em>
-<a href="#SubscriberSpec">
-SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -2175,8 +2175,8 @@ sent to a channel as specified by the Reply.</p>
 <td>
 <code>reply</code></br>
 <em>
-<a href="#ReplyStrategy">
-ReplyStrategy
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ReplyStrategy">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.ReplyStrategy
 </a>
 </em>
 </td>
@@ -2188,11 +2188,11 @@ the Subscriber target.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SubscriptionStatus">SubscriptionStatus
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriptionStatus">SubscriptionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Subscription">Subscription</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Subscription">Subscription</a>)
 </p>
 <p>
 <p>SubscriptionStatus (computed) for a subscription</p>
@@ -2227,7 +2227,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>physicalSubscription</code></br>
 <em>
-<a href="#SubscriptionStatusPhysicalSubscription">
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriptionStatusPhysicalSubscription">
 SubscriptionStatusPhysicalSubscription
 </a>
 </em>
@@ -2238,11 +2238,11 @@ SubscriptionStatusPhysicalSubscription
 </tr>
 </tbody>
 </table>
-<h3 id="SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SubscriptionStatus">SubscriptionStatus</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.SubscriptionStatus">SubscriptionStatus</a>)
 </p>
 <p>
 <p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
@@ -2280,11 +2280,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="TriggerFilter">TriggerFilter
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilter">TriggerFilter
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#TriggerSpec">TriggerSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.TriggerSpec">TriggerSpec</a>)
 </p>
 <p>
 </p>
@@ -2300,8 +2300,8 @@ string
 <td>
 <code>sourceAndType</code></br>
 <em>
-<a href="#TriggerFilterSourceAndType">
-TriggerFilterSourceAndType
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilterSourceAndType">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilterSourceAndType
 </a>
 </em>
 </td>
@@ -2310,11 +2310,11 @@ TriggerFilterSourceAndType
 </tr>
 </tbody>
 </table>
-<h3 id="TriggerFilterSourceAndType">TriggerFilterSourceAndType
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilterSourceAndType">TriggerFilterSourceAndType
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#TriggerFilter">TriggerFilter</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.TriggerFilter">TriggerFilter</a>)
 </p>
 <p>
 <p>TriggerFilterSourceAndType filters events based on exact matches on the cloud event&rsquo;s type and
@@ -2351,11 +2351,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="TriggerSpec">TriggerSpec
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerSpec">TriggerSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Trigger">Trigger</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Trigger">Trigger</a>)
 </p>
 <p>
 </p>
@@ -2383,8 +2383,8 @@ to &lsquo;default&rsquo;.</p>
 <td>
 <code>filter</code></br>
 <em>
-<a href="#TriggerFilter">
-TriggerFilter
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilter">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerFilter
 </a>
 </em>
 </td>
@@ -2398,8 +2398,8 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 <td>
 <code>subscriber</code></br>
 <em>
-<a href="#SubscriberSpec">
-SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">
+github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -2410,11 +2410,11 @@ is required.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="TriggerStatus">TriggerStatus
+<h3 id="github.com/knative/eventing/pkg/apis/eventing/v1alpha1.TriggerStatus">TriggerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Trigger">Trigger</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2feventing%2fv1alpha1.Trigger">Trigger</a>)
 </p>
 <p>
 <p>TriggerStatus represents the current state of a Trigger.</p>
@@ -2465,9 +2465,9 @@ string
 </p>
 Resource Types:
 <ul><li>
-<a href="#InMemoryChannel">InMemoryChannel</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.InMemoryChannel">InMemoryChannel</a>
 </li></ul>
-<h3 id="InMemoryChannel">InMemoryChannel
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.InMemoryChannel">InMemoryChannel
 </h3>
 <p>
 <p>InMemoryChannel is a resource representing an in memory channel</p>
@@ -2516,7 +2516,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#InMemoryChannelSpec">
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.InMemoryChannelSpec">
 InMemoryChannelSpec
 </a>
 </em>
@@ -2530,8 +2530,8 @@ InMemoryChannelSpec
 <td>
 <code>subscribable</code></br>
 <em>
-<a href="#Subscribable">
-Subscribable
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
 </a>
 </em>
 </td>
@@ -2546,7 +2546,7 @@ Subscribable
 <td>
 <code>status</code></br>
 <em>
-<a href="#InMemoryChannelStatus">
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.InMemoryChannelStatus">
 InMemoryChannelStatus
 </a>
 </em>
@@ -2559,11 +2559,11 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelTemplateSpec">ChannelTemplateSpec
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.ChannelTemplateSpec">ChannelTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SequenceSpec">SequenceSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.SequenceSpec">SequenceSpec</a>)
 </p>
 <p>
 <p>This should be duck so that Broker can also use this</p>
@@ -2595,7 +2595,7 @@ in verbatim to the Channel CRD as Spec section.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
 </h3>
 <p>
 <p>Internal version of ChannelTemplateSpec that includes ObjectMeta so that
@@ -2643,11 +2643,11 @@ in verbatim to the Channel CRD as Spec section.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="InMemoryChannelSpec">InMemoryChannelSpec
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.InMemoryChannelSpec">InMemoryChannelSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#InMemoryChannel">InMemoryChannel</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.InMemoryChannel">InMemoryChannel</a>)
 </p>
 <p>
 <p>InMemoryChannelSpec defines which subscribers have expressed interest in
@@ -2666,8 +2666,8 @@ arguments for a Channel.</p>
 <td>
 <code>subscribable</code></br>
 <em>
-<a href="#Subscribable">
-Subscribable
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable">
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
 </a>
 </em>
 </td>
@@ -2677,11 +2677,11 @@ Subscribable
 </tr>
 </tbody>
 </table>
-<h3 id="InMemoryChannelStatus">InMemoryChannelStatus
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.InMemoryChannelStatus">InMemoryChannelStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#InMemoryChannel">InMemoryChannel</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.InMemoryChannel">InMemoryChannel</a>)
 </p>
 <p>
 <p>ChannelStatus represents the current state of a Channel.</p>
@@ -2735,7 +2735,7 @@ provided targets from inside the cluster.</p>
 <td>
 <code>SubscribableTypeStatus</code></br>
 <em>
-<a href="#SubscribableTypeStatus">
+<a href="#github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
 </a>
 </em>
@@ -2749,7 +2749,7 @@ SubscribableTypeStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Sequence">Sequence
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.Sequence">Sequence
 </h3>
 <p>
 <p>Sequence defines a sequence of Subscribers that will be wired in
@@ -2782,7 +2782,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#SequenceSpec">
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceSpec">
 SequenceSpec
 </a>
 </em>
@@ -2796,8 +2796,8 @@ SequenceSpec
 <td>
 <code>steps</code></br>
 <em>
-<a href="#SubscriberSpec">
-[]SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">
+[][]github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -2810,7 +2810,7 @@ provided.</p>
 <td>
 <code>channelTemplate</code></br>
 <em>
-<a href="#ChannelTemplateSpec">
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.ChannelTemplateSpec">
 ChannelTemplateSpec
 </a>
 </em>
@@ -2847,7 +2847,7 @@ it will be reflected in the Subscription&rsquo;s status.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#SequenceStatus">
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceStatus">
 SequenceStatus
 </a>
 </em>
@@ -2860,11 +2860,11 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SequenceChannelStatus">SequenceChannelStatus
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceChannelStatus">SequenceChannelStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SequenceStatus">SequenceStatus</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.SequenceStatus">SequenceStatus</a>)
 </p>
 <p>
 </p>
@@ -2902,11 +2902,11 @@ github.com/knative/pkg/apis.Condition
 </tr>
 </tbody>
 </table>
-<h3 id="SequenceSpec">SequenceSpec
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceSpec">SequenceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Sequence">Sequence</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.Sequence">Sequence</a>)
 </p>
 <p>
 </p>
@@ -2922,8 +2922,8 @@ github.com/knative/pkg/apis.Condition
 <td>
 <code>steps</code></br>
 <em>
-<a href="#SubscriberSpec">
-[]SubscriberSpec
+<a href="#github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec">
+[][]github.com/knative/eventing/pkg/apis/eventing/v1alpha1.SubscriberSpec
 </a>
 </em>
 </td>
@@ -2936,7 +2936,7 @@ provided.</p>
 <td>
 <code>channelTemplate</code></br>
 <em>
-<a href="#ChannelTemplateSpec">
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.ChannelTemplateSpec">
 ChannelTemplateSpec
 </a>
 </em>
@@ -2968,11 +2968,11 @@ it will be reflected in the Subscription&rsquo;s status.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SequenceStatus">SequenceStatus
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceStatus">SequenceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Sequence">Sequence</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.Sequence">Sequence</a>)
 </p>
 <p>
 <p>SequenceStatus represents the current state of a Sequence.</p>
@@ -3007,8 +3007,8 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>SubscriptionStatuses</code></br>
 <em>
-<a href="#SequenceSubscriptionStatus">
-[]SequenceSubscriptionStatus
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceSubscriptionStatus">
+[][]github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceSubscriptionStatus
 </a>
 </em>
 </td>
@@ -3021,8 +3021,8 @@ Matches the Spec.Steps array in the order.</p>
 <td>
 <code>ChannelStatuses</code></br>
 <em>
-<a href="#SequenceChannelStatus">
-[]SequenceChannelStatus
+<a href="#github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceChannelStatus">
+[][]github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceChannelStatus
 </a>
 </em>
 </td>
@@ -3051,11 +3051,11 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 </tr>
 </tbody>
 </table>
-<h3 id="SequenceSubscriptionStatus">SequenceSubscriptionStatus
+<h3 id="github.com/knative/eventing/pkg/apis/messaging/v1alpha1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#SequenceStatus">SequenceStatus</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fmessaging%2fv1alpha1.SequenceStatus">SequenceStatus</a>)
 </p>
 <p>
 </p>
@@ -3100,13 +3100,13 @@ github.com/knative/pkg/apis.Condition
 </p>
 Resource Types:
 <ul><li>
-<a href="#ApiServerSource">ApiServerSource</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ApiServerSource">ApiServerSource</a>
 </li><li>
-<a href="#ContainerSource">ContainerSource</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ContainerSource">ContainerSource</a>
 </li><li>
-<a href="#CronJobSource">CronJobSource</a>
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.CronJobSource">CronJobSource</a>
 </li></ul>
-<h3 id="ApiServerSource">ApiServerSource
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerSource">ApiServerSource
 </h3>
 <p>
 <p>ApiServerSource is the Schema for the apiserversources API</p>
@@ -3154,7 +3154,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ApiServerSourceSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerSourceSpec">
 ApiServerSourceSpec
 </a>
 </em>
@@ -3167,8 +3167,8 @@ ApiServerSourceSpec
 <td>
 <code>resources</code></br>
 <em>
-<a href="#ApiServerResource">
-[]ApiServerResource
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerResource">
+[][]github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerResource
 </a>
 </em>
 </td>
@@ -3223,7 +3223,7 @@ string
 <td>
 <code>status</code></br>
 <em>
-<a href="#ApiServerSourceStatus">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerSourceStatus">
 ApiServerSourceStatus
 </a>
 </em>
@@ -3233,7 +3233,7 @@ ApiServerSourceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="ContainerSource">ContainerSource
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ContainerSource">ContainerSource
 </h3>
 <p>
 <p>ContainerSource is the Schema for the containersources API</p>
@@ -3281,7 +3281,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ContainerSourceSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.ContainerSourceSpec">
 ContainerSourceSpec
 </a>
 </em>
@@ -3383,7 +3383,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>status</code></br>
 <em>
-<a href="#ContainerSourceStatus">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.ContainerSourceStatus">
 ContainerSourceStatus
 </a>
 </em>
@@ -3393,7 +3393,7 @@ ContainerSourceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="CronJobSource">CronJobSource
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobSource">CronJobSource
 </h3>
 <p>
 <p>CronJobSource is the Schema for the cronjobsources API.</p>
@@ -3441,7 +3441,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#CronJobSourceSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobSourceSpec">
 CronJobSourceSpec
 </a>
 </em>
@@ -3502,7 +3502,7 @@ Adapter Deployment.</p>
 <td>
 <code>resources</code></br>
 <em>
-<a href="#CronJobResourceSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobResourceSpec">
 CronJobResourceSpec
 </a>
 </em>
@@ -3518,7 +3518,7 @@ CronJobResourceSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#CronJobSourceStatus">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobSourceStatus">
 CronJobSourceStatus
 </a>
 </em>
@@ -3528,11 +3528,11 @@ CronJobSourceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="ApiServerResource">ApiServerResource
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerResource">ApiServerResource
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ApiServerSourceSpec">ApiServerSourceSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
 </p>
 <p>
 <p>ApiServerResource defines the resource to watch</p>
@@ -3581,11 +3581,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="ApiServerSourceSpec">ApiServerSourceSpec
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ApiServerSource">ApiServerSource</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ApiServerSource">ApiServerSource</a>)
 </p>
 <p>
 <p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
@@ -3602,8 +3602,8 @@ bool
 <td>
 <code>resources</code></br>
 <em>
-<a href="#ApiServerResource">
-[]ApiServerResource
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerResource">
+[][]github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerResource
 </a>
 </em>
 </td>
@@ -3653,11 +3653,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="ApiServerSourceStatus">ApiServerSourceStatus
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ApiServerSourceStatus">ApiServerSourceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ApiServerSource">ApiServerSource</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ApiServerSource">ApiServerSource</a>)
 </p>
 <p>
 <p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
@@ -3702,11 +3702,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="ContainerSourceSpec">ContainerSourceSpec
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ContainerSourceSpec">ContainerSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ContainerSource">ContainerSource</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ContainerSource">ContainerSource</a>)
 </p>
 <p>
 <p>ContainerSourceSpec defines the desired state of ContainerSource</p>
@@ -3807,11 +3807,11 @@ Kubernetes core/v1.ObjectReference
 </tr>
 </tbody>
 </table>
-<h3 id="ContainerSourceStatus">ContainerSourceStatus
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.ContainerSourceStatus">ContainerSourceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ContainerSource">ContainerSource</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.ContainerSource">ContainerSource</a>)
 </p>
 <p>
 <p>ContainerSourceStatus defines the observed state of ContainerSource</p>
@@ -3856,11 +3856,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="CronJobLimitsSpec">CronJobLimitsSpec
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobLimitsSpec">CronJobLimitsSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#CronJobResourceSpec">CronJobResourceSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.CronJobResourceSpec">CronJobResourceSpec</a>)
 </p>
 <p>
 </p>
@@ -3894,11 +3894,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="CronJobRequestsSpec">CronJobRequestsSpec
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobRequestsSpec">CronJobRequestsSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#CronJobResourceSpec">CronJobResourceSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.CronJobResourceSpec">CronJobResourceSpec</a>)
 </p>
 <p>
 </p>
@@ -3932,11 +3932,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="CronJobResourceSpec">CronJobResourceSpec
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobResourceSpec">CronJobResourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#CronJobSourceSpec">CronJobSourceSpec</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.CronJobSourceSpec">CronJobSourceSpec</a>)
 </p>
 <p>
 </p>
@@ -3952,7 +3952,7 @@ string
 <td>
 <code>requests</code></br>
 <em>
-<a href="#CronJobRequestsSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobRequestsSpec">
 CronJobRequestsSpec
 </a>
 </em>
@@ -3964,7 +3964,7 @@ CronJobRequestsSpec
 <td>
 <code>limits</code></br>
 <em>
-<a href="#CronJobLimitsSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobLimitsSpec">
 CronJobLimitsSpec
 </a>
 </em>
@@ -3974,11 +3974,11 @@ CronJobLimitsSpec
 </tr>
 </tbody>
 </table>
-<h3 id="CronJobSourceSpec">CronJobSourceSpec
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobSourceSpec">CronJobSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#CronJobSource">CronJobSource</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.CronJobSource">CronJobSource</a>)
 </p>
 <p>
 <p>CronJobSourceSpec defines the desired state of the CronJobSource.</p>
@@ -4043,7 +4043,7 @@ Adapter Deployment.</p>
 <td>
 <code>resources</code></br>
 <em>
-<a href="#CronJobResourceSpec">
+<a href="#github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobResourceSpec">
 CronJobResourceSpec
 </a>
 </em>
@@ -4054,11 +4054,11 @@ CronJobResourceSpec
 </tr>
 </tbody>
 </table>
-<h3 id="CronJobSourceStatus">CronJobSourceStatus
+<h3 id="github.com/knative/eventing/pkg/apis/sources/v1alpha1.CronJobSourceStatus">CronJobSourceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#CronJobSource">CronJobSource</a>)
+<a href="#github.com%2fknative%2feventing%2fpkg%2fapis%2fsources%2fv1alpha1.CronJobSource">CronJobSource</a>)
 </p>
 <p>
 <p>CronJobSourceStatus defines the observed state of CronJobSource.</p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -18,9 +18,9 @@
 </p>
 Resource Types:
 <ul><li>
-<a href="#PodAutoscaler">PodAutoscaler</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscaler">PodAutoscaler</a>
 </li></ul>
-<h3 id="PodAutoscaler">PodAutoscaler
+<h3 id="github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodAutoscaler">PodAutoscaler
 </h3>
 <p>
 <p>PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
@@ -72,7 +72,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#PodAutoscalerSpec">
+<a href="#github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodAutoscalerSpec">
 PodAutoscalerSpec
 </a>
 </em>
@@ -103,7 +103,7 @@ not be used - use metadata.generation</p>
 <td>
 <code>concurrencyModel</code></br>
 <em>
-<a href="#RevisionRequestConcurrencyModelType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionRequestConcurrencyModelType">
 RevisionRequestConcurrencyModelType
 </a>
 </em>
@@ -117,7 +117,7 @@ RevisionRequestConcurrencyModelType
 <td>
 <code>containerConcurrency</code></br>
 <em>
-<a href="#RevisionContainerConcurrencyType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionContainerConcurrencyType">
 RevisionContainerConcurrencyType
 </a>
 </em>
@@ -175,7 +175,7 @@ github.com/knative/serving/pkg/apis/networking.ProtocolType
 <td>
 <code>status</code></br>
 <em>
-<a href="#PodAutoscalerStatus">
+<a href="#github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodAutoscalerStatus">
 PodAutoscalerStatus
 </a>
 </em>
@@ -187,11 +187,11 @@ PodAutoscalerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="PodAutoscalerSpec">PodAutoscalerSpec
+<h3 id="github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodAutoscalerSpec">PodAutoscalerSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#PodAutoscaler">PodAutoscaler</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscaler">PodAutoscaler</a>)
 </p>
 <p>
 <p>PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).</p>
@@ -224,7 +224,7 @@ not be used - use metadata.generation</p>
 <td>
 <code>concurrencyModel</code></br>
 <em>
-<a href="#RevisionRequestConcurrencyModelType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionRequestConcurrencyModelType">
 RevisionRequestConcurrencyModelType
 </a>
 </em>
@@ -238,7 +238,7 @@ RevisionRequestConcurrencyModelType
 <td>
 <code>containerConcurrency</code></br>
 <em>
-<a href="#RevisionContainerConcurrencyType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionContainerConcurrencyType">
 RevisionContainerConcurrencyType
 </a>
 </em>
@@ -291,11 +291,11 @@ github.com/knative/serving/pkg/apis/networking.ProtocolType
 </tr>
 </tbody>
 </table>
-<h3 id="PodAutoscalerStatus">PodAutoscalerStatus
+<h3 id="github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodAutoscalerStatus">PodAutoscalerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#PodAutoscaler">PodAutoscaler</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscaler">PodAutoscaler</a>)
 </p>
 <p>
 <p>PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).</p>
@@ -346,7 +346,7 @@ The service is managed by the PA object.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="PodScalable">PodScalable
+<h3 id="github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodScalable">PodScalable
 </h3>
 <p>
 <p>PodScalable is a duck type that the resources referenced by the
@@ -381,7 +381,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#PodScalableSpec">
+<a href="#github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodScalableSpec">
 PodScalableSpec
 </a>
 </em>
@@ -431,7 +431,7 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#PodScalableStatus">
+<a href="#github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodScalableStatus">
 PodScalableStatus
 </a>
 </em>
@@ -441,11 +441,11 @@ PodScalableStatus
 </tr>
 </tbody>
 </table>
-<h3 id="PodScalableSpec">PodScalableSpec
+<h3 id="github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodScalableSpec">PodScalableSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#PodScalable">PodScalable</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodScalable">PodScalable</a>)
 </p>
 <p>
 <p>PodScalableSpec is the specification for the desired state of a
@@ -495,11 +495,11 @@ Kubernetes core/v1.PodTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="PodScalableStatus">PodScalableStatus
+<h3 id="github.com/knative/serving/pkg/apis/autoscaling/v1alpha1.PodScalableStatus">PodScalableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#PodScalable">PodScalable</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodScalable">PodScalable</a>)
 </p>
 <p>
 <p>PodScalableStatus is the observed state of a PodScalable (or at
@@ -531,15 +531,15 @@ int32
 </p>
 Resource Types:
 <ul><li>
-<a href="#Certificate">Certificate</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Certificate">Certificate</a>
 </li><li>
-<a href="#ClusterIngress">ClusterIngress</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>
 </li><li>
-<a href="#Ingress">Ingress</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Ingress">Ingress</a>
 </li><li>
-<a href="#ServerlessService">ServerlessService</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ServerlessService">ServerlessService</a>
 </li></ul>
-<h3 id="Certificate">Certificate
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.Certificate">Certificate
 </h3>
 <p>
 <p>Certificate is responsible for provisioning a SSL certificate for the
@@ -592,7 +592,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#CertificateSpec">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.CertificateSpec">
 CertificateSpec
 </a>
 </em>
@@ -634,7 +634,7 @@ string
 <td>
 <code>status</code></br>
 <em>
-<a href="#CertificateStatus">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.CertificateStatus">
 CertificateStatus
 </a>
 </em>
@@ -647,7 +647,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 </tr>
 </tbody>
 </table>
-<h3 id="ClusterIngress">ClusterIngress
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.ClusterIngress">ClusterIngress
 </h3>
 <p>
 <p>ClusterIngress is a collection of rules that allow inbound connections to reach the
@@ -702,7 +702,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#IngressSpec">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressSpec">
 IngressSpec
 </a>
 </em>
@@ -734,8 +734,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>tls</code></br>
 <em>
-<a href="#IngressTLS">
-[]IngressTLS
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS
 </a>
 </em>
 </td>
@@ -752,8 +752,8 @@ ingress supports SNI.</p>
 <td>
 <code>rules</code></br>
 <em>
-<a href="#IngressRule">
-[]IngressRule
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule
 </a>
 </em>
 </td>
@@ -766,7 +766,7 @@ ingress supports SNI.</p>
 <td>
 <code>visibility</code></br>
 <em>
-<a href="#IngressVisibility">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressVisibility">
 IngressVisibility
 </a>
 </em>
@@ -782,7 +782,7 @@ IngressVisibility
 <td>
 <code>status</code></br>
 <em>
-<a href="#IngressStatus">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressStatus">
 IngressStatus
 </a>
 </em>
@@ -795,7 +795,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventi
 </tr>
 </tbody>
 </table>
-<h3 id="Ingress">Ingress
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.Ingress">Ingress
 </h3>
 <p>
 <p>Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
@@ -850,7 +850,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#IngressSpec">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressSpec">
 IngressSpec
 </a>
 </em>
@@ -882,8 +882,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>tls</code></br>
 <em>
-<a href="#IngressTLS">
-[]IngressTLS
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS
 </a>
 </em>
 </td>
@@ -900,8 +900,8 @@ ingress supports SNI.</p>
 <td>
 <code>rules</code></br>
 <em>
-<a href="#IngressRule">
-[]IngressRule
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule
 </a>
 </em>
 </td>
@@ -914,7 +914,7 @@ ingress supports SNI.</p>
 <td>
 <code>visibility</code></br>
 <em>
-<a href="#IngressVisibility">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressVisibility">
 IngressVisibility
 </a>
 </em>
@@ -930,7 +930,7 @@ IngressVisibility
 <td>
 <code>status</code></br>
 <em>
-<a href="#IngressStatus">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressStatus">
 IngressStatus
 </a>
 </em>
@@ -943,7 +943,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventi
 </tr>
 </tbody>
 </table>
-<h3 id="ServerlessService">ServerlessService
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessService">ServerlessService
 </h3>
 <p>
 <p>ServerlessService is a proxy for the K8s service objects containing the
@@ -997,7 +997,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ServerlessServiceSpec">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceSpec">
 ServerlessServiceSpec
 </a>
 </em>
@@ -1013,7 +1013,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventi
 <td>
 <code>mode</code></br>
 <em>
-<a href="#ServerlessServiceOperationMode">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceOperationMode">
 ServerlessServiceOperationMode
 </a>
 </em>
@@ -1055,7 +1055,7 @@ serving imports networking, so just use string.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#ServerlessServiceStatus">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceStatus">
 ServerlessServiceStatus
 </a>
 </em>
@@ -1068,11 +1068,11 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventi
 </tr>
 </tbody>
 </table>
-<h3 id="CertificateSpec">CertificateSpec
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.CertificateSpec">CertificateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Certificate">Certificate</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Certificate">Certificate</a>)
 </p>
 <p>
 <p>CertificateSpec defines the desired state of a <code>Certificate</code>.</p>
@@ -1110,11 +1110,11 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="CertificateStatus">CertificateStatus
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.CertificateStatus">CertificateStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Certificate">Certificate</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Certificate">Certificate</a>)
 </p>
 <p>
 <p>CertificateStatus defines the observed state of a <code>Certificate</code>.</p>
@@ -1165,8 +1165,8 @@ by this resource in spec.secretName.</p>
 <td>
 <code>http01Challenges</code></br>
 <em>
-<a href="#HTTP01Challenge">
-[]HTTP01Challenge
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTP01Challenge">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTP01Challenge
 </a>
 </em>
 </td>
@@ -1177,11 +1177,11 @@ in order to get the TLS certificate..</p>
 </tr>
 </tbody>
 </table>
-<h3 id="HTTP01Challenge">HTTP01Challenge
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTP01Challenge">HTTP01Challenge
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#CertificateStatus">CertificateStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.CertificateStatus">CertificateStatus</a>)
 </p>
 <p>
 <p>HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs
@@ -1241,11 +1241,11 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </tr>
 </tbody>
 </table>
-<h3 id="HTTPIngressPath">HTTPIngressPath
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPIngressPath">HTTPIngressPath
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#HTTPIngressRuleValue">HTTPIngressRuleValue</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.HTTPIngressRuleValue">HTTPIngressRuleValue</a>)
 </p>
 <p>
 <p>HTTPIngressPath associates a path regex with a backend. Incoming URLs matching
@@ -1281,8 +1281,8 @@ traffic to the backend.</p>
 <td>
 <code>splits</code></br>
 <em>
-<a href="#IngressBackendSplit">
-[]IngressBackendSplit
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressBackendSplit">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressBackendSplit
 </a>
 </em>
 </td>
@@ -1324,8 +1324,8 @@ Kubernetes meta/v1.Duration
 <td>
 <code>retries</code></br>
 <em>
-<a href="#HTTPRetry">
-HTTPRetry
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPRetry">
+github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPRetry
 </a>
 </em>
 </td>
@@ -1337,11 +1337,11 @@ HTTPRetry
 </tr>
 </tbody>
 </table>
-<h3 id="HTTPIngressRuleValue">HTTPIngressRuleValue
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPIngressRuleValue">HTTPIngressRuleValue
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#IngressRule">IngressRule</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.IngressRule">IngressRule</a>)
 </p>
 <p>
 <p>HTTPIngressRuleValue is a list of http selectors pointing to backends.
@@ -1362,8 +1362,8 @@ or &lsquo;#&rsquo;.</p>
 <td>
 <code>paths</code></br>
 <em>
-<a href="#HTTPIngressPath">
-[]HTTPIngressPath
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPIngressPath">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPIngressPath
 </a>
 </em>
 </td>
@@ -1374,11 +1374,11 @@ or &lsquo;#&rsquo;.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="HTTPRetry">HTTPRetry
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPRetry">HTTPRetry
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#HTTPIngressPath">HTTPIngressPath</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.HTTPIngressPath">HTTPIngressPath</a>)
 </p>
 <p>
 <p>HTTPRetry describes the retry policy to use when a HTTP request fails.</p>
@@ -1417,11 +1417,11 @@ Kubernetes meta/v1.Duration
 </tr>
 </tbody>
 </table>
-<h3 id="IngressBackend">IngressBackend
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressBackend">IngressBackend
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#IngressBackendSplit">IngressBackendSplit</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.IngressBackendSplit">IngressBackendSplit</a>)
 </p>
 <p>
 <p>IngressBackend describes all endpoints for a given service and port.</p>
@@ -1470,11 +1470,11 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 </tr>
 </tbody>
 </table>
-<h3 id="IngressBackendSplit">IngressBackendSplit
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressBackendSplit">IngressBackendSplit
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#HTTPIngressPath">HTTPIngressPath</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.HTTPIngressPath">HTTPIngressPath</a>)
 </p>
 <p>
 <p>IngressBackendSplit describes all endpoints for a given service and port.</p>
@@ -1491,7 +1491,7 @@ k8s.io/apimachinery/pkg/util/intstr.IntOrString
 <td>
 <code>IngressBackend</code></br>
 <em>
-<a href="#IngressBackend">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressBackend">
 IngressBackend
 </a>
 </em>
@@ -1532,11 +1532,11 @@ before forwarding a request to the destination service.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="IngressRule">IngressRule
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule">IngressRule
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#IngressSpec">IngressSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.IngressSpec">IngressSpec</a>)
 </p>
 <p>
 <p>IngressRule represents the rules mapping the paths under a specified host to
@@ -1578,8 +1578,8 @@ If multiple matching Hosts were provided, the first rule will take precedent.</p
 <td>
 <code>http</code></br>
 <em>
-<a href="#HTTPIngressRuleValue">
-HTTPIngressRuleValue
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPIngressRuleValue">
+github.com/knative/serving/pkg/apis/networking/v1alpha1.HTTPIngressRuleValue
 </a>
 </em>
 </td>
@@ -1590,12 +1590,12 @@ rule is satisfied, the request is routed to the specified backend.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="IngressSpec">IngressSpec
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressSpec">IngressSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ClusterIngress">ClusterIngress</a>, 
-<a href="#Ingress">Ingress</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Ingress">Ingress</a>)
 </p>
 <p>
 <p>IngressSpec describes the Ingress the user wishes to exist.</p>
@@ -1634,8 +1634,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>tls</code></br>
 <em>
-<a href="#IngressTLS">
-[]IngressTLS
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS
 </a>
 </em>
 </td>
@@ -1652,8 +1652,8 @@ ingress supports SNI.</p>
 <td>
 <code>rules</code></br>
 <em>
-<a href="#IngressRule">
-[]IngressRule
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressRule
 </a>
 </em>
 </td>
@@ -1666,7 +1666,7 @@ ingress supports SNI.</p>
 <td>
 <code>visibility</code></br>
 <em>
-<a href="#IngressVisibility">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressVisibility">
 IngressVisibility
 </a>
 </em>
@@ -1677,12 +1677,12 @@ IngressVisibility
 </tr>
 </tbody>
 </table>
-<h3 id="IngressStatus">IngressStatus
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressStatus">IngressStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ClusterIngress">ClusterIngress</a>, 
-<a href="#Ingress">Ingress</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Ingress">Ingress</a>)
 </p>
 <p>
 <p>IngressStatus describe the current state of the Ingress.</p>
@@ -1714,8 +1714,8 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>loadBalancer</code></br>
 <em>
-<a href="#LoadBalancerStatus">
-LoadBalancerStatus
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.LoadBalancerStatus">
+github.com/knative/serving/pkg/apis/networking/v1alpha1.LoadBalancerStatus
 </a>
 </em>
 </td>
@@ -1726,11 +1726,11 @@ LoadBalancerStatus
 </tr>
 </tbody>
 </table>
-<h3 id="IngressTLS">IngressTLS
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressTLS">IngressTLS
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#IngressSpec">IngressSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.IngressSpec">IngressSpec</a>)
 </p>
 <p>
 <p>IngressTLS describes the transport layer security associated with an Ingress.</p>
@@ -1808,21 +1808,21 @@ Defaults to <code>tls.key</code>.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="IngressVisibility">IngressVisibility
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.IngressVisibility">IngressVisibility
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#IngressSpec">IngressSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.IngressSpec">IngressSpec</a>)
 </p>
 <p>
 <p>IngressVisibility describes whether the Ingress should be exposed to
 public gateways or not.</p>
 </p>
-<h3 id="LoadBalancerIngressStatus">LoadBalancerIngressStatus
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.LoadBalancerIngressStatus">LoadBalancerIngressStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#LoadBalancerStatus">LoadBalancerStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.LoadBalancerStatus">LoadBalancerStatus</a>)
 </p>
 <p>
 <p>LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
@@ -1890,11 +1890,11 @@ bool
 </tr>
 </tbody>
 </table>
-<h3 id="LoadBalancerStatus">LoadBalancerStatus
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.LoadBalancerStatus">LoadBalancerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#IngressStatus">IngressStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.IngressStatus">IngressStatus</a>)
 </p>
 <p>
 <p>LoadBalancerStatus represents the status of a load-balancer.</p>
@@ -1911,8 +1911,8 @@ bool
 <td>
 <code>ingress</code></br>
 <em>
-<a href="#LoadBalancerIngressStatus">
-[]LoadBalancerIngressStatus
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.LoadBalancerIngressStatus">
+[][]github.com/knative/serving/pkg/apis/networking/v1alpha1.LoadBalancerIngressStatus
 </a>
 </em>
 </td>
@@ -1924,21 +1924,21 @@ Traffic intended for the service should be sent to these ingress points.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ServerlessServiceOperationMode">ServerlessServiceOperationMode
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceOperationMode">ServerlessServiceOperationMode
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServerlessServiceSpec">ServerlessServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ServerlessServiceSpec">ServerlessServiceSpec</a>)
 </p>
 <p>
 <p>ServerlessServiceOperationMode is an enumeration of the modes of operation
 for the ServerlessService.</p>
 </p>
-<h3 id="ServerlessServiceSpec">ServerlessServiceSpec
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceSpec">ServerlessServiceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServerlessService">ServerlessService</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ServerlessService">ServerlessService</a>)
 </p>
 <p>
 <p>ServerlessServiceSpec describes the ServerlessService.</p>
@@ -1955,7 +1955,7 @@ for the ServerlessService.</p>
 <td>
 <code>mode</code></br>
 <em>
-<a href="#ServerlessServiceOperationMode">
+<a href="#github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceOperationMode">
 ServerlessServiceOperationMode
 </a>
 </em>
@@ -1992,11 +1992,11 @@ serving imports networking, so just use string.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ServerlessServiceStatus">ServerlessServiceStatus
+<h3 id="github.com/knative/serving/pkg/apis/networking/v1alpha1.ServerlessServiceStatus">ServerlessServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServerlessService">ServerlessService</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ServerlessService">ServerlessService</a>)
 </p>
 <p>
 <p>ServerlessServiceStatus describes the current state of the ServerlessService.</p>
@@ -2058,15 +2058,15 @@ load balances over the user service pods backing this Revision.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#Configuration">Configuration</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Configuration">Configuration</a>
 </li><li>
-<a href="#Revision">Revision</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Revision">Revision</a>
 </li><li>
-<a href="#Route">Route</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Route">Route</a>
 </li><li>
-<a href="#Service">Service</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Service">Service</a>
 </li></ul>
-<h3 id="Configuration">Configuration
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.Configuration">Configuration
 </h3>
 <p>
 <p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions,
@@ -2120,7 +2120,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -2164,8 +2164,8 @@ perform to produce the Revision&rsquo;s container image.</p>
 <td>
 <code>revisionTemplate</code></br>
 <em>
-<a href="#RevisionTemplateSpec">
-RevisionTemplateSpec
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec
 </a>
 </em>
 </td>
@@ -2182,8 +2182,8 @@ DEPRECATED Use Template instead.</p>
 <td>
 <code>template</code></br>
 <em>
-<a href="#RevisionTemplateSpec">
-RevisionTemplateSpec
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec
 </a>
 </em>
 </td>
@@ -2200,7 +2200,7 @@ be stamped out.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#ConfigurationStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationStatus">
 ConfigurationStatus
 </a>
 </em>
@@ -2212,7 +2212,7 @@ ConfigurationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Revision">Revision
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.Revision">Revision
 </h3>
 <p>
 <p>Revision is an immutable snapshot of code and configuration.  A revision
@@ -2265,7 +2265,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -2280,7 +2280,7 @@ RevisionSpec
 <td>
 <code>RevisionSpec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -2311,7 +2311,7 @@ not be used - use metadata.generation</p>
 <td>
 <code>servingState</code></br>
 <em>
-<a href="#DeprecatedRevisionServingStateType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.DeprecatedRevisionServingStateType">
 DeprecatedRevisionServingStateType
 </a>
 </em>
@@ -2328,7 +2328,7 @@ updated by the system.</p>
 <td>
 <code>concurrencyModel</code></br>
 <em>
-<a href="#RevisionRequestConcurrencyModelType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionRequestConcurrencyModelType">
 RevisionRequestConcurrencyModelType
 </a>
 </em>
@@ -2396,7 +2396,7 @@ environment:
 <td>
 <code>status</code></br>
 <em>
-<a href="#RevisionStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionStatus">
 RevisionStatus
 </a>
 </em>
@@ -2408,7 +2408,7 @@ RevisionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Route">Route
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.Route">Route
 </h3>
 <p>
 <p>Route is responsible for configuring ingress over a collection of Revisions.
@@ -2462,7 +2462,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#RouteSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteSpec">
 RouteSpec
 </a>
 </em>
@@ -2493,8 +2493,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>traffic</code></br>
 <em>
-<a href="#TrafficTarget">
-[]TrafficTarget
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget">
+[][]github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget
 </a>
 </em>
 </td>
@@ -2510,7 +2510,7 @@ not be used - use metadata.generation</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#RouteStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteStatus">
 RouteStatus
 </a>
 </em>
@@ -2522,7 +2522,7 @@ RouteStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Service">Service
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.Service">Service
 </h3>
 <p>
 <p>Service acts as a top-level container that manages a set of Routes and
@@ -2580,7 +2580,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ServiceSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ServiceSpec">
 ServiceSpec
 </a>
 </em>
@@ -2610,8 +2610,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>runLatest</code></br>
 <em>
-<a href="#RunLatestType">
-RunLatestType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RunLatestType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.RunLatestType
 </a>
 </em>
 </td>
@@ -2626,8 +2626,8 @@ from the supplied configuration running.</p>
 <td>
 <code>pinned</code></br>
 <em>
-<a href="#PinnedType">
-PinnedType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.PinnedType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.PinnedType
 </a>
 </em>
 </td>
@@ -2640,8 +2640,8 @@ PinnedType
 <td>
 <code>manual</code></br>
 <em>
-<a href="#ManualType">
-ManualType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ManualType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.ManualType
 </a>
 </em>
 </td>
@@ -2656,8 +2656,8 @@ from the limited capabilities of Service to the full power of Route.</p>
 <td>
 <code>release</code></br>
 <em>
-<a href="#ReleaseType">
-ReleaseType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ReleaseType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.ReleaseType
 </a>
 </em>
 </td>
@@ -2671,7 +2671,7 @@ to be split between two revisions. This type replaces the deprecated Pinned type
 <td>
 <code>ConfigurationSpec</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -2691,7 +2691,7 @@ be deprecated, and then dropped in v1beta1.</p>
 <td>
 <code>RouteSpec</code></br>
 <em>
-<a href="#RouteSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteSpec">
 RouteSpec
 </a>
 </em>
@@ -2709,7 +2709,7 @@ RouteSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#ServiceStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ServiceStatus">
 ServiceStatus
 </a>
 </em>
@@ -2720,7 +2720,7 @@ ServiceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="CannotConvertError">CannotConvertError
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.CannotConvertError">CannotConvertError
 </h3>
 <p>
 <p>CannotConvertError is returned when a field cannot be converted.</p>
@@ -2755,15 +2755,15 @@ string
 </tr>
 </tbody>
 </table>
-<h3 id="ConfigurationSpec">ConfigurationSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">ConfigurationSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Configuration">Configuration</a>, 
-<a href="#PinnedType">PinnedType</a>, 
-<a href="#ReleaseType">ReleaseType</a>, 
-<a href="#RunLatestType">RunLatestType</a>, 
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Configuration">Configuration</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.PinnedType">PinnedType</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ReleaseType">ReleaseType</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RunLatestType">RunLatestType</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>ConfigurationSpec holds the desired state of the Configuration (from the client).</p>
@@ -2809,8 +2809,8 @@ perform to produce the Revision&rsquo;s container image.</p>
 <td>
 <code>revisionTemplate</code></br>
 <em>
-<a href="#RevisionTemplateSpec">
-RevisionTemplateSpec
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec
 </a>
 </em>
 </td>
@@ -2827,8 +2827,8 @@ DEPRECATED Use Template instead.</p>
 <td>
 <code>template</code></br>
 <em>
-<a href="#RevisionTemplateSpec">
-RevisionTemplateSpec
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec
 </a>
 </em>
 </td>
@@ -2840,11 +2840,11 @@ be stamped out.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ConfigurationStatus">ConfigurationStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationStatus">ConfigurationStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Configuration">Configuration</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Configuration">Configuration</a>)
 </p>
 <p>
 <p>ConfigurationStatus communicates the observed state of the Configuration (from the controller).</p>
@@ -2876,7 +2876,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>ConfigurationStatusFields</code></br>
 <em>
-<a href="#ConfigurationStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationStatusFields">
 ConfigurationStatusFields
 </a>
 </em>
@@ -2889,12 +2889,12 @@ ConfigurationStatusFields
 </tr>
 </tbody>
 </table>
-<h3 id="ConfigurationStatusFields">ConfigurationStatusFields
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationStatusFields">ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ConfigurationStatus">ConfigurationStatus</a>, 
-<a href="#ServiceStatus">ServiceStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ConfigurationStatus">ConfigurationStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
 <p>ConfigurationStatusFields holds all of the non-duckv1beta1.Status status fields of a Route.
@@ -2937,31 +2937,31 @@ Configuration. It might not be ready yet, for that use LatestReadyRevisionName.<
 </tr>
 </tbody>
 </table>
-<h3 id="DeprecatedRevisionServingStateType">DeprecatedRevisionServingStateType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.DeprecatedRevisionServingStateType">DeprecatedRevisionServingStateType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#RevisionSpec">RevisionSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionSpec">RevisionSpec</a>)
 </p>
 <p>
 <p>DeprecatedRevisionServingStateType is an enumeration of the levels of serving readiness of the Revision.
 See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/errors.md#error-conditions-and-reporting">https://github.com/knative/serving/blob/master/docs/spec/errors.md#error-conditions-and-reporting</a></p>
 </p>
-<h3 id="ManualType">ManualType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ManualType">ManualType
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>ManualType contains the options for configuring a manual service. See ServiceSpec for
 more details.</p>
 </p>
-<h3 id="PinnedType">PinnedType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.PinnedType">PinnedType
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>PinnedType is DEPRECATED. ReleaseType should be used instead. To get the behavior of PinnedType set
@@ -2992,7 +2992,7 @@ to a different service type.</p>
 <td>
 <code>configuration</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -3004,11 +3004,11 @@ ConfigurationSpec
 </tr>
 </tbody>
 </table>
-<h3 id="ReleaseType">ReleaseType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ReleaseType">ReleaseType
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>ReleaseType contains the options for slowly releasing revisions. See ServiceSpec for
@@ -3053,7 +3053,7 @@ revision. Valid values are between 0 and 99 inclusive.</p>
 <td>
 <code>configuration</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -3066,24 +3066,24 @@ come from a single configuration.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RevisionRequestConcurrencyModelType">RevisionRequestConcurrencyModelType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionRequestConcurrencyModelType">RevisionRequestConcurrencyModelType
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#PodAutoscalerSpec">PodAutoscalerSpec</a>, 
-<a href="#RevisionSpec">RevisionSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionSpec">RevisionSpec</a>)
 </p>
 <p>
 <p>RevisionRequestConcurrencyModelType is an enumeration of the
 concurrency models supported by a Revision.
 DEPRECATED in favor of RevisionContainerConcurrencyType.</p>
 </p>
-<h3 id="RevisionSpec">RevisionSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionSpec">RevisionSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Revision">Revision</a>, 
-<a href="#RevisionTemplateSpec">RevisionTemplateSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Revision">Revision</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
 <p>RevisionSpec holds the desired state of the Revision (from the client).</p>
@@ -3100,7 +3100,7 @@ DEPRECATED in favor of RevisionContainerConcurrencyType.</p>
 <td>
 <code>RevisionSpec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -3131,7 +3131,7 @@ not be used - use metadata.generation</p>
 <td>
 <code>servingState</code></br>
 <em>
-<a href="#DeprecatedRevisionServingStateType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.DeprecatedRevisionServingStateType">
 DeprecatedRevisionServingStateType
 </a>
 </em>
@@ -3148,7 +3148,7 @@ updated by the system.</p>
 <td>
 <code>concurrencyModel</code></br>
 <em>
-<a href="#RevisionRequestConcurrencyModelType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionRequestConcurrencyModelType">
 RevisionRequestConcurrencyModelType
 </a>
 </em>
@@ -3211,11 +3211,11 @@ environment:
 </tr>
 </tbody>
 </table>
-<h3 id="RevisionStatus">RevisionStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionStatus">RevisionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Revision">Revision</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Revision">Revision</a>)
 </p>
 <p>
 <p>RevisionStatus communicates the observed state of the Revision (from the controller).</p>
@@ -3287,11 +3287,11 @@ may be empty if the image comes from a registry listed to skip resolution.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RevisionTemplateSpec">RevisionTemplateSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionTemplateSpec">RevisionTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ConfigurationSpec">ConfigurationSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ConfigurationSpec">ConfigurationSpec</a>)
 </p>
 <p>
 <p>RevisionTemplateSpec describes the data a revision should have when created from a template.
@@ -3324,7 +3324,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -3338,7 +3338,7 @@ RevisionSpec
 <td>
 <code>RevisionSpec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -3369,7 +3369,7 @@ not be used - use metadata.generation</p>
 <td>
 <code>servingState</code></br>
 <em>
-<a href="#DeprecatedRevisionServingStateType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.DeprecatedRevisionServingStateType">
 DeprecatedRevisionServingStateType
 </a>
 </em>
@@ -3386,7 +3386,7 @@ updated by the system.</p>
 <td>
 <code>concurrencyModel</code></br>
 <em>
-<a href="#RevisionRequestConcurrencyModelType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RevisionRequestConcurrencyModelType">
 RevisionRequestConcurrencyModelType
 </a>
 </em>
@@ -3452,12 +3452,12 @@ environment:
 </tr>
 </tbody>
 </table>
-<h3 id="RouteSpec">RouteSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteSpec">RouteSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Route">Route</a>, 
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Route">Route</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>RouteSpec holds the desired state of the Route (from the client).</p>
@@ -3490,8 +3490,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>traffic</code></br>
 <em>
-<a href="#TrafficTarget">
-[]TrafficTarget
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget">
+[][]github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget
 </a>
 </em>
 </td>
@@ -3502,11 +3502,11 @@ not be used - use metadata.generation</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RouteStatus">RouteStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteStatus">RouteStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Route">Route</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Route">Route</a>)
 </p>
 <p>
 <p>RouteStatus communicates the observed state of the Route (from the controller).</p>
@@ -3538,7 +3538,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>RouteStatusFields</code></br>
 <em>
-<a href="#RouteStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteStatusFields">
 RouteStatusFields
 </a>
 </em>
@@ -3551,12 +3551,12 @@ RouteStatusFields
 </tr>
 </tbody>
 </table>
-<h3 id="RouteStatusFields">RouteStatusFields
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteStatusFields">RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#RouteStatus">RouteStatus</a>, 
-<a href="#ServiceStatus">ServiceStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteStatus">RouteStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
 <p>RouteStatusFields holds all of the non-duckv1beta1.Status status fields of a Route.
@@ -3630,8 +3630,8 @@ github.com/knative/pkg/apis/duck/v1alpha1.Addressable
 <td>
 <code>traffic</code></br>
 <em>
-<a href="#TrafficTarget">
-[]TrafficTarget
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget">
+[][]github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget
 </a>
 </em>
 </td>
@@ -3645,11 +3645,11 @@ LatestReadyRevisionName that we last observed.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RunLatestType">RunLatestType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.RunLatestType">RunLatestType
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>RunLatestType contains the options for always having a route to the latest configuration. See
@@ -3667,7 +3667,7 @@ ServiceSpec for more details.</p>
 <td>
 <code>configuration</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -3679,11 +3679,11 @@ ConfigurationSpec
 </tr>
 </tbody>
 </table>
-<h3 id="ServiceSpec">ServiceSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ServiceSpec">ServiceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Service">Service</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceSpec represents the configuration for the Service object. Exactly one
@@ -3719,8 +3719,8 @@ not be used - use metadata.generation</p>
 <td>
 <code>runLatest</code></br>
 <em>
-<a href="#RunLatestType">
-RunLatestType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RunLatestType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.RunLatestType
 </a>
 </em>
 </td>
@@ -3735,8 +3735,8 @@ from the supplied configuration running.</p>
 <td>
 <code>pinned</code></br>
 <em>
-<a href="#PinnedType">
-PinnedType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.PinnedType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.PinnedType
 </a>
 </em>
 </td>
@@ -3749,8 +3749,8 @@ PinnedType
 <td>
 <code>manual</code></br>
 <em>
-<a href="#ManualType">
-ManualType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ManualType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.ManualType
 </a>
 </em>
 </td>
@@ -3765,8 +3765,8 @@ from the limited capabilities of Service to the full power of Route.</p>
 <td>
 <code>release</code></br>
 <em>
-<a href="#ReleaseType">
-ReleaseType
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ReleaseType">
+github.com/knative/serving/pkg/apis/serving/v1alpha1.ReleaseType
 </a>
 </em>
 </td>
@@ -3780,7 +3780,7 @@ to be split between two revisions. This type replaces the deprecated Pinned type
 <td>
 <code>ConfigurationSpec</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -3800,7 +3800,7 @@ be deprecated, and then dropped in v1beta1.</p>
 <td>
 <code>RouteSpec</code></br>
 <em>
-<a href="#RouteSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteSpec">
 RouteSpec
 </a>
 </em>
@@ -3813,11 +3813,11 @@ RouteSpec
 </tr>
 </tbody>
 </table>
-<h3 id="ServiceStatus">ServiceStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.ServiceStatus">ServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Service">Service</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceStatus represents the Status stanza of the Service resource.</p>
@@ -3849,7 +3849,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>RouteStatusFields</code></br>
 <em>
-<a href="#RouteStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.RouteStatusFields">
 RouteStatusFields
 </a>
 </em>
@@ -3864,7 +3864,7 @@ RouteStatusFields
 <td>
 <code>ConfigurationStatusFields</code></br>
 <em>
-<a href="#ConfigurationStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1alpha1.ConfigurationStatusFields">
 ConfigurationStatusFields
 </a>
 </em>
@@ -3877,12 +3877,12 @@ ConfigurationStatusFields
 </tr>
 </tbody>
 </table>
-<h3 id="TrafficTarget">TrafficTarget
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1alpha1.TrafficTarget">TrafficTarget
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#RouteSpec">RouteSpec</a>, 
-<a href="#RouteStatusFields">RouteStatusFields</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteSpec">RouteSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteStatusFields">RouteStatusFields</a>)
 </p>
 <p>
 <p>TrafficTarget holds a single entry of the routing table for a Route.</p>
@@ -3912,7 +3912,7 @@ target exclusively. It has the form: {name}.${route.status.domain}</p>
 <td>
 <code>TrafficTarget</code></br>
 <em>
-<a href="#TrafficTarget">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget">
 TrafficTarget
 </a>
 </em>
@@ -3933,15 +3933,15 @@ Ultimately all non-v1beta1 fields will be deprecated.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#Configuration">Configuration</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Configuration">Configuration</a>
 </li><li>
-<a href="#Revision">Revision</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Revision">Revision</a>
 </li><li>
-<a href="#Route">Route</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Route">Route</a>
 </li><li>
-<a href="#Service">Service</a>
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Service">Service</a>
 </li></ul>
-<h3 id="Configuration">Configuration
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.Configuration">Configuration
 </h3>
 <p>
 <p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions.
@@ -3964,7 +3964,7 @@ See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/over
 string</td>
 <td>
 <code>
-serving.knative.dev/v1alpha1
+serving.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -3994,7 +3994,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -4008,7 +4008,7 @@ ConfigurationSpec
 <td>
 <code>template</code></br>
 <em>
-<a href="#RevisionTemplateSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionTemplateSpec">
 RevisionTemplateSpec
 </a>
 </em>
@@ -4025,7 +4025,7 @@ RevisionTemplateSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#ConfigurationStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationStatus">
 ConfigurationStatus
 </a>
 </em>
@@ -4036,7 +4036,7 @@ ConfigurationStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Revision">Revision
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.Revision">Revision
 </h3>
 <p>
 <p>Revision is an immutable snapshot of code and configuration.  A revision
@@ -4058,7 +4058,7 @@ Configuration.</p>
 string</td>
 <td>
 <code>
-serving.knative.dev/v1alpha1
+serving.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -4088,7 +4088,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -4117,7 +4117,7 @@ Kubernetes core/v1.PodSpec
 <td>
 <code>containerConcurrency</code></br>
 <em>
-<a href="#RevisionContainerConcurrencyType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionContainerConcurrencyType">
 RevisionContainerConcurrencyType
 </a>
 </em>
@@ -4150,7 +4150,7 @@ be provided.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#RevisionStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionStatus">
 RevisionStatus
 </a>
 </em>
@@ -4161,7 +4161,7 @@ RevisionStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Route">Route
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.Route">Route
 </h3>
 <p>
 <p>Route is responsible for configuring ingress over a collection of Revisions.
@@ -4185,7 +4185,7 @@ See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/over
 string</td>
 <td>
 <code>
-serving.knative.dev/v1alpha1
+serving.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -4215,7 +4215,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#RouteSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RouteSpec">
 RouteSpec
 </a>
 </em>
@@ -4230,8 +4230,8 @@ RouteSpec
 <td>
 <code>traffic</code></br>
 <em>
-<a href="#TrafficTarget">
-[]TrafficTarget
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget">
+[][]github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget
 </a>
 </em>
 </td>
@@ -4248,7 +4248,7 @@ revisions and configurations.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#RouteStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RouteStatus">
 RouteStatus
 </a>
 </em>
@@ -4260,7 +4260,7 @@ RouteStatus
 </tr>
 </tbody>
 </table>
-<h3 id="Service">Service
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.Service">Service
 </h3>
 <p>
 <p>Service acts as a top-level container that manages a Route and Configuration
@@ -4288,7 +4288,7 @@ and Route, reflecting their statuses and conditions as its own.</p>
 string</td>
 <td>
 <code>
-serving.knative.dev/v1alpha1
+serving.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -4318,7 +4318,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#ServiceSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ServiceSpec">
 ServiceSpec
 </a>
 </em>
@@ -4332,7 +4332,7 @@ ServiceSpec
 <td>
 <code>ConfigurationSpec</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -4348,7 +4348,7 @@ ConfigurationSpec
 <td>
 <code>RouteSpec</code></br>
 <em>
-<a href="#RouteSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RouteSpec">
 RouteSpec
 </a>
 </em>
@@ -4370,7 +4370,7 @@ defaults).</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#ServiceStatus">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ServiceStatus">
 ServiceStatus
 </a>
 </em>
@@ -4381,12 +4381,12 @@ ServiceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="ConfigurationSpec">ConfigurationSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationSpec">ConfigurationSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Configuration">Configuration</a>, 
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Configuration">Configuration</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>ConfigurationSpec holds the desired state of the Configuration (from the client).</p>
@@ -4403,7 +4403,7 @@ ServiceStatus
 <td>
 <code>template</code></br>
 <em>
-<a href="#RevisionTemplateSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionTemplateSpec">
 RevisionTemplateSpec
 </a>
 </em>
@@ -4415,11 +4415,11 @@ RevisionTemplateSpec
 </tr>
 </tbody>
 </table>
-<h3 id="ConfigurationStatus">ConfigurationStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationStatus">ConfigurationStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Configuration">Configuration</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Configuration">Configuration</a>)
 </p>
 <p>
 <p>ConfigurationStatus communicates the observed state of the Configuration (from the controller).</p>
@@ -4451,7 +4451,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>ConfigurationStatusFields</code></br>
 <em>
-<a href="#ConfigurationStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationStatusFields">
 ConfigurationStatusFields
 </a>
 </em>
@@ -4464,12 +4464,12 @@ ConfigurationStatusFields
 </tr>
 </tbody>
 </table>
-<h3 id="ConfigurationStatusFields">ConfigurationStatusFields
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationStatusFields">ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ConfigurationStatus">ConfigurationStatus</a>, 
-<a href="#ServiceStatus">ServiceStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ConfigurationStatus">ConfigurationStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
 <p>ConfigurationStatusFields holds the fields of Configuration&rsquo;s status that
@@ -4512,24 +4512,24 @@ Configuration. It might not be ready yet, for that use LatestReadyRevisionName.<
 </tr>
 </tbody>
 </table>
-<h3 id="RevisionContainerConcurrencyType">RevisionContainerConcurrencyType
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionContainerConcurrencyType">RevisionContainerConcurrencyType
 (<code>int64</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#PodAutoscalerSpec">PodAutoscalerSpec</a>, 
-<a href="#RevisionSpec">RevisionSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RevisionSpec">RevisionSpec</a>)
 </p>
 <p>
 <p>RevisionContainerConcurrencyType is an integer expressing the maximum number of
 in-flight (concurrent) requests.</p>
 </p>
-<h3 id="RevisionSpec">RevisionSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionSpec">RevisionSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Revision">Revision</a>, 
-<a href="#RevisionSpec">RevisionSpec</a>, 
-<a href="#RevisionTemplateSpec">RevisionTemplateSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Revision">Revision</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionSpec">RevisionSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
 <p>RevisionSpec holds the desired state of the Revision (from the client).</p>
@@ -4561,7 +4561,7 @@ Kubernetes core/v1.PodSpec
 <td>
 <code>containerConcurrency</code></br>
 <em>
-<a href="#RevisionContainerConcurrencyType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionContainerConcurrencyType">
 RevisionContainerConcurrencyType
 </a>
 </em>
@@ -4589,11 +4589,11 @@ be provided.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RevisionStatus">RevisionStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionStatus">RevisionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Revision">Revision</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Revision">Revision</a>)
 </p>
 <p>
 <p>RevisionStatus communicates the observed state of the Revision (from the controller).</p>
@@ -4665,11 +4665,11 @@ may be empty if the image comes from a registry listed to skip resolution.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RevisionTemplateSpec">RevisionTemplateSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionTemplateSpec">RevisionTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#ConfigurationSpec">ConfigurationSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ConfigurationSpec">ConfigurationSpec</a>)
 </p>
 <p>
 <p>RevisionTemplateSpec describes the data a revision should have when created from a template.
@@ -4702,7 +4702,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#RevisionSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionSpec">
 RevisionSpec
 </a>
 </em>
@@ -4731,7 +4731,7 @@ Kubernetes core/v1.PodSpec
 <td>
 <code>containerConcurrency</code></br>
 <em>
-<a href="#RevisionContainerConcurrencyType">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RevisionContainerConcurrencyType">
 RevisionContainerConcurrencyType
 </a>
 </em>
@@ -4762,12 +4762,12 @@ be provided.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RouteSpec">RouteSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RouteSpec">RouteSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Route">Route</a>, 
-<a href="#ServiceSpec">ServiceSpec</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Route">Route</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
 <p>RouteSpec holds the desired state of the Route (from the client).</p>
@@ -4784,8 +4784,8 @@ be provided.</p>
 <td>
 <code>traffic</code></br>
 <em>
-<a href="#TrafficTarget">
-[]TrafficTarget
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget">
+[][]github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget
 </a>
 </em>
 </td>
@@ -4797,11 +4797,11 @@ revisions and configurations.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="RouteStatus">RouteStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RouteStatus">RouteStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Route">Route</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Route">Route</a>)
 </p>
 <p>
 <p>RouteStatus communicates the observed state of the Route (from the controller).</p>
@@ -4833,7 +4833,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>RouteStatusFields</code></br>
 <em>
-<a href="#RouteStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RouteStatusFields">
 RouteStatusFields
 </a>
 </em>
@@ -4846,12 +4846,12 @@ RouteStatusFields
 </tr>
 </tbody>
 </table>
-<h3 id="RouteStatusFields">RouteStatusFields
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.RouteStatusFields">RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#RouteStatus">RouteStatus</a>, 
-<a href="#ServiceStatus">ServiceStatus</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteStatus">RouteStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
 <p>RouteStatusFields holds the fields of Route&rsquo;s status that
@@ -4897,8 +4897,8 @@ github.com/knative/pkg/apis/duck/v1beta1.Addressable
 <td>
 <code>traffic</code></br>
 <em>
-<a href="#TrafficTarget">
-[]TrafficTarget
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget">
+[][]github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget
 </a>
 </em>
 </td>
@@ -4912,11 +4912,11 @@ LatestReadyRevisionName that we last observed.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ServiceSpec">ServiceSpec
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.ServiceSpec">ServiceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Service">Service</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceSpec represents the configuration for the Service object.
@@ -4939,7 +4939,7 @@ the appropriate &ldquo;run latest&rdquo; spec.</p>
 <td>
 <code>ConfigurationSpec</code></br>
 <em>
-<a href="#ConfigurationSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationSpec">
 ConfigurationSpec
 </a>
 </em>
@@ -4955,7 +4955,7 @@ ConfigurationSpec
 <td>
 <code>RouteSpec</code></br>
 <em>
-<a href="#RouteSpec">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RouteSpec">
 RouteSpec
 </a>
 </em>
@@ -4972,11 +4972,11 @@ defaults).</p>
 </tr>
 </tbody>
 </table>
-<h3 id="ServiceStatus">ServiceStatus
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.ServiceStatus">ServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#Service">Service</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceStatus represents the Status stanza of the Service resource.</p>
@@ -5008,7 +5008,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>ConfigurationStatusFields</code></br>
 <em>
-<a href="#ConfigurationStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.ConfigurationStatusFields">
 ConfigurationStatusFields
 </a>
 </em>
@@ -5025,7 +5025,7 @@ specific to ConfigurationStatus.</p>
 <td>
 <code>RouteStatusFields</code></br>
 <em>
-<a href="#RouteStatusFields">
+<a href="#github.com/knative/serving/pkg/apis/serving/v1beta1.RouteStatusFields">
 RouteStatusFields
 </a>
 </em>
@@ -5040,13 +5040,13 @@ specific to RouteStatus.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="TrafficTarget">TrafficTarget
+<h3 id="github.com/knative/serving/pkg/apis/serving/v1beta1.TrafficTarget">TrafficTarget
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#RouteSpec">RouteSpec</a>, 
-<a href="#RouteStatusFields">RouteStatusFields</a>, 
-<a href="#TrafficTarget">TrafficTarget</a>)
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteSpec">RouteSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteStatusFields">RouteStatusFields</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.TrafficTarget">TrafficTarget</a>)
 </p>
 <p>
 <p>TrafficTarget holds a single entry of the routing table for a Route.</p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -7,10 +7,10 @@
 <a href="#networking.internal.knative.dev">networking.internal.knative.dev</a>
 </li>
 <li>
-<a href="#serving.knative.dev">serving.knative.dev</a>
+<a href="#serving.knative.dev-v1alpha1">serving.knative.dev (v1alpha1)</a>
 </li>
 <li>
-<a href="#serving.knative.dev">serving.knative.dev</a>
+<a href="#serving.knative.dev-v1beta1">serving.knative.dev (v1beta1)</a>
 </li>
 </ul>
 <h2 id="autoscaling.internal.knative.dev">autoscaling.internal.knative.dev</h2>
@@ -1594,7 +1594,7 @@ rule is satisfied, the request is routed to the specified backend.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Ingress">Ingress</a>)
 </p>
 <p>
@@ -1681,7 +1681,7 @@ IngressVisibility
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.ClusterIngress">ClusterIngress</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fnetworking%2fv1alpha1.Ingress">Ingress</a>)
 </p>
 <p>
@@ -2053,7 +2053,7 @@ load balances over the user service pods backing this Revision.</p>
 </tbody>
 </table>
 <hr/>
-<h2 id="serving.knative.dev">serving.knative.dev</h2>
+<h2 id="serving.knative.dev-v1alpha1">serving.knative.dev (v1alpha1)</h2>
 <p>
 </p>
 Resource Types:
@@ -2759,10 +2759,10 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Configuration">Configuration</a>, 
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.PinnedType">PinnedType</a>, 
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ReleaseType">ReleaseType</a>, 
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RunLatestType">RunLatestType</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Configuration">Configuration</a>,
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.PinnedType">PinnedType</a>,
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ReleaseType">ReleaseType</a>,
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RunLatestType">RunLatestType</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -2893,7 +2893,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ConfigurationStatus">ConfigurationStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ConfigurationStatus">ConfigurationStatus</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -3070,7 +3070,7 @@ come from a single configuration.</p>
 (<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionSpec">RevisionSpec</a>)
 </p>
 <p>
@@ -3082,7 +3082,7 @@ DEPRECATED in favor of RevisionContainerConcurrencyType.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Revision">Revision</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Revision">Revision</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
@@ -3456,7 +3456,7 @@ environment:
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Route">Route</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.Route">Route</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -3555,7 +3555,7 @@ RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteStatus">RouteStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteStatus">RouteStatus</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -3881,7 +3881,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteSpec">RouteSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteSpec">RouteSpec</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RouteStatusFields">RouteStatusFields</a>)
 </p>
 <p>
@@ -3928,7 +3928,7 @@ Ultimately all non-v1beta1 fields will be deprecated.</p>
 </tbody>
 </table>
 <hr/>
-<h2 id="serving.knative.dev">serving.knative.dev</h2>
+<h2 id="serving.knative.dev-v1beta1">serving.knative.dev (v1beta1)</h2>
 <p>
 </p>
 Resource Types:
@@ -4385,7 +4385,7 @@ ServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Configuration">Configuration</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Configuration">Configuration</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -4468,7 +4468,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ConfigurationStatus">ConfigurationStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ConfigurationStatus">ConfigurationStatus</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -4516,7 +4516,7 @@ Configuration. It might not be ready yet, for that use LatestReadyRevisionName.<
 (<code>int64</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fautoscaling%2fv1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RevisionSpec">RevisionSpec</a>)
 </p>
 <p>
@@ -4527,8 +4527,8 @@ in-flight (concurrent) requests.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Revision">Revision</a>, 
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionSpec">RevisionSpec</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Revision">Revision</a>,
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.RevisionSpec">RevisionSpec</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
@@ -4766,7 +4766,7 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Route">Route</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.Route">Route</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -4850,7 +4850,7 @@ RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteStatus">RouteStatus</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteStatus">RouteStatus</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -5044,8 +5044,8 @@ specific to RouteStatus.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteSpec">RouteSpec</a>, 
-<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteStatusFields">RouteStatusFields</a>, 
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteSpec">RouteSpec</a>,
+<a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1beta1.RouteStatusFields">RouteStatusFields</a>,
 <a href="#github.com%2fknative%2fserving%2fpkg%2fapis%2fserving%2fv1alpha1.TrafficTarget">TrafficTarget</a>)
 </p>
 <p>


### PR DESCRIPTION
With a shiny new API build script (#1552), generated new API docs for 07 that include eventing-contrib, and also mention manual updates in README

Note: with new script, some manual edits must be made to the lists of Packages in both the serving.md and eventing-contrib-resources.md files

- Qualify v1alpha1 vs v1beta1 in serving.md
- Due to multiple directories, the eventing-contrib-resources.md file duplicates the sources.eventing.knative.dev Package - you must remove the duplicates from the list and then consolidate all the "Resource Types:" into a single list.

re: #1528