### PR TITLE
v0.8 - Convert all install cmds to dynamically use version (at site build time)

### DIFF
--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -16,9 +16,9 @@ know roughly how things fit together.
 
 ## Version
 
-This document works with
-[Eventing 0.3](https://github.com/knative/eventing/releases/tag/v0.3.0) and
-[Eventing-contrib resources 0.3](https://github.com/knative/eventing-contrib/releases/tag/v0.3.0).
+This Debugging content supports version v0.3.0 or later of
+[Knative Eventing](https://github.com/knative/eventing/releases/) and the
+[Eventing-contrib resources](https://github.com/knative/eventing-contrib/releases/).
 
 ## Prerequisites
 

--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -27,7 +27,7 @@ source is most useful as a bridge from other GCP services, such as
    PubSub event source from `release-gcppubsub.yaml`:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
+   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
    ```
 
 1. Enable the `Cloud Pub/Sub API` on your project:

--- a/docs/eventing/samples/iot-core/README.md
+++ b/docs/eventing/samples/iot-core/README.md
@@ -87,7 +87,7 @@ export IOTCORE_TOPIC_DEVICE="iot-demo-device-pubsub-topic"
     controller.
 
     ```shell
-    kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
+    kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
     ```
 
 ### Deploying
@@ -214,5 +214,5 @@ To cleanup the knative resources:
 1.  Remove the `GcpPubSubSource` controller:
 
     ```shell
-    kubectl delete --filename https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
+    kubectl delete --filename https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
     ```

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -82,7 +82,7 @@ The following Knative installation files are available:
 - **Eventing Component**:
   - https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
   - https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
-  - https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel.yaml
+  - https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel-crd.yaml
   - https://github.com/knative/eventing/releases/download/{{< version >}}/kafka.yaml
 - **Eventing Resources**:
   - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/github.yaml
@@ -113,7 +113,7 @@ files from the Knative repositories:
 | **knative/eventing**                           |                                                                                                                                                                        |                                                                                           |
 | [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource), [CronJobSource][6.2], the in-memory channel provisioner.                     |                                                                                           |
 | [`eventing.yaml`][4.2]                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource) and [CronJobSource][6.2]. Does not include the in-memory channel provisioner. |                                                                                           |
-| [`in-memory-channel.yaml`][4.3]                | Installs only the in-memory channel provisioner.                                                                                                                       | Eventing component                                                                        |
+| [`in-memory-channel-crd.yaml`][4.3]                | Installs only the in-memory channel provisioner.                                                                                                                       | Eventing component                                                                        |
 | [`kafka.yaml`][4.4]                            | Installs only the Kafka channel provisioner.                                                                                                                           | Eventing component                                                                        |
 | [`natss.yaml`][4.5]                            | Installs only the NATSS channel provisioner.                                                                                                                           | Eventing component                                                                        |
 | [`gcp-pubsub.yaml`][4.6]                       | Installs only the GCP PubSub channel provisioner.                                                                                                                      | Eventing component                                                                        |
@@ -160,7 +160,7 @@ for details about installing the various supported observability plugins.
 [4.2]:
   https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
 [4.3]:
-  https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel.yaml
+  https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel-crd.yaml
 [4.4]: https://github.com/knative/eventing/releases/download/{{< version >}}/kafka.yaml
 [4.5]: https://github.com/knative/eventing/releases/download/{{< version >}}/natss.yaml
 [4.6]:

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -71,24 +71,24 @@ with Knative.
 The following Knative installation files are available:
 
 - **Serving Component and Observability Plugins**:
-  - https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-logs-elasticsearch.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-metrics-prometheus.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger-in-mem.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
-  - https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
 - **Eventing Component**:
-  - https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
-  - https://github.com/knative/eventing/releases/download/v0.7.0/eventing.yaml
-  - https://github.com/knative/eventing/releases/download/v0.7.0/in-memory-channel.yaml
-  - https://github.com/knative/eventing/releases/download/v0.7.0/kafka.yaml
+  - https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
+  - https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
+  - https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel.yaml
+  - https://github.com/knative/eventing/releases/download/{{< version >}}/kafka.yaml
 - **Eventing Resources**:
-  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/github.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/camel.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
-  - https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/github.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/camel.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka.yaml
 
 #### Install details and options
 
@@ -133,51 +133,51 @@ for details about installing the various supported observability plugins.
 
 <!-- USE ONLY FULLY QUALIFIED URLS -->
 
-[1]: https://github.com/knative/serving/releases/tag/v0.7.0
-[1.1]: https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml
+[1]: https://github.com/knative/serving/releases/tag/{{< version >}}
+[1.1]: https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml
 [1.2]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
 [1.3]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-logs-elasticsearch.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
 [1.4]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-metrics-prometheus.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
 [1.5]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
 [1.6]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger-in-mem.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
 [1.7]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
 [1.8]:
-  https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
+  https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
 [2]: https://www.elastic.co/elk-stack
 [2.1]: https://prometheus.io
 [2.2]: https://grafana.com
 [2.3]: https://zipkin.io/
 [2.4]: https://jaegertracing.io/
 [2.5]: https://github.com/jaegertracing/jaeger-operator#installing-the-operator
-[4]: https://github.com/knative/eventing/releases/tag/v0.7.0
-[4.1]: https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
+[4]: https://github.com/knative/eventing/releases/tag/{{< version >}}
+[4.1]: https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
 [4.2]:
-  https://github.com/knative/eventing/releases/download/v0.7.0/eventing.yaml
+  https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
 [4.3]:
-  https://github.com/knative/eventing/releases/download/v0.7.0/in-memory-channel.yaml
-[4.4]: https://github.com/knative/eventing/releases/download/v0.7.0/kafka.yaml
-[4.5]: https://github.com/knative/eventing/releases/download/v0.7.0/natss.yaml
+  https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel.yaml
+[4.4]: https://github.com/knative/eventing/releases/download/{{< version >}}/kafka.yaml
+[4.5]: https://github.com/knative/eventing/releases/download/{{< version >}}/natss.yaml
 [4.6]:
-  https://github.com/knative/eventing/releases/download/v0.7.0/gcp-pubsub.yaml
-[5]: https://github.com/knative/eventing-contrib/releases/tag/v0.7.0
+  https://github.com/knative/eventing/releases/download/{{< version >}}/gcp-pubsub.yaml
+[5]: https://github.com/knative/eventing-contrib/releases/tag/{{< version >}}
 [5.1]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/github.yaml
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/github.yaml
 [5.2]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/gcppubsub.yaml
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
 [5.3]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/event-display.yaml
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/event-display.yaml
 [5.4]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/camel.yaml
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/camel.yaml
 [5.5]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/kafka.yaml
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka.yaml
 [5.6]:
-  https://github.com/knative/eventing-contrib/releases/download/v0.7.0/awssqs.yaml
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/awssqs.yaml
 [6]:
   https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#event-v1-core
 [6.1]: https://developer.github.com/v3/activity/events/types/
@@ -248,9 +248,9 @@ commands below.
 
       `[FILE_URL]`Examples:
 
-      - `https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
-      - `https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml`
-      - `https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml`
+      - `https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
+      - `https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml`
+      - `https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml`
 
       **Note**: By default, the Knative Serving component installation
       (`serving.yaml`) includes a controller for
@@ -271,16 +271,16 @@ commands below.
 
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
-          --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
-          --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+          --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
+          --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and the run
         the command to install the Serving component and observability plugins:
 
         ```bash
-        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
-          --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+        kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
+          --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
         ```
 
    - To install all three Knative components and the set of Eventing sources
@@ -294,8 +294,8 @@ commands below.
 
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
-          --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
+          --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+          --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and the run
@@ -303,8 +303,8 @@ commands below.
         Eventing sources and auto certificate controller:
 
         ```bash
-        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-          --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml
+        kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+          --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
         ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -183,9 +183,9 @@ your Knative installation, see
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -194,9 +194,9 @@ your Knative installation, see
    Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -68,7 +68,7 @@ Because you have limited resources available, use the
 which installs only Knative Serving:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
   | kubectl apply --selector networking.knative.dev/certificate-provider!=cert-manager --filename -
 ```

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -159,10 +159,10 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    race conditions during the install, which cause intermittent errors:
 
    ```bash
-   kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --selector knative.dev/crd-install=true \\
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -170,9 +170,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -115,9 +115,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -125,9 +125,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -160,7 +160,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 1. Run the following commands to install Knative:
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
+   curl -L https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --selector networking.knative.dev/certificate-provider!=cert-manager --filename -
    ```
@@ -176,13 +176,13 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    >   statement to install the controller.
 
    ```shell
-   curl -L https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+   curl -L https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
 
    ```shell
-   curl -L https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
+   curl -L https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml \
      | sed 's/LoadBalancer/NodePort/' \
      | kubectl apply --filename -
    ```
@@ -239,19 +239,19 @@ To remove Knative from your IBM Cloud Private cluster, run the following
 commands:
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
+curl -L https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
+curl -L https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```
 
 ```shell
-curl -L https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml \
+curl -L https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml \
  | sed 's/LoadBalancer/NodePort/' \
  | kubectl delete --filename -
 ```

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -199,9 +199,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -209,9 +209,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -123,9 +123,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```shell
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -133,9 +133,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -101,9 +101,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -111,9 +111,9 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -68,9 +68,9 @@ your Knative installation, see
 
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
 1. To complete the install of Knative and its dependencies, run the
@@ -78,9 +78,9 @@ your Knative installation, see
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
-   --filename https://github.com/knative/eventing/releases/download/v0.7.0/release.yaml \
-   --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
    > **Notes**:

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -31,7 +31,7 @@ sections to do so now.
 1. Run the following command to install Prometheus and Grafana:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-metrics-prometheus.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
    ```
 
 1. Ensure that the `grafana-*`, `kibana-logging-*`, `kube-state-metrics-*`,
@@ -90,7 +90,7 @@ install:
 1. Run the following command to install an ELK stack:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-logs-elasticsearch.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
    ```
 
 1. Ensure that the `elasticsearch-logging-*`, `fluentd-ds-*`, and
@@ -178,9 +178,8 @@ To configure and setup monitoring:
 1.  Clone the Knative Serving repository:
 
     ```shell
-    git clone https://github.com/knative/serving knative-serving
+    git clone -b {{< version >}} https://github.com/knative/serving knative-serving
     cd knative-serving
-    git checkout v0.4.0
     ```
 
 1.  Choose a container image that meets the
@@ -269,14 +268,14 @@ uninstall that tool before installing the new tool.
      end traces, run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin-in-mem.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
      ```
 
    - If Elasticsearch is installed and you want to persist end to end traces,
      first run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-zipkin.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
      ```
 
 1. Create an Elasticsearch index for end to end traces:
@@ -304,14 +303,14 @@ end traces.
      end traces, run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger-in-mem.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
      ```
 
    - If Elasticsearch is installed and you want to persist end to end traces,
      first run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.0/monitoring-tracing-jaeger.yaml
+     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
      ```
 
 1. Create an Elasticsearch index for end to end traces:

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -39,10 +39,9 @@ To enable Knative to automatically provision TLS certificates:
    install it:
 
    ```shell
-   # KNATIVE_VERSION needs to be 0.6.0 or above.
-   KNATIVE_VERSION=0.6.0
+   # Knative Serving must be v0.6.0 or later.
 
-   kubectl apply --filename https://github.com/knative/serving/releases/download/v${KNATIVE_VERSION}/serving.yaml \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --selector networking.knative.dev/certificate-provider=cert-manager
    ```
 


### PR DESCRIPTION
Update all install commands to use the `version` shortcode (https://github.com/knative/website/pull/71) so that version numbers are automatically added (defaults to 0.lastest-release.0).

Future install commands will be unnecessary unless manually add a patch release version number, in which case you can append `patch=#.#.#` to the `version` shortcode (where #.#.# are any integers - details in https://github.com/knative/website/pull/71)

**Staged preview: https://prstaging--knative-v1.netlify.com/docs/install/**