### PR TITLE
specify main Go file to support locally running golang helloworld

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -16,7 +16,7 @@ COPY . ./
 
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server helloworld.go
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine


### PR DESCRIPTION
Within this directory, `go build -v -o server && chmod +x server && ./server` fails with "syntax error near unexpected token `newline'" because there is no main Go file in the build. Adding the main Go file like `go build -v -o server helloworld.go && chmod +x server && ./server` works, which is the proposed file change. With this file change, we can then deploy the helloworld golang container locally via:
```
docker build . --tag gcr.io/monitoring-api-test/helloworld' && docker run --publish 8080:8080 --env PORT=8080 --name local gcr.io/monitoring-api-test/helloworld
```

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
