### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -116,18 +116,16 @@ namespace.
 kubectl -n default get broker default
 ```
 
-*NOTE* `Broker`s created due to annotation will not be removed if you
-remove the annotation. For example, if you annotate the namespace,
-which will then create the `Broker` as described above. If you now
-remove the annotation, the `Broker` will not be removed, you have
-to manually delete it.
+_NOTE_ `Broker`s created due to annotation will not be removed if you remove the
+annotation. For example, if you annotate the namespace, which will then create
+the `Broker` as described above. If you now remove the annotation, the `Broker`
+will not be removed, you have to manually delete it.
 
 For example, to delete the injected Broker from the foo namespace:
 
 ```shell
 kubectl -n foo delete broker default
 ```
-
 
 #### Manual Setup
 

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -1,5 +1,6 @@
 These samples show how to configure a Camel Source. It is an Event Source that
-can leverage one of the [250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
+can leverage one of the
+[250+ Apache Camel components](https://github.com/apache/camel/tree/master/components)
 for generating events.
 
 ## Prerequisites
@@ -17,14 +18,16 @@ for generating events.
    Documentation includes specific instructions for common Kubernetes
    environments, including development clusters.
 
-1.(Optional) Download Kail binaries for Linux or OSX, which can be found on the [latest release](https://github.com/boz/kail/releases/latest) page. You can use `kail` instead of `kubectl logs` to tail the logs of the subscriber.
+1.(Optional) Download Kail binaries for Linux or OSX, which can be found on the
+[latest release](https://github.com/boz/kail/releases/latest) page. You can use
+`kail` instead of `kubectl logs` to tail the logs of the subscriber.
 
-1. Install the Camel Source from the `camel.yaml` in the [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
+1. Install the Camel Source from the `camel.yaml` in the
+   [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
 
    ```shell
    kubectl apply --filename camel.yaml
    ```
-   
 
 ### Create a Channel and a Subscriber
 
@@ -47,7 +50,6 @@ kubectl apply --filename display_resources.yaml
 The samples directory contains some sample sources that can be used to generate
 events.
 
-
 The simplest example of the `CamelSource`, that does not require additional
 configuration, is the "timer" source.
 
@@ -63,24 +65,24 @@ Install the [timer CamelSource](source_timer.yaml) from source:
 kubectl apply -f source_timer.yaml
 ```
 
-
-Verify that the published events were sent into the Knative eventing
-system by looking at what is downstream of the `CamelSource`.
+Verify that the published events were sent into the Knative eventing system by
+looking at what is downstream of the `CamelSource`.
 
 ```shell
 kubectl logs --selector serving.knative.dev/service=camel-event-display -c user-container
 ```
-or 
 
