### PR TITLE
Removes references to a invalid sample file. Fixes #1457.

### DIFF
--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -9,11 +9,6 @@ A Knative `Build` runs on-cluster and is implemented by a
 Given a _builder_, or container image that you have created to perform a task or
 action, you can define a Knative `Build` through a single configuration file.
 
-Also consider using a Knative `Build` to build the source code of your apps into
-container images, which you can then run on
-[Knative `serving`](../serving/README.md). More information about this use case
-is demonstrated in [this sample](../serving/samples/source-to-url-go).
-
 ## Key features of Knative Builds
 
 - A `Build` can include multiple `steps` where each step specifies a `Builder`.


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1457 

## Proposed Changes

- Removes the reference and lead up to a defunct code sample. 
-
-
