### PR TITLE
fix links to repos in temp API refdocs files

### DIFF
--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -1,4 +1,4 @@
 
-<p>See the <a href="https://github.com/knative/eventing/tree/{{< branch >}}/pkg/apis">Knative Eventing repo</a> for the API.</p>
+<p>See the <a href="https://github.com/knative/eventing/tree/release-0.10/pkg/apis">Knative Eventing repo</a> for the API.</p>
 
 <p>There is currently an <a href="https://github.com/knative/docs/issues/1661">API doc build tool issue</a> that we hope to resolve soon.</p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1,4 +1,4 @@
 
-<p>See the <a href="https://github.com/knative/serving/tree/{{< branch >}}/pkg/apis">Knative Serving repo</a> for the API.</p>
+<p>See the <a href="https://github.com/knative/serving/tree/release-0.10/pkg/apis">Knative Serving repo</a> for the API.</p>
 
 <p>There is currently an <a href="https://github.com/knative/docs/issues/1661">API doc build tool issue</a> that we hope to resolve soon.</p>


### PR DESCRIPTION
fixes #1962

Added the dynamic variables in these temp files while the "API ref docs tool" is still not working but forgot that these reference files are "ignored" (to avoid build errors with the HTML thats normally here when the "API ref docs tool" is working.)