### PR TITLE
removing annotation does not remove broker

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -116,6 +116,12 @@ namespace.
 kubectl -n default get broker default
 ```
 
+*NOTE* `Broker`s created due to annotation will not be removed if you
+remove the annotation. For example, if you annotate the namespace,
+which will then create the `Broker` as described above. If you now
+remove the annotation, the `Broker` will not be removed, you have
+to manually delete it.
+
 #### Manual Setup
 
 In order to setup a `Broker` manually, we must first create the required

--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -122,6 +122,13 @@ which will then create the `Broker` as described above. If you now
 remove the annotation, the `Broker` will not be removed, you have
 to manually delete it.
 
+For example, to delete the injected Broker from the foo namespace:
+
+```shell
+kubectl -n foo delete broker default
+```
+
+
 #### Manual Setup
 
 In order to setup a `Broker` manually, we must first create the required


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes: https://github.com/knative/eventing/issues/1504

## Proposed Changes

- Add a note about removing of annotation on a namespace does not delete broker.
