### PR TITLE
remove cert-manager from serving install

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -35,11 +35,6 @@ to run multiple installation commands.
 
 ## Installing Istio
 
-> Note: [Ambassador](https://www.getambassador.io/) and
-> [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
-> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
-> [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
-
 Knative depends on [Istio](https://istio.io/docs/concepts/what-is-istio/) for
 traffic routing and ingress. You have the option of injecting Istio sidecars and
 enabling the Istio service mesh, but it's not required for all Knative
@@ -53,6 +48,11 @@ If you prefer to install Istio manually, if your cloud provider doesn't offer a
 managed Istio installation, or if you're installing Knative locally using
 Minkube or similar, see the
 [Installing Istio for Knative guide](./installing-istio.md).
+
+> Note: [Ambassador](https://www.getambassador.io/) and
+> [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
+> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
+> [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 ## Installing Knative components
 
@@ -72,6 +72,7 @@ The following Knative installation files are available:
 
 - **Serving Component and Observability Plugins**:
   - https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml
+  - https://github.com/knative/serving/releases/download/{{< version >}}/serving-cert-manager.yaml
   - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
   - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
   - https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
@@ -95,35 +96,36 @@ The following Knative installation files are available:
 The following table includes details about the available Knative installation
 files from the Knative repositories:
 
-- [Serving][1]
-- [Eventing][4]
-- [Eventing Resources][5]
+- [Serving][1.0]
+- [Eventing][4.0]
+- [Eventing Resources][5.0]
 
 | Knative Install Filename                       | Notes                                                                                                                                                                  | Dependencies                                                                              |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| **knative/serving**                            |                                                                                                                                                                        |                                                                                           |
-| [`serving.yaml`][1.1]†                         | Installs the Serving component.                                                                                                                                        |                                                                                           |
-| [`monitoring.yaml`][1.2]†                      | Installs the [ELK stack][2], [Prometheus][2.1], [Grafana][2.2], and [Zipkin][2.3]**\***                                                                                | Serving component                                                                         |
-| [`monitoring-logs-elasticsearch.yaml`][1.3]    | Installs only the [ELK stack][2]**\***                                                                                                                                 | Serving component                                                                         |
-| [`monitoring-metrics-prometheus.yaml`][1.4]    | Installs only [Prometheus][2.1]**\***                                                                                                                                  | Serving component                                                                         |
-| [`monitoring-tracing-jaeger.yaml`][1.5]        | Installs only [Jaeger][2.4]**\***                                                                                                                                      | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml), [Jaeger Operator][2.5] |
-| [`monitoring-tracing-jaeger-in-mem.yaml`][1.6] | Installs only [Jaeger in-memory][2.4]**\***                                                                                                                            | Serving component, [Jaeger Operator][2.5]                                                 |
-| [`monitoring-tracing-zipkin.yaml`][1.7]        | Installs only [Zipkin][2.3].**\***                                                                                                                                     | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml)                         |
-| [`monitoring-tracing-zipkin-in-mem.yaml`][1.8] | Installs only [Zipkin in-memory][2.3]**\***                                                                                                                            | Serving component                                                                         |
+| **knative/serving**                             |                                                                                                                                                                        |                                                                                           |
+| [`serving.yaml`][1.10]†                     | Installs the Serving component.                                                                                                                          |                                                                                     |
+| [`serving-cert-manager.yaml`][1.20]      | Installs support for `cert-manager` and [automatic TLS cert provisioning](../serving/using-auto-tls.md).    | Serving component                                        |
+| [`monitoring.yaml`][1.30]†                      | Installs the [ELK stack][2.0], [Prometheus][2.10], [Grafana][2.20], and [Zipkin][2.30]**\***                                                                                | Serving component                                                              |
+| [`monitoring-logs-elasticsearch.yaml`][1.40]    | Installs only the [ELK stack][2.0]**\***                                                                                                                                 | Serving component                                                                         |
+| [`monitoring-metrics-prometheus.yaml`][1.50]    | Installs only [Prometheus][2.10]**\***                                                                                                                                  | Serving component                                                                         |
+| [`monitoring-tracing-jaeger.yaml`][1.60]        | Installs only [Jaeger][2.40]**\***                                                                                                                                      | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml), [Jaeger Operator][2.50] |
+| [`monitoring-tracing-jaeger-in-mem.yaml`][1.70] | Installs only [Jaeger in-memory][2.40]**\***                                                                                                                            | Serving component, [Jaeger Operator][2.50]                           |
+| [`monitoring-tracing-zipkin.yaml`][1.80]        | Installs only [Zipkin][2.30].**\***                                                                                                                                     | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml)     |
+| [`monitoring-tracing-zipkin-in-mem.yaml`][1.90] | Installs only [Zipkin in-memory][2.30]**\***                                                                                                                            | Serving component                                                                  |
 | **knative/eventing**                           |                                                                                                                                                                        |                                                                                           |
-| [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource), [CronJobSource][6.2], the in-memory channel provisioner.                     |                                                                                           |
-| [`eventing.yaml`][4.2]                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource) and [CronJobSource][6.2]. Does not include the in-memory channel provisioner. |                                                                                           |
-| [`in-memory-channel-crd.yaml`][4.3]                | Installs only the in-memory channel provisioner.                                                                                                                       | Eventing component                                                                        |
-| [`kafka.yaml`][4.4]                            | Installs only the Kafka channel provisioner.                                                                                                                           | Eventing component                                                                        |
-| [`natss.yaml`][4.5]                            | Installs only the NATSS channel provisioner.                                                                                                                           | Eventing component                                                                        |
-| [`gcp-pubsub.yaml`][4.6]                       | Installs only the GCP PubSub channel provisioner.                                                                                                                      | Eventing component                                                                        |
+| [`release.yaml`][4.10]†                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource), [CronJobSource][6.2], the in-memory channel provisioner.                     |                                                                                           |
+| [`eventing.yaml`][4.20]                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource) and [CronJobSource][6.2]. Does not include the in-memory channel provisioner. |                                                                                           |
+| [`in-memory-channel-crd.yaml`][4.30]                | Installs only the in-memory channel provisioner.                                                                                                                       | Eventing component                                                                        |
+| [`kafka.yaml`][4.40]                            | Installs only the Kafka channel provisioner.                                                                                                                           | Eventing component                                                                        |
+| [`natss.yaml`][4.50]                            | Installs only the NATSS channel provisioner.                                                                                                                           | Eventing component                                                                        |
+| [`gcp-pubsub.yaml`][4.60]                       | Installs only the GCP PubSub channel provisioner.                                                                                                                      | Eventing component                                                                        |
 | **knative/eventing-contrib**                   |                                                                                                                                                                        |                                                                                           |
