### PR TITLE
Issue 1977

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -82,6 +82,15 @@ be persisted using Apache Kafka or NATS Streaming.
 
 See the [List of Channel implementations](../eventing/channels/channels.yaml).
 
+### Higher Level eventing constructs
+
+There are cases where you may want to utilize a set of co-operating functions
+together and for those use cases, Knative Eventing provides two additional
+resources:
+
+1. **[Sequence](./sequence.md)** provides a way to define an in-order list of functions.
+1. **[Parallel](./parallel.md)** provides a way to define a list of branches for events.
+
 ### Future design goals
 
 The focus for the next Eventing release will be to enable easy implementation of

--- a/docs/eventing/samples/parallel/README.md
+++ b/docs/eventing/samples/parallel/README.md
@@ -6,8 +6,8 @@ various flows.
 All examples require:
 
 - A Kubernetes cluster with
-  - Knative Eventing v0.9+
-  - Knative Service v0.8+
+  - Knative Eventing v0.11+
+  - Knative Serving v0.8+
 
 All examples are using the
 [default channel template](../../channels/default-channels.md).

--- a/docs/eventing/samples/parallel/multiple-branches/README.md
+++ b/docs/eventing/samples/parallel/multiple-branches/README.md
@@ -78,12 +78,33 @@ spec:
 kubectl create -f ./filters.yaml -f ./transformers.yaml
 ```
 
+### Create the Service displaying the events created by Sequence
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: event-display
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+```
+
+Change `default` below to create the `Sequence` in the Namespace where you want
+your resources to be created.
+
+```shell
+kubectl -n default create -f ./event-display.yaml
+```
+
 ### Create the Parallel
 
 The `parallel.yaml` file contains the specifications for creating the Parallel.
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Parallel
 metadata:
   name: odd-even-parallel
@@ -113,9 +134,10 @@ spec:
           kind: Service
           name: odd-transformer
   reply:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display
 ```
 
 ```shell
@@ -136,9 +158,10 @@ spec:
   schedule: "*/1 * * * *"
   data: '{"message": "Even or odd?"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Parallel
-    name: odd-even-parallel
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Parallel
+      name: odd-even-parallel
 ```
 
 ```shell

--- a/docs/eventing/samples/parallel/multiple-branches/cron-source.yaml
+++ b/docs/eventing/samples/parallel/multiple-branches/cron-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/1 * * * *"
   data: '{"message": "Even or odd?"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Parallel
-    name: odd-even-parallel
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Parallel
+      name: odd-even-parallel

--- a/docs/eventing/samples/parallel/multiple-branches/parallel.yaml
+++ b/docs/eventing/samples/parallel/multiple-branches/parallel.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Parallel
 metadata:
   name: odd-even-parallel
@@ -28,6 +28,7 @@ spec:
         kind: Service
         name: odd-transformer
   reply:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display

--- a/docs/eventing/samples/parallel/mutual-exclusivity/README.md
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/README.md
@@ -2,7 +2,7 @@ In this example, we are going to see how we can create a Parallel with mutually
 exclusive branches.
 
 This example is the same as the
