### PR TITLE
How to use a private registry

### DIFF
--- a/docs/serving/deploying/private-registry.md
+++ b/docs/serving/deploying/private-registry.md
@@ -1,310 +1,105 @@
 ---
-title: "Deploying apps from a private container registry"
+title: "Deploying images from a private container registry"
 linkTitle: "Deploying from private registries"
 weight: 10
 type: "docs"
 ---
 
-Learn how to configure Knative to use your private container registry
-credentials to deploy your images from a private container registry.
+Learn how to configure your Knative cluster to deploy images from a private 
+container registry.
 
-## Setting up permissions
+To enable access to your private container images, you create a `imagePullSecret` type 
+Kubernetes secret with your credentials, add that secret to your default
+[service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/),
+and then deploy those configurations to your Knative cluster.
 
-To deploy a private container image, you must create an `imagePullSecret` type
-Kubernetes secret and associate it with a service account:
+## Before you begin
 
-1. Create an `imagePullSecret` secret called `container-registry`:
+Ensure that you have the following setup and running:
+
+- Knative Serving. [Learn about installing Knative](../../install/README.md)
+- You must have access to and the credentials to the private container registry 
+  where your container image is stored.
+
+## Configuring your credentials in Knative
+
+1. Create a `imagePullSecret` type secret named `container-registry` that contains 
+   your credentials:
 
     ```shell
     kubectl create secret container-registry \
-    --docker-server=<var>DOCKER_REGISTRY_SERVER</var> \
-    --docker-email=<var>REGISTRY_EMAIL</var> \
-    --docker-username=<var>REGISTRY_USER</var> \
-    --docker-password=<var>REGISTRY_PASSWORD</var></pre>
+      --docker-server=[PRIVATE_REGISTRY_SERVER_URL] \
+      --docker-email=[PRIVATE_REGISTRY_EMAIL] \
+      --docker-username=[PRIVATE_REGISTRY_USER] \
+      --docker-password=[PRIVATE_REGISTRY_PASSWORD]
+    ```
 
