### PR TITLE
Format markdown

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -33,7 +33,8 @@ spec:
 ## Trigger
 
 A Trigger represents a desire to subscribe to events from a specific Broker.
-Exact match filtering on CloudEvents attributes as well as extensions are supported.
+Exact match filtering on CloudEvents attributes as well as extensions are
+supported.
 
 Example:
 
@@ -57,26 +58,25 @@ spec:
 
 ### Channel
 
-`Broker`s use their `spec.channelTemplateSpec` to create their internal [Channels](./channels/),
-which dictate the durability guarantees of events sent to that `Broker`. If
-`spec.channelTemplateSpec` is not specified, then the
-[default channel](./channels/default-channels.md)
-for their namespace is used.
+`Broker`s use their `spec.channelTemplateSpec` to create their internal
+[Channels](./channels/), which dictate the durability guarantees of events sent
+to that `Broker`. If `spec.channelTemplateSpec` is not specified, then the
+[default channel](./channels/default-channels.md) for their namespace is used.
 
 #### Setup
 
-Have a `Channel` CRD installed and set as the
-default channel for the namespace you are interested in. For development, the
+Have a `Channel` CRD installed and set as the default channel for the namespace
+you are interested in. For development, the
 [InMemoryChannel](https://github.com/knative/eventing/tree/master/config/channels/in-memory-channel)
 is normally used.
 
 #### Changing
 
-**Note** changing the `Channel` of a running `Broker` will
-lose all in-flight events.
+**Note** changing the `Channel` of a running `Broker` will lose all in-flight
+events.
 
-If you want to change which `Channel` is used by a given
-`Broker`, then determine if the `spec.channelTemplateSpec` is specified or not.
+If you want to change which `Channel` is used by a given `Broker`, then
+determine if the `spec.channelTemplateSpec` is specified or not.
 
 If `spec.channelTemplateSpec` is specified:
 
@@ -236,7 +236,8 @@ spec:
 
 #### Defaulting
 
-The Webhook will default the `spec.broker` field to `default`, if left unspecified. 
+The Webhook will default the `spec.broker` field to `default`, if left
+unspecified.
 
 The Webhook will default the YAML above to:
 

--- a/docs/eventing/choice.md
+++ b/docs/eventing/choice.md
@@ -4,10 +4,9 @@ weight: 20
 type: "docs"
 ---
 
-Choice CRD provides a way to easily define a list of branches, each
-receiving the same CloudEvent sent to the Choice ingress channel.
-Typically, each branch consists of a filter function guarding the execution
-of the branch.
+Choice CRD provides a way to easily define a list of branches, each receiving
+the same CloudEvent sent to the Choice ingress channel. Typically, each branch
+consists of a filter function guarding the execution of the branch.
 
 Choice creates `Channel`s and `Subscription`s under the hood.
 
@@ -34,12 +33,12 @@ Choice has three parts for the Spec:
 Choice has three parts for the Status:
 
 1. `conditions` which details the overall status of the Choice object
-1. `ingressChannelStatus` and `caseStatuses` which convey the status of underlying
-   `Channel` and `Subscription` resource that are created as part of this
-   Choice.
-1. `address` which is exposed so that Choice can be used where Addressable
-   can be used. Sending to this address will target the `Channel` which is
-   fronting this Choice (same as `ingressChannelStatus`).
+1. `ingressChannelStatus` and `caseStatuses` which convey the status of
+   underlying `Channel` and `Subscription` resource that are created as part of
+   this Choice.
+1. `address` which is exposed so that Choice can be used where Addressable can
+   be used. Sending to this address will target the `Channel` which is fronting
+   this Choice (same as `ingressChannelStatus`).
 
 ## Examples
 

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -70,10 +70,10 @@ see Performing a Custom Knative Installation.
 
 Knative was originally built using Istio to handle cluster networking. While the
 Istio gateway provides the functionality needed to serve requests to your
-application, installing a service mesh just to handle north-south traffic 
-carries some operational overhead with it. Ambassador provides a way to get 
-traffic to your Knative application without the overhead or complexity of a 
-full service mesh.
+application, installing a service mesh just to handle north-south traffic
+carries some operational overhead with it. Ambassador provides a way to get
+traffic to your Knative application without the overhead or complexity of a full
+service mesh.
 
 You can install Ambassador with `kubectl`:
 

--- a/docs/smoketest.md
+++ b/docs/smoketest.md
@@ -11,24 +11,24 @@ Below are a set of site elements that have causes issues in the past.
 
 ## Lists
 
-* Top level:
+- Top level:
   1. A nested list item.
      1. another level lower
-  1. Nested code sample:
-     <br>Syntax: <code>{<code>{< readfile file="../community/samples/serving/helloworld-java-quarkus/service.yaml" code="true" lang="yaml" >}</code>}</code>
-     <br>Example:
+  1. Nested code sample: <br>Syntax: <code>{<code>{< readfile
+     file="../community/samples/serving/helloworld-java-quarkus/service.yaml"
+     code="true" lang="yaml" >}</code>}</code> <br>Example:
      {{< readfile file="../community/samples/serving/helloworld-java-quarkus/service.yaml" code="true" lang="yaml" >}}
   1. This should be the third bullet (3.).
-     1. More nested code:
-        <br>Shortcode: <code>{<code>{< readfile file="/serving/samples/hello-world/helloworld-go/Dockerfile" code="true" lang="go" >}</code>}</code>
-        <br>Example:
+     1. More nested code: <br>Shortcode: <code>{<code>{< readfile
+        file="/serving/samples/hello-world/helloworld-go/Dockerfile" code="true"
+        lang="go" >}</code>}</code> <br>Example:
         {{< readfile file="./serving/samples/hello-world/helloworld-go/Dockerfile" code="true" lang="go" >}}
      1. Another nested ordered list item (2.)
 
-
 ## Code samples
 
-The following use the [`readfile` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/readfile.md)
+The following use the
+[`readfile` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/readfile.md)
 
 {{< readfile file="../hack/reference-docs-gen-config.json" code="true" lang="json" >}}
 
@@ -36,26 +36,33 @@ The following use the [`readfile` shortcode](https://github.com/knative/website/
 
 ## Install version numbers and Clone branch commands
 
-Examples of how the manual and dynamic version number or branch name can be added in-line with the
+Examples of how the manual and dynamic version number or branch name can be
+added in-line with the
 [`version` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/version.md)
-(uses the define values from [config/_default/params.toml](https://github.com/knative/website/blob/master/config/_default/params.toml))
+(uses the define values from
+[config/\_default/params.toml](https://github.com/knative/website/blob/master/config/_default/params.toml))
 
 1. Shortcode: <code>{<code>{% version %}</code>}</code>
 
-    Example: `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`
+   Example:
+   `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`
 
 1. Shortcode: <code>{<code>{% version override="v0.2.2" %}</code>}</code>
 
-    Example: `kubectl apply the-version-override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`
+   Example:
+   `kubectl apply the-version-override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`
 
 1. Shortcode: <code>{<code>{% version patch=".20" %}</code>}</code>
 
-    Example: `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`
+   Example:
+   `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`
 
 1. Shortcode: <code>{<code>{% branch %}</code>}</code>
 
-    Example: `git clone -b "{{% branch %}}" https://github.com/knative/docs knative-docs`
+   Example:
+   `git clone -b "{{% branch %}}" https://github.com/knative/docs knative-docs`
 
 1. Shortcode: <code>{<code>{% branch override="release-0.NEXT" %}</code>}</code>
 
-    Example: `git clone -b "{{% branch override="release-0.NEXT" %}}" https://github.com/knative/docs knative-docs`
+   Example:
+   `git clone -b "{{% branch override="release-0.NEXT" %}}" https://github.com/knative/docs knative-docs`

--- a/smoketest.md
+++ b/smoketest.md
@@ -11,24 +11,23 @@ Below are a set of site elements that have causes issues in the past.
 
 ## Lists
 
-* Top level:
+- Top level:
   1. A nested list item.
      1. another level lower
-  1. Nested code sample:
-        <br>Shortcode: <code>{<code>{< readfile file="./hack/reference-docs-gen-config.json" code="true" lang="json" >}</code>}</code>
-        <br>Example:
-        {{< readfile file="./hack/reference-docs-gen-config.json" code="true" lang="json" >}}
+  1. Nested code sample: <br>Shortcode: <code>{<code>{< readfile
+     file="./hack/reference-docs-gen-config.json" code="true"
+     lang="json" >}</code>}</code> <br>Example:
+     {{< readfile file="./hack/reference-docs-gen-config.json" code="true" lang="json" >}}
   1. This should be the third bullet (3.).
-     1. More nested code:
-        <br>Shortcode: <code>{<code>{< readfile file="Gopkg.toml" code="true" lang="toml" >}</code>}</code>
-        <br>Example:
+     1. More nested code: <br>Shortcode: <code>{<code>{< readfile
+        file="Gopkg.toml" code="true" lang="toml" >}</code>}</code> <br>Example:
         {{< readfile file="Gopkg.toml" code="true" lang="toml" >}}
      1. Another nested ordered list item (2.)
 
-
 ## Code samples
 
-The following use the [`readfile` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/readfile.md)
+The following use the
+[`readfile` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/readfile.md)
 
 {{< readfile file="hack/reference-docs-gen-config.json" code="true" lang="json" >}}
 
@@ -36,26 +35,33 @@ The following use the [`readfile` shortcode](https://github.com/knative/website/
 
 ## Install version numbers and Clone branch commands
 
-Examples of how the manual and dynamic version number or branch name can be added in-line with the
+Examples of how the manual and dynamic version number or branch name can be
+added in-line with the
 [`version` shortcode](https://github.com/knative/website/blob/master/layouts/shortcodes/version.md)
-(uses the define values from [config/_default/params.toml](https://github.com/knative/website/blob/master/config/_default/params.toml))
+(uses the define values from
+[config/\_default/params.toml](https://github.com/knative/website/blob/master/config/_default/params.toml))
 
 1. Shortcode: <code>{<code>{% version %}</code>}</code>
 
-    Example: `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`
+   Example:
+   `kubectl apply version/{{% version %}}/is-the-latest/docs-version.yaml`
 
 1. Shortcode: <code>{<code>{% version override="v0.2.2" %}</code>}</code>
 
-    Example: `kubectl apply the-version-override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`
+   Example:
+   `kubectl apply the-version-override/{{% version override="v0.2.2" %}}/is-manually-specified.yaml`
 
 1. Shortcode: <code>{<code>{% version patch=".20" %}</code>}</code>
 
-    Example: `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`
+   Example:
+   `kubectl apply this-is-a-point-release/{{% version patch=".20" %}}/filename.yaml`
 
 1. Shortcode: <code>{<code>{% branch %}</code>}</code>
 
-    Example: `git clone -b "{{% branch %}}" https://github.com/knative/docs knative-docs`
+   Example:
+   `git clone -b "{{% branch %}}" https://github.com/knative/docs knative-docs`
 
 1. Shortcode: <code>{<code>{% branch override="release-0.NEXT" %}</code>}</code>
 
-    Example: `git clone -b "{{% branch override="release-0.NEXT" %}}" https://github.com/knative/docs knative-docs`
+   Example:
+   `git clone -b "{{% branch override="release-0.NEXT" %}}" https://github.com/knative/docs knative-docs`


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @samodell
