### PR TITLE
fix incorrect link format

### DIFF
--- a/docs/eventing/sequence.md
+++ b/docs/eventing/sequence.md
@@ -52,7 +52,7 @@ We also use a very simple
 trivial transformation of the incoming events to demonstrate they have passed
 through each stage.
 
-### (Sequence with no reply (terminal last Step))[./samples/sequence/sequence-terminal/README.md)
+### [Sequence with no reply (terminal last Step)](./samples/sequence/sequence-terminal/README.md)
 
 For the first example, we'll use a 3 Step `Sequence` that is wired directly into
 the `CronJobSource`. Each of the steps simply tacks on "- Handled by


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Fix the incorrect markdown link syntax.
-
-
