### PR TITLE
reference: fix api grouping in reference docs

### DIFF
--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -23,7 +23,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 REFDOCS_PKG="github.com/ahmetb/gen-crd-api-reference-docs"
 REFDOCS_REPO="https://${REFDOCS_PKG}.git"
-REFDOCS_VER="v0.1.4"
+REFDOCS_VER="v0.1.5"
 
 KNATIVE_SERVING_REPO="github.com/knative/serving"
 KNATIVE_SERVING_COMMIT="${KNATIVE_SERVING_COMMIT:?specify the \$KNATIVE_SERVING_COMMIT variable}"


### PR DESCRIPTION
This bumps the `gen-crd-api-reference-docs` to v0.1.5 which has two notable
fixes impacting Knative:

1. Prevent types in same apiGroup but different apiVersion (e.g v1beta1 vs
   v1alpha1) from grouped together.
2. De-duplicate the apiGroups list when types belonging to that api group come
   from different Go packages.

Fixes #1559.
/assign @richieescarez