### PR TITLE
update note on eventing dependency

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -93,8 +93,7 @@ Learn more about Eventing development in the
 
 ## Installation
 
-Knative Eventing currently requires Knative Serving and Istio version 1.0 or
-later installed.
+Knative Eventing currently requires Knative Serving installed with either Istio version >=1.0, or Gloo version >=0.18.16.
 [Follow the instructions to install on the platform of your choice](../install/README.md).
 
 Many of the sources require making outbound connections to create the event


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Currently, the Eventing README states that Eventing requires Istio 1.0 or greater. Eventing 0.7 and greater have been tested to wrok with Gloo >=v0.18.16 

## Proposed Changes

- Update the Eventing README to mention Eventing support offered by Gloo
