### PR TITLE
Fixing Broker manual event emit curl example

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -273,11 +273,11 @@ While SSHed into a `Pod` and run:
 curl -v "http://default-broker.default.svc.cluster.local/" \
   -X POST \
   -H "X-B3-Flags: 1" \
-  -H "CE-CloudEventsVersion: 0.1" \
-  -H "CE-EventType: dev.knative.foo.bar" \
-  -H "CE-EventTime: 2018-04-05T03:56:24Z" \
-  -H "CE-EventID: 45a8b444-3213-4758-be3f-540bf93f85ff" \
-  -H "CE-Source: dev.knative.example" \
+  -H "ce-specversion: 0.2" \
+  -H "ce-type: dev.knative.foo.bar" \
+  -H "ce-time: 2018-04-05T03:56:24Z" \
+  -H "ce-id: 45a8b444-3213-4758-be3f-540bf93f85ff" \
+  -H "ce-source: dev.knative.example" \
   -H 'Content-Type: application/json' \
   -d '{ "much": "wow" }'
 ```


### PR DESCRIPTION
Upgrading the curl example in Broker's manual event emit example as the CloudEvents v0.1 format and no longer works, v0.2 does.

Tested with Knative Eventing 0.6
