### PR TITLE
Create smoke test pages (for testing site elements)

### DIFF
--- a/docs/smoketest.md
+++ b/docs/smoketest.md
@@ -1,0 +1,61 @@
+# Spacer Title
+
+<br>
+
+# Hidden smoketest page
+
+Use this page to test your changes and ensure that there are not any issues,
+unwanted behaviors, or regression that are caused by your changes.
+
+Below are a set of site elements that have causes issues in the past.
+
+## Lists
+
+* Top level:
+  1. A nested list item.
+     1. another level lower
+  1. Nested code sample:
+     <br>Syntax: <code>{<code>{< readfile file="../community/samples/serving/helloworld-java-quarkus/service.yaml" code="true" lang="yaml" >}</code>}</code>
+     <br>Example:
+     {{< readfile file="../community/samples/serving/helloworld-java-quarkus/service.yaml" code="true" lang="yaml" >}}
+  1. This should be the third bullet (3.).
+     1. More nested code:
+        <br>Shortcode: <code>{<code>{< readfile file="/serving/samples/hello-world/helloworld-go/Dockerfile" code="true" lang="go" >}</code>}</code>
+        <br>Example:
+        {{< readfile file="./serving/samples/hello-world/helloworld-go/Dockerfile" code="true" lang="go" >}}
+     1. Another nested ordered list item (2.)
+
+
+## Code samples
+
+The following use the [`readfile` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/readfile.md)
+
+{{< readfile file="../hack/reference-docs-gen-config.json" code="true" lang="json" >}}
+
+{{< readfile file="../Gopkg.toml" code="true" lang="toml" >}}
+
+## Install version numbers and Clone branch commands
+
+Examples of how the manual and dynamic version number or branch name can be added in-line with the
+[`version` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/version.md)
+(uses the define values from [config/_default/params.toml](https://github.com/knative/website/blob/master/config/_default/params.toml))
+
+1. Shortcode: <code>{<code>{% version %}</code>}</code>
+
+    Example: `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`
+
+1. Shortcode: <code>{<code>{% version override="v0.2.2" %}</code>}</code>
+
+    Example: `kubectl apply the-version-override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`
+
+1. Shortcode: <code>{<code>{% version patch=".20" %}</code>}</code>
+
+    Example: `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`
+
+1. Shortcode: <code>{<code>{% branch %}</code>}</code>
+
+    Example: `git clone -b "{{% branch %}}" https://github.com/knative/docs knative-docs`
+
+1. Shortcode: <code>{<code>{% branch override="release-0.NEXT" %}</code>}</code>
+
+    Example: `git clone -b "{{% branch override="release-0.NEXT" %}}" https://github.com/knative/docs knative-docs`

--- a/smoketest.md
+++ b/smoketest.md
@@ -1,0 +1,61 @@
+# Spacer Title
+
+<br>
+
+# Hidden smoketest page
+
+Use this page to test your changes and ensure that there are not any issues,
+unwanted behaviors, or regression that are caused by your changes.
+
+Below are a set of site elements that have causes issues in the past.
+
+## Lists
+
+* Top level:
+  1. A nested list item.
+     1. another level lower
+  1. Nested code sample:
+        <br>Shortcode: <code>{<code>{< readfile file="./hack/reference-docs-gen-config.json" code="true" lang="json" >}</code>}</code>
+        <br>Example:
+        {{< readfile file="./hack/reference-docs-gen-config.json" code="true" lang="json" >}}
+  1. This should be the third bullet (3.).
+     1. More nested code:
+        <br>Shortcode: <code>{<code>{< readfile file="Gopkg.toml" code="true" lang="toml" >}</code>}</code>
+        <br>Example:
+        {{< readfile file="Gopkg.toml" code="true" lang="toml" >}}
+     1. Another nested ordered list item (2.)
+
+
+## Code samples
+
+The following use the [`readfile` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/readfile.md)
+
+{{< readfile file="hack/reference-docs-gen-config.json" code="true" lang="json" >}}
+
+{{< readfile file="Gopkg.toml" code="true" lang="toml" >}}
+
+## Install version numbers and Clone branch commands
+
+Examples of how the manual and dynamic version number or branch name can be added in-line with the
+[`version` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/version.md)
+(uses the define values from [config/_default/params.toml](https://github.com/knative/website/blob/master/config/_default/params.toml))
+
+1. Shortcode: <code>{<code>{% version %}</code>}</code>
+
+    Example: `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`
+
+1. Shortcode: <code>{<code>{% version override="v0.2.2" %}</code>}</code>
+
+    Example: `kubectl apply the-version-override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`
+
+1. Shortcode: <code>{<code>{% version patch=".20" %}</code>}</code>
+
+    Example: `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`
+
+1. Shortcode: <code>{<code>{% branch %}</code>}</code>
+
+    Example: `git clone -b "{{% branch %}}" https://github.com/knative/docs knative-docs`
+
+1. Shortcode: <code>{<code>{% branch override="release-0.NEXT" %}</code>}</code>
+
+    Example: `git clone -b "{{% branch override="release-0.NEXT" %}}" https://github.com/knative/docs knative-docs`


### PR DESCRIPTION
two hidden yet published pages that can be used to verify that known site pain points haven't broken

the smoketest.md file at root allows for local testing and /docs/smoketest.md gets copied into that versions build (for v0.8 and forward)

related:
https://github.com/knative/website/pull/71
https://github.com/knative/website/pull/63
https://github.com/knative/website/pull/74

Replaces #1643 

Staged previews:
https://prstaging--knative-v1.netlify.com/docs/smoketest/