### PR TITLE
initial delivery options doc

### DIFF
--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -1,0 +1,64 @@
+---
+title: "Event Delivery"
+weight: 20
+type: "docs"
+---
+
+## Overview
+
+Knative Eventing provides various configuration parameters to control the delivery
+of events in case of failure. For instance, you can decide to retry sending events
+that failed to be consumed, and if this didn't work you can decide to forward those
+events to a dead letter sink.
+
+## Configurating Subscription Delivery
+
+Knative Eventing offers fine-grained control on how events are delivered for each subscription by adding a `delivery` section. Consider this example:
+
+```yaml
+apiVersion: messaging.knative.dev/v1alpha1
+kind: Subscription
+metadata:
+  name: with-dead-letter-sink
+spec:
+  channel:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: InMemoryChannel
+    name: default
+  delivery:
+    deadLetterSink:
+      ref:
+        apiVersion: serving.knative.dev/v1alpha1
+        kind: Service
+        name: error-handler
+  subscriber:
+    uri: http://doesnotexist.default.svc.cluster.local
+```
+
+The `deadLetterSink` specifies where to send events that failed be consumed by `subscriber`.
+
+## Common Delivery Parameters
+
+### deadLetterSink
+
+When present, events that failed to be consumed are sent to the `deadLetterSink`.
+In case of failure, the event is dropped and an error is logged into the system.
+
+The `deadLetterSink` value must be a [Destination](https://godoc.org/knative.dev/pkg/apis/v1alpha1#Destination).
+
+```yaml
+spec:
+  delivery:
+    deadLetterSink: <Destination>
+```
+
+## Channel Support
+
+The table below summarizes what delivery parameters are supported for each channel implementation.
+
+| Channel Type | Supported Delivery Parameters |
+| - | - |
+| In-Memory | `deadLetterSink` |
+| Kafka | none |
+| Natss | none |
+| GCP PubSub | none |

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -11,7 +11,7 @@ of events in case of failure. For instance, you can decide to retry sending even
 that failed to be consumed, and if this didn't work you can decide to forward those
 events to a dead letter sink.
 
-## Configurating Subscription Delivery
+## Configuring Subscription Delivery
 
 Knative Eventing offers fine-grained control on how events are delivered for each subscription by adding a `delivery` section. Consider this example:
 
@@ -28,7 +28,7 @@ spec:
   delivery:
     deadLetterSink:
       ref:
-        apiVersion: serving.knative.dev/v1alpha1
+        apiVersion: serving.knative.dev/v1
         kind: Service
         name: error-handler
   subscriber:
@@ -44,7 +44,7 @@ The `deadLetterSink` specifies where to send events that failed be consumed by `
 When present, events that failed to be consumed are sent to the `deadLetterSink`.
 In case of failure, the event is dropped and an error is logged into the system.
 
-The `deadLetterSink` value must be a [Destination](https://godoc.org/knative.dev/pkg/apis/v1alpha1#Destination).
+The `deadLetterSink` value must be a [Destination](https://godoc.org/knative.dev/pkg/apis/duck/v1#Destination).
 
 ```yaml
 spec:


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1952

## Proposed Changes

- add event delivery section
