### PR TITLE
remove mention of Knative Build as an option

### DIFF
--- a/docs/serving/samples/rest-api-go/README.md
+++ b/docs/serving/samples/rest-api-go/README.md
@@ -31,11 +31,7 @@ like `AAPL`,`AMZN`, `GOOG`, `MSFT`, etc.
 ## Setup
 
 In order to run an application on Knative Serving a container image must be
-available to fetch from a container registry. Building and pushing a container
-image can be accomplished locally using
-[Docker](https://docs.docker.com/get-started) or
-[ko](https://github.com/google/go-containerregistry/tree/master/cmd/ko) as well
-as remotely using [Knative Build](../../../build).
+available to fetch from a container registry.
 
 This sample uses Docker for both building and pushing.
 


### PR DESCRIPTION
Knative Build has been deprecated.

Related: https://github.com/knative/docs/pull/1656