### PR TITLE
v0.8 API ref docs and updated build scripts

### DIFF
--- a/docs/reference/eventing/eventing-contrib-resources.md
+++ b/docs/reference/eventing/eventing-contrib-resources.md
@@ -3,6 +3,9 @@
 <li>
 <a href="#sources.eventing.knative.dev%2fv1alpha1">sources.eventing.knative.dev/v1alpha1</a>
 </li>
+<li>
+<a href="#messaging.knative.dev%2fv1alpha1">messaging.knative.dev/v1alpha1</a>
+</li>
 </ul>
 <h2 id="sources.eventing.knative.dev/v1alpha1">sources.eventing.knative.dev/v1alpha1</h2>
 <p>
@@ -54,7 +57,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -92,7 +95,7 @@ string
 <td>
 <code>awsCredsSecret</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secretkeyselector-v1-core">
 Kubernetes core/v1.SecretKeySelector
 </a>
 </em>
@@ -105,7 +108,7 @@ Kubernetes core/v1.SecretKeySelector
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -179,7 +182,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -217,36 +220,9 @@ CamelSourceOriginSpec
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DEPRECATED: moved inside the specific CamelSourceOriginSpec
-ServiceAccountName is the name of the ServiceAccount to use to run this
-source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DEPRECATED: use the context field in CamelSourceOriginSpec
-Image is an optional base image used to run the source.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -307,7 +283,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -334,7 +310,7 @@ GcpPubSubSourceSpec
 <td>
 <code>gcpCredsSecret</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secretkeyselector-v1-core">
 Kubernetes core/v1.SecretKeySelector
 </a>
 </em>
@@ -342,8 +318,8 @@ Kubernetes core/v1.SecretKeySelector
 <td>
 <p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
 to create or delete the Subscription, only to poll it. The value of the secret entry must be