-You can also use [`kail`](https://github.com/boz/kail) to tail the logs of the subscriber.
+or
+
+You can also use [`kail`](https://github.com/boz/kail) to tail the logs of the
+subscriber.
 
 ```shell
 kail -d camel-event-display --since=10m
 ```
 
-If you have deployed the timer source, you should see log lines appearing every 3
-seconds.
-
+If you have deployed the timer source, you should see log lines appearing every
+3 seconds.
 
 ### Run a CamelSource using the Telegram component
 
@@ -93,8 +95,8 @@ instructions on the Telegram website for creating a
 [Telegram Bot](https://core.telegram.org/bots). The quickest way to create a bot
 is to contact the [Bot Father](https://telegram.me/botfather), another Telegram
 Bot, using your preferred Telegram client (mobile or web). After you create the
-bot, you will receive an **authorization token** that is needed for the source to
-work.
+bot, you will receive an **authorization token** that is needed for the source
+to work.
 
 First, edit the [telegram CamelSource](source_telegram.yaml) and put the
 authorization token, replacing the `<put-your-token-here>` placeholder.
@@ -118,16 +120,18 @@ Start `kail` again and keep it open on the event display:
 kail -d camel-event-display --since=10m
 ```
 
-Now, you can contact your bot with any Telegram client. Each message you send
-to the bot will be printed by the event display as a cloudevent.
-
+Now, you can contact your bot with any Telegram client. Each message you send to
+the bot will be printed by the event display as a cloudevent.
 
 ### Run a Camel K Source
 
-For complex use cases that require multiple steps to be executed before event data is ready to be published, you can use Camel K sources.
-Camel K lets you use Camel DSL to design one or more routes that can define complex workflows before sending events to the target sink.
+For complex use cases that require multiple steps to be executed before event
+data is ready to be published, you can use Camel K sources. Camel K lets you use
+Camel DSL to design one or more routes that can define complex workflows before
+sending events to the target sink.
 
-If you have previously deployed other CamelSources, to reduce noise in the event display, you can remove them all from the namespace:
+If you have previously deployed other CamelSources, to reduce noise in the event
+display, you can remove them all from the namespace:
 
 ```shell
 kubectl delete camelsource --all
@@ -145,5 +149,6 @@ Start `kail` again and keep it open on the event display:
 kail -d camel-event-display --since=10m
 ```
 
-The event display will show some JSON data periodically pulled from an external REST API.
-The API in the example is static, but you can use your own dynamic API by replacing the endpoint.
+The event display will show some JSON data periodically pulled from an external
+REST API. The API in the example is static, but you can use your own dynamic API
+by replacing the endpoint.

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -202,8 +202,8 @@ spec:
 
 ```
 
-Change `default` below to create the `Service` and `Trigger` in the Namespace where you have
-configured your `Broker`.
+Change `default` below to create the `Service` and `Trigger` in the Namespace
+where you have configured your `Broker`.
 
 ```shell
 kubectl -n default create -f ./display-trigger.yaml

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -10,64 +10,58 @@ procedure:
     ```
 -->
 
-Event Sources are Kubernetes Custom Resources which provide a mechanism for registering interest in
-a class of events from a particular software system. Since different event sources may be described
-by different Custom Resources, this page provides an index of the available source resource types as
-well as links to installation instructions.
+Event Sources are Kubernetes Custom Resources which provide a mechanism for
+registering interest in a class of events from a particular software system.
+Since different event sources may be described by different Custom Resources,
+this page provides an index of the available source resource types as well as
+links to installation instructions.
 
 This is a non-exhaustive list of Event sources for Knative.
 
-
 ### Inclusion in this list is not an endorsement, nor does it imply any level of support.
-
 
 ## Sources
 
 These are sources that are installed as `CRD`s.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[AWS SQS](https://github.com/knative/eventing-contrib/blob/master/contrib/awssqs/pkg/apis/sources/v1alpha1/aws_sqs_types.go) | Proof of Concept | None | Brings [AWS Simple Queue Service](https://aws.amazon.com/sqs/) messages into Knative.
-[Apache Camel](https://github.com/knative/eventing-contrib/blob/master/camel/source/pkg/apis/sources/v1alpha1/camelsource_types.go) | Proof of Concept | None | Allows to use [Apache Camel](https://github.com/apache/camel) components for pushing events into Knative.
-[Apache Kafka](https://github.com/knative/eventing-contrib/blob/master/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go) | Proof of Concept | None | Brings [Apache Kafka](https://kafka.apache.org/) messages into Knative.
-[BitBucket](https://github.com/nachocano/bitbucket-source) | Proof of Concept | None | Registers for events of the specified types on the specified BitBucket organization/repository. Brings those events into Knative.
-[Cron Job](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go) | Proof of Concept | None | Uses an in-memory timer to produce events on the specified Cron schedule.
-[GCP PubSub](https://github.com/knative/eventing-contrib/blob/master/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go) | Proof of Concept | None | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.
-[GitHub](https://github.com/knative/eventing-contrib/blob/master/contrib/github/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
-[GitLab](https://gitlab.com/triggermesh/gitlabsource) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
-[Google Cloud Scheduler](https://github.com/vaikas-google/csr) | Active Development | None | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative.
-[Google Cloud Storage](https://github.com/vaikas-google/gcs) | Active Development | None | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.
-[Kubernetes](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/apiserver_types.go) | Active Development | Knative | Brings Kubernetes API server events into Knative.
-
-
+| Name                                                                                                                                  | Status             | Support | Description                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [AWS SQS](https://github.com/knative/eventing-contrib/blob/master/contrib/awssqs/pkg/apis/sources/v1alpha1/aws_sqs_types.go)          | Proof of Concept   | None    | Brings [AWS Simple Queue Service](https://aws.amazon.com/sqs/) messages into Knative.                                                                           |
+| [Apache Camel](https://github.com/knative/eventing-contrib/blob/master/camel/source/pkg/apis/sources/v1alpha1/camelsource_types.go)   | Proof of Concept   | None    | Allows to use [Apache Camel](https://github.com/apache/camel) components for pushing events into Knative.                                                       |
+| [Apache Kafka](https://github.com/knative/eventing-contrib/blob/master/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go)         | Proof of Concept   | None    | Brings [Apache Kafka](https://kafka.apache.org/) messages into Knative.                                                                                         |
+| [BitBucket](https://github.com/nachocano/bitbucket-source)                                                                            | Proof of Concept   | None    | Registers for events of the specified types on the specified BitBucket organization/repository. Brings those events into Knative.                               |
+| [Cron Job](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go)                               | Proof of Concept   | None    | Uses an in-memory timer to produce events on the specified Cron schedule.                                                                                       |
+| [GCP PubSub](https://github.com/knative/eventing-contrib/blob/master/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go) | Proof of Concept   | None    | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.                                                                                    |
+| [GitHub](https://github.com/knative/eventing-contrib/blob/master/contrib/github/pkg/apis/sources/v1alpha1/githubsource_types.go)      | Proof of Concept   | None    | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.                                  |
+| [GitLab](https://gitlab.com/triggermesh/gitlabsource)                                                                                 | Proof of Concept   | None    | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.                                               |
+| [Google Cloud Scheduler](https://github.com/vaikas-google/csr)                                                                        | Active Development | None    | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative. |
+| [Google Cloud Storage](https://github.com/vaikas-google/gcs)                                                                          | Active Development | None    | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.          |
+| [Kubernetes](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/apiserver_types.go)                            | Active Development | Knative | Brings Kubernetes API server events into Knative.                                                                                                               |
 
 ## Meta Sources
 
 These are not directly usable, but make writing a Source much easier.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[Auto Container Source](https://github.com/Harwayne/auto-container-source) | Proof of Concept | None | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure.
-[Container Source](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.
-[Sample Source](https://github.com/grantr/sample-source) | Proof of Concept | None | SampleSource is a reference implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).
-
-
+| Name                                                                                                                   | Status             | Support | Description                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Auto Container Source](https://github.com/Harwayne/auto-container-source)                                             | Proof of Concept   | None    | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure. |
+| [Container Source](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.                      |
+| [Sample Source](https://github.com/grantr/sample-source)                                                               | Proof of Concept   | None    | SampleSource is a reference implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).                                                                                                         |
 
 ### ContainerSource Containers
 
 These are containers intended to be used with `ContainerSource`.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Active Development | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
-[AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito) | Active Development | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.
-[AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb) | Active Development | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
-[AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis) | Active Development | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
-[AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns) | Active Development | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.
-[AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs) | Active Development | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.
-[FTP / SFTP](https://github.com/vaikas-google/ftp) | Proof of concept | None | Watches for files being uploaded into a FTP/SFTP and generates events for those.
-[Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source) | Proof of Concept | None | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure.
-[Heartbeats](https://github.com/knative/eventing-contrib/tree/master/cmd/heartbeats) | Proof of Concept | None | Uses an in-memory timer to produce events at the specified interval.
-[K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source) | Proof of Concept | None | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.
-[WebSocket](https://github.com/knative/eventing-contrib/tree/master/cmd/websocketsource) | Active Development | None | Opens a WebSocket to the specified source and packages each received message as a Knative event.
-
+| Name                                                                                              | Status             | Support     | Description                                                                                                                  |
+| ------------------------------------------------------------------------------------------------- | ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| [AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Active Development | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.    |
+| [AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito)       | Active Development | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.                                                          |
+| [AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb)     | Active Development | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.                               |
+| [AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis)       | Active Development | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.                                  |
+| [AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns)               | Active Development | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.                                    |
+| [AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs)               | Active Development | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.                                       |
+| [FTP / SFTP](https://github.com/vaikas-google/ftp)                                                | Proof of concept   | None        | Watches for files being uploaded into a FTP/SFTP and generates events for those.                                             |
+| [Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source)       | Proof of Concept   | None        | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure. |
+| [Heartbeats](https://github.com/knative/eventing-contrib/tree/master/cmd/heartbeats)              | Proof of Concept   | None        | Uses an in-memory timer to produce events at the specified interval.                                                         |
+| [K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source)             | Proof of Concept   | None        | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.                       |
+| [WebSocket](https://github.com/knative/eventing-contrib/tree/master/cmd/websocketsource)          | Active Development | None        | Opens a WebSocket to the specified source and packages each received message as a Knative event.                             |

--- a/docs/install/getting-started-knative-app.md
+++ b/docs/install/getting-started-knative-app.md
@@ -105,31 +105,33 @@ assigned an external IP address.
    fi
 
    kubectl get svc $INGRESSGATEWAY --namespace istio-system
-```
+   ```
+
+````
 
 The command will return something similar to this:
 
 ```shell
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
    istio-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
+````
 
-   Take note of the `EXTERNAL-IP` address.
+Take note of the `EXTERNAL-IP` address.
 
-   You can also export the IP address as a variable with the following command:
+You can also export the IP address as a variable with the following command:
 
 ```shell
    export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY --namespace istio-system --output 'jsonpath={.status.loadBalancer.ingress[0].ip}')
-   ```
+```
 
-   > Note: If you use minikube or a baremetal cluster that has no external load
-   > balancer, the `EXTERNAL-IP` field is shown as `<pending>`. You need to use
-   > `NodeIP` and `NodePort` to interact your app instead. To get your app's
-   > `NodeIP` and `NodePort`, enter the following command:
+> Note: If you use minikube or a baremetal cluster that has no external load
+> balancer, the `EXTERNAL-IP` field is shown as `<pending>`. You need to use
+> `NodeIP` and `NodePort` to interact your app instead. To get your app's
+> `NodeIP` and `NodePort`, enter the following command:
 
 ```shell
    export IP_ADDRESS=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
-   ```
+```
 
 1. To find the host URL for your service, enter:
 
@@ -138,7 +140,7 @@ The command will return something similar to this:
    ```
 
    The command will return the following:
-   
+
    ```shell
    NAME                URL
    helloworld-go       http://helloworld-go.default.example.com

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -9,26 +9,28 @@ By default services deployed through Knative are published to an external IP
 address, making them public services on a public IP address and with a
 [public URL](./using-a-custom-domain.md).
 
-While this is useful for services that need to be accessible from outside
-of the cluster, frequently you may be building a backend service which
-should not be available off-cluster.
+While this is useful for services that need to be accessible from outside of the
+cluster, frequently you may be building a backend service which should not be
+available off-cluster.
 
 Knative provides two ways to enable private services which are only available
 inside the cluster:
 
-1. To make all services only cluster-local, change the default domain
-   to `svc.cluster.local` by [editing the `config-domain` config map](./using-a-custom-domain.md).
-   This will change all services deployed through Knative to only be published
-   to the cluster, none will be available off-cluster.
+1. To make all services only cluster-local, change the default domain to
+   `svc.cluster.local` by
+   [editing the `config-domain` config map](./using-a-custom-domain.md). This
+   will change all services deployed through Knative to only be published to the
+   cluster, none will be available off-cluster.
 1. To make an individual service cluster-local, the service or route can be
    labeled in such a way to prevent it from getting published to the external
    gateway.
-   
+
 ## Label a service to be cluster-local
 
-To configure a KService to only be available on the cluster-local network (and not
-on the public Internet), you can apply the `serving.knative.dev/visibility=cluster-local`
-label to the KService or Route object.
+To configure a KService to only be available on the cluster-local network (and
+not on the public Internet), you can apply the
+`serving.knative.dev/visibility=cluster-local` label to the KService or Route
+object.
 
 To label the KService:
 
@@ -49,8 +51,8 @@ and then convert it to be an cluster-local service by labeling the service:
 kubectl label kservice helloworld-go serving.knative.dev/visibility=cluster-local
 ```
 
-You can then verify that the change has been made by verifying the URL for
-the helloworld-go service:
+You can then verify that the change has been made by verifying the URL for the
+helloworld-go service:
 
 ```shell
 kubectl get ksvc helloworld-go
@@ -59,5 +61,5 @@ NAME            URL                                              LATESTCREATED  
 helloworld-go   http://helloworld-go.default.svc.cluster.local   helloworld-go-2bz5l   helloworld-go-2bz5l   True
 ```
 
-The service returns the a URL with the `svc.cluster.local`
-domain, indicating the service is only available in the cluster local network.
+The service returns the a URL with the `svc.cluster.local` domain, indicating
+the service is only available in the cluster local network.

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -168,7 +168,7 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address of your service, use: 
+1. To find the IP address of your service, use:
 
    ```shell
    # In Knative 0.2.x and prior versions, the `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
@@ -196,12 +196,11 @@ folder) you're ready to build and deploy the sample app.
      --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
    ```
 
-   **Note**
-   If your cluster is new, it may take some time for the service to get
-   assigned an external IP address. Instead of rerunning the command, you
-   can add `--watch` to the command below to view the component's status
-   updates in real time. Use CTRL+C to exit watch mode. 
-   
+   **Note** If your cluster is new, it may take some time for the service to get
+   assigned an external IP address. Instead of rerunning the command, you can
+   add `--watch` to the command below to view the component's status updates in
+   real time. Use CTRL+C to exit watch mode.
+
 1. To find the URL of your service, use:
 
    ```shell
@@ -221,11 +220,11 @@ folder) you're ready to build and deploy the sample app.
    Hello Spring Boot Sample v1!
    ```
 
-**Note**
-Replace `{IP_ADDRESS}` with the address you saw returned in the previous
-step. i.e. `EXTERNAL-IP`
+**Note** Replace `{IP_ADDRESS}` with the address you saw returned in the
+previous step. i.e. `EXTERNAL-IP`
 
 ## Removing the sample app deployment
+
 1. To remove the sample app from your cluster, use:
 
 ```shell


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
