### PR TITLE
Updating PubSub example due to change in Destination

### DIFF
--- a/docs/eventing/samples/gcp-pubsub-source/README.md
+++ b/docs/eventing/samples/gcp-pubsub-source/README.md
@@ -142,8 +142,7 @@ to the `default` Broker.
 
 1. We need to wait for the downstream pods to get started and receive our event,
    wait a few seconds.
-
-   - You can check the status of the downstream pods with:
+   You can check the status of the downstream pods with:
 
      ```shell
      kubectl get pods --selector serving.knative.dev/service=event-display
@@ -167,7 +166,7 @@ Context Attributes,
   Source: //pubsub.googleapis.com/projects/PROJECT_ID/topics/testing
   ID: 815117146007971
   Time: 2019-10-31T04:49:12.582Z
-  DataContentType: application/json
+  DataContentType: application/octet-stream
   Extensions:
     knativecemode: binary
     knativearrivaltime: 2019-10-31T04:49:12Z

--- a/docs/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
+++ b/docs/eventing/samples/gcp-pubsub-source/gcp-pubsub-source.yaml
@@ -5,8 +5,9 @@ metadata:
 spec:
   topic: testing
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: default
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default
   # If running in GKE, we will ask the metadata server for the project.
   #project: MY_GCP_PROJECT


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- Updating PubSub example due to change in Destination