-a service account key in the JSON format (see
-<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys">https://cloud.google.com/iam/docs/creating-managing-service-account-keys</a>.</p>
+a service account key in the JSON format
+( see <a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys">https://cloud.google.com/iam/docs/creating-managing-service-account-keys</a> ).</p>
 </td>
 </tr>
 <tr>
@@ -374,7 +350,7 @@ unique identifier within the project, not the entire name. E.g. it must be &lsqu
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -388,7 +364,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>transformer</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -461,7 +437,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -561,7 +537,7 @@ secret token</p>
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -647,7 +623,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -719,7 +695,7 @@ KafkaSourceNetSpec
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -803,7 +779,7 @@ string
 <td>
 <code>awsCredsSecret</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secretkeyselector-v1-core">
 Kubernetes core/v1.SecretKeySelector
 </a>
 </em>
@@ -816,7 +792,7 @@ Kubernetes core/v1.SecretKeySelector
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -862,9 +838,7 @@ run the Receive Adapter Deployment.</p>
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
-github.com/knative/pkg/apis/duck/v1alpha1.Status
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.Status
 </em>
 </td>
 <td>
@@ -980,7 +954,8 @@ CamelSourceOriginComponentSpec
 </em>
 </td>
 <td>
-<p>Component is a kind of source that directly references a Camel component</p>
+<p>Component is a kind of source that directly references a Camel component
+DEPRECATED</p>
 </td>
 </tr>
 <tr>
@@ -992,6 +967,17 @@ github.com/apache/camel-k/pkg/apis/camel/v1alpha1.IntegrationSpec
 </td>
 <td>
 <p>Integration is a kind of source that contains a Camel K integration</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>flow</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Flow is a kind of source that contains a single Camel YAML flow route</p>
 </td>
 </tr>
 </tbody>
@@ -1028,36 +1014,9 @@ CamelSourceOriginSpec
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DEPRECATED: moved inside the specific CamelSourceOriginSpec
-ServiceAccountName is the name of the ServiceAccount to use to run this
-source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>image</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DEPRECATED: use the context field in CamelSourceOriginSpec
-Image is an optional base image used to run the source.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -1090,9 +1049,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
-github.com/knative/pkg/apis/duck/v1alpha1.Status
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.Status
 </em>
 </td>
 <td>
@@ -1139,7 +1096,7 @@ string
 <td>
 <code>gcpCredsSecret</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secretkeyselector-v1-core">
 Kubernetes core/v1.SecretKeySelector
 </a>
 </em>
@@ -1147,8 +1104,8 @@ Kubernetes core/v1.SecretKeySelector
 <td>
 <p>GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
 to create or delete the Subscription, only to poll it. The value of the secret entry must be
-a service account key in the JSON format (see
-<a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys)">https://cloud.google.com/iam/docs/creating-managing-service-account-keys)</a>.</p>
+a service account key in the JSON format
+( see <a href="https://cloud.google.com/iam/docs/creating-managing-service-account-keys">https://cloud.google.com/iam/docs/creating-managing-service-account-keys</a> ).</p>
 </td>
 </tr>
 <tr>
@@ -1179,7 +1136,7 @@ unique identifier within the project, not the entire name. E.g. it must be &lsqu
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -1193,7 +1150,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>transformer</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -1238,9 +1195,7 @@ Adapter Deployment.</p>
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
-github.com/knative/pkg/apis/duck/v1alpha1.Status
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.Status
 </em>
 </td>
 <td>
@@ -1372,7 +1327,7 @@ secret token</p>
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -1430,9 +1385,7 @@ bool
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
-github.com/knative/pkg/apis/duck/v1alpha1.Status
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.Status
 </em>
 </td>
 <td>
@@ -1752,7 +1705,7 @@ KafkaSourceNetSpec
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -1810,9 +1763,7 @@ KafkaResourceSpec
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Status">
-github.com/knative/pkg/apis/duck/v1alpha1.Status
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.Status
 </em>
 </td>
 <td>
@@ -1912,6 +1863,38 @@ SecretValueFromSource
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#sources.eventing.knative.dev/v1alpha1.GitHubSourceSpec">GitHubSourceSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.eventing.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
 <a href="#sources.eventing.knative.dev/v1alpha1.KafkaSourceSASLSpec">KafkaSourceSASLSpec</a>, 
 <a href="#sources.eventing.knative.dev/v1alpha1.KafkaSourceTLSSpec">KafkaSourceTLSSpec</a>)
 </p>
@@ -1930,39 +1913,7 @@ SecretValueFromSource
 <td>
 <code>secretKeyRef</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.eventing.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.eventing.knative.dev/v1alpha1.GitHubSourceSpec">GitHubSourceSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#secretkeyselector-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#secretkeyselector-v1-core">
 Kubernetes core/v1.SecretKeySelector
 </a>
 </em>
@@ -1974,7 +1925,246 @@ Kubernetes core/v1.SecretKeySelector
 </tbody>
 </table>
 <hr/>
+<h2 id="messaging.knative.dev/v1alpha1">messaging.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>
+</li></ul>
+<h3 id="messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel
+</h3>
+<p>
+<p>KafkaChannel is a resource representing a Kafka Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>KafkaChannel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannelSpec">
+KafkaChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>numPartitions</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationFactor</code></br>
+<em>
+int16
+</em>
+</td>
+<td>
+<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
+</em>
+</td>
+<td>
+<p>KafkaChannel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannelStatus">
+KafkaChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the KafkaChannel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.KafkaChannelSpec">KafkaChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>)
+</p>
+<p>
+<p>KafkaChannelSpec defines the specification for a KafkaChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>numPartitions</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationFactor</code></br>
+<em>
+int16
+</em>
+</td>
+<td>
+<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.Subscribable
+</em>
+</td>
+<td>
+<p>KafkaChannel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.KafkaChannelStatus">KafkaChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>)
+</p>
+<p>
+<p>KafkaChannelStatus represents the current state of a KafkaChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>KafkaChannel is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+github.com/knative/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>641f98fe</code>.
+on git commit <code>4bda4fca</code>.
 </em></p>

--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -1,34 +1,32 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#eventing.knative.dev%2fv1alpha1">eventing.knative.dev/v1alpha1</a>
-</li>
-<li>
 <a href="#messaging.knative.dev%2fv1alpha1">messaging.knative.dev/v1alpha1</a>
 </li>
 <li>
 <a href="#sources.eventing.knative.dev%2fv1alpha1">sources.eventing.knative.dev/v1alpha1</a>
 </li>
+<li>
+<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#eventing.knative.dev%2fv1alpha1">eventing.knative.dev/v1alpha1</a>
+</li>
 </ul>
-<h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
+<h2 id="messaging.knative.dev/v1alpha1">messaging.knative.dev/v1alpha1</h2>
 <p>
 <p>Package v1alpha1 is the v1alpha1 version of the API.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>
+<a href="#messaging.knative.dev/v1alpha1.Channel">Channel</a>
 </li><li>
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>
+<a href="#messaging.knative.dev/v1alpha1.InMemoryChannel">InMemoryChannel</a>
 </li></ul>
-<h3 id="duck.knative.dev/v1alpha1.Channelable">Channelable
+<h3 id="messaging.knative.dev/v1alpha1.Channel">Channel
 </h3>
 <p>
-<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+<p>Channel represents a generic Channel. It is normally used when we want a Channel, but don&rsquo;t need a specific Channel implementation.</p>
 </p>
 <table>
 <thead>
@@ -44,712 +42,7 @@ Channelable ObjectReferences and access their subscription and address data.  Th
 string</td>
 <td>
 <code>
-duck.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Channelable</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableType">SubscribableType
-</h3>
-<p>
-<p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-duck.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>SubscribableType</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableTypeSpec is the part where Subscribable object is
-configured as to be compatible with Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableTypeStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#AddressStatus">
-github.com/knative/pkg/apis/duck/v1alpha1.AddressStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.Subscribable">Subscribable
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">ChannelSpec</a>, 
-<a href="#messaging.knative.dev/v1alpha1.InMemoryChannelSpec">InMemoryChannelSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
-</p>
-<p>
-<p>Subscribable is the schema for the subscribable portion of the spec
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>)
-</p>
-<p>
-<p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>, 
-<a href="#eventing.knative.dev/v1alpha1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#messaging.knative.dev/v1alpha1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
-</p>
-<p>
-<p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribablestatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.
-Ref is a reference to the Subscription this SubscriberSpec was created for
-SubscriberURI is the endpoint for the subscriber
-ReplyURI is the endpoint for the reply
-At least one of SubscriberURI and ReplyURI must be present</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ref</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: use UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberURI</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyURI</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscriberStatus">SubscriberStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>)
-</p>
-<p>
-<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#conditionstatus-v1-core">
-Kubernetes core/v1.ConditionStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>message</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>A human readable message indicating details of Ready status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="eventing.knative.dev/v1alpha1">eventing.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#eventing.knative.dev/v1alpha1.Broker">Broker</a>
-</li><li>
-<a href="#eventing.knative.dev/v1alpha1.Channel">Channel</a>
-</li><li>
-<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>
-</li><li>
-<a href="#eventing.knative.dev/v1alpha1.EventType">EventType</a>
-</li><li>
-<a href="#eventing.knative.dev/v1alpha1.Subscription">Subscription</a>
-</li><li>
-<a href="#eventing.knative.dev/v1alpha1.Trigger">Trigger</a>
-</li></ul>
-<h3 id="eventing.knative.dev/v1alpha1.Broker">Broker
-</h3>
-<p>
-<p>Broker collects a pool of events that are consumable using Triggers. Brokers
-provide a well-known endpoint for event delivery that senders can use with
-minimal knowledge of the event routing strategy. Receivers use Triggers to
-request delivery of events from a Broker&rsquo;s pool to a specific URL or
-Addressable endpoint.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Broker</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.BrokerSpec">
-BrokerSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Broker.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">
-ChannelSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeprecatedChannelTemplate, if specified will be used to create all the Channels used internally by the
-Broker. Only Provisioner and Arguments may be specified. If left unspecified, the default
-Channel for the namespace will be used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplateSpec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>ChannelTemplate specifies which Channel CRD to use to create all the Channels used internally by the
-Broker.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.BrokerStatus">
-BrokerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Broker. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.Channel">Channel
-</h3>
-<p>
-<p>Channel is an abstract resource that implements the Addressable contract.
-The Provisioner provisions infrastructure to accepts events and
-deliver to Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1alpha1
+messaging.knative.dev/v1alpha1
 </code>
 </td>
 </tr>
@@ -764,7 +57,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -779,7 +72,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">
+<a href="#messaging.knative.dev/v1alpha1.ChannelSpec">
 ChannelSpec
 </a>
 </em>
@@ -791,43 +84,16 @@ ChannelSpec
 <table>
 <tr>
 <td>
-<code>generation</code></br>
+<code>channelTemplate</code></br>
 <em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TODO By enabling the status subresource metadata.generation should increment
-thus making this property obsolete.</p>
-<p>We should be able to drop this property with a CRD conversion webhook
-in the future</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provisioner</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
+ChannelTemplateSpec
 </a>
 </em>
 </td>
 <td>
-<p>Provisioner defines the name of the Provisioner backing this channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>arguments</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments defines the arguments to pass to the Provisioner which
-provisions this Channel.</p>
+<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
+This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
 </td>
 </tr>
 <tr>
@@ -850,7 +116,7 @@ Subscribable
 <td>
 <code>status</code></br>
 <em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelStatus">
+<a href="#messaging.knative.dev/v1alpha1.ChannelStatus">
 ChannelStatus
 </a>
 </em>
@@ -863,1610 +129,6 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner
-</h3>
-<p>
-<p>ClusterChannelProvisioner encapsulates a provisioning strategy for the
-backing resources required to realize a particular resource type.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ClusterChannelProvisioner</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisionerSpec">
-ClusterChannelProvisionerSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the Types provisioned by this Provisioner.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TODO By enabling the status subresource metadata.generation should increment
-thus making this property obsolete.</p>
-<p>We should be able to drop this property with a CRD conversion webhook
-in the future</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisionerStatus">
-ClusterChannelProvisionerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status is the current status of the Provisioner.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.EventType">EventType
-</h3>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>EventType</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.EventTypeSpec">
-EventTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the EventType.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>type</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Type represents the CloudEvents type. It is authoritative.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Source is a URI, it represents the CloudEvents source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schema</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Schema is a URI, it represents the CloudEvents schemaurl extension attribute.
-It may be a JSON schema, a protobuf schema, etc. It is optional.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>broker</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Broker refers to the Broker that can provide the EventType.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is an optional field used to describe the EventType, in any meaningful way.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.EventTypeStatus">
-EventTypeStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the EventType.
-This data may be out of date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.Subscription">Subscription
-</h3>
-<p>
-<p>Subscription routes events received on a Channel to a DNS name and
-corresponds to the subscriptions.channels.knative.dev CRD.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Subscription</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriptionSpec">
-SubscriptionSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TODO By enabling the status subresource metadata.generation should increment
-thus making this property obsolete.</p>
-<p>We should be able to drop this property with a CRD conversion webhook
-in the future</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>This field is immutable. We have no good answer on what happens to
-the events that are currently in the channel being consumed from
-and what the semantics there should be. For now, you can always
-delete the Subscription and recreate it to point to a different
-channel, giving the user more control over what semantics should
-be used (drain the channel first, possibly have events dropped,
-etc.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
-SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
-Events from the Channel will be delivered here and replies are
-sent to a channel as specified by the Reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ReplyStrategy">
-ReplyStrategy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply specifies (optionally) how to handle events returned from
-the Subscriber target.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriptionStatus">
-SubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.Trigger">Trigger
-</h3>
-<p>
-<p>Trigger represents a request to have events delivered to a consumer from a
-Broker&rsquo;s event pool.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Trigger</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerSpec">
-TriggerSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Trigger.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>broker</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Broker is the broker that this trigger receives events from. If not specified, will default
-to &lsquo;default&rsquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">
-TriggerFilter
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
-filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
-SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
-is required.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerStatus">
-TriggerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Trigger. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.BrokerSpec">BrokerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Broker">Broker</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">
-ChannelSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeprecatedChannelTemplate, if specified will be used to create all the Channels used internally by the
-Broker. Only Provisioner and Arguments may be specified. If left unspecified, the default
-Channel for the namespace will be used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplateSpec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>ChannelTemplate specifies which Channel CRD to use to create all the Channels used internally by the
-Broker.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.BrokerStatus">BrokerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Broker">Broker</a>)
-</p>
-<p>
-<p>BrokerStatus represents the current state of a Broker.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Addressable">
-github.com/knative/pkg/apis/duck/v1alpha1.Addressable
-</a>
-</em>
-</td>
-<td>
-<p>Broker is Addressable. It currently exposes the endpoint as a
-fully-qualified DNS name which will distribute traffic over the
-provided targets from inside the cluster.</p>
-<p>It generally has the form {broker}-router.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>triggerChannel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>TriggerChannel is an objectref to the object for the TriggerChannel</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>IngressChannel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>IngressChannel is an objectref to the object for the IngressChannel</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.ChannelProvisionerDefaulter">ChannelProvisionerDefaulter
-</h3>
-<p>
-<p>ChannelProvisionerDefaulter sets the default Provisioner and Arguments on Channels that do not
-specify any Provisioner.</p>
-</p>
-<h3 id="eventing.knative.dev/v1alpha1.ChannelSpec">ChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Channel">Channel</a>, 
-<a href="#eventing.knative.dev/v1alpha1.BrokerSpec">BrokerSpec</a>)
-</p>
-<p>
-<p>ChannelSpec specifies the Provisioner backing a channel and the configuration
-arguments for a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TODO By enabling the status subresource metadata.generation should increment
-thus making this property obsolete.</p>
-<p>We should be able to drop this property with a CRD conversion webhook
-in the future</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provisioner</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Provisioner defines the name of the Provisioner backing this channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>arguments</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Arguments defines the arguments to pass to the Provisioner which
-provisions this Channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
-</a>
-</em>
-</td>
-<td>
-<p>Channel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.ChannelStatus">ChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Channel">Channel</a>)
-</p>
-<p>
-<p>ChannelStatus represents the current state of a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#Addressable">
-github.com/knative/pkg/apis/duck/v1alpha1.Addressable
-</a>
-</em>
-</td>
-<td>
-<p>Channel is Addressable. It currently exposes the endpoint as a
-fully-qualified DNS name which will distribute traffic over the
-provided targets from inside the cluster.</p>
-<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>internal</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Internal is status unique to each ClusterChannelProvisioner.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.ChannelTemplateSpec">ChannelTemplateSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.BrokerSpec">BrokerSpec</a>)
-</p>
-<p>
-<p>This should be duck so that Broker can also use this</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>Raw</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>Raw is the underlying serialization of this object.</p>
-<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>-</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.Object
-</em>
-</td>
-<td>
-<p>Object can hold a representation of this extension - useful for working with versioned
-structs.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
-</h3>
-<p>
-<p>Internal version of ChannelTemplateSpec that includes ObjectMeta so that
-we can easily create new Channels off of it.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>Raw</code></br>
-<em>
-[]byte
-</em>
-</td>
-<td>
-<p>Raw is the underlying serialization of this object.</p>
-<p>TODO: Determine how to detect ContentType and ContentEncoding of &lsquo;Raw&rsquo; data.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>-</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.Object
-</em>
-</td>
-<td>
-<p>Object can hold a representation of this extension - useful for working with versioned
-structs.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.ClusterChannelProvisionerSpec">ClusterChannelProvisionerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
-</p>
-<p>
-<p>ClusterChannelProvisionerSpec is the spec for a ClusterChannelProvisioner resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TODO By enabling the status subresource metadata.generation should increment
-thus making this property obsolete.</p>
-<p>We should be able to drop this property with a CRD conversion webhook
-in the future</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.ClusterChannelProvisionerStatus">ClusterChannelProvisionerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
-</p>
-<p>
-<p>ClusterChannelProvisionerStatus is the status for a ClusterChannelProvisioner resource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.EventTypeSpec">EventTypeSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.EventType">EventType</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Type represents the CloudEvents type. It is authoritative.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Source is a URI, it represents the CloudEvents source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schema</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Schema is a URI, it represents the CloudEvents schemaurl extension attribute.
-It may be a JSON schema, a protobuf schema, etc. It is optional.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>broker</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Broker refers to the Broker that can provide the EventType.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>description</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Description is an optional field used to describe the EventType, in any meaningful way.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.EventTypeStatus">EventTypeStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.EventType">EventType</a>)
-</p>
-<p>
-<p>EventTypeStatus represents the current state of a EventType.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.HasSpec">HasSpec
-</h3>
-<p>
-</p>
-<h3 id="eventing.knative.dev/v1alpha1.ReplyStrategy">ReplyStrategy
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriptionSpec">SubscriptionSpec</a>)
-</p>
-<p>
-<p>ReplyStrategy specifies the handling of the SubscriberSpec&rsquo;s returned replies.
-If no SubscriberSpec is specified, the identity function is assumed.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>You can specify only the following fields of the ObjectReference:
-- Kind
-- APIVersion
-- Name
-The resource pointed by this ObjectReference must meet the Addressable contract
-with a reference to the Addressable duck type. If the resource does not meet this contract,
-it will be reflected in the Subscription&rsquo;s status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.SequenceSpec">SequenceSpec</a>, 
-<a href="#eventing.knative.dev/v1alpha1.SubscriptionSpec">SubscriptionSpec</a>, 
-<a href="#eventing.knative.dev/v1alpha1.TriggerSpec">TriggerSpec</a>)
-</p>
-<p>
-<p>SubscriberSpec specifies the reference to an object that&rsquo;s expected to
-provide the resolved target of the action.
-Currently we inspect the objects Status and see if there&rsquo;s a predefined
-Status field that we will then use to dispatch events to be processed by
-the target. Currently must resolve to a k8s service.
-Note that in the future we should try to utilize subresources (/resolve ?) to
-make this cleaner, but CRDs do not support subresources yet, so we need
-to rely on a specified Status field today. By relying on this behaviour
-we can utilize a dynamic client instead of having to understand all
-kinds of different types of objects. As long as they adhere to this
-particular contract, they can be used as a Target.</p>
-<p>This ensures that we can support external targets and for ease of use
-we also allow for an URI to be specified.
-There of course is also a requirement for the resolved SubscriberSpec to
-behave properly at the data plane level.
-TODO: Add a pointer to a real spec for this.
-For now, this means: Receive an event payload, and respond with one of:
-success and an optional response event, or failure.
-Delivery failures may be retried by the channel</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ref</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reference to an object that will be used to find the target
-endpoint, which should implement the Addressable duck type.
-For example, this could be a reference to a Route resource
-or a Knative Service resource.
-TODO: Specify the required fields the target object must
-have in the status.
-You can specify only the following fields of the ObjectReference:
-- Kind
-- APIVersion
-- Name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>dnsName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Deprecated: Use URI instead.
-Reference to a &lsquo;known&rsquo; endpoint where no resolving is done.
-<a href="http://k8s-service">http://k8s-service</a> for example
-<a href="http://myexternalhandler.example.com/foo/bar">http://myexternalhandler.example.com/foo/bar</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>uri</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reference to a &lsquo;known&rsquo; endpoint where no resolving is done.
-<a href="http://k8s-service">http://k8s-service</a> for example
-<a href="http://myexternalhandler.example.com/foo/bar">http://myexternalhandler.example.com/foo/bar</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.SubscriptionSpec">SubscriptionSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Subscription">Subscription</a>)
-</p>
-<p>
-<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
-for processing those events and where to put the result of the processing. Only
-From (where the events are coming from) is always required. You can optionally
-only Process the events (results in no output events) by leaving out the Result.
-You can also perform an identity transformation on the incoming events by leaving
-out the Subscriber and only specifying Result.</p>
-<p>The following are all valid specifications:
-channel &ndash;[subscriber]&ndash;&gt; reply
-Sink, no outgoing events:
-channel &ndash; subscriber
-no-op function (identity transformation):
-channel &ndash;&gt; reply</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TODO By enabling the status subresource metadata.generation should increment
-thus making this property obsolete.</p>
-<p>We should be able to drop this property with a CRD conversion webhook
-in the future</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>This field is immutable. We have no good answer on what happens to
-the events that are currently in the channel being consumed from
-and what the semantics there should be. For now, you can always
-delete the Subscription and recreate it to point to a different
-channel, giving the user more control over what semantics should
-be used (drain the channel first, possibly have events dropped,
-etc.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
-SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
-Events from the Channel will be delivered here and replies are
-sent to a channel as specified by the Reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.ReplyStrategy">
-ReplyStrategy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply specifies (optionally) how to handle events returned from
-the Subscriber target.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.SubscriptionStatus">SubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Subscription">Subscription</a>)
-</p>
-<p>
-<p>SubscriptionStatus (computed) for a subscription</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>physicalSubscription</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriptionStatusPhysicalSubscription">
-SubscriptionStatusPhysicalSubscription
-</a>
-</em>
-</td>
-<td>
-<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriptionStatus">SubscriptionStatus</a>)
-</p>
-<p>
-<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
-Subscription.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscriberURI</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyURI</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.TriggerFilter">TriggerFilter
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerSpec">TriggerSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>sourceAndType</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerFilterSourceAndType">
-TriggerFilterSourceAndType
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.TriggerFilterSourceAndType">TriggerFilterSourceAndType
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">TriggerFilter</a>)
-</p>
-<p>
-<p>TriggerFilterSourceAndType filters events based on exact matches on the cloud event&rsquo;s type and
-source attributes. Only exact matches will pass the filter. Either or both type and source can
-use the value &lsquo;Any&rsquo; to indicate all strings match.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>type</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.TriggerSpec">TriggerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Trigger">Trigger</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>broker</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Broker is the broker that this trigger receives events from. If not specified, will default
-to &lsquo;default&rsquo;.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">
-TriggerFilter
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
-filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
-SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
-is required.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1alpha1.TriggerStatus">TriggerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1alpha1.Trigger">Trigger</a>)
-</p>
-<p>
-<p>TriggerStatus represents the current state of a Trigger.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1beta1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberURI</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>SubscriberURI is the resolved URI of the receiver for this Trigger.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="messaging.knative.dev/v1alpha1">messaging.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#messaging.knative.dev/v1alpha1.InMemoryChannel">InMemoryChannel</a>
-</li></ul>
 <h3 id="messaging.knative.dev/v1alpha1.InMemoryChannel">InMemoryChannel
 </h3>
 <p>