-[multiple barnaches example](../multiple-branches/README.md) except that we are now
+[multiple branches example](../multiple-branches/README.md) except that we are now
 going to rely on the Knative
 [switch](https://github.com/lionelvillard/knative-functions#switch) function
 to provide a soft mutual exclusivity guarantee.
@@ -69,12 +69,33 @@ spec:
 kubectl create -f ./switcher.yaml -f ./transformers.yaml
 ```
 
+### Create the Service displaying the events created by Sequence
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: event-display
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+```
+
+Change `default` below to create the `Sequence` in the Namespace where you want
+your resources to be created.
+
+```shell
+kubectl -n default create -f ./event-display.yaml
+```
+
 ### Create the Parallel object
 
 The `parallel.yaml` file contains the specifications for creating the Parallel object.
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Parallel
 metadata:
   name: me-odd-even-parallel
@@ -98,9 +119,10 @@ spec:
           kind: Service
           name: me-odd-transformer
   reply:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: me-event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: me-event-display
 ```
 
 ```shell
@@ -121,9 +143,10 @@ spec:
   schedule: "*/1 * * * *"
   data: '{"message": "Even or odd?"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Parallel
-    name: me-odd-even-parallel
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Parallel
+      name: me-odd-even-parallel
 ```
 
 ```shell

--- a/docs/eventing/samples/parallel/mutual-exclusivity/cron-source.yaml
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/cron-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/1 * * * *"
   data: '{"message": "Even or odd?"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Parallel
-    name: me-odd-even-parallel
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Parallel
+      name: me-odd-even-parallel

--- a/docs/eventing/samples/parallel/mutual-exclusivity/parallel.yaml
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/parallel.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Parallel
 metadata:
   name: me-odd-even-parallel
@@ -22,6 +22,7 @@ spec:
         kind: Service
         name: me-odd-transformer
   reply:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: me-event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: me-event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -37,7 +37,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "0"
@@ -51,7 +51,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "1"
@@ -64,7 +64,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "2"
@@ -83,7 +83,7 @@ If you are using a different type of Channel, you need to change the
 spec.channelTemplate to point to your desired Channel.
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: sequence
@@ -105,9 +105,10 @@ spec:
         kind: Service
         name: third
   reply:
-    kind: Service
-    apiVersion: serving.knative.dev/v1
-    name: event-display
+    ref:
+      kind: Service
+      apiVersion: serving.knative.dev/v1
+      name: event-display
 ```
 
 Change `default` below to create the `Sequence` in the Namespace where you want
@@ -152,9 +153,10 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Sequence
-    name: sequence
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Sequence
+      name: sequence
 ```
 
 ```shell

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -11,6 +11,9 @@ taking the output of that `Sequence` and displaying the resulting output.
 
 ![Logical Configuration](./sequence-reply-to-event-display.png)
 
+The functions used in these examples live in
+(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+
 ## Prerequisites
 
 For this example, we'll assume you have set up an `InMemoryChannel` as well as

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/cron-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/cron-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Sequence
-    name: sequence
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Sequence
+      name: sequence

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/sequence.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: sequence
@@ -20,6 +20,7 @@ spec:
       kind: Service
       name: third
   reply:
-    kind: Service
-    apiVersion: serving.knative.dev/v1
-    name: event-display
+    ref:
+      kind: Service
+      apiVersion: serving.knative.dev/v1
+      name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/steps.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "0"
@@ -20,7 +20,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "1"
@@ -33,7 +33,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "2"

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -12,6 +12,9 @@ finally displaying the resulting output.
 
 ![Logical Configuration](./sequence-reply-to-sequence.png)
 
+The functions used in these examples live in
+(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+
 ## Prerequisites
 
 For this example, we'll assume you have set up a an `InMemoryChannel` as well as

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -38,7 +38,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "0"
@@ -52,7 +52,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "1"
@@ -65,7 +65,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "2"
@@ -78,7 +78,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "3"
@@ -92,7 +92,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "4"
@@ -105,7 +105,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "5"
@@ -124,7 +124,7 @@ If you are using a different type of Channel, you need to change the
 spec.channelTemplate to point to your desired Channel.
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: first-sequence
@@ -146,9 +146,10 @@ spec:
         kind: Service
         name: third
   reply:
-    kind: Sequence
-    apiVersion: messaging.knative.dev/v1alpha1
-    name: second-sequence
+    ref:
+      kind: Sequence
+      apiVersion: flows.knative.dev/v1alpha1
+      name: second-sequence
 ```
 
 Change `default` below to create the `Sequence` in the Namespace where you want
@@ -165,7 +166,7 @@ If you are using a different type of Channel, you need to change the
 spec.channelTemplate to point to your desired Channel.
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: second-sequence
@@ -187,9 +188,10 @@ spec:
         kind: Service
         name: sixth
   reply:
-    kind: Service
-    apiVersion: serving.knative.dev/v1
-    name: event-display
+    ref:
+      kind: Service
+      apiVersion: serving.knative.dev/v1
+      name: event-display
 ```
 
 ### Create the Service displaying the events created by Sequence
@@ -227,9 +229,10 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Sequence
-    name: first-sequence
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Sequence
+      name: first-sequence
 ```
 
 ```shell

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/cron-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/cron-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Sequence
-    name: first-sequence
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Sequence
+      name: first-sequence

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence1.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence1.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: first-sequence
@@ -20,6 +20,7 @@ spec:
       kind: Service
       name: third
   reply:
-    kind: Sequence
-    apiVersion: messaging.knative.dev/v1alpha1
-    name: second-sequence
+    ref:
+      kind: Sequence
+      apiVersion: flows.knative.dev/v1alpha1
+      name: second-sequence

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence2.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence2.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: second-sequence
@@ -20,6 +20,7 @@ spec:
       kind: Service
       name: sixth
   reply:
-    kind: Service
-    apiVersion: serving.knative.dev/v1
-    name: event-display
+    ref:
+      kind: Service
+      apiVersion: serving.knative.dev/v1
+      name: event-display

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/steps.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "0"
@@ -20,7 +20,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "1"
@@ -33,7 +33,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "2"
@@ -47,7 +47,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "3"
@@ -60,7 +60,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "4"
@@ -73,7 +73,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "5"

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -36,7 +36,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "0"
@@ -50,7 +50,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "1"
@@ -63,7 +63,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "2"
@@ -82,7 +82,7 @@ If you are using a different type of Channel, you need to change the
 spec.channelTemplate to point to your desired Channel.
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: sequence
@@ -126,9 +126,10 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Sequence
-    name: sequence
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Sequence
+      name: sequence
 ```
 
 Here, if you are using different type of Channel, you need to change the
@@ -151,7 +152,7 @@ kubectl -n default get pods
 Let's look at the logs for the first `Step` in the `Sequence`:
 
 ```shell
-kubectl -n default logs -l serving.knative.dev/service=first -c user-container
+kubectl -n default logs --tail=50 -l serving.knative.dev/service=first -c user-container
 Got Event Context: Context Attributes,
   specversion: 0.2
   type: dev.knative.cronjob.event
@@ -186,7 +187,7 @@ Got Transport Context: Transport Context,
 Then we can look at the output of the second Step in the `Sequence`:
 
 ```shell
-kubectl -n default logs -l serving.knative.dev/service=second -c user-container
+kubectl -n default logs --tail=50 -l serving.knative.dev/service=second -c user-container
 Got Event Context: Context Attributes,
   cloudEventsVersion: 0.1
   eventType: samples.http.mod3
@@ -222,7 +223,7 @@ Exciting :)
 Then we can look at the output of the last Step in the `Sequence`:
 
 ```shell
-kubectl -n default logs -l serving.knative.dev/service=third -c user-container
+kubectl -n default logs --tail=50 -l serving.knative.dev/service=third -c user-container
 Got Event Context: Context Attributes,
   cloudEventsVersion: 0.1
   eventType: samples.http.mod3

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -11,6 +11,9 @@ can then do either external work, or out of band create additional events.
 
 ![Logical Configuration](./sequence-terminal.png)
 
+The functions used in these examples live in
+(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+
 ## Prerequisites
 
 For this example, we'll assume you have set up an `InMemoryChannel` as well as

--- a/docs/eventing/samples/sequence/sequence-terminal/cron-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/cron-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: Sequence
-    name: sequence
+    ref:
+      apiVersion: flows.knative.dev/v1alpha1
+      kind: Sequence
+      name: sequence

--- a/docs/eventing/samples/sequence/sequence-terminal/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/sequence.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: sequence

--- a/docs/eventing/samples/sequence/sequence-terminal/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/steps.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "0"
@@ -20,7 +20,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "1"
@@ -33,7 +33,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "2"

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -39,7 +39,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "0"
@@ -53,7 +53,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "1"
@@ -66,7 +66,7 @@ spec:
   template:
     spec:
       containers:
-        - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
           env:
             - name: STEP
               value: "2"
@@ -88,7 +88,7 @@ spec.channelTemplate to point to your desired Channel.
 Also, change the spec.reply.name to point to your `Broker`
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: sequence
@@ -110,9 +110,10 @@ spec:
         kind: Service
         name: third
   reply:
-    kind: Broker
-    apiVersion: eventing.knative.dev/v1alpha1
-    name: broker-test
+    ref:
+      kind: Broker
+      apiVersion: eventing.knative.dev/v1alpha1
+      name: default
 ```
 
 Change `default` below to create the `Sequence` in the Namespace where you have
