### PR TITLE
Add documentation for subroutes and k8s service visibility tagging

### DIFF
--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -77,6 +77,7 @@ in the Knative Serving repository.
 - [Configuring cluster local routes](./cluster-local-route.md)
 - [Using a custom domain](./using-a-custom-domain.md)
 - [Assigning a static IP address for Knative on Google Kubernetes Engine](./gke-assigning-static-ip-address.md)
+- [Using subroutes](./using-subroutes.md)
 
 ## Known Issues
 

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -29,8 +29,8 @@ inside the cluster:
 
 To configure a KService to only be available on the cluster-local network (and
 not on the public Internet), you can apply the
-`serving.knative.dev/visibility=cluster-local` label to the KService or Route
-object.
+`serving.knative.dev/visibility=cluster-local` label to the KService, Route or 
+Kubernetes Service object.
 
 To label the KService:
 
@@ -43,6 +43,16 @@ To label a route:
 ```shell
 kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local
 ```
+
+To label a kubernetes service:
+
+```shell
+kubectl label route ${SERVICE_NAME} serving.knative.dev/visibility=cluster-local
+```
+
+By labeling the kubernetes service it allows you to restrict visibility in a more
+fine-grained way. See [subroutes](./using-subroutes.md) for information about
+tagged routes.
 
 For example, you can deploy the [Hello World sample](./samples/hello-world/helloworld-go/README.md)
 and then convert it to be an cluster-local service by labeling the service:

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -44,13 +44,13 @@ To label a route:
 kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
-To label a kubernetes service:
+To label a Kubernetes service:
 
 ```shell
 kubectl label route ${SERVICE_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
-By labeling the kubernetes service it allows you to restrict visibility in a more
+By labeling the Kubernetes service it allows you to restrict visibility in a more
 fine-grained way. See [subroutes](./using-subroutes.md) for information about
 tagged routes.
 

--- a/docs/serving/using-subroutes.md
+++ b/docs/serving/using-subroutes.md
@@ -1,0 +1,37 @@
+---
+title: "Creating and using Subroutes"
+linkTitle: "Configuring cluster-local services"
+weight: 20
+type: "docs"
+---
+
+Subroutes are most effective when used with multiple revisions. When defining a knative service/route, the traffic section of the spec can split between the different revisions. For example:
+
+```yaml
+traffic:
+- percent: 0
+  revisionName: foo
+- percent: 40
+  revisionName: bar
+- percent: 60
+  revisionName: baz
+```
+
+This allows anyone targeting the main route to have a 0% chance of hitting revision `foo`, 40% chance of hitting revision `bar` and 60% chance of hitting revision `baz`.
+
+As part of the spec there's a key called `tag`. When a `tag` can be applied to the routes, this will generate an address for the specific traffic target.
+
+```yaml
+traffic:
+- percent: 0
+  revisionName: foo
+  tag: staging
+- percent: 40
+  revisionName: bar
+- percent: 60
+  revisionName: baz
+```
+
+In the above example, we can access the staging target by accessing `staging-<route name>.<namespace>.<domain>`. Whereas the targets for `bar` and `baz` can only be accessible via the main route `<route name>.<namespace>.<domain>`.
+
+When a traffic target gets tagged, a new kubernetes service is created for it so that other services can also access it within the cluster. From the above example, a new kubernetes service called `staging-<route name>` will be created in the same namespace. This service has the ability to override the visibility of this specific route by applying the label `serving.knative.dev/visibility` with value `cluster-local`. See [cluster local routes](./cluster-local-route.md#label-a-service-to-be-cluster-local) for more information about how to restrict visibility on the specific route.

--- a/docs/serving/using-subroutes.md
+++ b/docs/serving/using-subroutes.md
@@ -1,11 +1,10 @@
 ---
 title: "Creating and using Subroutes"
-linkTitle: "Configuring cluster-local services"
 weight: 20
 type: "docs"
 ---
 
-Subroutes are most effective when used with multiple revisions. When defining a knative service/route, the traffic section of the spec can split between the different revisions. For example:
+Subroutes are most effective when used with multiple revisions. When defining a Knative service/route, the traffic section of the spec can split between the different revisions. For example:
 
 ```yaml
 traffic:
@@ -19,7 +18,9 @@ traffic:
 
 This allows anyone targeting the main route to have a 0% chance of hitting revision `foo`, 40% chance of hitting revision `bar` and 60% chance of hitting revision `baz`.
 
-As part of the spec there's a key called `tag`. When a `tag` can be applied to the routes, this will generate an address for the specific traffic target.
+## Using tags to create target URLs
+
+The spec defines an attribute called `tag`. When a `tag` is applied to a route, an address for the specific traffic target is created.
 
 ```yaml
 traffic:
@@ -32,6 +33,6 @@ traffic:
   revisionName: baz
 ```
 
-In the above example, we can access the staging target by accessing `staging-<route name>.<namespace>.<domain>`. Whereas the targets for `bar` and `baz` can only be accessible via the main route `<route name>.<namespace>.<domain>`.
+In the above example, you can access the staging target by accessing `staging-<route name>.<namespace>.<domain>`. The targets for `bar` and `baz` can only be accessed using the main route, `<route name>.<namespace>.<domain>`.
 
-When a traffic target gets tagged, a new kubernetes service is created for it so that other services can also access it within the cluster. From the above example, a new kubernetes service called `staging-<route name>` will be created in the same namespace. This service has the ability to override the visibility of this specific route by applying the label `serving.knative.dev/visibility` with value `cluster-local`. See [cluster local routes](./cluster-local-route.md#label-a-service-to-be-cluster-local) for more information about how to restrict visibility on the specific route.
+When a traffic target gets tagged, a new Kubernetes service is created for it so that other services can also access it within the cluster. From the above example, a new Kubernetes service called `staging-<route name>` will be created in the same namespace. This service has the ability to override the visibility of this specific route by applying the label `serving.knative.dev/visibility` with value `cluster-local`. See [cluster local routes](./cluster-local-route.md#label-a-service-to-be-cluster-local) for more information about how to restrict visibility on the specific route.


### PR DESCRIPTION
Add documentation detailing how subroutes are used.
Add documentation detailing how to set visibility of a route via k8s service.

This is documentation relevant to knative starting at v0.8.

I'm looking for guidance on how to make it better if anyone has improvement tips.