### PR TITLE
v0.8 - convert git clone cmds to use dynamic variables

### DIFF
--- a/community/samples/serving/helloworld-java-quarkus/README.md
+++ b/community/samples/serving/helloworld-java-quarkus/README.md
@@ -39,7 +39,7 @@ Use this method to clone and then immediate run the sample. To clone the sample
 code, run the following commands:
 
 ```
-git clone https://github.com/knative/docs.git knative/docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs.git knative/docs
 cd knative/docs/community/samples/serving/helloworld-java-quarkus
 ```
 

--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -24,7 +24,7 @@ Knative [event-sources](https://github.com/knative/eventing-contrib) has a
 sample of heartbeats event source. You could clone the source codes by
 
 ```
-git clone -b "release-0.7" https://github.com/knative/eventing-contrib.git
+git clone -b "{{< branch >}}" https://github.com/knative/eventing-contrib.git
 ```
 
 And then build a heartbeats image and publish to your image repo with

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -17,7 +17,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 1. Clone this repository, and move into the sample directory:
 
    ```shell
-   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+   git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
    cd knative-docs
    ```
 

--- a/docs/serving/samples/gitwebhook-go/README.md
+++ b/docs/serving/samples/gitwebhook-go/README.md
@@ -32,7 +32,7 @@ You must meet the following requirements to run this sample:
 1. Download a copy of the code:
 
    ```shell
-   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+   git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
    cd knative-docs/serving/samples/gitwebhook-go
    ```
 

--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -16,7 +16,7 @@ A simple gRPC server written in Go that you can use for testing.
 - Download a copy of the code:
 
   ```shell
-  git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+  git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
   cd knative-docs/docs/serving/samples/grpc-ping-go
   ```
 

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-csharp
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-go
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-java-spark/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/README.md
@@ -27,7 +27,7 @@ recreate the source files from this folder.
 1. Clone the repo from the following path:
 
    ```shell
-   https://github.com/knative/docs.git
+   git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
    ```
 
 2. Navigate to the helloworld-java-spark directory

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs cd
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs cd
 knative-docs/docs/serving/samples/hello-world/helloworld-java-spring
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-kotlin
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-nodejs
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-php
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-python
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-ruby/README.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-scala/README.md
+++ b/docs/serving/samples/hello-world/helloworld-scala/README.md
@@ -16,7 +16,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-scala
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-shell/README.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/README.md
@@ -14,7 +14,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-shell
 ```
 

--- a/docs/serving/samples/rest-api-go/README.md
+++ b/docs/serving/samples/rest-api-go/README.md
@@ -24,7 +24,7 @@ like `AAPL`,`AMZN`, `GOOG`, `MSFT`, etc.
 1. Download a copy of the code:
 
    ```shell
-   git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+   git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
    cd knative-docs/serving/samples/rest-api-go
    ```
 

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -15,7 +15,7 @@ cluster. You can also download a working copy of the sample, by running the
 following commands:
 
 ```shell
-git clone -b "release-0.7" https://github.com/knative/docs knative-docs
+git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/serving/samples/secrets-go
 ```
 


### PR DESCRIPTION
Update all `git clone` commands to use the `branch` shortcode (https://github.com/knative/website/pull/74) so that branch names are automatically added at site build time. (this makes the need for future command updates unnecessary)

**Staged preview: https://prstaging--knative-v1.netlify.com/docs/serving/samples/**