### PR TITLE
fix default-channels rendering and prevent nested shortcodes

### DIFF
--- a/docs/eventing/channels/README.md
+++ b/docs/eventing/channels/README.md
@@ -1,40 +1,10 @@
----
-title: "Knative Eventing channels"
-linkTitle: "Eventing channels"
-weight: 40
-type: "docs"
----
 
-<!--
-This is a generated file and should not be changed manually. All changes should follow the
-procedure:
-
-1. Update the information in [`channels.yaml`](channels.yaml).
-
-2. Run the generator tool:
-    ```shell
-    go run eventing/channels/generator/main.go
-    ```
--->
-
-Channels are Kubernetes Custom Resources which define a single event forwarding
-and persistence layer. Messaging implementations may provide implementations of
-Channels via the
+Channels are Kubernetes Custom Resources that define a single event forwarding
+and persistence layer in Knative.
+Messaging implementations provide implementations of Channels via the
 [ClusterChannelProvisioner](https://github.com/knative/eventing/blob/master/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go#L35)
-object, supporting different technologies, such as Apache Kafka or NATS
+object, and support different technologies, such as Apache Kafka or NATS
 Streaming.
 
-This is a non-exhaustive list of Channels for Knative.
-
-### Inclusion in this list is not an endorsement, nor does it imply any level of support.
-
-## Channels
-
-These are the channels `CRD`s.
-
-| Name                                                                                               | Status           | Support | Description                                                                                                           |
-| -------------------------------------------------------------------------------------------------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
-| [Apache Kafka](https://github.com/knative/eventing/tree/master/contrib/kafka/config)               | Proof of Concept | None    | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.                                               |
-| [GCP PubSub](https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config)             | Proof of Concept | None    | Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).                                                |
-| [In-Memory](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel) | Proof of Concept | None    | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development. |
-| [Natss](https://github.com/knative/eventing/tree/master/contrib/natss/config)                      | Proof of Concept | None    | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).                |
+Note: Cluster Channel Provisioner (CCP) has been deprecated and will be
+unsupported in v0.9. You should now use the Channels CRDs.

--- a/docs/eventing/channels/_index.md
+++ b/docs/eventing/channels/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Knative Eventing channels"
+linkTitle: "Eventing channels"
+weight: 40
+type: "docs"
+showlandingtoc: "true"
+---
+
+{{% readfile file="README.md" relative="true" markdown="true" %}}

--- a/docs/eventing/channels/channels-crds.md
+++ b/docs/eventing/channels/channels-crds.md
@@ -1,6 +1,6 @@
 ---
-title: "Available Channels CRDs"
-linkTitle: "Channels CRDs"
+title: "Available Channels"
+#linkTitle: "Channels"
 weight: 40
 type: "docs"
 ---
@@ -17,7 +17,7 @@ procedure:
     ```
 -->
 
-This is a non-exhaustive list of Channels `CRD`s for Knative.
+This is a non-exhaustive list of the available Channels for Knative Eventing.
 
 Notes:
 

--- a/docs/eventing/channels/channels-crds.md
+++ b/docs/eventing/channels/channels-crds.md
@@ -1,0 +1,40 @@
+---
+title: "Available Channels CRDs"
+linkTitle: "Channels CRDs"
+weight: 40
+type: "docs"
+---
+
+<!--
+This is a generated file and should not be changed manually. All changes should follow the
+procedure:
+
+1. Update the information in [`channels.yaml`](channels.yaml).
+
+2. Run the generator tool:
+    ```shell
+    go run eventing/channels/generator/main.go
+    ```
+-->
+
+This is a non-exhaustive list of Channels `CRD`s for Knative.
+
+Notes:
+
+* Inclusion in this list is not an endorsement, nor does it imply any level of
+  support.
+
+* Cluster Channel Provisioner (CCP) has been deprecated and will be
+  unsupported in v0.9. You should now use the Channels CRDs.
+
+Name | Status | Support | Description
+--- | --- | --- | ---
+[CCP - Apache Kafka](https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config/provisioner) | Proof of Concept | None | Deprecated: Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
+[CCP - GCP PubSub](https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config) | Proof of Concept | None | Deprecated: Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).
+[CCP - In-Memory](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel) | Proof of Concept | None | Deprecated: In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
+[CCP - Natss](https://github.com/knative/eventing/tree/master/contrib/natss/config/provisioner) | Proof of Concept | None | Deprecated: Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
+[CRD - InMemoryChannel](https://github.com/knative/eventing/tree/master/config/channels/in-memory-channel) | Proof of Concept | None | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
+[CRD - KafkaChannel](https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config) | Proof of Concept | None | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
+[CRD - NatssChannel](https://github.com/knative/eventing/tree/master/contrib/natss/config) | Proof of Concept | None | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
+
+

--- a/docs/eventing/channels/channels.yaml
+++ b/docs/eventing/channels/channels.yaml
@@ -1,24 +1,42 @@
-# List of available Channel implementation for persistence of the events associated with a given channel 
+# List of available Channel implementation for persistence of the events associated with a given channel
 channels:
-  - name: In-Memory
+  - name: CCP - In-Memory
     url: https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel
     status: Proof of Concept
     support: None
     description: >
-      In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
-  - name: Apache Kafka
-    url: https://github.com/knative/eventing/tree/master/contrib/kafka/config
+      Deprecated: In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
+  - name: CCP - Apache Kafka
+    url: https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config/provisioner
     status: Proof of Concept
     support: None
     description: >
-      Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
-  - name: GCP PubSub
+      Deprecated: Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
+  - name: CCP - GCP PubSub
     url: https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config
     status: Proof of Concept
     support: None
     description: >
-      Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).
-  - name: Natss
+      Deprecated: Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).
+  - name: CCP - Natss
+    url: https://github.com/knative/eventing/tree/master/contrib/natss/config/provisioner
+    status: Proof of Concept
+    support: None
+    description: >
+      Deprecated: Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
+  - name: CRD - InMemoryChannel
+    url: https://github.com/knative/eventing/tree/master/config/channels/in-memory-channel
+    status: Proof of Concept
+    support: None
+    description: >
+      In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
+  - name: CRD - KafkaChannel
+    url: https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config
+    status: Proof of Concept
+    support: None
+    description: >
+      Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
+  - name: CRD - NatssChannel
     url: https://github.com/knative/eventing/tree/master/contrib/natss/config
     status: Proof of Concept
     support: None

--- a/docs/eventing/channels/generator/ReadmeTemplate.gomd
+++ b/docs/eventing/channels/generator/ReadmeTemplate.gomd
@@ -1,6 +1,6 @@
 ---
-title: "Knative Eventing channels"
-linkTitle: "Eventing channels"
+title: "Available Channels CRDs"
+linkTitle: "Channels CRDs"
 weight: 40
 type: "docs"
 ---
@@ -22,20 +22,15 @@ procedure:
     ```
 -->
 
-Channels are Kubernetes Custom Resources which define a single event forwarding and persistence layer.
-Messaging implementations may provide implementations of Channels via the
-[ClusterChannelProvisioner](https://github.com/knative/eventing/blob/master/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go#L35)
-object, supporting different technologies, such as Apache Kafka or NATS Streaming.
+This is a non-exhaustive list of Channels `CRD`s for Knative.
 
-This is a non-exhaustive list of Channels for Knative.
+Notes:
 
+* Inclusion in this list is not an endorsement, nor does it imply any level of
+  support.
 
-### Inclusion in this list is not an endorsement, nor does it imply any level of support.
-
-
-## Channels
-
-These are the channels `CRD`s.
+* Cluster Channel Provisioner (CCP) has been deprecated and will be
+  unsupported in v0.9. You should now use the Channels CRDs.
 
 Name | Status | Support | Description
 --- | --- | --- | ---

--- a/docs/eventing/channels/generator/ReadmeTemplate.gomd
+++ b/docs/eventing/channels/generator/ReadmeTemplate.gomd
@@ -1,6 +1,6 @@
 ---
-title: "Available Channels CRDs"
-linkTitle: "Channels CRDs"
+title: "Available Channels"
+#linkTitle: "Channels"
 weight: 40
 type: "docs"
 ---
@@ -22,7 +22,7 @@ procedure:
     ```
 -->
 
-This is a non-exhaustive list of Channels `CRD`s for Knative.
+This is a non-exhaustive list of the available Channels for Knative Eventing.
 
 Notes:
 

--- a/docs/eventing/channels/generator/main.go
+++ b/docs/eventing/channels/generator/main.go
@@ -30,7 +30,7 @@ import (
 var (
 	yamlFile     = flag.String("yaml", "eventing/channels/channels.yaml", "The YAML file to parse to generate the mark down.")
 	templateFile = flag.String("template", "eventing/channels/generator/ReadmeTemplate.gomd", "The template file to fill in.")
-	mdFile       = flag.String("md", "eventing/channels/README.md", "The mark down file to write to. Any existing file will be overwritten.")
+	mdFile       = flag.String("md", "eventing/channels/channels-crds.md", "The mark down file to write to. Any existing file will be overwritten.")
 )
 
 func main() {


### PR DESCRIPTION
- Fix the "default-channels" topic (the channels directory requires the _index.md file)
- Prevent nested markdown processing
   - Move auto gen table into separate topic (prevents past issue of double rendering = displays hidden html comments)
- Add fix from #1486 (add missing Channels CRDs and qualify CCPs)