### PR TITLE
Eventing doesn't require Istio

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -31,8 +31,7 @@ Currently, three options exist which provide this functionality:
 
 [Installing with Ambassador](./Knative-with-Ambassador.md) gives us an
 alternative to installing a service mesh for routing to applications with the
-Knative Serving component. Note that Istio is required for the Knative Eventing
-component.
+Knative Serving component.
 
 ## Installing Knative with Gloo
 


### PR DESCRIPTION
I don't remember exactly when this became true, but Eventing hasn't required Istio for several releases.

## Proposed Changes

- Remove sentence asserting that eventing requires Istio

/cc @rgregg 