### PR TITLE
Use cpu metric for CPU-based autoscaling sample

### DIFF
--- a/docs/serving/configuring-the-autoscaler.md
+++ b/docs/serving/configuring-the-autoscaler.md
@@ -180,9 +180,11 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/metric: concurrency
+        autoscaling.knative.dev/metric: cpu
+        autoscaling.knative.dev/target: 70
         autoscaling.knative.dev/class: hpa.autoscaling.knative.dev
 ```
+
 
 ## Additional resources
 


### PR DESCRIPTION
Using `autoscaling.knative.dev/metric: concurrency`
made no sense to me so I'm doing a quick PR.

An example of this can be found at https://medium.com/@mchmarny_google/https-medium-com-p-knative-autoscaling-love-story-e32a27b7855
but let's not try to send people to external links to find how to do this.