@@ -136,9 +137,10 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: broker-test
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default
 ```
 
 Here, if you are using different type of Channel, you need to change the
@@ -165,7 +167,7 @@ spec:
       type: dev.knative.cronjob.event
   subscriber:
     ref:
-      apiVersion: messaging.knative.dev/v1alpha1
+      apiVersion: flows.knative.dev/v1alpha1
       kind: Sequence
       name: sequence
 ```
@@ -227,7 +229,7 @@ kubectl -n default get pods
 Then look at the logs for the event-display pod:
 
 ```shell
-kubectl -n default logs -l serving.knative.dev/service=sequence-display -c user-container
+kubectl -n default logs --tail=50 -l serving.knative.dev/service=sequence-display -c user-container
 ☁️  cloudevents.Event
 Validation: valid
 Context Attributes,

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -23,6 +23,9 @@ If you want to use different type of `Channel`, you will have to modify the
 
 ![Logical Configuration](./sequence-with-broker-trigger.png)
 
+The functions used in these examples live in
+(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+
 ## Setup
 
 ### Create the Knative Services

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/cron-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/cron-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: broker-test
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
@@ -13,7 +13,7 @@ kind: Trigger
 metadata:
   name: display-trigger
 spec:
-  broker: broker-test
+  broker: default
   filter:
     sourceAndType:
       type: samples.http.mod3

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/sequence.yaml
@@ -1,4 +1,4 @@
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: flows.knative.dev/v1alpha1
 kind: Sequence
 metadata:
   name: sequence
@@ -20,6 +20,7 @@ spec:
       kind: Service
       name: third
   reply:
-    kind: Broker
-    apiVersion: eventing.knative.dev/v1alpha1
-    name: broker-test
+    ref:
+      kind: Broker
+      apiVersion: eventing.knative.dev/v1alpha1
+      name: default

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/steps.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "0"
@@ -20,7 +20,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "1"
@@ -33,7 +33,7 @@ spec:
   template:
     spec:
       containers:
-      - image: us.gcr.io/probable-summer-223122/cmd-03315b715ae8f3e08e3a9378df706fbb@sha256:2656f39a7fcb6afd9fc79e7a4e215d14d651dc674f38020d1d18c6f04b220700
+      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
         env:
         - name: STEP
           value: "2"

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/trigger.yaml
@@ -3,12 +3,12 @@ kind: Trigger
 metadata:
   name: sequence-trigger
 spec:
-  broker: broker-test
+  broker: default
   filter:
     sourceAndType:
       type: dev.knative.cronjob.event
   subscriber:
     ref:
-      apiVersion: messaging.knative.dev/v1alpha1
+      apiVersion: flows.knative.dev/v1alpha1
       kind: Sequence
       name: sequence


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1977

## Proposed Changes

- Update examples for sequence/parallel to use flows.knative.dev instead of messaging.knative.dev
- Add a pointer and a blurp about sequence/parallel to main Eventing Readme for easier discoverability.
- update cronjobsource specs to reflect new Sink format (v1.destination duck).
