### PR TITLE
fix a wrong indentation at knative routing go sample docs

### DIFF
--- a/docs/serving/samples/knative-routing-go/README.md
+++ b/docs/serving/samples/knative-routing-go/README.md
@@ -243,25 +243,25 @@ kubectl get VirtualService entry-route --output yaml
         --output jsonpath="{.status.loadBalancer.ingress[*]['ip']}"`
     ```
 
-        * Send a request to the Search service:
-        ```shell
-        curl http://${GATEWAY_IP}/search --header "Host: example.com"
-        ```
-        or
-        ```shell
-        curl http://${GATEWAY_IP}/search --header "Host: <YOUR_DOMAIN_NAME>"
-        ```
-        for the case using your own domain.
+* Send a request to the Search service:
+    ```shell
+    curl http://${GATEWAY_IP}/search --header "Host: example.com"
+    ```
+    or
+    ```shell
+    curl http://${GATEWAY_IP}/search --header "Host: <YOUR_DOMAIN_NAME>"
+    ```
+    for the case using your own domain.
 
-        * Send a request to the Login service:
-        ```shell
-        curl http://${GATEWAY_IP}/login --header "Host: example.com"
-        ```
-        or
-        ```shell
-        curl http://${GATEWAY_IP}/login --header "Host: <YOUR_DOMAIN_NAME>"
-        ```
-        for the case using your own domain.
+    * Send a request to the Login service:
+    ```shell
+    curl http://${GATEWAY_IP}/login --header "Host: example.com"
+    ```
+    or
+    ```shell
+    curl http://${GATEWAY_IP}/login --header "Host: <YOUR_DOMAIN_NAME>"
+    ```
+    for the case using your own domain.
 
 ## How It Works
 


### PR DESCRIPTION
## Proposed Changes
Fix a wrong indentation at knative routing go sample documentation.

![image](https://user-images.githubusercontent.com/1796577/65479553-4196ab80-de64-11e9-90cb-42f5bd6b8bd9.png)
