### PR TITLE
Add Documentation for Install Knative with Ambassador

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -35,7 +35,8 @@ to run multiple installation commands.
 
 ## Installing Istio
 
-> Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
+> Note: [Ambassador](https://www.getambassador.io/) and [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
+> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on [Istio](https://istio.io/docs/concepts/what-is-istio/) for

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -133,7 +133,8 @@ recommended configuration for a cluster is:
 
 ## Installing Istio
 
-> Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
+> Note: [Ambassador](https://www.getambassador.io/) and [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
+> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on Istio. If your cloud platform offers a managed Istio

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -5,8 +5,8 @@ weight: 15
 type: "docs"
 ---
 
-[Ambassador](https://www.getambassador.io/) is a popular, Kubernetes native,
- open-source API gateway and the most popular distrbution of 
+[Ambassador](https://www.getambassador.io/) is a popular Kubernetes-native,
+ open-source API gateway built on
  [Envoy Proxy](https://www.envoyproxy.io/).
 
 This guide walks you through the installation of the latest version of Knative
@@ -30,10 +30,9 @@ Knative was originally built using Istio to handle cluster networking. While
 the Istio gateway provides the functionality needed to serve requests to your 
 application, installing a service mesh to handle north-south traffic carries 
 some operational overhead with it. Ambassador provides a way to get traffic to 
-your Knative application without the overhead of a full service mesh.
+your Knative application without the overhead or complexity of a full service mesh.
 
-You can easily install Ambassador as your ingress controller using two 
-`kubectl` commands:
+You can install Ambassador with `kubectl`:
 
 ```
 kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-knative.yaml

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -1,0 +1,170 @@
+---
+title: "Installing Istio for Knative"
+linkTitle: "Ambassador API Gatway and Knative"
+weight: 15
+type: "docs"
+---
+
+[Ambassador](https://www.getambassador.io/) is a popular, Kubernetes native,
+ open-source API gateway and the most popular distrbution of 
+ [Envoy Proxy](https://www.envoyproxy.io/).
+
+This guide walks you through the installation of the latest version of Knative
+ using pre-built images.
+
+## Before you Begin
+
+Knative requires a Kubernetes cluster v1.11 or newer with the 
+[MutatingAdmissionWebhook admission controller](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#how-do-i-turn-on-an-admission-controller) 
+enabled. 
+
+`kubectl` v1.10 is also required. 
+
+This guide assumes that you have already 
+[created a Kubernetes cluster](https://kubernetes.io/docs/setup/) and are using
+ bash in a Mac or Linux environment.
+
+## Install Ambassador
+
+Knative was originally built using Istio to handle cluster networking. While 
+the Istio gateway provides the functionality we need to serve requests to our 
+application, needing to install a service mesh to handle north-south traffic 
+brings some operational overhead. Ambassador provides a way to get traffic to 
+your Knative application without the overhead of a full service mesh.
+
+You can easily install Ambassador as your ingress controller using two 
+`kubectl` commands:
+
+```
+kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-knative.yaml
+kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-service.yaml
+```
+
+Ambassador will watch for and create routes based off of Knative 
+`ClusterIngress` resources. These will then be accessible over the external IP 
+address of the Ambassador service we just created.
+
+Get this external IP address and save it in a variable named `AMBASSADOR_IP`
+
+```
+$ kubectl get svc ambassador
+
+NAME         TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)        AGE
+ambassador   LoadBalancer   10.59.246.30   35.229.120.99   80:32073/TCP   13m
+
+$ AMBASSADOR_IP=35.229.120.99
+```
+
+## Install Knative
+
+Now that we have Ambassador installed to handle ingress to our serverless 
+applications we need to install Knative to manage them.
+
+The following commands install all available Knative components as well as the 
+standard set of observability plugins. To customize your Knative installation, 
+see Performing a Custom Knative Installation.
+
+1. To install Knative, first install the CRDs by running the `kubectl apply` 
+command once with the `-l knative.dev/crd-install=true` flag. This prevents 
+race conditions during the install, which cause intermittent errors:
+
+    ```
+    kubectl apply -l knative.dev/crd-install=true \
+    --filename https://github.com/knative/serving/releases/download/v0.7.1/serving.yaml \
+    --filename https://github.com/knative/build/releases/download/v0.7.1/build.yaml \
+    --filename https://github.com/knative/serving/releases/download/v0.7.1/monitoring.yaml
+    ```
+2. To complete the install of Knative and it's dependencies, run the 
+`kubectl apply` command again, this time without the 
+`-l knative.dev/crd-install=true`:
+
+    ```
+    kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.1 serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+    --filename https://github.com/knative/build/releases/download/v0.7.1/build.yaml \
+    --filename https://github.com/knative/serving/releases/download/v0.7.1/monitoring.yaml
+    ```
+   > **Notes**:
+   >
+   > - By default, the Knative Serving component installation (`serving.yaml`)
+   >   includes a controller for
+   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
+   >   If you do intend on immediately enabling auto certificates in Knative,
+   >   you can remove the
+   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
+   >   statement to install the controller. Otherwise, you can choose to install
+   >   the auto certificates feature and controller at a later time.
+
+3. Monitor the Knative namespaces and wait until all of the pods come up with
+ a `STATUS` of `Running`:
+
+    ```
+    kubectl get pods -w --all-namespaces
+    ```
+
+## Deploying an Application
+
+Now that we have Knative and Ambassador running, we can use them to manage and 
+route traffic to a serverless application.
+
+1. Create a `Knative Service`
+
+   For this demo, we will use a simple helloworld application written in go. 
+   Copy the YAML below to a file called `helloworld-go.yaml` and apply it 
+   with `kubectl`
+
+    ```yaml
+    apiVersion: serving.knative.dev/v1alpha1
+    kind: Service
+    metadata:
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        spec:
+          containers:
+          - image: gcr.io/knative-samples/helloworld-go
+            env: 
+            - name: TARGET
+              value: Go Sample v1
+    ```
+
+    ```
+    kubectl apply -f helloworld-go.yaml
+    ```
+
+2. Send a request
+
+    `Knative Service`s are exposed via a `Host` header assigned by Knative. 
+    By default, Knative will assign the 
+    `Host`: `{service-name}.{namespace}.example.com`. You can verify this by 
+    checking the `EXTERNAL-IP` of the `helloworld-go` service we created above.
+
+    ```
+    $ kubectl get service helloworld-go
+
+    NAME            TYPE           CLUSTER-IP   EXTERNAL-IP                         PORT(S)   AGE
+    helloworld-go   ExternalName   <none>       helloworld-go.default.example.com   <none>    32m
+    ```
+
+    Ambassador will use this `Host` header to route requests to the correct 
+    service. We can send a request to the `helloworld-go` service with curl 
+    using the `Host` and `AMBASSADOR_IP` from above:
+
+    ```
+    $ curl -H "Host: helloworld-go.default.example.com" $AMBASSADOR_IP
+
+    Hello Go Sample v1!
+    ```
+
+Congratulations! You have successfully installed Knative with Ambassador to 
+manage and route to serverless applications!
+
+## What's next
+
+- Try the
+  [Getting Started with App Deployment guide](./getting-started-knative-app/)
+  for Knative serving.
+- Take a look at the rest of what 
+  [Knative has to offer](https://knative.dev/docs/index.html)
+
+

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -1,5 +1,5 @@
 ---
-title: "Installing Istio for Knative"
+title: "Installing Knative with Ambassador"
 linkTitle: "Ambassador API Gatway and Knative"
 weight: 15
 type: "docs"

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -27,9 +27,9 @@ This guide assumes that you have already
 ## Install Ambassador
 
 Knative was originally built using Istio to handle cluster networking. While 
-the Istio gateway provides the functionality we need to serve requests to our 
-application, needing to install a service mesh to handle north-south traffic 
-brings some operational overhead. Ambassador provides a way to get traffic to 
+the Istio gateway provides the functionality needed to serve requests to your 
+application, installing a service mesh to handle north-south traffic carries 
+some operational overhead with it. Ambassador provides a way to get traffic to 
 your Knative application without the overhead of a full service mesh.
 
 You can easily install Ambassador as your ingress controller using two 
@@ -42,7 +42,7 @@ kubectl apply -f https://getambassador.io/yaml/ambassador/ambassador-service.yam
 
 Ambassador will watch for and create routes based off of Knative 
 `ClusterIngress` resources. These will then be accessible over the external IP 
-address of the Ambassador service we just created.
+address of the Ambassador service you just created.
 
 Get this external IP address and save it in a variable named `AMBASSADOR_IP`
 
@@ -57,8 +57,8 @@ $ AMBASSADOR_IP=35.229.120.99
 
 ## Install Knative
 
-Now that we have Ambassador installed to handle ingress to our serverless 
-applications we need to install Knative to manage them.
+Now that Ambassador is installed to handle ingress to your serverless 
+applications, you need to install Knative to manage them.
 
 The following commands install all available Knative components as well as the 
 standard set of observability plugins. To customize your Knative installation, 
@@ -103,12 +103,12 @@ race conditions during the install, which cause intermittent errors:
 
 ## Deploying an Application
 
-Now that we have Knative and Ambassador running, we can use them to manage and 
+Now that Knative and Ambassador are running, you can use them to manage and 
 route traffic to a serverless application.
 
 1. Create a `Knative Service`
 
-   For this demo, we will use a simple helloworld application written in go. 
+   For this demo, a simple helloworld application written in go will be used.
    Copy the YAML below to a file called `helloworld-go.yaml` and apply it 
    with `kubectl`
 
@@ -137,7 +137,7 @@ route traffic to a serverless application.
     `Knative Service`s are exposed via a `Host` header assigned by Knative. 
     By default, Knative will assign the 
     `Host`: `{service-name}.{namespace}.example.com`. You can verify this by 
-    checking the `EXTERNAL-IP` of the `helloworld-go` service we created above.
+    checking the `EXTERNAL-IP` of the `helloworld-go` service created above.
 
     ```
     $ kubectl get service helloworld-go
@@ -147,7 +147,7 @@ route traffic to a serverless application.
     ```
 
     Ambassador will use this `Host` header to route requests to the correct 
-    service. We can send a request to the `helloworld-go` service with curl 
+    service. You can send a request to the `helloworld-go` service with curl 
     using the `Host` and `AMBASSADOR_IP` from above:
 
     ```

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -118,7 +118,7 @@ the recommended configuration for a cluster is:
 1. Create a Kubernetes cluster on GKE with the required specifications:
 
 > Note: If this setup is for development, or a non-Istio networking layer (e.g.
-> [Ambassador](https://getambassador.io/) or [Gloo](./Knative-with-Gloo.md)) 
+> [Ambassador](./Knative-with-Ambassador.md) or [Gloo](./Knative-with-Gloo.md)) 
 > will be used, then you can remove the `--addons` line below.
 
 > Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -118,8 +118,8 @@ the recommended configuration for a cluster is:
 1. Create a Kubernetes cluster on GKE with the required specifications:
 
 > Note: If this setup is for development, or a non-Istio networking layer (e.g.
-> [Gloo](./Knative-with-Gloo.md)) will be used, then you can remove the
-> `--addons` line below.
+> [Ambassador](https://getambassador.io/) or [Gloo](./Knative-with-Gloo.md)) 
+> will be used, then you can remove the `--addons` line below.
 
 > Note: If you want to use [Auto TLS feature](../serving/using-auto-tls.md), you
 > need to remove the `--addons` line below, and follow the

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -58,7 +58,8 @@ minikube start --memory=8192 --cpus=6 \
 
 ## Installing Istio
 
-> Note: [Gloo](https://gloo.solo.io/) is available as an alternative to Istio.
+> Note: [Ambassador](https://www.getambassador.io/) and [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
+> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 Knative depends on Istio. Run the following to install Istio. (We are changing

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -21,9 +21,17 @@ clusters.
 Knative depends on an Ingress/Gateway which is capable of routing requests to
 Knative Services.
 
-Currently, two options exist which provide this functionality:
-[Istio](https://istio.io/), the Envoy-based Service Mesh, and
-[Gloo](https://gloo.solo.io/), the Envoy-based API Gateway.
+Currently, three options exist which provide this functionality:
+[Ambassador](https://www.getambassador.io/), an Envoy-based API Gateway,
+[Gloo](https://gloo.solo.io), an Envoy-based API Gateway, and
+[Istio](https://istio.io/), an Envoy-based Service Mesh.
+
+## Installing Knative with Ambassador
+
+[Installing with Ambassador](./Knative-with-Ambassador.md) gives us an
+alternative to installing a service mesh for routing to applications 
+with the Knative Serving component. Note that Istio is required for the 
+Knative Eventing component.
 
 ## Installing Knative with Gloo
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Ambassador recently released an update that gives it the ability to create routes based off of Knative `ClusterIngress` resources. 

This PR adds Ambassador to the list of envoy-based solutions for install Knative.