@@ -2501,7 +163,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2559,14 +221,15 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="messaging.knative.dev/v1alpha1.ChannelTemplateSpec">ChannelTemplateSpec
+<h3 id="messaging.knative.dev/v1alpha1.ChannelSpec">ChannelSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.SequenceSpec">SequenceSpec</a>)
+<a href="#messaging.knative.dev/v1alpha1.Channel">Channel</a>)
 </p>
 <p>
-<p>This should be duck so that Broker can also use this</p>
+<p>ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
+It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.</p>
 </p>
 <table>
 <thead>
@@ -2578,28 +241,119 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>spec</code></br>
+<code>channelTemplate</code></br>
 <em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-</table>
+<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
+This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+<p>Channel conforms to Duck type Subscribable.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="messaging.knative.dev/v1alpha1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
+<h3 id="messaging.knative.dev/v1alpha1.ChannelStatus">ChannelStatus
 </h3>
 <p>
-<p>Internal version of ChannelTemplateSpec that includes ObjectMeta so that
-we can easily create new Channels off of it.</p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>Channel is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is an ObjectReference to the Channel CRD backing this Channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.Choice">Choice
+</h3>
+<p>
+<p>Choice defines conditional branches that will be wired in
+series through Channels and Subscriptions.</p>
 </p>
 <table>
 <thead>
