### PR TITLE
Fix syntax error in custom-certs example

### DIFF
--- a/docs/serving/tag-resolution.md
+++ b/docs/serving/tag-resolution.md
@@ -45,7 +45,8 @@ spec:
               value: /path/to/custom/certs
       volumes:
         - name: custom-certs
-          secret: custom-certs
+          secret:
+            secretName: custom-certs
 ```
 
 ## Corporate Proxy


### PR DESCRIPTION
The secret field should be a map, not a string