### PR TITLE
Add annotatios in autoscale example

### DIFF
--- a/docs/serving/configuring-the-autoscaler.md
+++ b/docs/serving/configuring-the-autoscaler.md
@@ -179,8 +179,9 @@ template.
 spec:
   template:
     metadata:
-      autoscaling.knative.dev/metric: concurrency
-      autoscaling.knative.dev/class: hpa.autoscaling.knative.dev
+      annotations:
+        autoscaling.knative.dev/metric: concurrency
+        autoscaling.knative.dev/class: hpa.autoscaling.knative.dev
 ```
 
 ## Additional resources


### PR DESCRIPTION
The original autoscale example misses annotations

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1900

## Proposed Changes

-
-
-