@@ -2613,7 +367,7 @@ we can easily create new Channels off of it.</p>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2628,17 +382,439 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
+<a href="#messaging.knative.dev/v1alpha1.ChoiceSpec">
+ChoiceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Choice.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>cases</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceCase">
+[]ChoiceCase
+</a>
+</em>
+</td>
+<td>
+<p>Cases is the list of Filter/Subscribers pairs. Filters are evaluated in the order
+provided, until one pass (returns true)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name</p>
+<p>The resource pointed by this ObjectReference must meet the Addressable contract
+with a reference to the Addressable duck type. If the resource does not meet this contract,
+it will be reflected in the Subscription&rsquo;s status.</p>
+</td>
+</tr>
 </table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceStatus">
+ChoiceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Choice. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.ChoiceCase">ChoiceCase
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceSpec">ChoiceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>Filter is the expression guarding the branch/case</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>Subscriber receiving the event when the filter passes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
+If not specified, sent the result to the Choice Reply</p>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name</p>
+<p>The resource pointed by this ObjectReference must meet the Addressable contract
+with a reference to the Addressable duck type. If the resource does not meet this contract,
+it will be reflected in the Subscription&rsquo;s status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.ChoiceCaseStatus">ChoiceCaseStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceStatus">ChoiceStatus</a>)
+</p>
+<p>
+<p>ChoiceCaseStatus represents the current state of a Choice case</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filterSubscriptionStatus</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceSubscriptionStatus">
+ChoiceSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filterChannelStatus</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceChannelStatus">
+ChoiceChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterChannelStatus corresponds to the filter channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberSubscriptionStatus</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceSubscriptionStatus">
+ChoiceSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.ChoiceChannelStatus">ChoiceChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceCaseStatus">ChoiceCaseStatus</a>, 
+<a href="#messaging.knative.dev/v1alpha1.ChoiceStatus">ChoiceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.ChoiceSpec">ChoiceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.Choice">Choice</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cases</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceCase">
+[]ChoiceCase
+</a>
+</em>
+</td>
+<td>
+<p>Cases is the list of Filter/Subscribers pairs. Filters are evaluated in the order
+provided, until one pass (returns true)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name</p>
+<p>The resource pointed by this ObjectReference must meet the Addressable contract
+with a reference to the Addressable duck type. If the resource does not meet this contract,
+it will be reflected in the Subscription&rsquo;s status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.ChoiceStatus">ChoiceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.Choice">Choice</a>)
+</p>
+<p>
+<p>ChoiceStatus represents the current state of a Choice.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressChannelStatus</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceChannelStatus">
+ChoiceChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>IngressChannelStatus corresponds to the ingress channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caseStatuses</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceCaseStatus">
+[]ChoiceCaseStatus
+</a>
+</em>
+</td>
+<td>
+<p>CaseStatuses is an array of corresponding to cases status.
+Matches the Spec.Cases array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Choice. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.ChoiceSubscriptionStatus">ChoiceSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceCaseStatus">ChoiceCaseStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
 </td>
 </tr>
 </tbody>
