### PR TITLE
Fixed the numbering of steps

### DIFF
--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -24,9 +24,9 @@ v1.12 or newer.
    version. You need v1.10 or newer. If your `kubectl` is older, follow the next
    step to install a newer version.
 
-1. [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
+2. [Install the kubectl CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl).
 
-1. [Install and configure minikube](https://github.com/kubernetes/minikube#installation)
+3. [Install and configure minikube](https://github.com/kubernetes/minikube#installation)
    version v0.28.1 or later with a
    [VM driver](https://github.com/kubernetes/minikube#requirements), e.g. `kvm2`
    on Linux or `hyperkit` on macOS.
@@ -115,7 +115,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    prevent modifications to Eventing Source resources, those changes will not be
    completed until the upgrade process finishes.
 
-1. To install Knative, first install the CRDs by running the `kubectl apply`
+2. To install Knative, first install the CRDs by running the `kubectl apply`
    command once with the `-l knative.dev/crd-install=true` flag. This prevents
    race conditions during the install, which cause intermittent errors:
 
@@ -127,7 +127,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
    ```
 
-1. To complete the install of Knative and its dependencies, run the
+3. To complete the install of Knative and its dependencies, run the
    `kubectl apply` command again, this time without the `--selector` flag, to
    complete the install of Knative and its dependencies:
 
@@ -149,7 +149,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   statement to install the controller. Otherwise, you can choose to install
    >   the auto certificates feature and controller at a later time.
 
-1. Monitor the Knative components until all of the components show a `STATUS` of
+4. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
 
    ```shell


### PR DESCRIPTION
Numbering of steps were 1. 1. 1., fixed to incremental steps under "Install kubectl and Minikube" and "Installing Knative". If that was intention, feel free to reject the changes.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
