### PR TITLE
Secrets use GOOGLE_APPLICATION_CREDENTIALS as key

### DIFF
--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -56,7 +56,7 @@ cd knative-docs/serving/samples/secrets-go
     log.Print("Secrets sample started.")
 
     // This sets up the standard GCS storage client, which will pull
-    // credentials from GOOGLE_APPLICATION_DEFAULT if specified.
+    // credentials from GOOGLE_APPLICATION_CREDENTIALS if specified.
     ctx := context.Background()
     client, err := storage.NewClient(ctx)
     if err != nil {
@@ -184,7 +184,7 @@ cd knative-docs/serving/samples/secrets-go
                #  - `robot.json` is determined by the "key" that is used to hold the
                #   secret content in the Kubernetes secret.  This can be changed
                #   if both places are changed.
-               - name: GOOGLE_APPLICATION_DEFAULT
+               - name: GOOGLE_APPLICATION_CREDENTIALS
                  value: /var/secret/robot.json
 
              # This section specified where in the container we want the


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1744

## Proposed Changes

- Change `GOOGLE_APPLICATION_DEFAULT` to `GOOGLE_APPLICATION_CREDENTIALS` as per the GCP documentation https://cloud.google.com/docs/authentication/getting-started
