### PR TITLE
Drop the manual gateway resolution from samples.

### DIFF
--- a/community/samples/serving/helloworld-clojure/README.md
+++ b/community/samples/serving/helloworld-clojure/README.md
@@ -11,7 +11,7 @@ specified, it will use "World" as the TARGET.
 
 ## Prerequisites
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../install/README.md) if you need to create
   one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -137,34 +137,20 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-clojure --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-clojure  http://helloworld-clojure.default.example.com
+   helloworld-clojure  http://helloworld-clojure.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the results. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-clojure.default.example.com" http://{$IP_ADDRESS}
-   Hello World: Clojure Sample v1!
+   curl http://helloworld-clojure.default.1.2.3.4.xip.io
+   Hello World!
    ```
 
 ## Removing the sample app deployment

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -12,7 +12,7 @@ that you can use for testing. It reads in the env variable `TARGET` and prints
 
 ## Prerequisites
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../install/README.md) if you need to create
   one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -136,33 +136,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get assigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-dart  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME             URL
-   helloworld-dart  http://helloworld-dart.default.example.com
+   helloworld-dart  http://helloworld-dart.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-dart.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-dart.default.1.2.3.4.xip.io
    Hello Dart Sample v1
    ```
 

--- a/community/samples/serving/helloworld-elixir/README.md
+++ b/community/samples/serving/helloworld-elixir/README.md
@@ -160,33 +160,20 @@ above.
       for your app.
     - Automatically scale your pods up and down (including to zero active pods).
 
