### PR TITLE
Fixing PubSub source example

### DIFF
--- a/docs/eventing/samples/gcp-pubsub-source/event-display.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/event-display.yaml
@@ -1,0 +1,13 @@
+# This is a very simple Knative Service that writes the input request to its log.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: event-display
+spec:
+  template:
+    spec:
+      containers:
+        - # This corresponds to
+          # https://github.com/knative/eventing-contrib/blob/release-0.5/cmd/event_display/main.go
+          image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d

--- a/docs/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
@@ -1,17 +1,12 @@
-# Replace the following before applying this file:
-#   MY_GCP_PROJECT: Replace with the GCP Project's ID.
-
-apiVersion: sources.eventing.knative.dev/v1alpha1
-kind: GcpPubSubSource
+apiVersion: events.cloud.google.com/v1alpha1
+kind: PubSub
 metadata:
   name: testing-source
 spec:
-  gcpCredsSecret:  # A secret in the knative-sources namespace
-    name: google-cloud-key
-    key: key.json
-  googleCloudProject: MY_GCP_PROJECT  # Replace this
   topic: testing
   sink:
     apiVersion: eventing.knative.dev/v1alpha1
     kind: Broker
     name: default
+  # If running in GKE, we will ask the metadata server for the project.
+  #project: MY_GCP_PROJECT

--- a/docs/eventing/samples/gcp-pubsub-source/trigger.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/trigger.yaml
@@ -1,26 +1,10 @@
-# This is a very simple Knative Service that writes the input request to its log.
-
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: event-display
-spec:
-  template:
-    spec:
-      containers:
-      - # This corresponds to
-        # https://github.com/knative/eventing-contrib/blob/release-0.5/cmd/event_display/main.go           
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
-
----
-
-# The GcpPubSubSource's output goes to the default Broker. This Trigger subscribes to events in the
+# The PubSub source output goes to the default Broker. This Trigger subscribes to events in the
 # default Broker.
 
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Trigger
 metadata:
-  name: gcppubsub-source-sample
+  name: trigger-gcp-pubsub
 spec:
   subscriber:
     ref:

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -34,17 +34,17 @@ These are sources that are installed as `CRD`s.
 
 Name | Status | Support | Description
 --- | --- | --- | ---
-[AWS SQS](https://github.com/knative/eventing-contrib/blob/master/contrib/awssqs/pkg/apis/sources/v1alpha1/aws_sqs_types.go) | Proof of Concept | None | Brings [AWS Simple Queue Service](https://aws.amazon.com/sqs/) messages into Knative.
+[AWS SQS](https://github.com/knative/eventing-contrib/blob/master/awssqs/pkg/apis/sources/v1alpha1/aws_sqs_types.go) | Proof of Concept | None | Brings [AWS Simple Queue Service](https://aws.amazon.com/sqs/) messages into Knative.
 [Apache Camel](https://github.com/knative/eventing-contrib/blob/master/camel/source/pkg/apis/sources/v1alpha1/camelsource_types.go) | Proof of Concept | None | Allows to use [Apache Camel](https://github.com/apache/camel) components for pushing events into Knative.
 [Apache CouchDB](https://github.com/knative/eventing-contrib/tree/{{< branch >}}/couchdb) | Active Development | None | Brings [Apache CouchDB](https://couchdb.apache.org/) messages into Knative.
 [Apache Kafka](https://github.com/knative/eventing-contrib/blob/master/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go) | Proof of Concept | None | Brings [Apache Kafka](https://kafka.apache.org/) messages into Knative.
 [BitBucket](https://github.com/nachocano/bitbucket-source) | Proof of Concept | None | Registers for events of the specified types on the specified BitBucket organization/repository. Brings those events into Knative.
 [Cron Job](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go) | Proof of Concept | None | Uses an in-memory timer to produce events on the specified Cron schedule.
-[GCP PubSub](https://github.com/knative/eventing-contrib/blob/master/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go) | Proof of Concept | None | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.
-[GitHub](https://github.com/knative/eventing-contrib/blob/master/contrib/github/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
+[GCP PubSub](https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/pubsub_types.go) | Proof of Concept | None | Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.
+[GitHub](https://github.com/knative/eventing-contrib/blob/master/github/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
 [GitLab](https://gitlab.com/triggermesh/gitlabsource) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
-[Google Cloud Scheduler](https://github.com/vaikas-google/csr) | Active Development | None | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative.
-[Google Cloud Storage](https://github.com/vaikas-google/gcs) | Active Development | None | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.
+[Google Cloud Scheduler](https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/scheduler_types.go) | Active Development | None | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative.
+[Google Cloud Storage](https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/storage_types.go) | Active Development | None | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.
 [Kubernetes](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/apiserver_types.go) | Active Development | Knative | Brings Kubernetes API server events into Knative.
 
 

--- a/docs/eventing/sources/sources.yaml
+++ b/docs/eventing/sources/sources.yaml
@@ -34,7 +34,7 @@ sources:
     description: >
       Allows to use [Apache Camel](https://github.com/apache/camel) components for pushing events into Knative.
   - name: AWS SQS
-    url: https://github.com/knative/eventing-contrib/blob/master/contrib/awssqs/pkg/apis/sources/v1alpha1/aws_sqs_types.go
+    url: https://github.com/knative/eventing-contrib/blob/master/awssqs/pkg/apis/sources/v1alpha1/aws_sqs_types.go
     status: Proof of Concept
     support: None
     description: >
@@ -46,13 +46,13 @@ sources:
     description: >
       Uses an in-memory timer to produce events on the specified Cron schedule.
   - name: GCP PubSub
-    url: https://github.com/knative/eventing-contrib/blob/master/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go
+    url: https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/pubsub_types.go
     status: Proof of Concept
     support: None
     description: >
       Brings [GCP PubSub](https://cloud.google.com/pubsub/) messages into Knative.
   - name: GitHub
-    url: https://github.com/knative/eventing-contrib/blob/master/contrib/github/pkg/apis/sources/v1alpha1/githubsource_types.go
+    url: https://github.com/knative/eventing-contrib/blob/master/github/pkg/apis/sources/v1alpha1/githubsource_types.go
     status: Proof of Concept
     support: None
     description: >
@@ -79,14 +79,14 @@ sources:
     description: >
       Brings Kubernetes API server events into Knative.
   - name: Google Cloud Scheduler
-    url: https://github.com/vaikas-google/csr
+    url: https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/scheduler_types.go
     status: Active Development
     support: None
     description: >
       Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/)
       Jobs. When those jobs are triggered, receive the event inside Knative.
   - name: Google Cloud Storage
-    url: https://github.com/vaikas-google/gcs
+    url: https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/storage_types.go
     status: Active Development
     support: None
     description: >


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes https://github.com/knative/docs/issues/1814
Fixes https://github.com/knative/docs/issues/1905
Fixes https://github.com/knative/docs/issues/1843
Fixes https://github.com/knative/docs/issues/1262
Fixes https://github.com/knative/docs/issues/1885
Helps with https://github.com/knative/docs/issues/1750

## Proposed Changes

- Updating PubSub source example to use newer knative-gcp stuff. 
- We should later on revisit whether this documentation should lie here or somewhere else. For now, given that this is published in the knative.dev website, I've decided to put it here.
- Fix old links in others places. Regenerated files...