-    * Replace <var>DOCKER_REGISTRY_SERVER</var> with your private
-      registry FQDN (ex: [https://gcr.io/](https://gcr.io/) for
-      {{registry_name}} or [https://index.docker.io/v1/](https://index.docker.io/v1/)
-      for DockerHub).
-    * Replace <var>REGISTRY_EMAIL</var> with your email.
-    * Replace <var>REGISTRY_USER</var> with your container registry
-      username.
+    Where
+    - `[PRIVATE_REGISTRY_SERVER_URL]` is the URL to the private
+      registry where your container image is stored. 
+       
+       Examples:
+       - Google Container Registry: [https://gcr.io/](https://gcr.io/)
+       - DockerHub [https://index.docker.io/v1/](https://index.docker.io/v1/)
+       
+    * `[PRIVATE_REGISTRY_EMAIL]` is your email address that is associated with
+      the private registry.
+      
+    * `[PRIVATE_REGISTRY_USER]` is your container registry username.
 
-      If you're using {{registry_name}} and would like to store and pull
-      long-lived credentials instead of passing short-lived access tokens, see
-      [Authentication methods: JSON key file](/container-registry/docs/advanced-authentication#json_key_file).
-    * Replace <var>REGISTRY_PASSWORD</var> with your container registry
-      password.
+       Tip: 
+       If you're using GCR and prefer to store and pull
+       long-lived credentials instead of passing short-lived access tokens, see
+       [Authentication methods: JSON key file](/container-registry/docs/advanced-authentication#json_key_file).
+       
+    * `[PRIVATE_REGISTRY_PASSWORD]` is your container registry password.
 
+1. Add the `container-registry` secret to your `default` service account in the
+   `default` namespace.
+   
+    Note: By default, the `default` service account in each of the 
+    [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) 
+    of your Knative cluster are use by your revisions unless 
+    [`serviceAccountName`](../spec/knative-api-specification-1.0.md) is specified.
 
-1. Add your secret to your `default` [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/):
+   1. Run the following command to edit your `default` service account:
+   
+       ```shell
+       kubectl edit serviceaccount default --namespace default
+       ```
 
-    <pre class="prettyprint lang-sh">kubectl edit serviceaccount default --namespace default</pre>
+   1. Add the `container-registry` secret under the `imagePullSecrets` element in 
+      your `default` service account:
 
-    Every [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/){: target="_blank" class="external"}
-    in your Kubernetes cluster has a default service account called `default`.
-    This default service account is used to pull your container image unless
-    otherwise specified in your {{cloud_run_anthos_name}} service's [Revision Spec](/run/docs/reference/rest/v1/RevisionSpec).
+       ```
+       imagePullSecrets:
+       - name: container-registry
+       ```
 
-1. Add the newly created `imagePullSecret` secret to your default service
-    account:
+      Example:
+       
+       ```yaml
+       apiVersion: v1
+       kind: ServiceAccount
+       metadata:
+         name: default
+         namespace: default
+         ...
+       secrets:
+       - name: default-token-zd84v
+       imagePullSecrets:
+       - name: container-registry
+       ```
 
-        imagePullSecrets:
-        - name: container-registry
-
-    Your service account should now look like this:
-
-        apiVersion: v1
-        kind: ServiceAccount
-        metadata:
-          name: default
-          namespace: default
-          ...
-        secrets:
-        - name: default-token-zd84v
-        # The secret we just created:
-        imagePullSecrets:
-        - name: container-registry
-
-Now, any new pods created in the current `default` namespace will have the
-`imagePullSecret` secret defined.
-
-## Set up a private container registry and obtain credentials
-
-If you do not want your container image to be publicly available, you may want
-to use a private container registry. In this example, we'll use IBM Container
-Registry, but most of these concepts will be similar for other clouds.
-
-1. Ensure you have the
-   [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/reference/ibmcloud/download_cli.html#install_use)
-   installed.
-
-1. Install the container registry plugin:
-
-   ```
-   ibmcloud plugin install container-registry
-   ```
-
-1. Choose a name for your first namespace, and then create it:
-
-   ```
-   ibmcloud cr namespace-add <my_namespace>
-   ```
-
-   A namespace represents the spot within a registry that holds your images. You
-   can set up multiple namespaces as well as control access to your namespaces
-   by using IAM policies.
-
-1. Create a token:
-
-   ```
-   ibmcloud cr token-add --description "token description" --non-expiring --readwrite
-   ```
-
-   The automated build processes you'll be setting up will use this token to
-   access your images.
-
-1. The CLI output should include a token identifier and the token. Make note of
-   the token. You can verify that the token was created by listing all tokens:
-
-   ```
-   ibmcloud cr token-list
-   ```
-
-## Provide container registry credentials to Knative
-
-You will use the credentials you obtained in the previous section to
-authenticate to your private container registry. First, you'll need to create a
-secret to store the credentials for this registry. This secret will be used to
-push the built image to the container registry.
-
-A Secret is a Kubernetes object containing sensitive data such as a password, a
-token, or a key. You can also read more about
-[Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
-
-1. Create a file named `registry-push-secret.yaml` containing the following:
-
-   ```yaml
-   apiVersion: v1
-   kind: Secret
-   metadata:
-     name: registry-push-secret
-     annotations:
-       build.knative.dev/docker-0: https://registry.ng.bluemix.net
-   type: kubernetes.io/basic-auth
-   stringData:
-     username: token
-     password: <token_value>
-   ```
-
-1. Update the "password" with your <token_value>. Note that username will be the
-   string `token`. Save the file.
-
-1. Apply the secret to your cluster.
-
-   ```bash
-   kubectl apply --filename registry-push-secret.yaml
-   ```
-
-1. You will also need a secret for the knative-serving component to pull down an
-   image from the private container registry. This secret will be a
-   `docker-registry` type secret. You can create this via the commandline. For
-   username, simply use the string `token`. For <token_value>, use the token you
-   made note of earlier.
-
-   ```bash
-   kubectl create secret docker-registry ibm-cr-secret --docker-server=https://registry.ng.bluemix.net --docker-username=token --docker-password=<token_value>
-   ```
-
-A Service Account provides an identity for processes that run in a Pod. This
-Service Account will be used to link the build process for Knative to the
-Secrets you just created.
-
-1. Create a file named `service-account.yaml` containing the following:
-
-   ```yaml
-   apiVersion: v1
-   kind: ServiceAccount
-   metadata:
-     name: build-bot
-   secrets:
-     - name: registry-push-secret
-   imagePullSecrets:
-     - name: ibm-cr-secret
-   ```
-
-1. Apply the service account to your cluster:
+1. Apply the service account to your Knative cluster:
 
    ```bash
    kubectl apply --filename service-account.yaml
    ```
+Now, all the new pods that are created in the `default` namespace will include
+your credentials and have access to your container images in the private registry.
 
-## Deploy to Knative
+## What's next
 
-To build our application from the source on GitHub, and push the resulting image
-to the IBM Container Registry, we will use the Kaniko build template.
-
-1. Install the Kaniko build template
-
-   ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
-   ```
-
-1. You need to create a service manifest which defines the service to deploy,
-   including where the source code is and which build-template to use. Create a
-   file named `service.yaml` and copy the following definition. Make sure to
-   replace {NAMESPACE} with your own namespace you created earlier:
-
-   ```yaml
-   apiVersion: serving.knative.dev/v1alpha1
-   kind: Service
-   metadata:
-     name: helloworld-go
-     namespace: default
-   spec:
-     runLatest:
-       configuration:
-         build:
-           apiVersion: build.knative.dev/v1alpha1
-           kind: Build
-           spec:
-             serviceAccountName: build-bot
-             source:
-               git:
-                 url: https://github.com/knative/docs
-                 revision: master
-               subPath: docs/serving/samples/hello-world/helloworld-go
-             template:
-               name: kaniko
-               arguments:
-                 - name: IMAGE
-                   value: registry.ng.bluemix.net/{NAMESPACE}/helloworld-go:latest
-         revisionTemplate:
-           spec:
-             serviceAccountName: build-bot
-             container:
-               image: registry.ng.bluemix.net/{NAMESPACE}/helloworld-go:latest
-               imagePullPolicy: Always
-               env:
-                 - name: TARGET
-                   value: "Go Sample v1"
-   ```
-
-1. Apply the configuration using `kubectl`:
-
-   ```bash
-   kubectl apply --filename service.yaml
-   ```
-
-   Applying this service definition will kick off a series of events:
-
-   - Fetches the revision specified from GitHub and builds it into a container,
-     using the Kaniko build template.
-   - Pushes the latest image to the private registry using the
-     registry-push-secret
-   - Pulls down the latest image from the private registry using the
-     ibm-cr-secret.
-   - Starts the service, and your app will be live.
-
-1. You can run `kubectl get pods --watch` to see the pods initializing.
-
-1. Once all the pods are initialized, you can see that your container image was
-   built and pushed to the IBM Container Registry:
-
-   ```
-   ibmcloud cr image-list
-   ```
-
-## Test Application Behavior
-
-1. Run the following command to find the external IP address for your service:
-
-   ```shell
-   INGRESSGATEWAY=istio-ingressgateway
-   kubectl get svc $INGRESSGATEWAY --namespace istio-system
-   ```
-
-   Example:
-
-   ```shell
-   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
-   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
-   ```
-
-1. Run the following command to find the domain URL for your service:
-
-   ```shell
-   kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
-   ```
-
-   Example:
-
-   ```shell
-   NAME                DOMAIN
-   helloworld-go       helloworld-go.default.example.com
-   ```
-
-1. Test your app by sending it a request. Use the following `curl` command with
-   the domain URL `helloworld-go.default.example.com` and `EXTERNAL-IP` address
-   that you retrieved in the previous steps:
-
-   ```shell
-   curl -H "Host: helloworld-go.default.example.com" http://{EXTERNAL_IP_ADDRESS}
-   ```
-
-   Example:
-
-   ```shell
-   curl -H "Host: helloworld-go.default.example.com" http://35.203.155.229
-   Hello Go Sample v1!
-   ```
-
-   > Note: Add `-v` option to get more detail if the `curl` command failed.
-
-## Removing the sample app deployment
-
-To remove the sample app from your cluster, delete the service record:
-
-```shell
-kubectl delete --filename service.yaml
-```
+You can now create a service that uses your container images from the private registry. 
+[Learn how to create a Knative service](../getting-started-knative-app.md)

--- a/docs/serving/deploying/private-registry.md
+++ b/docs/serving/deploying/private-registry.md
@@ -8,26 +8,26 @@ type: "docs"
 Learn how to configure your Knative cluster to deploy images from a private 
 container registry.
 
-To enable access to your private container images, you create a `imagePullSecret` type 
-Kubernetes secret with your credentials, add that secret to your default
+To share access to your private container images across multiple services and 
+revisions, you create a list of Kubernetes secrets
+([`imagePullSecrets`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pod-v1-core))
+using your registry credentials, add that `imagePullSecrets` to your default
 [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/),
 and then deploy those configurations to your Knative cluster.
 
 ## Before you begin
 
-Ensure that you have the following setup and running:
+You need:
 
-- Knative Serving. [Learn about installing Knative](../../install/README.md)
-- You must have access to and the credentials to the private container registry 
-  where your container image is stored.
+- A Kubernetes cluster with [Knative Serving installed](../../install/README.md).
+- The credentials to the private container registry where your container images are stored.
 
 ## Configuring your credentials in Knative
 
-1. Create a `imagePullSecret` type secret named `container-registry` that contains 
-   your credentials:
+1. Create a `imagePullSecrets` that contains your credentials as a list of secrets:
 
     ```shell
-    kubectl create secret container-registry \
+    kubectl create secret [REGISTRY-CRED-SECRETS] \
       --docker-server=[PRIVATE_REGISTRY_SERVER_URL] \
       --docker-email=[PRIVATE_REGISTRY_EMAIL] \
       --docker-username=[PRIVATE_REGISTRY_USER] \
@@ -35,26 +35,42 @@ Ensure that you have the following setup and running:
     ```
 
     Where
+    - `[REGISTRY-CRED-SECRETS]` is the name that you want for your secrets
+      (`imagePullSecrets` object). For example, `container-registry`.
+
     - `[PRIVATE_REGISTRY_SERVER_URL]` is the URL to the private
-      registry where your container image is stored. 
-       
+      registry where your container images are stored. 
+
        Examples:
        - Google Container Registry: [https://gcr.io/](https://gcr.io/)
        - DockerHub [https://index.docker.io/v1/](https://index.docker.io/v1/)
-       
+
     * `[PRIVATE_REGISTRY_EMAIL]` is your email address that is associated with
       the private registry.
-      
-    * `[PRIVATE_REGISTRY_USER]` is your container registry username.
 
-       Tip: 
-       If you're using GCR and prefer to store and pull
-       long-lived credentials instead of passing short-lived access tokens, see
-       [Authentication methods: JSON key file](/container-registry/docs/advanced-authentication#json_key_file).
-       
-    * `[PRIVATE_REGISTRY_PASSWORD]` is your container registry password.
+    * `[PRIVATE_REGISTRY_USER]` is the username that you use to access the
+      private container registry.
 
-1. Add the `container-registry` secret to your `default` service account in the
+    * `[PRIVATE_REGISTRY_PASSWORD]` is the password that you use to access
+      the private container registry.
+    
+     Example:
+     
+    ```shell
+    kubectl create secret `container-registry` \
+      --docker-server=https://gcr.io/ \
+      --docker-email=my-account-email@address.com \
+      --docker-username=my-grc-username \
+      --docker-password=my-gcr-password
+    ```
+     
+    Tip: After creating the `imagePullSecrets`, you can view those secret's by running:
+    
+    ```shell
+    kubectl get secret [REGISTRY-CRED-SECRETS] --output=yaml
+    ```
+
+1. Add the `imagePullSecrets` to your `default` service account in the
    `default` namespace.
    
     Note: By default, the `default` service account in each of the 
@@ -68,15 +84,17 @@ Ensure that you have the following setup and running:
        kubectl edit serviceaccount default --namespace default
        ```
 
-   1. Add the `container-registry` secret under the `imagePullSecrets` element in 
-      your `default` service account:
+   1. Add the `imagePullSecrets` element in your `default` service account :
+
+       For example, if you named your secrets `container-registry`, then you
+       add the following lines to your service account configuration:
 
        ```
        imagePullSecrets:
        - name: container-registry
        ```
 
-      Example:
+      Example service account with `imagePullSecrets`:
        
        ```yaml
        apiVersion: v1
@@ -91,15 +109,16 @@ Ensure that you have the following setup and running:
        - name: container-registry
        ```
 
-1. Apply the service account to your Knative cluster:
+1. Deploy the updated service account to your Knative cluster:
 
-   ```bash
+    ```bash
    kubectl apply --filename service-account.yaml
    ```
+
 Now, all the new pods that are created in the `default` namespace will include
 your credentials and have access to your container images in the private registry.
 
 ## What's next
 
 You can now create a service that uses your container images from the private registry. 
-[Learn how to create a Knative service](../getting-started-knative-app.md)
+[Learn how to create a Knative service](../getting-started-knative-app.md).

--- a/docs/serving/deploying/private-registry.md
+++ b/docs/serving/deploying/private-registry.md
@@ -1,0 +1,310 @@
+---
+title: "Deploying apps from a private container registry"
+linkTitle: "Deploying from private registries"
+weight: 10
+type: "docs"
+---
+
+Learn how to configure Knative to use your private container registry
+credentials to deploy your images from a private container registry.
+
+## Setting up permissions
+
+To deploy a private container image, you must create an `imagePullSecret` type
+Kubernetes secret and associate it with a service account:
+
+1. Create an `imagePullSecret` secret called `container-registry`:
+
+    ```shell
+    kubectl create secret container-registry \
+    --docker-server=<var>DOCKER_REGISTRY_SERVER</var> \
+    --docker-email=<var>REGISTRY_EMAIL</var> \
+    --docker-username=<var>REGISTRY_USER</var> \
+    --docker-password=<var>REGISTRY_PASSWORD</var></pre>
+
+    * Replace <var>DOCKER_REGISTRY_SERVER</var> with your private
+      registry FQDN (ex: [https://gcr.io/](https://gcr.io/) for
+      {{registry_name}} or [https://index.docker.io/v1/](https://index.docker.io/v1/)
+      for DockerHub).
+    * Replace <var>REGISTRY_EMAIL</var> with your email.
+    * Replace <var>REGISTRY_USER</var> with your container registry
+      username.
+
+      If you're using {{registry_name}} and would like to store and pull
+      long-lived credentials instead of passing short-lived access tokens, see
+      [Authentication methods: JSON key file](/container-registry/docs/advanced-authentication#json_key_file).
+    * Replace <var>REGISTRY_PASSWORD</var> with your container registry
+      password.
+
+
+1. Add your secret to your `default` [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/):
+
+    <pre class="prettyprint lang-sh">kubectl edit serviceaccount default --namespace default</pre>
+
+    Every [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/){: target="_blank" class="external"}
+    in your Kubernetes cluster has a default service account called `default`.
+    This default service account is used to pull your container image unless
+    otherwise specified in your {{cloud_run_anthos_name}} service's [Revision Spec](/run/docs/reference/rest/v1/RevisionSpec).
+
+1. Add the newly created `imagePullSecret` secret to your default service
+    account:
+
+        imagePullSecrets:
+        - name: container-registry
+
+    Your service account should now look like this:
+
+        apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          name: default
+          namespace: default
+          ...
+        secrets:
+        - name: default-token-zd84v
+        # The secret we just created:
+        imagePullSecrets:
+        - name: container-registry
+
+Now, any new pods created in the current `default` namespace will have the
+`imagePullSecret` secret defined.
+
+## Set up a private container registry and obtain credentials
+
+If you do not want your container image to be publicly available, you may want
+to use a private container registry. In this example, we'll use IBM Container
+Registry, but most of these concepts will be similar for other clouds.
+
+1. Ensure you have the
+   [IBM Cloud CLI](https://cloud.ibm.com/docs/cli/reference/ibmcloud/download_cli.html#install_use)
+   installed.
+
+1. Install the container registry plugin:
+
+   ```
+   ibmcloud plugin install container-registry
+   ```
+
+1. Choose a name for your first namespace, and then create it:
+
+   ```
+   ibmcloud cr namespace-add <my_namespace>
+   ```
+
+   A namespace represents the spot within a registry that holds your images. You
+   can set up multiple namespaces as well as control access to your namespaces
+   by using IAM policies.
+
+1. Create a token:
+
+   ```
+   ibmcloud cr token-add --description "token description" --non-expiring --readwrite
+   ```
+
+   The automated build processes you'll be setting up will use this token to
+   access your images.
+
+1. The CLI output should include a token identifier and the token. Make note of
+   the token. You can verify that the token was created by listing all tokens:
+
+   ```
+   ibmcloud cr token-list
+   ```
+
+## Provide container registry credentials to Knative
+
+You will use the credentials you obtained in the previous section to
+authenticate to your private container registry. First, you'll need to create a
+secret to store the credentials for this registry. This secret will be used to
+push the built image to the container registry.
+
+A Secret is a Kubernetes object containing sensitive data such as a password, a
+token, or a key. You can also read more about
+[Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+1. Create a file named `registry-push-secret.yaml` containing the following:
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: registry-push-secret
+     annotations:
+       build.knative.dev/docker-0: https://registry.ng.bluemix.net
+   type: kubernetes.io/basic-auth
+   stringData:
+     username: token
+     password: <token_value>
+   ```
+
+1. Update the "password" with your <token_value>. Note that username will be the
+   string `token`. Save the file.
+
+1. Apply the secret to your cluster.
+
+   ```bash
+   kubectl apply --filename registry-push-secret.yaml
+   ```
+
+1. You will also need a secret for the knative-serving component to pull down an
+   image from the private container registry. This secret will be a
+   `docker-registry` type secret. You can create this via the commandline. For
+   username, simply use the string `token`. For <token_value>, use the token you
+   made note of earlier.
+
+   ```bash
+   kubectl create secret docker-registry ibm-cr-secret --docker-server=https://registry.ng.bluemix.net --docker-username=token --docker-password=<token_value>
+   ```
+
+A Service Account provides an identity for processes that run in a Pod. This
+Service Account will be used to link the build process for Knative to the
+Secrets you just created.
+
+1. Create a file named `service-account.yaml` containing the following:
+
+   ```yaml
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: build-bot
+   secrets:
+     - name: registry-push-secret
+   imagePullSecrets:
+     - name: ibm-cr-secret
+   ```
+
+1. Apply the service account to your cluster:
+
+   ```bash
+   kubectl apply --filename service-account.yaml
+   ```
+
+## Deploy to Knative
+
+To build our application from the source on GitHub, and push the resulting image
+to the IBM Container Registry, we will use the Kaniko build template.
+
+1. Install the Kaniko build template
+
+   ```bash
+   kubectl apply --filename https://raw.githubusercontent.com/knative/build-templates/master/kaniko/kaniko.yaml
+   ```
+
+1. You need to create a service manifest which defines the service to deploy,
+   including where the source code is and which build-template to use. Create a
+   file named `service.yaml` and copy the following definition. Make sure to
+   replace {NAMESPACE} with your own namespace you created earlier:
+
+   ```yaml
+   apiVersion: serving.knative.dev/v1alpha1
+   kind: Service
+   metadata:
+     name: helloworld-go
+     namespace: default
+   spec:
+     runLatest:
+       configuration:
+         build:
+           apiVersion: build.knative.dev/v1alpha1
+           kind: Build
+           spec:
+             serviceAccountName: build-bot
+             source:
+               git:
+                 url: https://github.com/knative/docs
+                 revision: master
+               subPath: docs/serving/samples/hello-world/helloworld-go
+             template:
+               name: kaniko
+               arguments:
+                 - name: IMAGE
+                   value: registry.ng.bluemix.net/{NAMESPACE}/helloworld-go:latest
+         revisionTemplate:
+           spec:
+             serviceAccountName: build-bot
+             container:
+               image: registry.ng.bluemix.net/{NAMESPACE}/helloworld-go:latest
+               imagePullPolicy: Always
+               env:
+                 - name: TARGET
+                   value: "Go Sample v1"
+   ```
+
+1. Apply the configuration using `kubectl`:
+
+   ```bash
+   kubectl apply --filename service.yaml
+   ```
+
+   Applying this service definition will kick off a series of events:
+
+   - Fetches the revision specified from GitHub and builds it into a container,
+     using the Kaniko build template.
+   - Pushes the latest image to the private registry using the
+     registry-push-secret
+   - Pulls down the latest image from the private registry using the
+     ibm-cr-secret.
+   - Starts the service, and your app will be live.
+
+1. You can run `kubectl get pods --watch` to see the pods initializing.
+
+1. Once all the pods are initialized, you can see that your container image was
+   built and pushed to the IBM Container Registry:
+
+   ```
+   ibmcloud cr image-list
+   ```
+
+## Test Application Behavior
+
+1. Run the following command to find the external IP address for your service:
+
+   ```shell
+   INGRESSGATEWAY=istio-ingressgateway
+   kubectl get svc $INGRESSGATEWAY --namespace istio-system
+   ```
+
+   Example:
+
+   ```shell
+   NAME                     TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                                      AGE
+   xxxxxxx-ingressgateway   LoadBalancer   10.23.247.74   35.203.155.229   80:32380/TCP,443:32390/TCP,32400:32400/TCP   2d
+   ```
+
+1. Run the following command to find the domain URL for your service:
+
+   ```shell
+   kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,DOMAIN:.status.domain
+   ```
+
+   Example:
+
+   ```shell
+   NAME                DOMAIN
+   helloworld-go       helloworld-go.default.example.com
+   ```
+
+1. Test your app by sending it a request. Use the following `curl` command with
+   the domain URL `helloworld-go.default.example.com` and `EXTERNAL-IP` address
+   that you retrieved in the previous steps:
+
+   ```shell
+   curl -H "Host: helloworld-go.default.example.com" http://{EXTERNAL_IP_ADDRESS}
+   ```
+
+   Example:
+
+   ```shell
+   curl -H "Host: helloworld-go.default.example.com" http://35.203.155.229
+   Hello Go Sample v1!
+   ```
+
+   > Note: Add `-v` option to get more detail if the `curl` command failed.
+
+## Removing the sample app deployment
+
+To remove the sample app from your cluster, delete the service record:
+
+```shell
+kubectl delete --filename service.yaml
+```


### PR DESCRIPTION
The IBM version of how to use a private registry were deleted when Knative build was deprecated.

This is a new non-host specific task about how to create a secret and use it to access a private container registry.