### PR TITLE
Update default Istio version to 1.3.5

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -57,7 +57,7 @@ without automatic sidecar injection.
 
    ```shell
    # Download and unpack Istio
-   export ISTIO_VERSION=1.1.7
+   export ISTIO_VERSION=1.3.5
    curl -L https://git.io/getLatestIstio | sh -
    cd istio-${ISTIO_VERSION}
    ```


### PR DESCRIPTION
Fixes https://github.com/knative/serving/issues/6118

## Proposed Changes
Update documentation to reflect the fact that
- 1.2.x has been dropped: https://github.com/knative/serving/pull/6110
- 1.3.5 is the new recommended version: https://github.com/knative/serving/pull/6021
