### PR TITLE
Fix invalid format in Getting Started with App Deployment

### DIFF
--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -106,7 +106,7 @@ The command will return something similar to this:
 ```shell
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
    istio-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-````
+```
 
 Take note of the `EXTERNAL-IP` address.
 


### PR DESCRIPTION
## Proposed Changes

- Fix invalid markdown format in Getting Started with App Deployment.

Please refer to the code block in under the `The command will return something similar to this:` in
https://knative.dev/docs/serving/getting-started-knative-app/#interacting-with-your-app The format is broken because of extra "`".