### PR TITLE
Update installing-istio.md

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -57,7 +57,7 @@ without automatic sidecar injection.
 
    ```shell
    # Download and unpack Istio
-   export ISTIO_VERSION=1.1.7
+   export ISTIO_VERSION=1.4.0
    curl -L https://git.io/getLatestIstio | sh -
    cd istio-${ISTIO_VERSION}
    ```


### PR DESCRIPTION
The `https://git.io/getLatestIstio` script now downloads Istio 1.4.0.