### PR TITLE
Fix the Subscription's apiVersion in debugging.

### DIFF
--- a/docs/eventing/debugging/example.yaml
+++ b/docs/eventing/debugging/example.yaml
@@ -40,7 +40,7 @@ metadata:
 
 # The Subscription to the InMemoryChannel.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: sub


### PR DESCRIPTION
Fix the Subscription's apiVersion in eventing debugging example.yaml file.

According to the api register in `https://github.com/knative/eventing/tree/master/pkg/apis/messaging`. 
The Subscription Kind should be in `messaging.knative.dev/v1alpha1`, while the original file is `eventing.knative.dev/v1alpha1`.
If apply the original file, the error happened `error: unable to recognize "example.yaml": no matches for kind "Subscription" in version "eventing.knative.dev/v1alpha1"`

This update fix this bug.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1913 

## Proposed Changes

- Change the apiVersion of Subscription Kind into `messaging.knative.dev/v1alpha1` in example.yaml line 43 https://github.com/knative/docs/blob/release-0.9/docs/eventing/debugging/example.yaml#L43.

