### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/channels/README.md
+++ b/docs/eventing/channels/README.md
@@ -1,7 +1,6 @@
-
 Channels are Kubernetes Custom Resources that define a single event forwarding
-and persistence layer in Knative.
-Messaging implementations provide implementations of Channels via the
+and persistence layer in Knative. Messaging implementations provide
+implementations of Channels via the
 [ClusterChannelProvisioner](https://github.com/knative/eventing/blob/master/pkg/apis/eventing/v1alpha1/cluster_channel_provisioner_types.go#L35)
 object, and support different technologies, such as Apache Kafka or NATS
 Streaming.

--- a/docs/eventing/channels/channels-crds.md
+++ b/docs/eventing/channels/channels-crds.md
@@ -21,20 +21,18 @@ This is a non-exhaustive list of the available Channels for Knative Eventing.
 
 Notes:
 
-* Inclusion in this list is not an endorsement, nor does it imply any level of
+- Inclusion in this list is not an endorsement, nor does it imply any level of
   support.
 
-* Cluster Channel Provisioner (CCP) has been deprecated and will be
-  unsupported in v0.9. You should now use the Channels CRDs.
+- Cluster Channel Provisioner (CCP) has been deprecated and will be unsupported
+  in v0.9. You should now use the Channels CRDs.
 
-Name | Status | Support | Description
---- | --- | --- | ---
-[CCP - Apache Kafka](https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config/provisioner) | Proof of Concept | None | Deprecated: Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
-[CCP - GCP PubSub](https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config) | Proof of Concept | None | Deprecated: Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).
-[CCP - In-Memory](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel) | Proof of Concept | None | Deprecated: In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
-[CCP - Natss](https://github.com/knative/eventing/tree/master/contrib/natss/config/provisioner) | Proof of Concept | None | Deprecated: Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
-[CRD - InMemoryChannel](https://github.com/knative/eventing/tree/master/config/channels/in-memory-channel) | Proof of Concept | None | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
-[CRD - KafkaChannel](https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config) | Proof of Concept | None | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
-[CRD - NatssChannel](https://github.com/knative/eventing/tree/master/contrib/natss/config) | Proof of Concept | None | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
-
-
+| Name                                                                                                           | Status           | Support | Description                                                                                                                       |
+| -------------------------------------------------------------------------------------------------------------- | ---------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [CCP - Apache Kafka](https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config/provisioner) | Proof of Concept | None    | Deprecated: Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.                                               |
+| [CCP - GCP PubSub](https://github.com/knative/eventing/tree/master/contrib/gcppubsub/config)                   | Proof of Concept | None    | Deprecated: Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).                                                |
+| [CCP - In-Memory](https://github.com/knative/eventing/tree/master/config/provisioners/in-memory-channel)       | Proof of Concept | None    | Deprecated: In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development. |
+| [CCP - Natss](https://github.com/knative/eventing/tree/master/contrib/natss/config/provisioner)                | Proof of Concept | None    | Deprecated: Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).                |
+| [CRD - InMemoryChannel](https://github.com/knative/eventing/tree/master/config/channels/in-memory-channel)     | Proof of Concept | None    | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.             |
+| [CRD - KafkaChannel](https://github.com/knative/eventing-contrib/tree/master/kafka/channel/config)             | Proof of Concept | None    | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.                                                           |
+| [CRD - NatssChannel](https://github.com/knative/eventing/tree/master/contrib/natss/config)                     | Proof of Concept | None    | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).                            |


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