@@ -2698,9 +874,7 @@ Subscribable
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
+knative.dev/pkg/apis/duck/v1beta1.Status
 </em>
 </td>
 <td>
@@ -2716,9 +890,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 <td>
 <code>AddressStatus</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#AddressStatus">
-github.com/knative/pkg/apis/duck/v1alpha1.AddressStatus
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </em>
 </td>
 <td>
@@ -2767,7 +939,7 @@ series through Channels and Subscriptions.</p>
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -2810,20 +982,22 @@ provided.</p>
 <td>
 <code>channelTemplate</code></br>
 <em>
-<a href="#messaging.knative.dev/v1alpha1.ChannelTemplateSpec">
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
 ChannelTemplateSpec
 </a>
 </em>
 </td>
 <td>
-<p>ChannelTemplate specifies which Channel CRD to use</p>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>reply</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -2880,7 +1054,7 @@ date.</p>
 <td>
 <code>channel</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -2893,7 +1067,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>ready</code></br>
 <em>
-github.com/knative/pkg/apis.Condition
+knative.dev/pkg/apis.Condition
 </em>
 </td>
 <td>
@@ -2936,20 +1110,22 @@ provided.</p>
 <td>
 <code>channelTemplate</code></br>
 <em>
-<a href="#messaging.knative.dev/v1alpha1.ChannelTemplateSpec">
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
 ChannelTemplateSpec
 </a>
 </em>
 </td>
 <td>
-<p>ChannelTemplate specifies which Channel CRD to use</p>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>reply</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -2989,9 +1165,7 @@ it will be reflected in the Subscription&rsquo;s status.</p>
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
+knative.dev/pkg/apis/duck/v1beta1.Status
 </em>
 </td>
 <td>
@@ -3005,7 +1179,7 @@ github.com/knative/pkg/apis/duck/v1beta1.Status
 </tr>
 <tr>
 <td>
-<code>SubscriptionStatuses</code></br>
+<code>subscriptionStatuses</code></br>
 <em>
 <a href="#messaging.knative.dev/v1alpha1.SequenceSubscriptionStatus">
 []SequenceSubscriptionStatus
@@ -3019,7 +1193,7 @@ Matches the Spec.Steps array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>ChannelStatuses</code></br>
+<code>channelStatuses</code></br>
 <em>
 <a href="#messaging.knative.dev/v1alpha1.SequenceChannelStatus">
 []SequenceChannelStatus
@@ -3035,9 +1209,7 @@ Matches the Spec.Steps array in the order.</p>
 <td>
 <code>AddressStatus</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1alpha1#AddressStatus">
-github.com/knative/pkg/apis/duck/v1alpha1.AddressStatus
-</a>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </em>
 </td>
 <td>
@@ -3071,7 +1243,7 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <td>
 <code>subscription</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -3084,7 +1256,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>ready</code></br>
 <em>
-github.com/knative/pkg/apis.Condition
+knative.dev/pkg/apis.Condition
 </em>
 </td>
 <td>
@@ -3140,7 +1312,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -3193,7 +1365,7 @@ source.</p>
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -3267,7 +1439,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -3294,7 +1466,7 @@ ContainerSourceSpec
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -3334,7 +1506,7 @@ When <code>Template</code> is set, this field is ignored.</p>
 <td>
 <code>env</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
 </a>
 </em>
@@ -3366,7 +1538,7 @@ When <code>Template</code> is set, this field is ignored.</p>
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -3427,7 +1599,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>
@@ -3476,7 +1648,7 @@ string
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -3628,7 +1800,7 @@ source.</p>
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -3674,9 +1846,7 @@ string
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
+knative.dev/pkg/apis/duck/v1beta1.Status
 </em>
 </td>
 <td>
@@ -3723,7 +1893,7 @@ string
 <td>
 <code>template</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#podtemplatespec-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
@@ -3763,7 +1933,7 @@ When <code>Template</code> is set, this field is ignored.</p>
 <td>
 <code>env</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#envvar-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#envvar-v1-core">
 []Kubernetes core/v1.EnvVar
 </a>
 </em>
@@ -3795,7 +1965,7 @@ When <code>Template</code> is set, this field is ignored.</p>
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -3828,9 +1998,7 @@ Kubernetes core/v1.ObjectReference
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
+knative.dev/pkg/apis/duck/v1beta1.Status
 </em>
 </td>
 <td>
@@ -4017,7 +2185,7 @@ string
 <td>
 <code>sink</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#objectreference-v1-core">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
 </a>
 </em>
@@ -4075,9 +2243,7 @@ CronJobResourceSpec
 <td>
 <code>Status</code></br>
 <em>
