### PR TITLE
Remove "Documentation" main menu config

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -3,9 +3,6 @@ title: "Welcome to Knative"
 linkTitle: "Documentation"
 weight: 10
 type: "docs"
-menu:
-  main:
-    weight: 10
 ---
 
 {{% readfile file="README.md" relative="true" markdown="true" %}}


### PR DESCRIPTION
All main menu configuration now lives in the sites default config.toml
https://github.com/knative/website/pull/61
