### PR TITLE
Fix dead link

### DIFF
--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -3,4 +3,4 @@ The Knative Build component has been deprecated. For more information,
 see the [**knative/build repository**](https://github.com/knative/build/blob/master/README.md).
 
 Documentation for the final release of Knative Build is available in the
-[**v0.7 docs release**](https://knative.dev/v0.7-docs/build/).
+[**v0.7 docs release**](../../v0.7-docs/build/).

--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -3,4 +3,4 @@ The Knative Build component has been deprecated. For more information,
 see the [**knative/build repository**](https://github.com/knative/build/blob/master/README.md).
 
 Documentation for the final release of Knative Build is available in the
-[**v0.7 docs release**](../v0.7-docs/build/).
+[**v0.7 docs release**](https://knative.dev/v0.7-docs/build/).


### PR DESCRIPTION
In the [generated docs](https://knative.dev/docs/build/) the link "v0.7 docs release" is wrong: https://knative.dev/docs/v0.7-docs/build/.
The correct link is https://knative.dev/v0.7-docs/build/.
