### PR TITLE
Switch numbering to bullets

### DIFF
--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -117,7 +117,7 @@ you can create Triggers to subscribe to particular events.
 Here are a few example Triggers that subscribe to events using exact matching on
 `type` and/or `source`, based on the above registry output:
 
-1. Subscribes to GitHub _pushes_ from any source.
+- Subscribes to GitHub _pushes_ from any source.
 
    ```yaml
    apiVersion: eventing.knative.dev/v1alpha1
@@ -142,7 +142,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
    new sources are registered for GitHub pushes, this trigger will be able to
    consume them.
 
-1. Subscribes to GitHub _pull requests_ from _knative's eventing_ repository.
+- Subscribes to GitHub _pull requests_ from _knative's eventing_ repository.
 
    ```yaml
    apiVersion: eventing.knative.dev/v1alpha1
@@ -163,7 +163,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
          name: gh-knative-eventing-pull-service
    ```
 
-1. Subscribes to Kafka messages sent to the _knative-demo_ topic
+- Subscribes to Kafka messages sent to the _knative-demo_ topic
 
    ```yaml
    apiVersion: eventing.knative.dev/v1alpha1
@@ -184,7 +184,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
          name: kafka-knative-demo-service
    ```
 
-1. Subscribes to PubSub messages from GCP's _knative_ project sent to the
+- Subscribes to PubSub messages from GCP's _knative_ project sent to the
    _testing_ topic
 
    ```yaml


### PR DESCRIPTION
On the knative.dev site (https://knative.dev/docs/eventing/event-registry/) the numbering for subscribing to events all show up as item 1 - this is unlike the github readme generated by the same file.  This change switches it to bullets.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- change numbering to bullets in readme