### PR TITLE
Format markdown

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -88,8 +88,8 @@ To generate a version of the API:
 1. Copy the generated API files into the `docs/reference` directory of your
    knative/docs clone.
 
-1. IMPORTANT: There are some limitations to the build script that require
-   manual changes to the HTML. For the `serving.md` and
+1. IMPORTANT: There are some limitations to the build script that require manual
+   changes to the HTML. For the `serving.md` and
    `eventing-contrib-resources.md`, you must manually fix the `Packages` lists.
    Details for the required manual changes are in
    [PR 1552](https://github.com/knative/docs/pull/1552#issuecomment-506891983).

--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -5,13 +5,17 @@ weight: 9
 type: "docs"
 ---
 
-This guide describes the [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/) that are active when running Knative Serving.
+This guide describes the
+[Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+that are active when running Knative Serving.
 
 ## Before You Begin
 
 1. This guide assumes that you have installed Knative Serving. If you have not,
-   instructions on how to do this are located [here](https://knative.dev/docs/install/knative-custom-install/).
-2. Verify that you have the proper components in your cluster. To view the services installed in your cluster, use the commmand:
+   instructions on how to do this are located
+   [here](https://knative.dev/docs/install/knative-custom-install/).
+2. Verify that you have the proper components in your cluster. To view the
+   services installed in your cluster, use the commmand:
 
    ```sh
    $ kubectl get services -n knative-serving
@@ -20,12 +24,14 @@ This guide describes the [Kubernetes Services](https://kubernetes.io/docs/concep
    This should return the following output:
 
    ```sh
-NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                  AGE
-activator-service   ClusterIP   10.96.61.11      <none>        80/TCP,81/TCP,9090/TCP   1h
-autoscaler          ClusterIP   10.104.217.223   <none>        8080/TCP,9090/TCP        1h
-controller          ClusterIP   10.101.39.220    <none>        9090/TCP                 1h
-webhook             ClusterIP   10.107.144.50    <none>        443/TCP                  1h
-```
+   NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                  AGE
+   activator-service   ClusterIP   10.96.61.11      <none>        80/TCP,81/TCP,9090/TCP   1h
+   autoscaler          ClusterIP   10.104.217.223   <none>        8080/TCP,9090/TCP        1h
+   controller          ClusterIP   10.101.39.220    <none>        9090/TCP                 1h
+   webhook             ClusterIP   10.107.144.50    <none>        443/TCP                  1h
+   ```
+
+````
  3. To view the deployments in your cluster, use the following command:
 
     ```sh
@@ -42,30 +48,36 @@ controller               1         1         1            1           1h
 networking-certmanager   1         1         1            1           1h
 networking-istio         1         1         1            1           1h
 webhook                  1         1         1            1           1h
-```
+````
 
-These services and deployments are installed by the `serving.yaml` file during install. The next section describes their function.
+These services and deployments are installed by the `serving.yaml` file during
+install. The next section describes their function.
 
 ## Components
 
 ### Service: activator
 
-The activator is responsible for receiving & buffering requests for inactive revisions and reporting metrics to the autoscaler. It also retries requests to a revision after the autoscaler scales the revision based on the reported metrics.
+The activator is responsible for receiving & buffering requests for inactive
+revisions and reporting metrics to the autoscaler. It also retries requests to a
+revision after the autoscaler scales the revision based on the reported metrics.
 
 ### Service: autoscaler
 
-The autoscaler receives request metrics and adjusts the number of pods required to handle the load of traffic.
+The autoscaler receives request metrics and adjusts the number of pods required
+to handle the load of traffic.
 
 ### Service: controller
 
 The controller service reconciles all the public Knative objects and autoscaling
 CRDs. When a user applies a Knative service to the Kubernetes API, this creates
-the configuration and route. It will convert the configuration into revisions and the revisions into deployments and Knative Pod Autoscalers (KPAs).
+the configuration and route. It will convert the configuration into revisions
+and the revisions into deployments and Knative Pod Autoscalers (KPAs).
 
 ### Service: webhook
 
-The webhook intercepts all Kubernetes API calls as well as all CRD insertions and updates.
-It sets default values, rejects inconsitent and invalid objects, and validates and mutates Kubernetes API calls.
+The webhook intercepts all Kubernetes API calls as well as all CRD insertions
+and updates. It sets default values, rejects inconsitent and invalid objects,
+and validates and mutates Kubernetes API calls.
 
 ### Deployment: networking-certmanager
 
@@ -73,11 +85,14 @@ The certmanager reconciles cluster ingresses into cert manager objects.
 
 ### Deployment: networking-istio
 
-The networking-istio deployment reconciles a cluster's ingress into an [Istio virtual service](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/).
+The networking-istio deployment reconciles a cluster's ingress into an
+[Istio virtual service](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/).
 
 ## What's Next
 
-- For a deeper look at the services and deployments involved in Knative Serving, click [here](https://github.com/knative/serving/blob/master/docs/spec/overview.md#service).
+- For a deeper look at the services and deployments involved in Knative Serving,
+  click
+  [here](https://github.com/knative/serving/blob/master/docs/spec/overview.md#service).
 - For a high-level analysis of Serving, look at the [documentation here](./).
-- Check out the Knative Seriving code samples [here](./samples/) for more hands-on tutorials.
-
+- Check out the Knative Seriving code samples [here](./samples/) for more
+  hands-on tutorials.


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
