### PR TITLE
remove build folder for good

### DIFF
--- a/docs/build/README.md
+++ b/docs/build/README.md
@@ -1,6 +1,0 @@
-
-The Knative Build component has been deprecated. For more information,
-see the [**knative/build repository**](https://github.com/knative/build/blob/master/README.md).
-
-Documentation for the final release of Knative Build is available in the
-[**v0.7 docs release**](../../v0.7-docs/build/).

--- a/docs/build/_index.md
+++ b/docs/build/_index.md
@@ -1,8 +1,0 @@
----
-title: "Deprecated: Knative Build Component"
-linkTitle: "(Deprecated) Build"
-weight: 200
-type: "docs"
----
-
-{{% readfile file="README.md" %}}


### PR DESCRIPTION
removing this unnecessary folder and redirect for the deprecated build content
(also see dependent https://github.com/knative/website/pull/99)
