### PR TITLE
change the worng serial number

### DIFF
--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -74,7 +74,7 @@ your Knative installation, see
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
-1. To complete the install of Knative and its dependencies, run the
+2. To complete the install of Knative and its dependencies, run the
    `kubectl apply` command again, this time without the `--selector` flag, to
    complete the install of Knative and its dependencies:
 
@@ -96,7 +96,7 @@ your Knative installation, see
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
 
-1. Monitor the Knative components until all of the components show a `STATUS` of
+3. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
 
    ```bash


### PR DESCRIPTION
change the worng installation procedure serial number

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->


## Proposed Changes

- change the serial number of Install on a Kubernetes cluster's doc
