### PR TITLE
Replace eventing.yaml with release.yaml in the install instructions

### DIFF
--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -89,6 +89,7 @@ The following Knative installation files are available:
   - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/camel.yaml
   - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/gcppubsub.yaml
   - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka.yaml
+  - https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka-channel.yaml
 
 #### Install details and options
 
@@ -112,9 +113,9 @@ files from the Knative repositories:
 | [`monitoring-tracing-zipkin.yaml`][1.80]        | Installs only [Zipkin][2.30].**\***                                                                                                                                     | Serving component, ELK stack (monitoring-logs-elasticsearch.yaml)     |
 | [`monitoring-tracing-zipkin-in-mem.yaml`][1.90] | Installs only [Zipkin in-memory][2.30]**\***                                                                                                                            | Serving component                                                                  |
 | **knative/eventing**                           |                                                                                                                                                                        |                                                                                           |
-| [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource), [CronJobSource][6.2], the in-memory channel provisioner.                     |                                                                                           |
-| [`eventing.yaml`][4.2]                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource) and [CronJobSource][6.2]. Does not include the in-memory channel provisioner. |                                                                                           |
-| [`in-memory-channel-crd.yaml`][4.3]                | Installs only the in-memory channel provisioner.                                                                                                                       | Eventing component                                                                        |
+| [`release.yaml`][4.1]†                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource), [CronJobSource][6.2], InMemoryChannel.                     |                                                                                           |
+| [`eventing.yaml`][4.2]                         | Installs the Eventing component. Includes [ContainerSource](../eventing#containersource) and [CronJobSource][6.2]. Does not include any Channel. |                                                                                           |
+| [`in-memory-channel-crd.yaml`][4.3]                | Installs only the InMemoryChannel.                                                                                                                       | Eventing component                                                                        |
 | [`natss.yaml`][4.5]                            | Installs only the NATSS channel provisioner.                                                                                                                           | Eventing component                                                                        |
 | [`gcp-pubsub.yaml`][4.6]                       | Installs only the GCP PubSub channel provisioner.                                                                                                                      | Eventing component                                                                        |
 | **knative/eventing-contrib**                   |                                                                                                                                                                        |                                                                                           |
@@ -122,7 +123,8 @@ files from the Knative repositories:
 | [`camel.yaml`][5.40]                            | Installs the Apache Camel source.                                                                                                                                      | Eventing component                                                                        |
 | [`gcppubsub.yaml`][5.20]                        | Installs the [GCP PubSub source][6.30]                                                                                                                                  | Eventing component                                                                        |
 | [`kafka.yaml`][5.50]                            | Installs the Apache Kafka source.                                                                                                                                      | Eventing component                                                                        |
-| [`awssqs.yaml`][5.60]                           | Installs the AWS SQS source.                                                                                                                                           | Eventing component                                                                        |
+| [`kafka-channel.yaml`][5.60]                            | Installs the KafkaChannel.                                                                                                                                      | Eventing component                                                                        |
+| [`awssqs.yaml`][5.70]                           | Installs the AWS SQS source.                                                                                                                                           | Eventing component                                                                        |
 | [`event-display.yaml`][5.30]                    | Installs a Knative Service that logs events received for use in samples and debugging.                                                                                 | Serving component, Eventing component                                                     |
 
 _\*_ See
@@ -178,6 +180,8 @@ for details about installing the various supported observability plugins.
 [5.50]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka.yaml
 [5.60]:
+  https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka-channel.yaml
+[5.70]:
   https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/awssqs.yaml
 [6.10]: https://developer.github.com/v3/activity/events/types/
 [6.20]:
@@ -248,7 +252,7 @@ commands below.
       `[FILE_URL]`Examples:
 
       - `https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml`
-      - `https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml`
+      - `https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml`
       - `https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml`
 
       **Example install commands:**
@@ -280,7 +284,7 @@ commands below.
         ```bash
         kubectl apply --selector knative.dev/crd-install=true \
           --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-          --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
+          --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
         ```
 
      1. Remove the `--selector knative.dev/crd-install=true` flag and then run
@@ -289,7 +293,7 @@ commands below.
 
         ```bash
         kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-          --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
+          --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
         ```
 
 1. Depending on what you chose to install, view the status of your installation

--- a/docs/install/Knative-with-GKE.md
+++ b/docs/install/Knative-with-GKE.md
@@ -161,7 +161,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
@@ -171,7 +171,7 @@ see [Performing a Custom Knative Installation](./Knative-custom-install.md).
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -69,7 +69,7 @@ your Knative installation, see
    ```bash
    kubectl apply --selector knative.dev/crd-install=true \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 
@@ -79,7 +79,7 @@ your Knative installation, see
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
+   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml \
    --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
    ```
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- Replace eventing.yaml with release.yaml in the install instructions to have a fully working system with InMemoryChannel installed.