-| [`github.yaml`][5.1]†                          | Installs the [GitHub][6.1] source.                                                                                                                                     | Eventing component                                                                        |
-| [`camel.yaml`][5.4]                            | Installs the Apache Camel source.                                                                                                                                      | Eventing component                                                                        |
-| [`gcppubsub.yaml`][5.2]                        | Installs the [GCP PubSub source][6.3]                                                                                                                                  | Eventing component                                                                        |
-| [`kafka.yaml`][5.5]                            | Installs the Apache Kafka source.                                                                                                                                      | Eventing component                                                                        |
-| [`awssqs.yaml`][5.6]                           | Installs the AWS SQS source.                                                                                                                                           | Eventing component                                                                        |
-| [`event-display.yaml`][5.3]                    | Installs a Knative Service that logs events received for use in samples and debugging.                                                                                 | Serving component, Eventing component                                                     |
+| [`github.yaml`][5.10]†                          | Installs the [GitHub][6.10] source.                                                                                                                                     | Eventing component                                                                        |
+| [`camel.yaml`][5.40]                            | Installs the Apache Camel source.                                                                                                                                      | Eventing component                                                                        |
+| [`gcppubsub.yaml`][5.20]                        | Installs the [GCP PubSub source][6.30]                                                                                                                                  | Eventing component                                                                        |
+| [`kafka.yaml`][5.50]                            | Installs the Apache Kafka source.                                                                                                                                      | Eventing component                                                                        |
+| [`awssqs.yaml`][5.60]                           | Installs the AWS SQS source.                                                                                                                                           | Eventing component                                                                        |
+| [`event-display.yaml`][5.30]                    | Installs a Knative Service that logs events received for use in samples and debugging.                                                                                 | Serving component, Eventing component                                                     |
 
 _\*_ See
 [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
@@ -133,57 +135,56 @@ for details about installing the various supported observability plugins.
 
 <!-- USE ONLY FULLY QUALIFIED URLS -->
 
-[1]: https://github.com/knative/serving/releases/tag/{{< version >}}
-[1.1]: https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml
-[1.2]:
+[1.0]: https://github.com/knative/serving/releases/tag/{{< version >}}
+[1.10]: https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml
+[1.20]: https://github.com/knative/serving/releases/download/{{< version >}}/serving-cert-manager.yaml
+[1.30]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
-[1.3]:
+[1.40]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
-[1.4]:
+[1.50]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
-[1.5]:
+[1.60]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
-[1.6]:
+[1.70]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
-[1.7]:
+[1.80]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
-[1.8]:
+[1.90]:
   https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
-[2]: https://www.elastic.co/elk-stack
-[2.1]: https://prometheus.io
-[2.2]: https://grafana.com
-[2.3]: https://zipkin.io/
-[2.4]: https://jaegertracing.io/
-[2.5]: https://github.com/jaegertracing/jaeger-operator#installing-the-operator
-[4]: https://github.com/knative/eventing/releases/tag/{{< version >}}
-[4.1]: https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
-[4.2]:
+[2.0]: https://www.elastic.co/elk-stack
+[2.10]: https://prometheus.io
+[2.20]: https://grafana.com
+[2.30]: https://zipkin.io/
+[2.40]: https://jaegertracing.io/
+[2.50]: https://github.com/jaegertracing/jaeger-operator#installing-the-operator
+[4.0]: https://github.com/knative/eventing/releases/tag/{{< version >}}
+[4.10]: https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
+[4.20]:
   https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
-[4.3]:
+[4.30]:
   https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel-crd.yaml
-[4.4]: https://github.com/knative/eventing/releases/download/{{< version >}}/kafka.yaml
-[4.5]: https://github.com/knative/eventing/releases/download/{{< version >}}/natss.yaml
-[4.6]:
+[4.40]: https://github.com/knative/eventing/releases/download/{{< version >}}/kafka.yaml
+[4.50]: https://github.com/knative/eventing/releases/download/{{< version >}}/natss.yaml
+[4.60]:
   https://github.com/knative/eventing/releases/download/{{< version >}}/gcp-pubsub.yaml
-[5]: https://github.com/knative/eventing-contrib/releases/tag/{{< version >}}
-[5.1]:
+[5.0]: https://github.com/knative/eventing-contrib/releases/tag/{{< version >}}
+[5.10]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/github.yaml
-[5.2]:
+[5.20]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
-[5.3]:
+[5.30]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/event-display.yaml
-[5.4]:
+[5.40]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/camel.yaml
-[5.5]:
+[5.50]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka.yaml
-[5.6]:
+[5.60]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/awssqs.yaml
-[6]:
-  https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#event-v1-core
-[6.1]: https://developer.github.com/v3/activity/events/types/
-[6.2]:
+[6.10]: https://developer.github.com/v3/activity/events/types/
+[6.20]:
   https://github.com/knative/eventing-contrib/blob/master/samples/cronjob-source/README.md
-[6.3]: https://cloud.google.com/pubsub/
+[6.30]: https://cloud.google.com/pubsub/
 
 ### Installing Knative
 
@@ -248,48 +249,34 @@ commands below.
 
       `[FILE_URL]`Examples:
 
-      - `https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager`
+      - `https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml`
       - `https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml`
       - `https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml`
-
-      **Note**: By default, the Knative Serving component installation
-      (`serving.yaml`) includes a controller for
-      [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-      If you do intend on immediately enabling auto certificates in Knative, you
-      can remove the
-      `--selector networking.knative.dev/certificate-provider!=cert-manager`
-      statement to install the controller. Otherwise, you can choose to install
-      the auto certificates feature and controller at a later time.
 
       **Example install commands:**
 
    - To install the Knative Serving component with the set of observability
-     plugins but exclude the auto certificates controller, run the following
-     commands:
+     plugins, run the following commands:
 
      1. Installs the CRDs only:
 
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
-          --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
+          --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
           --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
         ```
 
-     1. Remove the `--selector knative.dev/crd-install=true` flag and the run
+     1. Remove the `--selector knative.dev/crd-install=true` flag and then run
         the command to install the Serving component and observability plugins:
 
         ```bash
-        kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager\
+        kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
           --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
         ```
 
-   - To install all three Knative components and the set of Eventing sources
-     without an observability plugin, run the following commands.
-
-     In this example, the auto certificate controller is installed so that you
-     can
-     [enable automatic certificates provisioning](../serving/using-auto-tls.md).
-
+   - To install all three Knative components without an observability plugin, 
+     run the following commands.
+     
      1. Installs the CRDs only:
 
         ```bash
@@ -298,9 +285,9 @@ commands below.
           --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
         ```
 
-     1. Remove the `--selector knative.dev/crd-install=true` flag and the run
+     1. Remove the `--selector knative.dev/crd-install=true` flag and then run
         the command to install all the Knative components, including the
-        Eventing sources and auto certificate controller:
+        Eventing resources:
 
         ```bash
         kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
@@ -327,9 +314,14 @@ commands below.
    kubectl get pods --namespace knative-monitoring
    ```
 
-   See
-   [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md)
-   for details about setting up the various supported observability plugins.
+See the following topics for information about installing other Knative features:
+
+- [Installing logging, metrics, and traces](../serving/installing-logging-metrics-traces.md):
+  Learn how to install and set up the various observability plugins.
+   
+- [Installing Cert-Manager](../serving/installing-cert-manager.md):
+  Learn how to set up and configure secure HTTPS requests and enable
+  [automatic TLS cert provisioning](../serving/using-auto-tls.md).
 
 You are now ready to deploy an app or start sending and receiving
 events in your Knative cluster.

--- a/docs/install/Knative-with-AKS.md
+++ b/docs/install/Knative-with-AKS.md
@@ -133,11 +133,6 @@ recommended configuration for a cluster is:
 
 ## Installing Istio
 
-> Note: [Ambassador](https://www.getambassador.io/) and
-> [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
-> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
-> [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
-
 Knative depends on Istio. If your cloud platform offers a managed Istio
 installation, we recommend installing Istio that way, unless you need the
 ability to customize your installation.
@@ -149,6 +144,11 @@ Minkube or similar, see the
 
 You must install Istio on your Kubernetes cluster before continuing with these
 instructions to install Knative.
+
+> Note: [Ambassador](https://www.getambassador.io/) and
+> [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
+> [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
+> [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
 
 ## Installing Knative
 
@@ -194,21 +194,10 @@ your Knative installation, see
    Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -223,12 +212,15 @@ your Knative installation, see
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
-To get started with Knative Eventing, pick one of the
-[Eventing Samples](../eventing/samples/) to walk through.
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -36,15 +36,15 @@ see Performing a Custom Knative Installation.
     race conditions during the install, which cause intermittent errors:
 
         kubectl apply -l knative.dev/crd-install=true \
-        --filename https://github.com/knative/serving/releases/download/v0.7.1/serving.yaml \
-                --filename https://github.com/knative/serving/releases/download/v0.7.1/monitoring.yaml
+        --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+                --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
 
 2.  To complete the install of Knative and it's dependencies, run the
     `kubectl apply` command again, this time without the
     `-l knative.dev/crd-install=true`:
 
-        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.1 serving.yaml \
-                --filename https://github.com/knative/serving/releases/download/v0.7.1/monitoring.yaml
+        kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
+                --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
 
 3.  Monitor the Knative namespaces and wait until all of the pods come up with a
     `STATUS` of `Running`:

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -149,5 +149,3 @@ manage and route to serverless applications!
   for Knative serving.
 - Get started with Knative Eventing by walking through one of the
   [Eventing Samples](../eventing/samples/).
-- [Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
-  [automatic TLS cert provisioning feature](../serving/using-auto-tls.md).

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -43,19 +43,8 @@ see Performing a Custom Knative Installation.
     `kubectl apply` command again, this time without the
     `-l knative.dev/crd-install=true`:
 
-        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.1 serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+        kubectl apply --filename https://github.com/knative/serving/releases/download/v0.7.1 serving.yaml \
                 --filename https://github.com/knative/serving/releases/download/v0.7.1/monitoring.yaml
-
-    > **Notes**:
-    >
-    > - By default, the Knative Serving component installation (`serving.yaml`)
-    >   includes a controller for
-    >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-    >   If you do intend on immediately enabling auto certificates in Knative,
-    >   you can remove the
-    >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-    >   statement to install the controller. Otherwise, you can choose to
-    >   install the auto certificates feature and controller at a later time.
 
 3.  Monitor the Knative namespaces and wait until all of the pods come up with a
     `STATUS` of `Running`:
@@ -158,5 +147,7 @@ manage and route to serverless applications!
 - Try the
   [Getting Started with App Deployment guide](./getting-started-knative-app/)
   for Knative serving.
-- Take a look at the rest of what
-  [Knative has to offer](https://knative.dev/docs/index.html)
+- Get started with Knative Eventing by walking through one of the
+  [Eventing Samples](../eventing/samples/).
+- [Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+  [automatic TLS cert provisioning feature](../serving/using-auto-tls.md).

--- a/docs/install/Knative-with-Docker-for-Mac.md
+++ b/docs/install/Knative-with-Docker-for-Mac.md
@@ -33,55 +33,33 @@ continuing.
 
 ## Installing Istio
 
-Knative depends on Istio. Run the following to install Istio. (This changes
-`LoadBalancer` to `NodePort` for the `istio-ingress` service).
+Knative depends on [Istio](https://istio.io/docs/concepts/what-is-istio/) for
+traffic routing and ingress. You have the option of injecting Istio sidecars and
+enabling the Istio service mesh, but it's not required for all Knative
+components.
 
-```shell
-curl -L https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml \
-  | sed 's/LoadBalancer/NodePort/' \
-  | kubectl apply --filename -
+If your cloud platform offers a managed Istio installation, we recommend
+installing Istio that way, unless you need the ability to customize your
+installation.
 
-# Label the default namespace with istio-injection=enabled.
-kubectl label namespace default istio-injection=enabled
-```
-
-Monitor the Istio components until all of the components show a `STATUS` of
-`Running` or `Completed`:
-
-```shell
-kubectl get pods --namespace istio-system
-```
-
-It will take a few minutes for all the components to be up and running; you can
-rerun the command to see the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL+C to
-> exit watch mode.
+If you prefer to install Istio manually, if your cloud provider doesn't offer a
+managed Istio installation, or if you're installing Knative locally using
+Minkube or similar, see the
+[Installing Istio for Knative guide](./installing-istio.md).
 
 ## Installing Knative Serving
 
 Next, install [Knative Serving](https://github.com/knative/serving).
 
 Because you have limited resources available, use the
-`https://github.com/knative/serving/releases/download/v0.5.2/serving.yaml` file,
+`https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml` file,
 which installs only Knative Serving:
 
 ```shell
 curl -L https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
   | sed 's/LoadBalancer/NodePort/' \
-  | kubectl apply --selector networking.knative.dev/certificate-provider!=cert-manager --filename -
+  | kubectl apply --filename -
 ```
-
-**Notes**:
-
-> - By default, the Knative Serving component installation (`serving.yaml`)
->   includes a controller for
->   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
->   If you do intend on immediately enabling auto certificates in Knative, you
->   can remove the
->   `--selector networking.knative.dev/certificate-provider!=cert-manager`
->   statement to install the controller.
 
 > Note: Unlike minikube, we're not changing the LoadBalancer to a NodePort here.
 > Docker for Mac will assign `localhost` as the host for that LoadBalancer,
@@ -118,6 +96,12 @@ head to the [sample apps](../serving/samples/README.md) repo.
 
 > Note: You can replace the {IP_ADDRESS} placeholder used in the samples with
 > `localhost` as mentioned above.
+
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -170,21 +170,10 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -200,12 +189,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
-To get started with Knative Eventing, pick one of the
-[Eventing Samples](../eventing/samples/) to walk through.
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-Gardener.md
+++ b/docs/install/Knative-with-Gardener.md
@@ -125,21 +125,10 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -185,12 +174,15 @@ kind: ConfigMap
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
-To get started with Knative Eventing, pick one of the
-[Eventing Samples](../eventing/samples/) to walk through.
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-ICP.md
+++ b/docs/install/Knative-with-ICP.md
@@ -162,18 +162,8 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```shell
    curl -L https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
      | sed 's/LoadBalancer/NodePort/' \
-     | kubectl apply --selector networking.knative.dev/certificate-provider!=cert-manager --filename -
+     | kubectl apply --filename -
    ```
-
-   **Notes**:
-
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller.
 
    ```shell
    curl -L https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
@@ -217,7 +207,7 @@ Now you can deploy an app to your newly created Knative cluster.
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
@@ -230,8 +220,11 @@ echo $(ICP cluster ip):$(kubectl get svc istio-ingressgateway --namespace istio-
 --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
 ```
 
-To get started with Knative Eventing, walk through one of the
+Get started with Knative Eventing by walking through one of the
 [Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-IKS.md
+++ b/docs/install/Knative-with-IKS.md
@@ -209,21 +209,10 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -238,12 +227,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
-To get started with Knative Eventing, pick one of the
-[Eventing Samples](../eventing/samples/) to walk through.
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-Minikube.md
+++ b/docs/install/Knative-with-Minikube.md
@@ -58,37 +58,24 @@ minikube start --memory=8192 --cpus=6 \
 
 ## Installing Istio
 
+Knative depends on [Istio](https://istio.io/docs/concepts/what-is-istio/) for
+traffic routing and ingress. You have the option of injecting Istio sidecars and
+enabling the Istio service mesh, but it's not required for all Knative
+components.
+
+If your cloud platform offers a managed Istio installation, we recommend
+installing Istio that way, unless you need the ability to customize your
+installation.
+
+If you prefer to install Istio manually, if your cloud provider doesn't offer a
+managed Istio installation, or if you're installing Knative locally using
+Minkube or similar, see the
+[Installing Istio for Knative guide](./installing-istio.md).
+
 > Note: [Ambassador](https://www.getambassador.io/) and
 > [Gloo](https://gloo.solo.io/) are available as an alternative to Istio.
 > [Click here](./Knative-with-Ambassador.md) to install Knative with Ambassador.
 > [Click here](./Knative-with-Gloo.md) to install Knative with Gloo.
-
-Knative depends on Istio. Run the following to install Istio. (We are changing
-`LoadBalancer` to `NodePort` for the `istio-ingress` service).
-
-```shell
-kubectl apply --filename https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio-crds.yaml &&
-curl -L https://raw.githubusercontent.com/knative/serving/v0.5.2/third_party/istio-1.0.7/istio.yaml \
-  | sed 's/LoadBalancer/NodePort/' \
-  | kubectl apply --filename -
-
-# Label the default namespace with istio-injection=enabled.
-kubectl label namespace default istio-injection=enabled
-```
-
-Monitor the Istio components until all of the components show a `STATUS` of
-`Running` or `Completed`:
-
-```shell
-kubectl get pods --namespace istio-system
-```
-
-It will take a few minutes for all the components to be up and running; you can
-rerun the command to see the current status.
-
-> Note: Instead of rerunning the command, you can add `--watch` to the above
-> command to view the component's status updates in real time. Use CTRL+C to
-> exit watch mode.
 
 ## Installing Knative
 
@@ -133,21 +120,10 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:

--- a/docs/install/Knative-with-PKS.md
+++ b/docs/install/Knative-with-PKS.md
@@ -62,12 +62,6 @@ Minkube or similar, see the
 You must install Istio on your Kubernetes cluster before continuing with these
 instructions to install Knative.
 
-## Installing Cert-Manager
-
-Follow the [instructions](../serving/installing-cert-manager.md) to install
-Cert-Manager if you want to use use
-[Auto TLS feature](../serving/using-auto-tls.md).
-
 ## Installing Knative
 
 The following commands install all available Knative components as well as the
@@ -111,21 +105,10 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -140,12 +123,15 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
-To get started with Knative Eventing, pick one of the
-[Eventing Samples](../eventing/samples/) to walk through.
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
 
 ## Cleaning up
 

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -78,21 +78,10 @@ your Knative installation, see
    complete the install of Knative and its dependencies:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml --selector networking.knative.dev/certificate-provider!=cert-manager \
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
-
-   > **Notes**:
-   >
-   > - By default, the Knative Serving component installation (`serving.yaml`)
-   >   includes a controller for
-   >   [enabling automatic TLS certificate provisioning](../serving/using-auto-tls.md).
-   >   If you do intend on immediately enabling auto certificates in Knative,
-   >   you can remove the
-   >   `--selector networking.knative.dev/certificate-provider!=cert-manager`
-   >   statement to install the controller. Otherwise, you can choose to install
-   >   the auto certificates feature and controller at a later time.
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
@@ -108,9 +97,12 @@ your Knative installation, see
 Now that your cluster has Knative installed, you can see what Knative has to
 offer.
 
-To deploy your first app with Knative, follow the step-by-step
+To deploy your first app with the
 [Getting Started with Knative App Deployment](./getting-started-knative-app.md)
 guide.
 
-To get started with Knative Eventing, pick one of the
-[Eventing Samples](../eventing/samples/) to walk through.
+Get started with Knative Eventing by walking through one of the
+[Eventing Samples](../eventing/samples/).
+
+[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
+[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -26,24 +26,20 @@ provisioning:
 
 ## Enabling automatic certificate provisioning
 
-To enable Knative to automatically provision TLS certificates:
+To enable support for automatic TLS certificate provisioning in Knative:
 
-1. Determine if `networking-certmanager` is installed by running the following
-   command:
+1. Determine if `networking-certmanager` is already installed by running the 
+    following command:
 
-   ```shell
-   kubectl get deployment networking-certmanager -n knative-serving
-   ```
+    ```shell
+    kubectl get deployment networking-certmanager -n knative-serving
+    ```
 
-1. If `networking-certmanager` is not found, run the following commands to
-   install it:
-
-   ```shell
-   # Knative Serving must be v0.6.0 or later.
-
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --selector networking.knative.dev/certificate-provider=cert-manager
-   ```
+1. If `networking-certmanager` is not found, run the following command:
+   
+    ```shell
+    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-cert-manager.yaml
+    ```
 
 1. Create and add the `ClusterIssuer` configuration file to your Knative cluster
    to define who issues the TLS certificates, how requests are validated


### PR DESCRIPTION
fixes: #1614 

the cert-manager controller is no longer installed by default

Related UX issue: https://github.com/knative/serving/issues/4120