### PR TITLE
updates for kafka based on 0.10.x release

### DIFF
--- a/docs/eventing/samples/kafka/channel/020-k8s-events.yaml
+++ b/docs/eventing/samples/kafka/channel/020-k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: default
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -21,7 +21,7 @@ You must also have the following tools installed:
 
 Install the `KafkaChannel` sub-component on your Knative Eventing cluster:
    ```
-   curl -L "https://github.com/knative/eventing-contrib/releases/download/v0.9.0/kafka-channel.yaml" \
+   curl -L "https://github.com/knative/eventing-contrib/releases/download/v0.10.1/kafka-channel.yaml" \
     | sed 's/REPLACE_WITH_CLUSTER_URL/my-cluster-kafka-bootstrap.kafka:9092/' \
     | kubectl apply --filename -
    ```

--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -18,7 +18,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
 
 1. Install the `KafkaSource` sub-component to your Knative cluster:
    ```
-   kubectl apply -f https://github.com/knative/eventing-contrib/releases/download/v0.9.0/kafka-source.yaml
+   kubectl apply -f https://github.com/knative/eventing-contrib/releases/download/v0.10.1/kafka-source.yaml
 
    ```
 2. Check that the `kafka-controller-manager-0` pod is running.
@@ -109,9 +109,10 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
      bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092 #note the kafka namespace
      topics: knative-demo-topic
      sink:
-       apiVersion: serving.knative.dev/v1
-       kind: Service
-       name: event-display
+       ref:
+         apiVersion: serving.knative.dev/v1
+         kind: Service
+         name: event-display
    ```
 
 1. Deploy the event source.
@@ -189,7 +190,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
    ```
 3. Remove the Apache Kafka Event Controller
    ```
-   $ kubectl delete -f https://github.com/knative/eventing-contrib/releases/download/v0.9.0/kafka-importer.yaml
+   $ kubectl delete -f https://github.com/knative/eventing-contrib/releases/download/v0.10.1/kafka-importer.yaml
    serviceaccount "kafka-controller-manager" deleted
    clusterrole.rbac.authorization.k8s.io "eventing-sources-kafka-controller" deleted
    clusterrolebinding.rbac.authorization.k8s.io "eventing-sources-kafka-controller" deleted

--- a/docs/eventing/samples/kafka/source/event-source.yaml
+++ b/docs/eventing/samples/kafka/source/event-source.yaml
@@ -70,6 +70,7 @@ spec:
       cpu: 250m
       memory: 512Mi
   sink:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- updates for 0.10 for kafka doc
-
-