-1.  To find the IP address for your service, use these commands to get the
-    ingress IP for your cluster. If your cluster is new, it may take sometime
-    for the service to get asssigned an external IP address.
-
-    ```shell
-    INGRESSGATEWAY=istio-ingressgateway
-
-    kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-    xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-    ```
-
 1.  To find the URL for your service, use
 
     ```
     kubectl get ksvc helloworld-elixir --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
     NAME                URL
-    helloworld-elixir   http://helloworld-elixir.default.example.com
+    helloworld-elixir   http://helloworld-elixir.default.1.2.3.4.xip.io
     ```
 
 1.  Now you can make a request to your app to see the results. Replace
     `{IP_ADDRESS}` with the address you see returned in the previous step.
 
         ```shell
-        curl -H "Host: helloworld-elixir.default.example.com" http://{IP_ADDRESS}
+        curl http://helloworld-elixir.default.1.2.3.4.xip.io
 
         ...
         # HTML from your application is returned.

--- a/community/samples/serving/helloworld-haskell/README.md
+++ b/community/samples/serving/helloworld-haskell/README.md
@@ -11,7 +11,7 @@ specified, it will use "World" as the TARGET.
 
 ## Prerequisites
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../install/README.md) if you need to create
   one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -163,40 +163,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, enter these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take some time
-   for the service to get assigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
-   For minikube or bare-metal, get IP_ADDRESS by running the following command
-
-   ```shell
-   echo $(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
-
-   ```
-
 1. To find the URL for your service, enter:
 
    ```
    kubectl get ksvc helloworld-haskell  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                   URL
-   helloworld-haskell     http://helloworld-haskell.default.example.com
+   helloworld-haskell     http://helloworld-haskell.default.1.2.3.4.xip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-haskell.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-haskell.default.1.2.3.4.xip.io
    Hello world: Haskell Sample v1
    ```
 

--- a/community/samples/serving/helloworld-java-micronaut/README.md
+++ b/community/samples/serving/helloworld-java-micronaut/README.md
@@ -19,8 +19,7 @@ deploying your app to your Knative cluster.
 
 You must meet the following requirements to complete this sample:
 
-- A version of the Knative Serving component installed and running on your
-  Kubernetes cluster. Follow the
+- A version of the Knative Serving component installed and DNS configured. Follow the
   [Knative installation instructions](../../../../install/README.md) if you need
   to create a Knative cluster.
 - The following software downloaded and install on your loacal machine:
@@ -251,44 +250,25 @@ your sample app to your cluster:
 
 To verify that your sample app has been successfully deployed:
 
-1. View your the ingress IP address of your service by running the following
-   `kubectl get` command. Note that it may take sometime for the new service to
-   get asssigned an external IP address, especially if your cluster was newly
-   created.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-   ```
-
-   Example result:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. Retrieve the URL for your service, by running the following `kubectl get`
    command:
 
    ```shell
-   kubectl get services.serving.knative.dev helloworld-java-micronaut  --output=custom-columns=NAME:.metadata.name,URL:.status.url
+   kubectl get ksvc helloworld-java-micronaut  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example result:
 
    ```shell
    NAME                          URL
-   helloworld-java-micronaut     http://helloworld-java-micronaut.default.example.com
+   helloworld-java-micronaut     http://helloworld-java-micronaut.default.1.2.3.4.xip.io
    ```
 
-1. Run the following `curl` command to test your deployed sample app. You must
-   replace the `{IP_ADDRESS}` variable the URL that your retrieve in the
-   previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-java-micronaut.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-java-micronaut.default.1.2.3.4.xip.io
    ```
 
    Example result:

--- a/community/samples/serving/helloworld-java-quarkus/README.md
+++ b/community/samples/serving/helloworld-java-quarkus/README.md
@@ -249,40 +249,20 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use. If your cluster is new, it may
-   take sometime for the service to get assigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   # Now you can assign the external IP address to the env variable.
-   export IP_ADDRESS=<EXTERNAL-IP column from the command above>
-
-   # Or just execute:
-   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY \
-     --namespace istio-system \
-     --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
-   ```
-
 1. To find the URL for your service, use
 
    ```shell
    kubectl get ksvc helloworld-java-quarkus
 
    NAME                     URL
-   helloworld-java-quarkus  http://helloworld-java-quarkus.default.example.com
+   helloworld-java-quarkus  http://helloworld-java-quarkus.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Presuming, the IP
-   address you got in the step above is in the `${IP_ADDRESS}` env variable:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-java-quarkus.default.example.com" http://${IP_ADDRESS}
+   curl http://helloworld-java-quarkus.default.1.2.3.4.xip.io
 
    Namaste Knative World!
    ```

--- a/community/samples/serving/helloworld-r/README.md
+++ b/community/samples/serving/helloworld-r/README.md
@@ -159,23 +159,6 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. Run the following command to find the external IP address for your service.
-   The ingress IP for your cluster is returned. If you just created your
-   cluster, you might need to wait and rerun the command until your service gets
-   asssigned an external IP address.
-
-   ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
-   ```
-
-   Example:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. Run the following command to find the domain URL for your service:
 
    ```shell
@@ -186,21 +169,20 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-r    http://helloworld-r.default.example.com
+   helloworld-r        http://helloworld-r.default.1.2.3.4.xip.io
    ```
 
-1. Test your app by sending it a request. Use the following `curl` command with
-   the domain URL `helloworld-r.default.example.com` and `EXTERNAL-IP`
-   address that you retrieved in the previous steps:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-r.default.example.com" http://{EXTERNAL_IP_ADDRESS}
+   curl http://helloworld-r.default.1.2.3.4.xip.io
    ```
 
    Example:
 
    ```shell
-   curl -H "Host: helloworld-r.default.example.com" http://35.203.155.229
+   curl http://helloworld-r.default.1.2.3.4.xip.io
    [1] "Hello R Sample v1!"
    ```
 

--- a/community/samples/serving/helloworld-rserver/README.md
+++ b/community/samples/serving/helloworld-rserver/README.md
@@ -130,23 +130,6 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. Run the following command to find the external IP address for your service.
-   The ingress IP for your cluster is returned. If you just created your
-   cluster, you might need to wait and rerun the command until your service gets
-   asssigned an external IP address.
-
-   ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
-   ```
-
-   Example:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. Run the following command to find the domain URL for your service:
 
    ```shell
@@ -157,21 +140,20 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-r    http://helloworld-r.default.example.com
+   helloworld-r    http://helloworld-r.default.1.2.3.4.xip.io
    ```
 
-1. Test your app by sending it a request. Use the following `curl` command with
-   the domain URL `helloworld-rserver.default.example.com` and `EXTERNAL-IP`
-   address that you retrieved in the previous steps:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-rserver.default.example.com" http://{EXTERNAL_IP_ADDRESS}
+   curl http://helloworld-rserver.default.1.2.3.4.xip.io
    ```
 
    Example:
 
    ```shell
-   curl -H "Host: helloworld-rserver.default.example.com" http://35.203.155.229
+   curl http://helloworld-rserver.default.1.2.3.4.xip.io
    [1] "Hello R Sample v1!"
    ```
 

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -12,7 +12,7 @@ TARGET is not specified, it will use "World" as the TARGET.
 
 ## Prerequisites
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../install/README.md) if you need to create
   one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -161,33 +161,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, enter these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. To find the URL for your service, enter:
 
    ```
    kubectl get ksvc helloworld-rust  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-rust     http://helloworld-rust.default.example.com
+   helloworld-rust     http://helloworld-rust.default.1.2.3.4.xip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-rust.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-rust.default.1.2.3.4.xip.io
    Hello World!
    ```
 

--- a/community/samples/serving/helloworld-swift/README.md
+++ b/community/samples/serving/helloworld-swift/README.md
@@ -11,8 +11,8 @@ specified, the app uses "World" as the TARGET.
 
 ## Prerequisites
 
-- You must have a Kubernetes cluster with Knative installed. If you need to
-  create a cluster, follow the
+- You must have a Kubernetes cluster with Knative installed and DNS configured.
+  If you need to create a cluster, follow the
   [installation instructions](../../../install/README.md).
 - You must have [Docker](https://www.docker.com) installed and running on your
   local machine, and a Docker Hub account configured (used for container
@@ -144,32 +144,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scales your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get svc knative-ingressgateway --namespace istio-system` to get the
-   ingress IP for your cluster. If your cluster is new, it might take sometime
-   for the service to get asssigned an external IP address.
-
-   ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. To find the URL for your service, use the following command:
 
    ```
    kubectl get ksvc helloworld-swift  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME               URL
-   helloworld-swift   http://helloworld-swift.default.example.com
+   helloworld-swift   http://helloworld-swift.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-swift.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-swift.default.1.2.3.4.xip.io
    Hello Swift
    ```
 

--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -218,44 +218,25 @@ your sample app to your cluster:
 
 To verify that your sample app has been successfully deployed:
 
-1. View your the ingress IP address of your service by running the following
-   `kubectl get` command. Note that it may take sometime for the new service to
-   get asssigned an external IP address, especially if your cluster was newly
-   created.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-   ```
-
-   Example result:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. Retrieve the URL for your service, by running the following `kubectl get`
    command:
 
    ```shell
-   kubectl get services.serving.knative.dev helloworld-vertx  --output=custom-columns=NAME:.metadata.name,URL:.status.url
+   kubectl get ksvc helloworld-vertx  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example result:
 
    ```shell
    NAME                URL
-   helloworld-vertx    http://helloworld-vertx.default.example.com
+   helloworld-vertx    http://helloworld-vertx.default.1.2.3.4.xip.io
    ```
 
-1. Run the following `curl` command to test your deployed sample app. You must
-   replace the `{IP_ADDRESS}` variable the URL that your retrieve in the
-   previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-vertx.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-vertx.default.1.2.3.4.xip.io
    ```
 
    Example result:

--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -62,13 +62,14 @@ Use following command to create the service from `service.yaml`:
 ```shell
 kubectl apply --filename service.yaml
 ```
+
 The status of the created service can be seen using:
 
 ```shell
 kubectl get ksvc
 
-NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
-event-display   http://event-display.default.example.com   event-display-gqjbw   event-display-gqjbw   True    
+NAME            URL                                           LATESTCREATED         LATESTREADY           READY   REASON
+event-display   http://event-display.default.1.2.3.4.xip.io   event-display-gqjbw   event-display-gqjbw   True    
 ```
 
 ### Create a ContainerSource using the heartbeats image

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -87,72 +87,33 @@ Now that your service is created, Knative will perform the following steps:
 
 ### Interacting with your app
 
-To see if your app has been deployed successfully, you need the host URL and IP
-address created by Knative.
+To see if your app has been deployed successfully, you need the URL created by Knative.
 
-Note: If your cluster is new, it can take some time before the service is
-assigned an external IP address.
-
-1. To find the IP address for your service, enter:
+1. To find the URL for your service, enter:
 
    ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-   ```
-
-The command will return something similar to this:
-
-```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   istio-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-```
-
-Take note of the `EXTERNAL-IP` address.
-
-You can also export the IP address as a variable with the following command:
-
-```shell
-   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY --namespace istio-system --output 'jsonpath={.status.loadBalancer.ingress[0].ip}')
-```
-
-> Note: If you use minikube or a baremetal cluster that has no external load
-> balancer, the `EXTERNAL-IP` field is shown as `<pending>`. You need to use
-> `NodeIP` and `NodePort` to interact your app instead. To get your app's
-> `NodeIP` and `NodePort`, enter the following command:
-
-```shell
-   export IP_ADDRESS=$(kubectl get node  --output 'jsonpath={.items[0].status.addresses[0].address}'):$(kubectl get svc $INGRESSGATEWAY --namespace istio-system   --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
-```
-
-1. To find the host URL for your service, enter:
-
-   ```shell
-   kubectl get route helloworld-go  --output=custom-columns=NAME:.metadata.name,URL:.status.url
+   kubectl get ksvc helloworld-go
    ```
 
    The command will return the following:
 
    ```shell
-   NAME                URL
-   helloworld-go       http://helloworld-go.default.example.com
+   NAME            URL                                                LATESTCREATED         LATESTREADY           READY   REASON
+   helloworld-go   http://helloworld-go.default.34.83.80.117.xip.io   helloworld-go-96dtk   helloworld-go-96dtk   True
    ```
 
-   > Note: By default, Knative uses the `example.com` domain. To configure a
-   > custom DNS domain, see
-   > [Using a Custom Domain](../serving/using-a-custom-domain.md).
+   > Note: If your URL includes `example.com` then consult the setup instructions for
+   > configuring DNS (e.g. with `xip.io`), or [using a Custom Domain](../serving/using-a-custom-domain.md).
 
    If you changed the name from `helloworld-go` to something else when creating
    the `.yaml` file, replace `helloworld-go` in the above commands with the name
    you entered.
 
 1. Now you can make a request to your app and see the results. Replace
-   `IP_ADDRESS` with the `EXTERNAL-IP` you wrote down, and replace
-   `helloworld-go.default.example.com` with the domain returned in the previous
-   step.
+   the URL with the one returned by the command in the previous step.
 
    ```shell
-   curl -H "Host: helloworld-go.default.example.com" http://${IP_ADDRESS}
+   # curl http://helloworld-go.default.34.83.80.117.xip.io
    Hello World: Go Sample v1!
    ```
 

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -29,45 +29,20 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    kubectl apply --filename docs/serving/samples/autoscale-go/service.yaml
    ```
 
-1. Obtain both the hostname and IP address of the `istio-ingressgateway` service
-   in the `istio-system` namespace, and then `export` them into the `IP_ADDRESS`
-   environment variable.
+1. Obtain the URL of the service (once `Ready`):
 
-   Note that each platform where you run your Kubernetes cluster is configured
-   differently. Details about the various ways that you can obatin your ingress
-   hostname and IP address is available in the Istio documentation under the
-   [Control Ingress Traffic](https://istio.io/docs/tasks/traffic-management/ingress/)
-   topic.
-
-   **Examples**:
-
-   - For GKE, you run the following commands:
-
-     ```shell
-     INGRESSGATEWAY=istio-ingressgateway
-
-     export IP_ADDRESS=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
-     ```
-
-   - For Minikube, you run the following command:
-
-     ```shell
-     export IP_ADDRESS=$(minikube ip)
-     ```
-
-   - For Docker Desktop, you run the following command:
-
-     ```shell
-     # The value can be 127.0.0.1 as well
-     export IP_ADDRESS=localhost
-     ```
+   ```
+   $ kubectl get ksvc autoscale-go
+   NAME            URL                                                LATESTCREATED         LATESTREADY           READY   REASON
+   autoscale-go    http://autoscale-go.default.1.2.3.4.xip.io    autoscale-go-96dtk    autoscale-go-96dtk    True
+   ```
 
 ## Load the Service
 
 1. Make a request to the autoscale app to see it consume some resources.
 
    ```shell
-   curl --header "Host: autoscale-go.default.example.com" "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5"
+   curl "http://autoscale-go.default.1.2.3.4.xip.io?sleep=100&prime=10000&bloat=5"
    ```
 
    ```
@@ -80,8 +55,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
    ```shell
    hey -z 30s -c 50 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5" \
+     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=100&prime=10000&bloat=5" \
      && kubectl get pods
    ```
 
@@ -258,24 +232,21 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 
    ```shell
    hey -z 60s -c 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=100&prime=10000&bloat=5"
+     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=100&prime=10000&bloat=5"
    ```
 
 1. Send 60 seconds of traffic maintaining 100 qps with short requests (10 ms).
 
    ```shell
    hey -z 60s -q 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=10"
+     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=10"
    ```
 
 1. Send 60 seconds of traffic maintaining 100 qps with long requests (1 sec).
 
    ```shell
    hey -z 60s -q 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?sleep=1000"
+     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=1000"
    ```
 
 1. Send 60 seconds of traffic with heavy CPU usage (~1 cpu/sec/request, total
@@ -283,8 +254,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 
    ```shell
    hey -z 60s -q 100 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?prime=40000000"
+     "http://autoscale-go.default.1.2.3.4.xip.io?prime=40000000"
    ```
 
 1. Send 60 seconds of traffic with heavy memory usage (1 gb/request, total 5
@@ -292,8 +262,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 
    ```shell
    hey -z 60s -c 5 \
-     -host "autoscale-go.default.example.com" \
-     "http://${IP_ADDRESS?}?bloat=1000"
+     "http://autoscale-go.default.1.2.3.4.xip.io?bloat=1000"
    ```
 
 ## Cleanup

--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -94,24 +94,11 @@ kubectl apply --filename blue-green-demo-route.yaml
 route "blue-green-demo" configured
 ```
 
-You'll now be able to view the sample app at
-http://blue-green-demo.default.YOUR_CUSTOM_DOMAIN.com (replace
-`YOUR_CUSTOM_DOMAIN`) with the [custom domain](../using-a-custom-domain.md) you
-configured for use with Knative.
+You'll now be able to view the sample app at the URL shown by:
 
-> Note: If you don't have a custom domain configured for use with Knative, you
-> can interact with your app using cURL requests if you have the host URL and IP
-> address:
-> `curl -H "Host: blue-green-demo.default.example.com" http://IP_ADDRESS`
-> Knative creates the host URL by combining the name of your Route object, the
-> namespace, and `example.com`, if you haven't configured a custom domain. For
-> example, `[route-name].[namespace].example.com`. You can get the IP address by
-> entering `kubectl get svc istio-ingressgateway --namespace istio-system` (or
-> `kubectl get svc istio-ingressgateway --namespace istio-system` if using
-> Knative 0.2.x or prior versions) and copying the `EXTERNAL-IP` returned by
-> that command. See
-> [Interacting with your app](../getting-started-knative-app.md#interacting-with-your-app)
-> for more information.
+```
+kubectl get route blue-green-demo
+```
 
 ## Deploying Revision 2 (Green)
 

--- a/docs/serving/samples/grpc-ping-go/README.md
+++ b/docs/serving/samples/grpc-ping-go/README.md
@@ -99,29 +99,19 @@ kubectl get revisions --output yaml
 Testing the gRPC service requires using a gRPC client built from the same
 protobuf definition used by the server.
 
-1. Fetch the created ingress hostname and IP.
+The Dockerfile builds the client binary. To run the client you will use the
+same container image deployed for the server with an override to the
+entrypoint command to use the client binary instead of the server binary.
 
-   ```shell
-   # Put the ingress IP into an environment variable.
-   export SERVICE_IP=$(kubectl get svc istio-ingressgateway --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
-   ```
+Replace `{username}` with your Docker Hub user name and run the command:
 
-1. Use the gRPC client to send message streams to the gRPC server.
+```shell
+docker run --rm {username}/grpc-ping-go \
+  /client \
+  -server_addr="grpc-ping.default.1.2.3.4.xip.io:80" \
+  -insecure
+```
 
-   The Dockerfile builds the client binary. To run the client you will use the
-   same container image deployed for the server with an override to the
-   entrypoint command to use the client binary instead of the server binary.
-
-   Replace `{username}` with your Docker Hub user name and run the command:
-
-   ```shell
-   docker run --rm {username}/grpc-ping-go \
-     /client \
-     -server_addr="${SERVICE_IP}:80" \
-     -server_host_override="grpc-ping.default.example.com" \
-     -insecure
-   ```
-
-   The arguments after the container tag `{username}/grpc-ping-go` are used
-   instead of the entrypoint command defined in the Dockerfile `CMD` statement.
+The arguments after the container tag `{username}/grpc-ping-go` are used
+instead of the entrypoint command defined in the Dockerfile `CMD` statement.
   

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-csharp
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -165,32 +165,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-csharp  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-csharp   http://helloworld-csharp.default.example.com
+   helloworld-csharp   http://helloworld-csharp.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-csharp.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-csharp.default.1.2.3.4.xip.io
    Hello C# Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -161,24 +161,6 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. Run the following command to find the external IP address for your service.
-   The ingress IP for your cluster is returned. If you just created your
-   cluster, you might need to wait and rerun the command until your service gets
-   asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-   ```
-
-   Example:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. Run the following command to find the domain URL for your service:
 
    ```shell
@@ -189,21 +171,14 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
     NAME                URL
-    helloworld-go       http://helloworld-go.default.example.com
+    helloworld-go       http://helloworld-go.default.1.2.3.4.xip.io
    ```
 
-1. Test your app by sending it a request. Use the following `curl` command with
-   the domain URL `helloworld-go.default.example.com` and `EXTERNAL-IP` address
-   that you retrieved in the previous steps:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-go.default.example.com" http://{EXTERNAL_IP_ADDRESS}
-   ```
-
-   Example:
-
-   ```shell
-   curl -H "Host: helloworld-go.default.example.com" http://35.203.155.229
+   curl http://helloworld-go.default.1.2.3.4.xip.io
    Hello Go Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-java-spark/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/README.md
@@ -10,7 +10,7 @@ testing.
 
 ## Prerequisites
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](https://github.com/knative/docs/blob/master/install/README.md)
   if you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -109,7 +109,7 @@ folder) you're ready to build and deploy the sample app.
    docker push {username}/helloworld-java
    ```
 
-2. After the build has completed and the container is pushed to docker hub, you
+1. After the build has completed and the container is pushed to docker hub, you
    can deploy the app into your cluster. Ensure that the container image value
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
@@ -118,48 +118,29 @@ folder) you're ready to build and deploy the sample app.
    kubectl apply --filename service.yaml
    ```
 
-3. Now that your service is created, Knative will perform the following steps:
+1. Now that your service is created, Knative will perform the following steps:
 
    - Create a new immutable revision for this version of the app.
    - Network programming to create a route, ingress, service, and load balancer
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-4. To find the IP address for your service, use. If your cluster is new, it may
-   take sometime for the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   # Now you can assign the external IP address to the env variable.
-   export IP_ADDRESS=<EXTERNAL-IP column from the command above>
-
-   # Or just execute:
-   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY \
-     --namespace istio-system \
-     --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
-   ```
-
-5. To find the URL for your service, use
+1. To find the URL for your service, use
 
    ```shell
    kubectl get ksvc helloworld-java \
        --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
    NAME                URL
-   helloworld-java     http://helloworld-java.default.example.com
+   helloworld-java     http://helloworld-java.default.1.2.3.4.xip.io
    ```
 
-6. Now you can make a request to your app to see the result. Presuming, the IP
-   address you got in the step above is in the `${IP_ADDRESS}` env variable:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-java.default.example.com" http://${IP_ADDRESS}
+   curl http://helloworld-java.default.1.2.3.4.xip.io
+   Hello World!
    ```
 
 ## Removing the sample app deployment

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -20,7 +20,7 @@ knative-docs/docs/serving/samples/hello-world/helloworld-java-spring
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -175,31 +175,6 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address of your service, use:
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   # Now you can assign the external IP address to the env variable.
-   export IP_ADDRESS=<EXTERNAL-IP column from the command above>
-
-   # Or just execute:
-
-   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY \
-     --namespace istio-system \
-     --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
-   ```
-
-   **Note** If your cluster is new, it may take some time for the service to get
-   assigned an external IP address. Instead of rerunning the command, you can
-   add `--watch` to the command below to view the component's status updates in
-   real time. Use CTRL+C to exit watch mode.
-
 1. To find the URL of your service, use:
 
    ```shell
@@ -207,20 +182,16 @@ folder) you're ready to build and deploy the sample app.
       --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
    NAME                       URL
-   helloworld-java-spring     http://helloworld-java-spring.default.example.com
+   helloworld-java-spring     http://helloworld-java-spring.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Presuming, the IP
-   address you got in the step above is in the `${IP_ADDRESS}` env variable:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-java-spring.default.example.com" http://${IP_ADDRESS}
-
+   curl http://helloworld-java-spring.default.1.2.3.4.xip.io
    Hello Spring Boot Sample v1!
    ```
-
-**Note** Replace `{IP_ADDRESS}` with the address you saw returned in the
-previous step. i.e. `EXTERNAL-IP`
 
 ## Removing the sample app deployment
 

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-kotlin
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -196,43 +196,20 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use
-   `kubectl get service knative-ingressgateway --namespace istio-system` to get
-   the ingress IP for your cluster. If your cluster is new, it may take sometime
-   for the service to get assigned an external IP address.
-
-   ```shell
-   kubectl get service knative-ingressgateway --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   # Now you can assign the external IP address to the env variable.
-   export IP_ADDRESS=<EXTERNAL-IP column from the command above>
-
-   # Or just execute:
-   export IP_ADDRESS=$(kubectl get svc $INGRESSGATEWAY \
-     --namespace istio-system \
-     --output jsonpath="{.status.loadBalancer.ingress[*].ip}")
-   ```
-
 1. To find the URL for your service, use
 
    ```shell
    kubectl get ksvc helloworld-kotlin  --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
    NAME                URL
-   helloworld-kotlin   http://helloworld-kotlin.default.example.com
+   helloworld-kotlin   http://helloworld-kotlin.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Presuming, the IP
-   address you got in the step above is in the `${IP_ADDRESS}` env variable:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-kotlin.default.example.com" http://${IP_ADDRESS}
-   ```
-
-   ```terminal
+   curl http://helloworld-kotlin.default.1.2.3.4.xip.io
    Hello Kotlin Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-nodejs
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -180,32 +180,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-nodejs  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-nodejs   http://helloworld-nodejs.default.example.com
+   helloworld-nodejs   http://helloworld-nodejs.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-nodejs.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-nodejs.default.1.2.3.4.xip.io
    Hello Node.js Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-php
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -126,33 +126,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-php  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-php      http://helloworld-php.default.example.com
+   helloworld-php      http://helloworld-php.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-php.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-php.default.1.2.3.4.xip.io
    Hello PHP Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -142,32 +142,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-python  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-python   http://helloworld-python.default.example.com
+   helloworld-python   http://helloworld-python.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-python.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-python.default.1.2.3.4.xip.io
    Hello Python Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-ruby/README.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -139,32 +139,19 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. To find the IP address for your service, use these commands to get the
-   ingress IP for your cluster. If your cluster is new, it may take sometime for
-   the service to get asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. To find the URL for your service, use
 
    ```
    kubectl get ksvc helloworld-ruby  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-ruby     http://helloworld-ruby.default.example.com
+   helloworld-ruby     http://helloworld-ruby.default.1.2.3.4.xip.io
    ```
 
-1. Now you can make a request to your app to see the result. Replace
-   `{IP_ADDRESS}` with the address you see returned in the previous step.
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-ruby.default.example.com" http://{IP_ADDRESS}
+   curl http://helloworld-ruby.default.1.2.3.4.xip.io
    Hello Ruby Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-scala/README.md
+++ b/docs/serving/samples/hello-world/helloworld-scala/README.md
@@ -106,33 +106,6 @@ local Docker Repository.
 
 ## Deploying to Knative Serving
 
-Locate the Knative Serving gateway address:
-
-```shell
-# In Knative 0.2.x and prior versions, `knative-ingressgateway` service was used instead of `istio-ingressgateway`.
-
-kubectl get svc istio-ingressgateway --namespace istio-system
-```
-
-Example output, see the address under **EXTERNAL-IP**:
-
-```shell
-NAME                     TYPE           CLUSTER-IP       EXTERNAL-IP       PORTS)                                      AGE
-xxxxxxx-ingressgateway   LoadBalancer   123.456.789.01   111.111.111.111   80:32380/TCP,443:32390/TCP,32400:32400/TCP   1m
-```
-
-Then export the external address obtained for ease of reuse later:
-
-```shell
-export SERVING_GATEWAY=<replace this with the address obtained>
-```
-
-If you use Minikube, then you will likely have to do the following instead:
-
-```shell
-export SERVING_GATEWAY=$(minikube ip):$(kubectl get svc istio-ingressgateway --namespace istio-system --output 'jsonpath={.spec.ports[?(@.port==80)].nodePort}')
-```
-
 Apply the [Service yaml definition](./helloworld-scala.yaml):
 
 ```shell
@@ -145,15 +118,15 @@ Then find the service host:
 kubectl get ksvc helloworld-scala \
     --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
-# It will print something like this, the URL is what you're going to use as HTTP Host header:
+# It will print something like this, the URL is what you're looking for.
 # NAME                URL
-# helloworld-scala    http://helloworld-scala.default.example.com
+# helloworld-scala    http://helloworld-scala.default.1.2.3.4.xip.io
 ```
 
-Finally, to try your service, use the obtained address in the Host header:
+Finally, to try your service, use the obtained URL:
 
 ```shell
-curl -v -H "Host: helloworld-scala.default.example.com" http://$SERVING_GATEWAY
+curl -v http://helloworld-scala.default.1.2.3.4.xip.io
 ```
 
 ## Cleanup

--- a/docs/serving/samples/hello-world/helloworld-shell/README.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/README.md
@@ -20,7 +20,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-shell
 
 ## Before you begin
 
-- A Kubernetes cluster with Knative installed. Follow the
+- A Kubernetes cluster with Knative installed and DNS configured. Follow the
   [installation instructions](../../../../install/README.md) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
@@ -155,23 +155,6 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. Run the following command to find the external IP address for your service.
-   The ingress IP for your cluster is returned. If you just created your
-   cluster, you might need to wait and rerun the command until your service gets
-   asssigned an external IP address.
-
-   ```shell
-   kubectl get svc knative-ingressgateway --namespace istio-system
-   ```
-
-   Example:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   knative-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-
-   ```
-
 1. Run the following command to find the domain URL for your service:
 
    ```shell
@@ -182,21 +165,20 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-shell    http://helloworld-shell.default.example.com
+   helloworld-shell    http://helloworld-shell.default.1.2.3.4.xip.io
    ```
 
-1. Test your app by sending it a request. Use the following `curl` command with
-   the domain URL `helloworld-shell.default.example.com` and `EXTERNAL-IP`
-   address that you retrieved in the previous steps:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: helloworld-shell.default.example.com" http://{EXTERNAL_IP_ADDRESS}
+   curl http://helloworld-shell.default.1.2.3.4.xip.io
    ```
 
    Example:
 
    ```shell
-   curl -H "Host: helloworld-shell.default.example.com" http://35.203.155.229
+   curl http://helloworld-shell.default.1.2.3.4.xip.io
    Hello Shell Sample v1!
    ```
 

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -234,24 +234,6 @@ folder) you're ready to build and deploy the sample app.
      for your app.
    - Automatically scale your pods up and down (including to zero active pods).
 
-1. Run the following command to find the external IP address for your service.
-   The ingress IP for your cluster is returned. If you just created your
-   cluster, you might need to wait and rerun the command until your service gets
-   asssigned an external IP address.
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-   ```
-
-   Example:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
 1. Run the following command to find the domain URL for your service:
 
    ```shell
@@ -262,21 +244,14 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME             URL
-   secrets-go       http://secrets-go.default.example.com
+   secrets-go       http://secrets-go.default.1.2.3.4.xip.io
    ```
 
-1. Test your app by sending it a request. Use the following `curl` command with
-   the domain URL `secrets-go.default.example.com` and `EXTERNAL-IP` address
-   that you retrieved in the previous steps:
+1. Now you can make a request to your app and see the result. Replace
+   the URL below the with URL returned in the previous command.
 
    ```shell
-   curl -H "Host: secrets-go.default.example.com" http://{EXTERNAL_IP_ADDRESS}
-   ```
-
-   Example:
-
-   ```shell
-   curl -H "Host: secrets-go.default.example.com" http://35.203.155.229
+   curl http://secrets-go.default.1.2.3.4.xip.io
    bucket knative-secrets-sample, created at 2019-02-01 14:44:05.804 +0000 UTC, is located in US with storage class MULTI_REGIONAL
    ```
 

--- a/docs/serving/samples/telemetry-go/README.md
+++ b/docs/serving/samples/telemetry-go/README.md
@@ -15,7 +15,7 @@ dedicated Prometheus instance rather than using the default installation.
 ## Prerequisites
 
 1. A Kubernetes cluster with [Knative Serving](../../../install/README.md)
-   installed.
+   installed and DNS configured.
 2. Check if Knative monitoring components are installed:
 
 ```
@@ -118,31 +118,13 @@ kubectl get revisions --output yaml
 
 To access this service via `curl`, you need to determine its ingress address.
 
-1. To determine if your service is ready: Check the status of your Knative
-   gateway:
+1. To determine if your service is ready:
 
 ```
-INGRESSGATEWAY=istio-ingressgateway
-
-kubectl get svc $INGRESSGATEWAY --namespace istio-system --watch
+kubectl get ksvc --output yaml
 ```
 
-When the service is ready, you'll see an IP address in the `EXTERNAL-IP` field:
-
-```
-NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-```
-
-CTRL+C to end watch.
-
-Check the status of your route:
-
-```
-kubectl get route --output yaml
-```
-
-When the route is ready, you'll see the following fields reported as:
+When the service is ready, you'll see the following fields reported as:
 
 ```YAML
 status:
@@ -150,28 +132,20 @@ status:
     ...
     status: "True"
     type: Ready
-  url: http://telemetrysample-route.default.example.com
+  url: http://telemetrysample-route.default.1.2.3.4.xip.io
 ```
 
-2. Export the ingress IP as an environment variable:
+1. Make a request to the service to see the `Hello World!` message:
 
 ```
-INGRESSGATEWAY=istio-ingressgateway
-
-export SERVICE_IP=`kubectl get svc $INGRESSGATEWAY --namespace istio-system --output jsonpath="{.status.loadBalancer.ingress[*].ip}"`
+curl http://telemetrysample-route.default.1.2.3.4.xip.io
 ```
 
-3. Make a request to the service to see the `Hello World!` message:
-
-```
-curl --header "Host:telemetrysample-route.default.example.com" http://${SERVICE_IP}
-```
-
-4. Make a request to the `/log` endpoint to generate logs to the `stdout` file
+1. Make a request to the `/log` endpoint to generate logs to the `stdout` file
    and generate files under `/var/log` in both `JSON` and plain text formats:
 
 ```
-curl --header "Host:telemetrysample-route.default.example.com" http://${SERVICE_IP}/log
+curl http://telemetrysample-route.default.1.2.3.4.xip.io/log
 ```
 
 ## Access Logs


### PR DESCRIPTION
This builds on these changes to allow us to drop the manual gateway resolution from our samples:
https://github.com/knative/docs/pull/1839
https://github.com/knative/docs/pull/1840
https://github.com/knative/docs/pull/1841

The expectation is that samples are run in an environment with DNS suitably configured, even if
that is simply `xip.io` for development.