### PR TITLE
Remove extra spaces to correct format

### DIFF
--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -31,23 +31,23 @@ that are active when running Knative Serving.
    webhook             ClusterIP   10.107.144.50    <none>        443/TCP                  1h
    ```
 
- 3. To view the deployments in your cluster, use the following command:
+3. To view the deployments in your cluster, use the following command:
 
-    ```sh
-    $ kubectl get deployments -n knative-serving
-    ```
+   ```sh
+   $ kubectl get deployments -n knative-serving
+   ```
 
-    This should return the following output:
+   This should return the following output:
 
-     ```sh
-     NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-     activator                1         1         1            1           1h
-     autoscaler               1         1         1            1           1h
-     controller               1         1         1            1           1h
-     networking-certmanager   1         1         1            1           1h
-     networking-istio         1         1         1            1           1h
-     webhook                  1         1         1            1           1h
-     ```
+   ```sh
+   NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+   activator                1         1         1            1           1h
+   autoscaler               1         1         1            1           1h
+   controller               1         1         1            1           1h
+   networking-certmanager   1         1         1            1           1h
+   networking-istio         1         1         1            1           1h
+   webhook                  1         1         1            1           1h
+   ```
 
 These services and deployments are installed by the `serving.yaml` file during
 install. The next section describes their function.


### PR DESCRIPTION
Please refer to https://knative.dev/docs/serving/knative-kubernetes-services/ in ` 3. To view the deployments in your cluster, use the following command`. It has a broken format.

## Proposed Changes

- Remove extra spaces to correct format
