### PR TITLE
Format markdown

### DIFF
--- a/community/samples/_index.md
+++ b/community/samples/_index.md
@@ -6,4 +6,3 @@ type: "docs"
 ---
 
 {{% readfile file="README.md" relative="true" markdown="true" %}}
-

--- a/docs/eventing/channels/README.md
+++ b/docs/eventing/channels/README.md
@@ -17,26 +17,24 @@ procedure:
     ```
 -->
 
-Channels are Kubernetes Custom Resources which define a single event forwarding and persistence layer.
-Messaging implementations may provide implementations of Channels via the
+Channels are Kubernetes Custom Resources which define a single event forwarding
+and persistence layer. Messaging implementations may provide implementations of
+Channels via the
 [ClusterChannelProvisioner](https://github.com/knative/eventing/blob/master/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go#L35)
-object, supporting different technologies, such as Apache Kafka or NATS Streaming.
+object, supporting different technologies, such as Apache Kafka or NATS
+Streaming.
 
 This is a non-exhaustive list of Channels for Knative.
 
-
 ### Inclusion in this list is not an endorsement, nor does it imply any level of support.
-
 
 ## Channels
 
 These are the channels `CRD`s.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[Apache Kafka](https://github.com/knative/eventing/tree/master/contrib/kafka/config) | Proof of Concept | None | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
-[GCP PubSub](https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config) | Proof of Concept | None | Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).
-[In-Memory](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel) | Proof of Concept | None | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
-[Natss](https://github.com/knative/eventing/tree/master/contrib/natss/config) | Proof of Concept | None | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
-
-
+| Name                                                                                               | Status           | Support | Description                                                                                                           |
+| -------------------------------------------------------------------------------------------------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| [Apache Kafka](https://github.com/knative/eventing/tree/master/contrib/kafka/config)               | Proof of Concept | None    | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.                                               |
+| [GCP PubSub](https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config)             | Proof of Concept | None    | Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).                                                |
+| [In-Memory](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel) | Proof of Concept | None    | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development. |
+| [Natss](https://github.com/knative/eventing/tree/master/contrib/natss/config)                      | Proof of Concept | None    | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).                |

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -17,10 +17,11 @@ procedure:
     ```
 -->
 
-Event Sources are Kubernetes Custom Resources which provide a mechanism for registering interest in
-a class of events from a particular software system. Since different event sources may be described
-by different Custom Resources, this page provides an index of the available source resource types as
-well as links to installation instructions.
+Event Sources are Kubernetes Custom Resources which provide a mechanism for
+registering interest in a class of events from a particular software system.
+Since different event sources may be described by different Custom Resources,
+this page provides an index of the available source resource types as well as
+links to installation instructions.
 
 This is a non-exhaustive list of Event sources for Knative.
 
@@ -48,11 +49,11 @@ These are sources that are installed as `CRD`s.
 
 These are not directly usable, but make writing a Source much easier.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[Auto Container Source](https://github.com/Harwayne/auto-container-source) | Proof of Concept | None | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure.
-[Container Source](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.
-[Sample Source](https://github.com/grantr/sample-source) | Proof of Concept | None | SampleSource is a reference implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).
+| Name                                                                                                                   | Status             | Support | Description                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Auto Container Source](https://github.com/Harwayne/auto-container-source)                                             | Proof of Concept   | None    | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure. |
+| [Container Source](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.                      |
+| [Sample Source](https://github.com/grantr/sample-source)                                                               | Proof of Concept   | None    | SampleSource is a reference implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).                                                                                                         |
 
 ### ContainerSource Containers
 


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