-<a href="https://godoc.org/github.com/knative/pkg/apis/duck/v1beta1#Status">
-github.com/knative/pkg/apis/duck/v1beta1.Status
-</a>
+knative.dev/pkg/apis/duck/v1beta1.Status
 </em>
 </td>
 <td>
@@ -4104,7 +2270,2482 @@ string
 </tbody>
 </table>
 <hr/>
+<h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>
+</li><li>
+<a href="#duck.knative.dev/v1alpha1.Resource">Resource</a>
+</li><li>
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>
+</li></ul>
+<h3 id="duck.knative.dev/v1alpha1.Channelable">Channelable
+</h3>
+<p>
+<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+duck.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Channelable</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.Resource">Resource
+</h3>
+<p>
+<p>Resource is a skeleton type wrapping all Kubernetes resources. It is typically used to watch
+arbitrary other resources (such as any Importer or Addressable). This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+duck.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Resource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableType">SubscribableType
+</h3>
+<p>
+<p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+duck.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>SubscribableType</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableTypeSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableTypeStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelDefaulter">ChannelDefaulter
+</h3>
+<p>
+<p>ChannelDefaulter sets the default Channel CRD and Arguments on Channels that do not
+specify any implementation.</p>
+</p>
+<h3 id="duck.knative.dev/v1alpha1.ChannelTemplateSpec">ChannelTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.BrokerSpec">BrokerSpec</a>, 
+<a href="#messaging.knative.dev/v1alpha1.ChannelSpec">ChannelSpec</a>, 
+<a href="#messaging.knative.dev/v1alpha1.ChoiceSpec">ChoiceSpec</a>, 
+<a href="#messaging.knative.dev/v1alpha1.SequenceSpec">SequenceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the Spec to use for each channel created. Passed
+in verbatim to the Channel CRD as Spec section.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
+</h3>
+<p>
+<p>ChannelTemplateSpecInternal is an internal only version that includes ObjectMeta so that
+we can easily create new Channels off of it.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the Spec to use for each channel created. Passed
+in verbatim to the Channel CRD as Spec section.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.Subscribable">Subscribable
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.ChannelSpec">ChannelSpec</a>, 
+<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">ChannelSpec</a>, 
+<a href="#messaging.knative.dev/v1alpha1.InMemoryChannelSpec">InMemoryChannelSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
+</p>
+<p>
+<p>Subscribable is the schema for the subscribable portion of the spec
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>)
+</p>
+<p>
+<p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>, 
+<a href="#messaging.knative.dev/v1alpha1.ChannelStatus">ChannelStatus</a>, 
+<a href="#eventing.knative.dev/v1alpha1.ChannelStatus">ChannelStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#messaging.knative.dev/v1alpha1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
+</p>
+<p>
+<p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribablestatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.
+Ref is a reference to the Subscription this SubscriberSpec was created for
+SubscriberURI is the endpoint for the subscriber
+ReplyURI is the endpoint for the reply
+At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ref</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: use UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscriberStatus">SubscriberStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>)
+</p>
+<p>
+<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A human readable message indicating details of Ready status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="eventing.knative.dev/v1alpha1">eventing.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#eventing.knative.dev/v1alpha1.Broker">Broker</a>
+</li><li>
+<a href="#eventing.knative.dev/v1alpha1.Channel">Channel</a>
+</li><li>
+<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>
+</li><li>
+<a href="#eventing.knative.dev/v1alpha1.EventType">EventType</a>
+</li><li>
+<a href="#eventing.knative.dev/v1alpha1.Subscription">Subscription</a>
+</li><li>
+<a href="#eventing.knative.dev/v1alpha1.Trigger">Trigger</a>
+</li></ul>
+<h3 id="eventing.knative.dev/v1alpha1.Broker">Broker
+</h3>
+<p>
+<p>Broker collects a pool of events that are consumable using Triggers. Brokers
+provide a well-known endpoint for event delivery that senders can use with
+minimal knowledge of the event routing strategy. Receivers use Triggers to
+request delivery of events from a Broker&rsquo;s pool to a specific URL or
+Addressable endpoint.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Broker</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.BrokerSpec">
+BrokerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Broker.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedChannelTemplate, if specified will be used to create all the Channels used internally by the
+Broker. Only Provisioner and Arguments may be specified. If left unspecified, the default
+Channel CRD for the namespace will be used using the channelTemplateSpec attribute.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplateSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use to create all the Channels used internally by the
+Broker. If left unspecified, it is set to the default Channel CRD for the namespace (or cluster, in case there
+are no defaults for the namespace).</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.BrokerStatus">
+BrokerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Broker. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.Channel">Channel
+</h3>
+<p>
+<p>Channel is an abstract resource that implements the Addressable contract.
+The Provisioner provisions infrastructure to accepts events and
+deliver to Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Channel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO By enabling the status subresource metadata.generation should increment
+thus making this property obsolete.</p>
+<p>We should be able to drop this property with a CRD conversion webhook
+in the future</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisioner</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Provisioner defines the name of the Provisioner backing this channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arguments</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments defines the arguments to pass to the Provisioner which
+provisions this Channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+<p>Channel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ChannelStatus">
+ChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Channel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner
+</h3>
+<p>
+<p>ClusterChannelProvisioner encapsulates a provisioning strategy for the
+backing resources required to realize a particular resource type.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ClusterChannelProvisioner</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisionerSpec">
+ClusterChannelProvisionerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the Types provisioned by this Provisioner.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO By enabling the status subresource metadata.generation should increment
+thus making this property obsolete.</p>
+<p>We should be able to drop this property with a CRD conversion webhook
+in the future</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisionerStatus">
+ClusterChannelProvisionerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status is the current status of the Provisioner.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.EventType">EventType
+</h3>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>EventType</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.EventTypeSpec">
+EventTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the EventType.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Type represents the CloudEvents type. It is authoritative.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Source is a URI, it represents the CloudEvents source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schema</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Schema is a URI, it represents the CloudEvents schemaurl extension attribute.
+It may be a JSON schema, a protobuf schema, etc. It is optional.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>broker</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Broker refers to the Broker that can provide the EventType.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is an optional field used to describe the EventType, in any meaningful way.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.EventTypeStatus">
+EventTypeStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the EventType.
+This data may be out of date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.Subscription">Subscription
+</h3>
+<p>
+<p>Subscription routes events received on a Channel to a DNS name and
+corresponds to the subscriptions.channels.knative.dev CRD.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Subscription</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriptionSpec">
+SubscriptionSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO By enabling the status subresource metadata.generation should increment
+thus making this property obsolete.</p>
+<p>We should be able to drop this property with a CRD conversion webhook
+in the future</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a channel as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ReplyStrategy">
+ReplyStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriptionStatus">
+SubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.Trigger">Trigger
+</h3>
+<p>
+<p>Trigger represents a request to have events delivered to a consumer from a
+Broker&rsquo;s event pool.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Trigger</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerSpec">
+TriggerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Trigger.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>broker</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Broker is the broker that this trigger receives events from. If not specified, will default
+to &lsquo;default&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">
+TriggerFilter
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
+filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
+is required.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerStatus">
+TriggerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Trigger. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.BrokerSpec">BrokerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Broker">Broker</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedChannelTemplate, if specified will be used to create all the Channels used internally by the
+Broker. Only Provisioner and Arguments may be specified. If left unspecified, the default
+Channel CRD for the namespace will be used using the channelTemplateSpec attribute.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplateSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use to create all the Channels used internally by the
+Broker. If left unspecified, it is set to the default Channel CRD for the namespace (or cluster, in case there
+are no defaults for the namespace).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.BrokerStatus">BrokerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Broker">Broker</a>)
+</p>
+<p>
+<p>BrokerStatus represents the current state of a Broker.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.Addressable
+</em>
+</td>
+<td>
+<p>Broker is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {broker}-router.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>triggerChannel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>TriggerChannel is an objectref to the object for the TriggerChannel</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>IngressChannel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>IngressChannel is an objectref to the object for the IngressChannel</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.ChannelProvisionerDefaulter">ChannelProvisionerDefaulter
+</h3>
+<p>
+<p>ChannelProvisionerDefaulter sets the default Provisioner and Arguments on Channels that do not
+specify any Provisioner.</p>
+</p>
+<h3 id="eventing.knative.dev/v1alpha1.ChannelSpec">ChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Channel">Channel</a>, 
+<a href="#eventing.knative.dev/v1alpha1.BrokerSpec">BrokerSpec</a>)
+</p>
+<p>
+<p>ChannelSpec specifies the Provisioner backing a channel and the configuration
+arguments for a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO By enabling the status subresource metadata.generation should increment
+thus making this property obsolete.</p>
+<p>We should be able to drop this property with a CRD conversion webhook
+in the future</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisioner</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Provisioner defines the name of the Provisioner backing this channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>arguments</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Arguments defines the arguments to pass to the Provisioner which
+provisions this Channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+<p>Channel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.ChannelStatus">ChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.Addressable
+</em>
+</td>
+<td>
+<p>Channel is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>internal</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Internal is status unique to each ClusterChannelProvisioner.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.ClusterChannelProvisionerSpec">ClusterChannelProvisionerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
+</p>
+<p>
+<p>ClusterChannelProvisionerSpec is the spec for a ClusterChannelProvisioner resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO By enabling the status subresource metadata.generation should increment
+thus making this property obsolete.</p>
+<p>We should be able to drop this property with a CRD conversion webhook
+in the future</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.ClusterChannelProvisionerStatus">ClusterChannelProvisionerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.ClusterChannelProvisioner">ClusterChannelProvisioner</a>)
+</p>
+<p>
+<p>ClusterChannelProvisionerStatus is the status for a ClusterChannelProvisioner resource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.EventTypeSpec">EventTypeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.EventType">EventType</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Type represents the CloudEvents type. It is authoritative.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Source is a URI, it represents the CloudEvents source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schema</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Schema is a URI, it represents the CloudEvents schemaurl extension attribute.
+It may be a JSON schema, a protobuf schema, etc. It is optional.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>broker</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Broker refers to the Broker that can provide the EventType.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>description</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Description is an optional field used to describe the EventType, in any meaningful way.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.EventTypeStatus">EventTypeStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.EventType">EventType</a>)
+</p>
+<p>
+<p>EventTypeStatus represents the current state of a EventType.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.HasSpec">HasSpec
+</h3>
+<p>
+</p>
+<h3 id="eventing.knative.dev/v1alpha1.ReplyStrategy">ReplyStrategy
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>ReplyStrategy specifies the handling of the SubscriberSpec&rsquo;s returned replies.
+If no SubscriberSpec is specified, the identity function is assumed.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+The resource pointed by this ObjectReference must meet the Addressable contract
+with a reference to the Addressable duck type. If the resource does not meet this contract,
+it will be reflected in the Subscription&rsquo;s status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.ChoiceCase">ChoiceCase</a>, 
+<a href="#messaging.knative.dev/v1alpha1.SequenceSpec">SequenceSpec</a>, 
+<a href="#eventing.knative.dev/v1alpha1.SubscriptionSpec">SubscriptionSpec</a>, 
+<a href="#eventing.knative.dev/v1alpha1.TriggerSpec">TriggerSpec</a>)
+</p>
+<p>
+<p>SubscriberSpec specifies the reference to an object that&rsquo;s expected to
+provide the resolved target of the action.
+Currently we inspect the objects Status and see if there&rsquo;s a predefined
+Status field that we will then use to dispatch events to be processed by
+the target. Currently must resolve to a k8s service.
+Note that in the future we should try to utilize subresources (/resolve ?) to
+make this cleaner, but CRDs do not support subresources yet, so we need
+to rely on a specified Status field today. By relying on this behaviour
+we can utilize a dynamic client instead of having to understand all
+kinds of different types of objects. As long as they adhere to this
+particular contract, they can be used as a Target.</p>
+<p>This ensures that we can support external targets and for ease of use
+we also allow for an URI to be specified.
+There of course is also a requirement for the resolved SubscriberSpec to
+behave properly at the data plane level.
+TODO: Add a pointer to a real spec for this.
+For now, this means: Receive an event payload, and respond with one of:
+success and an optional response event, or failure.
+Delivery failures may be retried by the channel</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ref</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reference to an object that will be used to find the target
+endpoint, which should implement the Addressable duck type.
+For example, this could be a reference to a Route resource
+or a Knative Service resource.
+TODO: Specify the required fields the target object must
+have in the status.
+You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>dnsName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Deprecated: Use URI instead.
+Reference to a &lsquo;known&rsquo; endpoint where no resolving is done.
+<a href="http://k8s-service">http://k8s-service</a> for example
+<a href="http://myexternalhandler.example.com/foo/bar">http://myexternalhandler.example.com/foo/bar</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>uri</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reference to a &lsquo;known&rsquo; endpoint where no resolving is done.
+<a href="http://k8s-service">http://k8s-service</a> for example
+<a href="http://myexternalhandler.example.com/foo/bar">http://myexternalhandler.example.com/foo/bar</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.SubscriptionSpec">SubscriptionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
+for processing those events and where to put the result of the processing. Only
+From (where the events are coming from) is always required. You can optionally
+only Process the events (results in no output events) by leaving out the Result.
+You can also perform an identity transformation on the incoming events by leaving
+out the Subscriber and only specifying Result.</p>
+<p>The following are all valid specifications:
+channel &ndash;[subscriber]&ndash;&gt; reply
+Sink, no outgoing events:
+channel &ndash; subscriber
+no-op function (identity transformation):
+channel &ndash;&gt; reply</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TODO By enabling the status subresource metadata.generation should increment
+thus making this property obsolete.</p>
+<p>We should be able to drop this property with a CRD conversion webhook
+in the future</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a channel as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.ReplyStrategy">
+ReplyStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.SubscriptionStatus">SubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionStatus (computed) for a subscription</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>physicalSubscription</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriptionStatusPhysicalSubscription">
+SubscriptionStatusPhysicalSubscription
+</a>
+</em>
+</td>
+<td>
+<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriptionStatus">SubscriptionStatus</a>)
+</p>
+<p>
+<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
+Subscription.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscriberURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.TriggerFilter">TriggerFilter
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerSpec">TriggerSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>sourceAndType</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerFilterSourceAndType">
+TriggerFilterSourceAndType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeprecatedSourceAndType filters events based on exact matches on the
+CloudEvents type and source attributes. This field has been replaced by the
+Attributes field.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>attributes</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerFilterAttributes">
+TriggerFilterAttributes
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Attributes filters events by exact match on event context attributes.
+Each key in the map is compared with the equivalent key in the event
+context. An event passes the filter if all values are equal to the
+specified values.</p>
+<p>Nested context attributes are not supported as keys. Only string values are supported.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.TriggerFilterAttributes">TriggerFilterAttributes
+(<code>map[string]string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">TriggerFilter</a>)
+</p>
+<p>
+<p>TriggerFilterAttributes is a map of context attribute names to values for
+filtering by equality. Only exact matches will pass the filter. You can use the value &ldquo;
+to indicate all strings match.</p>
+</p>
+<h3 id="eventing.knative.dev/v1alpha1.TriggerFilterSourceAndType">TriggerFilterSourceAndType
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">TriggerFilter</a>)
+</p>
+<p>
+<p>TriggerFilterSourceAndType filters events based on exact matches on the cloud event&rsquo;s type and
+source attributes. Only exact matches will pass the filter. Either or both type and source can
+use the value &ldquo; to indicate all strings match.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>type</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.TriggerSpec">TriggerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Trigger">Trigger</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>broker</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Broker is the broker that this trigger receives events from. If not specified, will default
+to &lsquo;default&rsquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.TriggerFilter">
+TriggerFilter
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
+filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+<a href="#eventing.knative.dev/v1alpha1.SubscriberSpec">
+SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
+is required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1alpha1.TriggerStatus">TriggerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1alpha1.Trigger">Trigger</a>)
+</p>
+<p>
+<p>TriggerStatus represents the current state of a Trigger.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1beta1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberURI</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>SubscriberURI is the resolved URI of the receiver for this Trigger.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>ab260095</code>.
+on git commit <code>a59dae6f</code>.
 </em></p>

