### PR TITLE
Correct path and attributes

### DIFF
--- a/docs/serving/samples/traffic-splitting/README.md
+++ b/docs/serving/samples/traffic-splitting/README.md
@@ -64,7 +64,7 @@ status:
    available via the sub-route "latest".
 
 ```shell
-kubectl apply --filename serving/samples/traffic-splitting/release_sample.yaml
+kubectl apply --filename docs/serving/samples/traffic-splitting/release_sample.yaml
 ```
 
 1. The `spec` of the Service should now show our `traffic` block with the
@@ -94,7 +94,7 @@ serving/samples/traffic-splitting/updated_sample.yaml
 1.  Execute the command below to update Service, resulting in a new Revision.
 
 ```shell
-kubectl apply --filename serving/samples/traffic-splitting/updated_sample.yaml
+kubectl apply --filename docs/erving/samples/traffic-splitting/updated_sample.yaml
 ```
 
 2. With our `traffic` block, traffic will _not_ shift to the new Revision
@@ -114,7 +114,7 @@ kubectl get ksvc stock-service-example --output yaml
 
 ```shell
 # Replace "latest" with whichever tag for which we want the hostname.
-export LATEST_HOSTNAME=`kubectl get ksvc stock-service-example --output jsonpath="{.status.traffic[?(@.name=='latest')].url}" | cut -d'/' -f 3`
+export LATEST_HOSTNAME=`kubectl get ksvc stock-service-example --output jsonpath="{.status.traffic[?(@.tag=='latest')].url}" | cut -d'/' -f 3`
 curl --header "Host: ${LATEST_HOSTNAME}" http://${INGRESS_IP}
 ```
 
@@ -135,7 +135,7 @@ extending our `traffic` list, and splitting the `percent` across them.
     split.
 
 ```shell
-kubectl apply --filename serving/samples/traffic-splitting/split_sample.yaml
+kubectl apply --filename docs/serving/samples/traffic-splitting/split_sample.yaml
 ```
 
 2. Verify the deployment by checking the service status:
@@ -157,5 +157,5 @@ curl --header "Host:${SERVICE_HOSTNAME}" http://${INGRESS_IP}
 To clean up the sample service:
 
 ```shell
-kubectl delete --filename serving/samples/traffic-splitting/split_sample.yaml
+kubectl delete --filename docs/serving/samples/traffic-splitting/split_sample.yaml
 ```

--- a/docs/serving/samples/traffic-splitting/README.md
+++ b/docs/serving/samples/traffic-splitting/README.md
@@ -94,7 +94,7 @@ serving/samples/traffic-splitting/updated_sample.yaml
 1.  Execute the command below to update Service, resulting in a new Revision.
 
 ```shell
-kubectl apply --filename docs/erving/samples/traffic-splitting/updated_sample.yaml
+kubectl apply --filename docs/serving/samples/traffic-splitting/updated_sample.yaml
 ```
 
 2. With our `traffic` block, traffic will _not_ shift to the new Revision


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->
- The path is wrong, since doc let user enter `cd $GOPATH/src/github.com/knative/docs` firstly, then the correct path should be `docs/serving/samples/traffic-splitting` rather than `serving/samples/traffic-splitting`
- The attribute should be `tag`, not `name`
