### PR TITLE
 Document usage of Camel K in sources

### DIFF
--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -17,6 +17,8 @@ for generating events.
    Documentation includes specific instructions for common Kubernetes
    environments, including development clusters.
 
+1. Download Kail binaries for Linux or OSX, which can be found on the [latest release](https://github.com/boz/kail/releases/latest) page. You can use `kail` instead of `kubectl logs` to tail the logs of the subscriber.
+
 1. Install the Camel Source from the `camel.yaml` in the [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
 
    ```shell
@@ -35,7 +37,7 @@ To verify that the `CamelSource` is working, we will create:
 Deploy the [`display_resources.yaml`](./display_resources.yaml):
 
 ```shell
-kubectl apply -f display_resources.yaml
+kubectl apply --filename display_resources.yaml
 ```
 
 ### Run a CamelSource using the Timer component
@@ -60,14 +62,19 @@ kubectl apply -f source_timer.yaml
 
 We will verify that the published message was sent to the Knative eventing
 system by looking at the downstream of the `CamelSource`.
+ 
+```shell
+kubectl logs --selector serving.knative.dev/service=camel-event-display -c user-container
+```
+or 
 
-1. Use [`kail`](https://github.com/boz/kail) to tail the logs of the subscriber.
+You can also use [`kail`](https://github.com/boz/kail) to tail the logs of the subscriber.
 
-   ```shell
-   kail -d camel-event-display --since=10m
-   ```
+```shell
+kail -d camel-event-display --since=10m
+```
 
-If you've deployed the timer source, you should see log lines appearing every 3
+If you have deployed the timer source, you should see log lines appearing every 3
 seconds.
 
 
@@ -101,7 +108,7 @@ Install the [telegram CamelSource](source_telegram.yaml) from source:
 kunbectl apply -f source_telegram.yaml
 ```
 
-Start kail again and keep it open on the event display:
+Start `kail` again and keep it open on the event display:
 
 ```shell
 kail -d camel-event-display --since=10m

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -17,28 +17,25 @@ for generating events.
    Documentation includes specific instructions for common Kubernetes
    environments, including development clusters.
 
-1. Install the Camel Source from the [yaml files in the config dir](../config/)
-   from source:
+1. Install the Camel Source from the `camel.yaml` in the [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
 
    ```shell
-   ko apply -f ../config/
+   kubectl apply --filename camel.yaml
    ```
-  
-  Or install a released version.   
    
 
 ### Create a Channel and a Subscriber
 
-To check that a `CamelSource` is fully working, we will create:
+To verify that the `CamelSource` is working, we will create:
 
 - a simple Knative event display service that prints incoming events to its log
 - an in-memory channel named `camel-test` that will buffer events created by the event source
 - a subscription to direct events from the test channel to the event display service
 
-Deploy `display_resources.yaml`, building it from source:
+Deploy the [`display_resources.yaml`](./display_resources.yaml):
 
 ```shell
-ko apply -f display_resources.yaml
+kubectl apply -f display_resources.yaml
 ```
 
 ### Run a CamelSource using the Timer component
@@ -58,7 +55,7 @@ All Camel components are documented in the
 Install the [timer CamelSource](source_timer.yaml) from source:
 
 ```shell
-ko apply -f source_timer.yaml
+kubectl apply -f source_timer.yaml
 ```
 
 We will verify that the published message was sent to the Knative eventing
@@ -101,7 +98,7 @@ kubectl delete camelsource camel-timer-source
 Install the [telegram CamelSource](source_telegram.yaml) from source:
 
 ```shell
-ko apply -f source_telegram.yaml
+kunbectl apply -f source_telegram.yaml
 ```
 
 Start kail again and keep it open on the event display:
@@ -128,10 +125,10 @@ kubectl delete camelsource --all
 Install the [Camel K Source](source_camel_k.yaml) from source:
 
 ```shell
-ko apply -f source_camel_k.yaml
+kubectl apply -f source_camel_k.yaml
 ```
 
-Start kail again and keep it open on the event display:
+Start `kail` again and keep it open on the event display:
 
 ```shell
 kail -d camel-event-display --since=10m

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -1,6 +1,5 @@
-These samples show how to configure a Camel source. It is a event source that
-can leverage one of the
-[250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
+These samples show how to configure a Camel Source. It is an Event Source that
+can leverage one of the[250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
 for generating events.
 
 ## Prerequisites
@@ -11,64 +10,71 @@ for generating events.
    any namespace where you want to run Camel sources.
 
    The preferred version that is compatible with Camel sources is
-   [Camel K v0.2.0](https://github.com/apache/camel-k/releases/tag/0.2.0).
+   [Camel K v0.3.3](https://github.com/apache/camel-k/releases/tag/0.3.3).
 
    Installation instruction are provided on the
    [Apache Camel K Github repository](https://github.com/apache/camel-k#installation).
    Documentation includes specific instructions for common Kubernetes
    environments, including development clusters.
 
-1. Install the Camel Source from the `camel.yaml` in the
-   [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
+1. Install the Camel Source from the [yaml files in the config dir](../config/)
+   from source:
 
    ```shell
-   kubectl apply --filename camel.yaml
+   ko apply -f ../config/
    ```
+  
+  Or install a released version.   
+   
 
-## Create a Channel and a Subscriber
+### Create a Channel and a Subscriber
 
-In order to check if a `CamelSource` is fully working, we will create:
+To check that a `CamelSource` is fully working, we will create:
 
 - a simple Knative event display service that prints incoming events to its log
-- a in-memory channel named `camel-test` that will buffer events created by the
-  event source
-- a subscription to direct events from the test channel to the event display
-  service
+- an in-memory channel named `camel-test` that will buffer events created by the event source
+- a subscription to direct events from the test channel to the event display service
 
-Deploy the [`display_resources.yaml`](./display_resources.yaml):
+Deploy `display_resources.yaml`, building it from source:
 
 ```shell
-kubectl apply --filename display_resources.yaml
+ko apply -f display_resources.yaml
 ```
 
-## Run a CamelSource using the Timer component
+### Run a CamelSource using the Timer component
 
-The simplest example of CamelSource, that does not require additional
-configuration, is the "timer" source.
+The samples directory contains some sample sources that can be used to generate
+events.
+
+The simplest one, that does not require additional configuration is the "timer"
+source.
 
 If you want, you can customize the source behavior using options available in
 the Apache Camel documentation for the
-[timer component](https://github.com/apache/camel/blob/master/components/camel-timer/src/main/docs/timer-component.adoc).
+[timer component](https://github.com/apache/camel/blob/master/camel-core/src/main/docs/timer-component.adoc).
 All Camel components are documented in the
 [Apache Camel github repository](https://github.com/apache/camel/tree/master/components).
 
-Install the [`source_timer.yaml`](source_timer.yaml) resource:
+Install the [timer CamelSource](source_timer.yaml) from source:
 
 ```shell
-kubectl apply --filename source_timer.yaml
+ko apply -f source_timer.yaml
 ```
 
-We will verify that the published events were sent into the Knative eventing
-system by looking at what is downstream of the `CamelSource`.
+We will verify that the published message was sent to the Knative eventing
+system by looking at the downstream of the `CamelSource`.
 
-```shell
-kubectl logs --selector serving.knative.dev/service=camel-event-display -c user-container
-```
+1. Use [`kail`](https://github.com/boz/kail) to tail the logs of the subscriber.
+
+   ```shell
+   kail -d camel-event-display --since=10m
+   ```
 
 If you've deployed the timer source, you should see log lines appearing every 3
 seconds.
 
-## Run a CamelSource using the Telegram component
+
+### Run a CamelSource using the Telegram component
 
 Another useful component available with Camel is the Telegram component. It can
 be used to forward messages of a [Telegram](https://telegram.org/) chat into
@@ -82,9 +88,8 @@ Bot, using your preferred Telegram client (mobile or web). After you create the
 bot, you'll receive an **authorization token** that is needed for the source to
 work.
 
-First, download and edit the [`source_telegram.yaml`](source_telegram.yaml) file
-and put the authorization token, replacing the `<put-your-token-here>`
-placeholder.
+First, edit the [telegram CamelSource](source_telegram.yaml) and put the
+authorization token, replacing the `<put-your-token-here>` placeholder.
 
 To reduce noise in the event display, you can remove the previously created
 timer CamelSource from the namespace:
@@ -93,19 +98,44 @@ timer CamelSource from the namespace:
 kubectl delete camelsource camel-timer-source
 ```
 
-Install the [`source_telegram.yaml`](source_telegram.yaml) resource:
+Install the [telegram CamelSource](source_telegram.yaml) from source:
 
 ```shell
-kubectl apply -f source_telegram.yaml
+ko apply -f source_telegram.yaml
 ```
 
-Now, you can **send messages to your bot** with any Telegram client.
-
-Check again the logs on the event display:
+Start kail again and keep it open on the event display:
 
 ```shell
-kubectl logs --selector serving.knative.dev/service=camel-event-display -c user-container
+kail -d camel-event-display --since=10m
 ```
 
-Each message you send to the bot will be printed by the event display as a
-cloudevent.
+Now, you can contact your bot with any Telegram client. Each message you send
+to the bot will be printed by the event display as a cloudevent.
+
+
+### Run a Camel K Source
+
+For complex use cases that require multiple steps to be executed before event data is ready to be published, you can use Camel K sources.
+Camel K lets you use Camel DSL to design one or more routes that can define arbitrarily complex workflows before sending events to the target sink.
+
+If you have previously deployed other CamelSources, to reduce noise in the event display, you can remove them all from the namespace:
+
+```shell
+kubectl delete camelsource --all
+```
+
+Install the [Camel K Source](source_camel_k.yaml) from source:
+
+```shell
+ko apply -f source_camel_k.yaml
+```
+
+Start kail again and keep it open on the event display:
+
+```shell
+kail -d camel-event-display --since=10m
+```
+
+The event display will show some JSON data periodically pulled from an external REST API.
+The API in the example is static, but you can use your own dynamic API by replacing the endpoint.

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -1,5 +1,5 @@
 These samples show how to configure a Camel Source. It is an Event Source that
-can leverage one of the[250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
+can leverage one of the [250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
 for generating events.
 
 ## Prerequisites
@@ -17,7 +17,7 @@ for generating events.
    Documentation includes specific instructions for common Kubernetes
    environments, including development clusters.
 
-1. Download Kail binaries for Linux or OSX, which can be found on the [latest release](https://github.com/boz/kail/releases/latest) page. You can use `kail` instead of `kubectl logs` to tail the logs of the subscriber.
+1.(Optional) Download Kail binaries for Linux or OSX, which can be found on the [latest release](https://github.com/boz/kail/releases/latest) page. You can use `kail` instead of `kubectl logs` to tail the logs of the subscriber.
 
 1. Install the Camel Source from the `camel.yaml` in the [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
 

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -50,9 +50,9 @@ source.
 
 If you want, you can customize the source behavior using options available in
 the Apache Camel documentation for the
-[timer component](https://github.com/apache/camel/blob/master/camel-core/src/main/docs/timer-component.adoc).
+[timer component](https://github.com/apache/camel/blob/master/components/camel-timer/src/main/docs/timer-component.adoc).
 All Camel components are documented in the
-[Apache Camel github repository](https://github.com/apache/camel/tree/master/components).
+[Apache Camel GitHub repository](https://github.com/apache/camel/tree/master/components).
 
 Install the [timer CamelSource](source_timer.yaml) from source:
 

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -121,7 +121,7 @@ to the bot will be printed by the event display as a cloudevent.
 ### Run a Camel K Source
 
 For complex use cases that require multiple steps to be executed before event data is ready to be published, you can use Camel K sources.
-Camel K lets you use Camel DSL to design one or more routes that can define arbitrarily complex workflows before sending events to the target sink.
+Camel K lets you use Camel DSL to design one or more routes that can define complex workflows before sending events to the target sink.
 
 If you have previously deployed other CamelSources, to reduce noise in the event display, you can remove them all from the namespace:
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- Update version for doc
- Brief explanation on running a Camel source

