### PR TITLE
[container source] Fix the docs to point to correct 'ko publish' command

### DIFF
--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -30,7 +30,7 @@ git clone -b "{{< branch >}}" https://github.com/knative/eventing-contrib.git
 And then build a heartbeats image and publish to your image repo with
 
 ```
-ko publish github.com/knative/eventing-contrib/cmd/heartbeats
+ko publish knative.dev/eventing-contrib/cmd/heartbeats
 ```
 
 **Note**: `ko publish` requires:
@@ -61,6 +61,14 @@ Use following command to create the service from `service.yaml`:
 
 ```shell
 kubectl apply --filename service.yaml
+```
+The status of the created service can be seen using:
+
+```shell
+kubectl get ksvc
+
+NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
+event-display   http://event-display.default.example.com   event-display-gqjbw   event-display-gqjbw   True    
 ```
 
 ### Create a ContainerSource using the heartbeats image


### PR DESCRIPTION


Fixes #1725 

## Proposed Changes
```
-ko publish github.com/knative/eventing-contrib/cmd/heartbeats
+ko publish knative.dev/eventing-contrib/cmd/heartbeats
```