--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -29,17 +29,13 @@ KNATIVE_SERVING_REPO="github.com/knative/serving"
 KNATIVE_SERVING_COMMIT="${KNATIVE_SERVING_COMMIT:?specify the \$KNATIVE_SERVING_COMMIT variable}"
 KNATIVE_SERVING_OUT_FILE="serving.md"
 
-KNATIVE_BUILD_REPO="github.com/knative/build"
-KNATIVE_BUILD_COMMIT="${KNATIVE_BUILD_COMMIT:?specify the \$KNATIVE_BUILD_COMMIT variable}"
-KNATIVE_BUILD_OUT_FILE="build.md"
-
 KNATIVE_EVENTING_REPO="github.com/knative/eventing"
 KNATIVE_EVENTING_COMMIT="${KNATIVE_EVENTING_COMMIT:?specify the \$KNATIVE_EVENTING_COMMIT variable}"
 KNATIVE_EVENTING_OUT_FILE="eventing/eventing.md"
 
-KNATIVE_EVENTING_SOURCES_REPO="github.com/knative/eventing-contrib"
-KNATIVE_EVENTING_SOURCES_COMMIT="${KNATIVE_EVENTING_SOURCES_COMMIT:?specify the \$KNATIVE_EVENTING_SOURCES_COMMIT variable}"
-KNATIVE_EVENTING_SOURCES_OUT_FILE="eventing/eventing-contrib-resources.md"
+KNATIVE_EVENTING_RESOURCES_REPO="github.com/knative/eventing-contrib"
+KNATIVE_EVENTING_RESOURCES_COMMIT="${KNATIVE_EVENTING_RESOURCES_COMMIT:?specify the \$KNATIVE_EVENTING_RESOURCES_COMMIT variable}"
+KNATIVE_EVENTING_RESOURCES_OUT_FILE="eventing/eventing-contrib-resources.md"
 
 cleanup_refdocs_root=
 cleanup_repo_clone_root=
