### PR TITLE
Add dgerd to eng-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,7 @@ aliases:
   eng-approvers:
   - evankanderson
   - mattmoor
+  - dgerd
   - vaikas-google
   - rgregg
   - mchmarny


### PR DESCRIPTION
I would like to have approval permission to help triage Serving API
related samples and PRs (docs/serving).

/cc @mattmoor @samodell

-
-
-
