### PR TITLE
Remove Istio requirement for Eventing

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -35,9 +35,7 @@ Knative Eventing component_ is not supported by Gloo at this time.
 ## Installing Knative with Istio
 
 Istio is a popular service mesh that includes a Knative-compatible ingress.
-Choose this option if you wish to use Istio service mesh features. You will also
-need to choose this installation option if you wish to use the Knative Eventing
-component, which currently depends on Istio.
+Choose this option if you wish to use Istio service mesh features.
 
 There are several options when installing Knative:
 


### PR DESCRIPTION
Eventing did not require Istio anymore from v0.6.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->