### PR TITLE
Knative doesn't depend on istio

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -31,8 +31,7 @@ Currently, three options exist which provide this functionality:
 
 [Installing with Ambassador](./Knative-with-Ambassador.md) gives us an
 alternative to installing a service mesh for routing to applications with the
-Knative Serving component. Note that Istio is required for the Knative Eventing
-component.
+Knative Serving component.
 
 ## Installing Knative with Gloo
 

--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -1,4 +1,4 @@
 
 <p>See the <a href="https://github.com/knative/eventing/tree/master/pkg/apis">Knative Eventing repo</a> for the API.</p>
 
-<p>There is currently an [API doc build tool issue](https://github.com/knative/docs/issues/1661) that we hope to resolve soon.</p>
+<p>There is currently an <a href="https://github.com/knative/docs/issues/1661">API doc build tool issue</a> that we hope to resolve soon.</p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1,4 +1,4 @@
 
 <p>See the <a href="https://github.com/knative/serving/tree/master/pkg/apis">Knative Serving repo</a> for the API.</p>
 
-<p>There is currently an [API doc build tool issue](https://github.com/knative/docs/issues/1661) that we hope to resolve soon.</p>
+<p>There is currently an <a href="https://github.com/knative/docs/issues/1661">API doc build tool issue</a> that we hope to resolve soon.</p>

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -14,7 +14,7 @@ using cURL requests.
 
 You need:
 
-- A Kubernetes cluster with [Knative installed](./README.md).
+- A Kubernetes cluster with [Knative installed](../install/README.md).
 - An image of the app that you'd like to deploy available on a container
   registry. The image of the sample app used in this guide is available on
   Google Container Registry.

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -114,7 +114,7 @@ The command will return something similar to this:
 ```shell
    NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
    istio-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-````
+```
 
 Take note of the `EXTERNAL-IP` address.
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
