### PR TITLE
Delete knative build in the doc for 0.8 version

### DIFF
--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -6,8 +6,7 @@ type: "docs"
 ---
 
 This guide walks you through the installation of the latest version of
-[Knative Serving](https://github.com/knative/serving) and
-[Knative Build](https://github.com/knative/build) using pre-built images and
+[Knative Serving](https://github.com/knative/serving) using pre-built images and
 demonstrates creating and deploying an image of a sample `hello world` app onto
 the newly created Knative cluster on
 [IBM Cloud Private](https://www.ibm.com/cloud/private).
@@ -117,9 +116,9 @@ Configure the namespaces `knative-serving` into pod security policy
    EOF
    ```
 
-**Important**: If you choose to install the Knative Build or observability
+**Important**: If you choose to install the Knative eventing or observability
 plugin, you must also create cluster role bindings for the service accounts in
-the`knative-build` and `knative-monitoring` namespaces.
+the`knative-eventing` and `knative-monitoring` namespaces.
 
 ## Installing Istio
 
@@ -177,12 +176,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   statement to install the controller.
 
    ```shell
-   curl -L https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
-     | sed 's/LoadBalancer/NodePort/' \
-     | kubectl apply --filename -
-   ```
-
-   ```shell
    curl -L https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
@@ -209,7 +202,6 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl get pods --namespace knative-serving
-   kubectl get pods --namespace knative-build
    kubectl get pods --namespace knative-eventing
    kubectl get pods --namespace knative-monitoring
    ```
@@ -241,9 +233,6 @@ echo $(ICP cluster ip):$(kubectl get svc istio-ingressgateway --namespace istio-
 To get started with Knative Eventing, walk through one of the
 [Eventing Samples](../eventing/samples/).
 
-To get started with Knative Build, read the [Build README](../build/README.md),
-then choose a sample to walk through.
-
 ## Cleaning up
 
 To remove Knative from your IBM Cloud Private cluster, run the following
@@ -251,12 +240,6 @@ commands:
 
 ```shell
 curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
- | sed 's/LoadBalancer/NodePort/' \
- | kubectl delete --filename -
-```
-
-```shell
-curl -L https://github.com/knative/build/releases/download/v0.7.0/build.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes https://github.com/knative/docs/issues/1655

## Proposed Changes

Delete the content of `knative build` in `docs/install/Knative-with-ICP.md`
