### PR TITLE
Correct image path in sample of "kubernetes-event-source"

### DIFF
--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -150,8 +150,8 @@ spec:
     spec:
       containers:
         - # This corresponds to
-          # https://github.com/knative/eventing-contrib/blob/release-0.5/cmd/event_display/main.go
-          image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+          # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
+          image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
 ```
 
 1. If the deployed `ApiServerSource` is pointing at a `Broker` other than

--- a/docs/eventing/samples/kubernetes-event-source/trigger.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/trigger.yaml
@@ -24,5 +24,5 @@ spec:
     spec:
       containers:
       - # This corresponds to
-        # https://github.com/knative/eventing-contrib/blob/release-0.5/cmd/event_display/main.go
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+        # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
+        image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes
The original image path is not work, will make the `Revision` failed and raise `container missing` error.