### PR TITLE
Remove namespace definition from hello-world service.yaml

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -126,7 +126,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-csharp
    kind: Service
    metadata:
      name: helloworld-csharp
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-csharp/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-csharp/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-csharp
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -112,7 +112,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    kind: Service
    metadata:
      name: helloworld-go
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-go/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-go/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-go
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-java-spark/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/README.md
@@ -84,7 +84,6 @@ recreate the source files from this folder.
    kind: Service
    metadata:
      name: helloworld-java
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-java-spark/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-java
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -131,7 +131,6 @@ knative-docs/docs/serving/samples/hello-world/helloworld-java-spring
    kind: Service
    metadata:
      name: helloworld-java-spring
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-java-spring/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-java-spring
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -152,7 +152,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-kotlin
    kind: Service
    metadata:
      name: helloworld-kotlin
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-kotlin/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-kotlin
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -136,7 +136,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-nodejs
    kind: Service
    metadata:
      name: helloworld-nodejs
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-nodejs/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-nodejs
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -82,7 +82,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-php
    kind: Service
    metadata:
      name: helloworld-php
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-php/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-php/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-php
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -98,7 +98,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    kind: Service
    metadata:
      name: helloworld-python
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-python/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-python/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-python
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-ruby/README.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/README.md
@@ -95,7 +95,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
    kind: Service
    metadata:
      name: helloworld-ruby
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-ruby/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-ruby/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-ruby
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-scala/README.md
+++ b/docs/serving/samples/hello-world/helloworld-scala/README.md
@@ -74,7 +74,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-scala
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-scala/helloworld-scala.yaml
+++ b/docs/serving/samples/hello-world/helloworld-scala/helloworld-scala.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-scala
-  namespace: default
 spec:
   template:
     spec:

--- a/docs/serving/samples/hello-world/helloworld-shell/README.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/README.md
@@ -122,7 +122,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-shell
    kind: Service
    metadata:
      name: helloworld-shell
-     namespace: default
    spec:
      template:
        spec:

--- a/docs/serving/samples/hello-world/helloworld-shell/service.yaml
+++ b/docs/serving/samples/hello-world/helloworld-shell/service.yaml
@@ -2,7 +2,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: helloworld-shell
-  namespace: default
 spec:
   template:
     spec:


### PR DESCRIPTION
## Proposed Changes

Remove the namespace definition from the service.yaml in each of the helloworld-*
samples.

### Why

Specifying the namespace in service.yaml expects there to exist a namespace with
the specified name, in this case 'default'.  When namespace is unspecified, the
service.yaml will default to using the namespace specified in the default $KUBECONFIG.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->
