### PR TITLE
Add port number to route example

### DIFF
--- a/docs/serving/samples/knative-routing-go/routing.yaml
+++ b/docs/serving/samples/knative-routing-go/routing.yaml
@@ -54,4 +54,6 @@ spec:
       # eventually be directed to LOgin service.
       - destination:
           host: istio-ingressgateway.istio-system.svc.cluster.local
+          port:
+            number: 80
         weight: 100

--- a/docs/serving/samples/knative-routing-go/routing.yaml
+++ b/docs/serving/samples/knative-routing-go/routing.yaml
@@ -40,6 +40,8 @@ spec:
       # eventually be directed to Search service.
       - destination:
           host: istio-ingressgateway.istio-system.svc.cluster.local
+          port:
+            number: 80
         weight: 100
   - match:
     - uri:


### PR DESCRIPTION
When having TLS termination in a Gateway, this example stops working because the gateway doesn't know what to do with HTTP traffic on port 443. Fixing the port to 80 solved this for me.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- Added port number to routing example