### PR TITLE
Fix Ambassador install instructions to avoid panic

### DIFF
--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -57,8 +57,13 @@ You can install Ambassador with `kubectl`:
 
 ```
 kubectl apply \
-  --filename https://getambassador.io/yaml/ambassador/ambassador-knative.yaml \
+  --filename https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
   --filename https://getambassador.io/yaml/ambassador/ambassador-service.yaml
+```
+
+Next, enable Knative support in Ambasssador:
+```
+kubectl set env deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
 ```
 
 ## Configuring DNS

--- a/docs/install/Knative-with-Ambassador.md
+++ b/docs/install/Knative-with-Ambassador.md
@@ -55,16 +55,31 @@ service mesh.
 
 You can install Ambassador with `kubectl`:
 
-```
-kubectl apply \
-  --filename https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
-  --filename https://getambassador.io/yaml/ambassador/ambassador-service.yaml
-```
+1. Create a namespace to install Ambassador in:
 
-Next, enable Knative support in Ambasssador:
-```
-kubectl set env deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
-```
+   ```
+   kubectl create namespace ambassador
+   ```
+
+2. Install Ambassador:
+
+   ```
+   kubectl apply --namespace ambassador \
+     --filename https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
+     --filename https://getambassador.io/yaml/ambassador/ambassador-service.yaml
+   ```
+
+3. Give Ambassador the required permissions:
+
+   ```
+   kubectl patch clusterrolebinding ambassador -p '{"subjects":[{"kind": "ServiceAccount", "name": "ambassador", "namespace": "ambassador"}]}'
+   ```
+
+4. Enable Knative support in Ambasssador:
+
+   ```
+   kubectl set env --namespace ambassador  deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
+   ```
 
 ## Configuring DNS
 
@@ -76,7 +91,7 @@ before DNS may be set up.
 Get this external IP address with:
 
 ```
-$ kubectl get svc ambassador
+$ kubectl get service ambassador -n ambassador
 
 NAME         TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)        AGE
 ambassador   LoadBalancer   10.59.246.30   35.229.120.99   80:32073/TCP   13m


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes https://github.com/datawire/ambassador/issues/1871

## Proposed Changes

This commit installs Ambassador using ambassador-rbac.yaml instead
of ambassador-knative.yaml which will be deprecated soon.

ambassador-rbac.yaml contains the latest Ambassador install
manifests which have sufficient RBAC to update ingress resources
when required. ambassador-knative.yaml does not have these
permissions and hence Ambassador panics for anyone who follows
the instructions.