### PR TITLE
Move scale bounds settings to annotation field

### DIFF
--- a/docs/serving/configuring-the-autoscaler.md
+++ b/docs/serving/configuring-the-autoscaler.md
@@ -139,8 +139,9 @@ used to prevent cold starts or to help control computing costs.
 spec:
   template:
     metadata:
-      autoscaling.knative.dev/minScale: "2"
-      autoscaling.knative.dev/maxScale: "10"
+      annotations:
+        autoscaling.knative.dev/minScale: "2"
+        autoscaling.knative.dev/maxScale: "10"
 ```
 
 Using these annotations in the revision template will propagate this to


### PR DESCRIPTION
## Proposed Changes
- This patch moves `autoscaling.knative.dev/{minScale,maxScale}` to `spec.template.metadata.annotations`, where is correct settings.

You can refer to https://github.com/knative/serving/blob/master/docs/scaling/README.md as well.
