### PR TITLE
Documentation fix for .NET core sample on Docker for Windows

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -134,6 +134,9 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-csharp
              env:
                - name: TARGET
                  value: "C# Sample v1"
+             ports:
+               - name: http1
+                 containerPort: 80
    ```
 
 ## Building and deploying the sample
@@ -181,7 +184,7 @@ folder) you're ready to build and deploy the sample app.
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-csharp.default.1.2.3.4.xip.io
+   curl -H "Host: helloworld-csharp.default.1.2.3.4.xip.io" http://localhost
    Hello C# Sample v1!
    ```
 


### PR DESCRIPTION
I had to make the following modifications to get the sample working on Docker for Windows.

1. Specify the port type and value.
2. Specify the Hostname in the header of cURL request. 

The URL received by executing the `kubectl get ksvc` command is also not correct. I can update the output of the command as well if the reviewers request that change as well.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Update the documentation