### PR TITLE
serving/samples: update helloworld-go to go:1.13 and go modules

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -3,12 +3,19 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.13 as builder
 
-# Copy local code to the container image.
+# Create and change to the app directory.
 WORKDIR /app
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+COPY go.* ./
+RUN go mod download
+
+# Copy local code to the container image.
 COPY . ./
 
 # Build the binary.
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld-server
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine
@@ -17,7 +24,7 @@ FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/helloworld-server /helloworld-server
+COPY --from=builder /app/server /server
 
 # Run the web service on container startup.
-CMD ["/helloworld-server"]
+CMD ["/server"]

--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3.10
+FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.

--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -10,7 +10,7 @@ COPY . ./
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld-server
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine
@@ -19,7 +19,7 @@ FROM alpine:3
 RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/helloworld /helloworld
+COPY --from=builder /app/helloworld-server /helloworld-server
 
 # Run the web service on container startup.
-CMD ["/helloworld"]
+CMD ["/helloworld-server"]

--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -1,24 +1,25 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 
 # Copy local code to the container image.
-WORKDIR /go/src/github.com/knative/docs/helloworld
-COPY . .
+WORKDIR /app
+COPY . ./
 
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
 
-# Use a Docker multi-stage build to create a lean production image.
+# Use the official Alpine image for a lean production container.
+# https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine
+FROM alpine:3.10
 RUN apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /go/src/github.com/knative/docs/helloworld/helloworld /helloworld
+COPY --from=builder /app/helloworld /helloworld
 
 # Run the web service on container startup.
 CMD ["/helloworld"]

--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -7,9 +7,7 @@ FROM golang:1.13 as builder
 WORKDIR /app
 COPY . ./
 
-# Build the command inside the container.
-# (You may fetch or manage dependencies here,
-# either manually or with a tool like "godep".)
+# Build the binary.
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld-server
 
 # Use the official Alpine image for a lean production container.

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -121,6 +121,13 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
                  value: "Go Sample v1"
    ```
 
+1. Use the go tool to create a
+   [`go.mod`](https://github.com/golang/go/wiki/Modules#gomod) manifest.
+
+   ```shell
+   go mod init github.com/knative/docs/docs/serving/samples/hello-world/helloworld-go
+   ```
+
 ## Building and deploying the sample
 
 Once you have recreated the sample code files (or used the files in the sample

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -74,12 +74,19 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    # https://hub.docker.com/_/golang
    FROM golang:1.13 as builder
 
-   # Copy local code to the container image.
+   # Create and change to the app directory.
    WORKDIR /app
+
+   # Retrieve application dependencies.
+   # This allows the container build to reuse cached dependencies.
+   COPY go.* ./
+   RUN go mod download
+
+   # Copy local code to the container image.
    COPY . ./
 
    # Build the binary.
-   RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld-server
+   RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
 
    # Use the official Alpine image for a lean production container.
    # https://hub.docker.com/_/alpine
@@ -88,10 +95,10 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    RUN apk add --no-cache ca-certificates
 
    # Copy the binary to the production image from the builder stage.
-   COPY --from=builder /app/helloworld-server /helloworld-server
+   COPY --from=builder /app/server /server
 
    # Run the web service on container startup.
-   CMD ["/helloworld-server"]
+   CMD ["/server"]
    ```
 
 1. Create a new file, `service.yaml` and copy the following service definition

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -73,27 +73,27 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
    FROM golang:1.13 as builder
-
+   
    # Copy local code to the container image.
    WORKDIR /app
    COPY . ./
-
+   
    # Build the command inside the container.
    # (You may fetch or manage dependencies here,
    # either manually or with a tool like "godep".)
-   RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
-
+   RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld-server
+   
    # Use the official Alpine image for a lean production container.
    # https://hub.docker.com/_/alpine
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-   FROM alpine:3.10
+   FROM alpine:3
    RUN apk add --no-cache ca-certificates
-
+   
    # Copy the binary to the production image from the builder stage.
-   COPY --from=builder /app/helloworld /helloworld
-
+   COPY --from=builder /app/helloworld-server /helloworld-server
+   
    # Run the web service on container startup.
-   CMD ["/helloworld"]
+   CMD ["/helloworld-server"]
    ```
 
 1. Create a new file, `service.yaml` and copy the following service definition

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -72,24 +72,25 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    # Use the offical Golang image to create a build artifact.
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
-   FROM golang:1.12 as builder
+   FROM golang:1.13 as builder
 
    # Copy local code to the container image.
-   WORKDIR /go/src/github.com/knative/docs/helloworld
-   COPY . .
+   WORKDIR /app
+   COPY . ./
 
    # Build the command inside the container.
    # (You may fetch or manage dependencies here,
    # either manually or with a tool like "godep".)
    RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld
 
-   # Use a Docker multi-stage build to create a lean production image.
+   # Use the official Alpine image for a lean production container.
+   # https://hub.docker.com/_/alpine
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-   FROM alpine
+   FROM alpine:3.10
    RUN apk add --no-cache ca-certificates
 
    # Copy the binary to the production image from the builder stage.
-   COPY --from=builder /go/src/github.com/knative/docs/helloworld/helloworld /helloworld
+   COPY --from=builder /app/helloworld /helloworld
 
    # Run the web service on container startup.
    CMD ["/helloworld"]

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -73,25 +73,23 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
    FROM golang:1.13 as builder
-   
+
    # Copy local code to the container image.
    WORKDIR /app
    COPY . ./
-   
-   # Build the command inside the container.
-   # (You may fetch or manage dependencies here,
-   # either manually or with a tool like "godep".)
+
+   # Build the binary.
    RUN CGO_ENABLED=0 GOOS=linux go build -v -o helloworld-server
-   
+
    # Use the official Alpine image for a lean production container.
    # https://hub.docker.com/_/alpine
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
    FROM alpine:3
    RUN apk add --no-cache ca-certificates
-   
+
    # Copy the binary to the production image from the builder stage.
    COPY --from=builder /app/helloworld-server /helloworld-server
-   
+
    # Run the web service on container startup.
    CMD ["/helloworld-server"]
    ```

--- a/docs/serving/samples/hello-world/helloworld-go/go.mod
+++ b/docs/serving/samples/hello-world/helloworld-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/knative/docs/docs/serving/samples/hello-world/helloworld-go
+
+go 1.13

--- a/test/sampleapp/config.yaml
+++ b/test/sampleapp/config.yaml
@@ -11,6 +11,7 @@ languages:
   - language: "go"
     expectedOutput: "Hello Go Sample v1!"
     copies:
+      - "go.mod"
       - "helloworld.go"
       - "service.yaml"
       - "Dockerfile"


### PR DESCRIPTION
First step toward #1686 

## Proposed Changes

- Upgrades from go 1.12 to go 1.13
- Upgrades to use go modules
- Pins alpine image to 3.10
- Tweaks working directory to /app
- Rename binary in container from `helloworld` to `server`
- Use `go mod download` to facilitate a layer cache of go deps.
- Use `-mod=readonly` flag on builds for strictness of container builds
- Some minor style changes around syntax and comments
