### PR TITLE
added knfun as external code

### DIFF
--- a/docs/samples.md
+++ b/docs/samples.md
@@ -29,5 +29,6 @@ A list of links to Knative code samples that live outside of
 
 - [Image processing using Knative Eventing, Cloud Run on GKE (Knative Serving implementation) and Google Cloud Vision API](https://github.com/akashrv/knative-samples/blob/master/docs/image-processing.md)
 - [A potpourri of Knative Eventing Examples](https://github.com/lionelvillard/knative-examples)
+- [Knfun - a complete Knative example of three functions using Twitter and Watson API that use kn to deploy and manage functions](https://github.com/maximilien/knfun/blob/master/README.md)
 
 _Please add links to your externally hosted Knative code sample._


### PR DESCRIPTION
KnFun is a complete example of three functions used to demonstrate serverless and Knative and its client: kn.

## Proposed Changes

- adds a link to KnFun example