### PR TITLE
Fix indentation for hello-display inline yaml.

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -140,7 +140,7 @@ Your event consumers receive the events sent by event producers. In this step, y
               # Source code: https://github.com/knative/eventing-contrib/blob/release-0.6/cmd/event_display/main.go
               image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:37ace92b63fc516ad4c8331b6b3b2d84e4ab2d8ba898e387c0b6f68f0e3081c4
 
-     ---
+    ---
 
     # Service pointing at the previous Deployment. This will be the target for event
     # consumption.


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- The inline YAML in step 1 of "Creating Eventing Consumers" in the "Getting Started" guide for Knative Eventing has an extra space before the `---`.  This means if you copy and paste the command into a terminal, you'll get the error:
```
error: error parsing STDIN: error converting YAML to JSON: yaml: line 18: did not find expected key
```
This PR simply removes the space.
