### PR TITLE
Add field imagePullSecrets

### DIFF
--- a/docs/serving/spec/knative-api-specification-1.0.md
+++ b/docs/serving/spec/knative-api-specification-1.0.md
@@ -2740,7 +2740,7 @@ Max: 1
    </td>
    <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">core/v1.LocalObjectReference</a>.
    </td>
-   <td>REQUIRED
+   <td>REQUIRED, if imagePullSecrets is supported.
    </td>
   </tr>
 

--- a/docs/serving/spec/knative-api-specification-1.0.md
+++ b/docs/serving/spec/knative-api-specification-1.0.md
@@ -30,7 +30,7 @@ APPROVED</p>
 
    </td>
    <td><p style="text-align: right">
-2019-08-02</p>
+2019-11-04</p>
 
    </td>
   </tr>
@@ -38,7 +38,7 @@ APPROVED</p>
    <td><p style="text-align: right">
 <strong>Version</strong></p>
    </td>
-   <td> 1.0  </td>
+   <td> 1.0.1  </td>
   </tr>
 </table>
 
@@ -1188,6 +1188,18 @@ constitutes a request.
    <td>RECOMMENDED
    </td>
   </tr>
+    <tr>
+     <td><code>imagePullSecrets</code>
+     </td>
+     <td>[]<a href="#localobjectreference">LocalObjectReference</a>
+  <br>
+  (Optional)
+     </td>
+     <td>The list of secrets for pulling images from private repositories.
+     </td>
+     <td>RECOMMENDED
+     </td>
+    </tr>
 </table>
 
 ### Status:
@@ -2706,4 +2718,30 @@ Max: 1
    <td>REQUIRED
    </td>
   </tr>
+</table>
+
+## LocalObjectReference
+
+<table>
+  <tr>
+   <td><strong>FieldName</strong>
+   </td>
+   <td><strong>Field Type</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Schema Requirement</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><code>name</code>
+   </td>
+   <td>string
+   </td>
+   <td>As specified in Kubernetes <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.13/#localobjectreference-v1-core">core/v1.LocalObjectReference</a>.
+   </td>
+   <td>REQUIRED
+   </td>
+  </tr>
+
 </table>


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1960

## Proposed Changes
- Add field imagePullSecrets to serving docs