@@ -160,13 +156,6 @@ main() {
     gen_refdocs "${refdocs_bin}" "${clone_root}" "${template_dir}" \
         "${out_dir}/${KNATIVE_SERVING_OUT_FILE}" "${knative_serving_root}" "./pkg/apis"
 
-    local knative_build_root
-    knative_build_root="${clone_root}/src/${KNATIVE_BUILD_REPO}"
-    clone_at_commit "https://${KNATIVE_BUILD_REPO}.git" "${KNATIVE_BUILD_COMMIT}" \
-        "${knative_build_root}"
-    gen_refdocs "${refdocs_bin}" "${clone_root}" "${template_dir}" \
-        "${out_dir}/${KNATIVE_BUILD_OUT_FILE}" "${knative_build_root}" "./pkg/apis"
-
     local knative_eventing_root
     knative_eventing_root="${clone_root}/src/${KNATIVE_EVENTING_REPO}"
     clone_at_commit "https://${KNATIVE_EVENTING_REPO}.git" "${KNATIVE_EVENTING_COMMIT}" \
@@ -174,12 +163,12 @@ main() {
     gen_refdocs "${refdocs_bin}" "${clone_root}" "${template_dir}" \
         "${out_dir}/${KNATIVE_EVENTING_OUT_FILE}" "${knative_eventing_root}" "./pkg/apis"
 
-    local knative_eventing_sources_root
-    knative_eventing_sources_root="${clone_root}/src/${KNATIVE_EVENTING_SOURCES_REPO}"
-    clone_at_commit "https://${KNATIVE_EVENTING_SOURCES_REPO}.git" "${KNATIVE_EVENTING_SOURCES_COMMIT}" \
-        "${knative_eventing_sources_root}"
+    local knative_eventing_resources_root
+    knative_eventing_resources_root="${clone_root}/src/${KNATIVE_EVENTING_RESOURCES_REPO}"
+    clone_at_commit "https://${KNATIVE_EVENTING_RESOURCES_REPO}.git" "${KNATIVE_EVENTING_RESOURCES_COMMIT}" \
+        "${knative_eventing_resources_root}"
     gen_refdocs "${refdocs_bin}" "${clone_root}" "${template_dir}" \
-        "${out_dir}/${KNATIVE_EVENTING_SOURCES_OUT_FILE}" "${knative_eventing_sources_root}" "."
+        "${out_dir}/${KNATIVE_EVENTING_RESOURCES_OUT_FILE}" "${knative_eventing_resources_root}" "."
 
     log "SUCCESS: Generated docs written to ${out_dir}/."
     log "Opening the ${out_dir}/ directory. You can now copy these API files"

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -13,7 +13,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",


### PR DESCRIPTION
```
cd hack
KNATIVE_EVENTING_COMMIT=v0.8.0 KNATIVE_EVENTING_RESOURCES_COMMIT=v0.8.0 KNATIVE_SERVING_COMMIT=v0.8.0 ./gen-api-reference-docs.sh
```

Per [knative/serving release notes](https://github.com/knative/serving/releases) bumped k8s api version up to 1.14

KNOWN ISSUE: https://github.com/knative/docs/issues/1661
