### PR TITLE
correct the README.md of docs/serving/samples/telemetry-go

### DIFF
--- a/docs/serving/samples/telemetry-go/README.md
+++ b/docs/serving/samples/telemetry-go/README.md
@@ -118,34 +118,29 @@ kubectl get revisions --output yaml
 
 To access this service via `curl`, you need to determine its ingress address.
 
-1. To determine if your service is ready:
+1. To determine if your route is ready:
 
 ```
-kubectl get ksvc --output yaml
+kubectl get route
 ```
 
-When the service is ready, you'll see the following fields reported as:
+When the route is ready, you'll see the following fields reported as:
 
 ```YAML
-status:
-  conditions:
-    ...
-    status: "True"
-    type: Ready
-  url: http://telemetrysample-route.default.1.2.3.4.xip.io
+telemetrysample-route   http://telemetrysample-route.default.example.com   True
 ```
 
 1. Make a request to the service to see the `Hello World!` message:
 
 ```
-curl http://telemetrysample-route.default.1.2.3.4.xip.io
+curl http://telemetrysample-route.default.example.com
 ```
 
 1. Make a request to the `/log` endpoint to generate logs to the `stdout` file
    and generate files under `/var/log` in both `JSON` and plain text formats:
 
 ```
-curl http://telemetrysample-route.default.1.2.3.4.xip.io/log
+curl http://telemetrysample-route.default.example.com/log
 ```
 
 ## Access Logs


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->
## Proposed Changes
The README.md mentioned `ksvc`, there is no `ksvc` in this sample, should check `Route`
