### PR TITLE
gRPC Go example fix

### DIFF
--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -10,7 +10,6 @@ A simple gRPC server written in Go that you can use for testing.
 
   ```shell
   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
-  cd knative-docs/docs/serving/samples/grpc-ping-go
   ```
 
 ## Build and run the gRPC server
@@ -29,6 +28,7 @@ Next, replace `{username}` in `sample.yaml` with your DockerHub username, and
 apply the yaml.
 
 ```shell
+$EDITOR docs/serving/samples/grpc-ping-go/sample.yaml
 kubectl apply --filename docs/serving/samples/grpc-ping-go/sample.yaml
 ```
 


### PR DESCRIPTION
This PR adds a fix to the gRPC Go README which had a broken command in it.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->