### PR TITLE
Cleanup Knative install versions page

### DIFF
--- a/docs/install/check-install-version.md
+++ b/docs/install/check-install-version.md
@@ -5,39 +5,33 @@ weight: 20
 type: "docs"
 ---
 
-## Knative Serving
 
-To query the version of Knative Serving running on the cluster enter the
-following command:
+To obtain the version of the Knative component that you have running on your cluster, you query for the 
+`[component].knative.dev/release` label with the following commands:
 
-```bash
-kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels
-"serving.knative.dev/release"}}'
-```
+* Knative Serving
+   ```bash
+   kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels
+   "serving.knative.dev/release"}}'
+   ```
 
-## Knative Eventing
-
-To query the version of Knative Eventing running on the cluster enter the
-following command:
-
-```bash
-kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels
-"eventing.knative.dev/release"}}'
-```
-
+* Knative Eventing
+   ```bash
+   kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels
+   "eventing.knative.dev/release"}}'
+   ```
 
 ## Older versions
 
 Early versions of Knative Eventing and Serving do not have release version
-labels on the components. Release labels were added in:
+labels on those components. Release labels were added in the following releases:
 
 * Knative Serving 0.4.0
 * Knative Eventing 0.7.0
 
-If you have a version earlier than the versions above, the release version will not
-be returned from the commands. The version will need to be determined from the
-container images of your Knative controllers.
+If you have an earlier version that excludes release labels, you must obtain the
+version from the container images of your Knative controllers:
 
-Query a Knative Controller and copy the full `gcr.io` url into into your browser. From
-this page you will be able to look up the release version from the `Tags`
-section.
+1. Query your Knative Controller to receive a URL.
+1. Navigate to the full `gcr.io` URL with your browser. 
+1. Review the contents for the release version from with the `Tags` section.

--- a/docs/install/check-install-version.md
+++ b/docs/install/check-install-version.md
@@ -32,6 +32,6 @@ labels on those components. Release labels were added in the following releases:
 If you have an earlier version that excludes release labels, you must obtain the
 version from the container images of your Knative controllers:
 
-1. Query your Knative Controller to receive a URL.
+1. Query your Knative Controller to receive the `Image` URL. For example, you can run `kubectl describe deploy controller --namespace knative-serving` or `kubectl describe deploy eventing-controller --namespace knative-eventing`
 1. Navigate to the full `gcr.io` URL with your browser. 
 1. Review the contents for the release version from with the `Tags` section.

--- a/docs/install/check-install-version.md
+++ b/docs/install/check-install-version.md
@@ -5,97 +5,39 @@ weight: 20
 type: "docs"
 ---
 
-## Knative Serving (0.4.0 and later)
+## Knative Serving
 
-If your installed version of Knative Serving is v0.4.0 or later, enter the
+To query the version of Knative Serving running on the cluster enter the
 following command:
 
 ```bash
-kubectl get deploy -n knative-serving --label-columns=serving.knative.dev/release
+kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels
+"serving.knative.dev/release"}}'
 ```
-
-This will return a list of deployments in the `knative-serving` namespace and
-their release versions:
-
-```
-NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE       RELEASE
-activator                1         1         1            0           8s        v0.6.0
-autoscaler               1         1         1            0           8s        v0.6.0
-controller               1         1         1            1           6s        v0.6.0
-networking-certmanager   1         1         1            1           6s        v0.6.0
-networking-istio         1         1         1            1           6s        v0.6.0
-webhook                  1         1         1            1           6s        v0.6.0
-```
-
-## Knative Serving (pre-0.4.0)
-
-If your installed version of Knative Serving is earlier than v0.4.0, enter the
-following command:
-
-```bash
-kubectl describe deploy controller --namespace knative-serving
-```
-
-This will return the description for the `knative-serving` controller; this
-information contains the link to the container that was used to install Knative:
-
-```yaml
----
-Pod Template:
-  Labels: app=controller
-  Annotations: sidecar.istio.io/inject=false
-  Service Account: controller
-  Containers:
-    controller:
-      # Link to container used to run the Knative Serving controller
-      Image: gcr.io/knative-releases/github.com/knative/serving/cmd/controller@sha256:59abc8765d4396a3fc7cac27a932a9cc151ee66343fa5338fb7146b607c6e306
-```
-
-Copy the full `gcr.io` link to the container and paste it into your browser. If
-you are already signed in to a Google account, you'll be taken to the Google
-Container Registry page for that container in the Google Cloud Platform console.
-If you aren't already signed in, you'll need to sign in to a Google account
-before you can view the container details.
-
-On the container details page, you'll see a section titled "Container
-classification," and in that section is a list of tags. The versions of Knative
-you have installed will appear in the list as `v0.1.1`, or whatever version you
-have installed:
-
-![Shows list of tags on container details page; v0.1.1 is the Knative version and is the first tag.](../images/knative-version.png)
 
 ## Knative Eventing
 
-To check what version of Knative serving you have installed, enter the following
-command:
+To query the version of Knative Eventing running on the cluster enter the
+following command:
 
 ```bash
-kubectl describe deploy eventing-controller --namespace knative-eventing
+kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels
+"eventing.knative.dev/release"}}'
 ```
 
-This will return the description for the `knative-eventing` controller; this
-information contains the link to the container that was used to install Knative:
 
-```yaml
----
-Pod Template:
-  Labels: app=eventing-controller eventing.knative.dev/release=devel
-  Service Account: eventing-controller
-  Containers:
-    eventing-controller:
-      # Link to container used to run the Knative Eventing controller
-      Image: gcr.io/knative-releases/github.com/knative/eventing/cmd/controller@sha256:85c010633944c06f4c16253108c2338dba271971b2b5f2d877b8247fa19ff5cb
-```
+## Older versions
 
-Copy the full `gcr.io` link to the container and paste it into your browser. If
-you are already signed in to a Google account, you'll be taken to the Google
-Container Registry page for that container in the Google Cloud Platform console.
-If you aren't already signed in, you'll need to sign in to a Google account
-before you can view the container details.
+Early versions of Knative Eventing and Serving do not have release version
+labels on the components. Release labels were added in:
 
-On the container details page, you'll see a section titled "Container
-classification," and in that section is a list of tags. The versions of Knative
-you have installed will appear in the list as `v0.1.1`, or whatever version you
-have installed:
+* Knative Serving 0.4.0
+* Knative Eventing 0.7.0
 
-![Shows list of tags on container details page; v0.1.1 is the Knative version and is the first tag.](../images/knative-version.png)
+If you have a version earlier than the versions above, the release version will not
+be returned from the commands. The version will need to be determined from the
+container images of your Knative controllers.
+
+Query a Knative Controller and copy the full `gcr.io` url into into your browser. From
+this page you will be able to look up the release version from the `Tags`
+section.


### PR DESCRIPTION
1. Change to a command that returns just the release version
2. Move current methods of querying to the top of the page
3. Combine old methods into a single section
  * Describe old steps rather than walk through as we expect very few
  people to be running these older versions.
