### PR TITLE
404 Fixes and Cherry-picks from 0.10

### DIFF
--- a/community/samples/_index.md
+++ b/community/samples/_index.md
@@ -5,4 +5,4 @@ weight: 40
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/community/samples/serving/helloworld-clojure/README.md
+++ b/community/samples/serving/helloworld-clojure/README.md
@@ -146,7 +146,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-clojure.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -145,7 +145,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-dart.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-haskell/README.md
+++ b/community/samples/serving/helloworld-haskell/README.md
@@ -172,7 +172,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-haskell.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-java-micronaut/README.md
+++ b/community/samples/serving/helloworld-java-micronaut/README.md
@@ -265,7 +265,7 @@ To verify that your sample app has been successfully deployed:
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-java-micronaut.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-java-quarkus/README.md
+++ b/community/samples/serving/helloworld-java-quarkus/README.md
@@ -259,7 +259,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-java-quarkus.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-r/README.md
+++ b/community/samples/serving/helloworld-r/README.md
@@ -173,7 +173,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-r.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-rserver/README.md
+++ b/community/samples/serving/helloworld-rserver/README.md
@@ -144,7 +144,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-rserver.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -170,7 +170,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-rust.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-swift/README.md
+++ b/community/samples/serving/helloworld-swift/README.md
@@ -153,7 +153,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-swift.default.1.2.3.4.xip.io

--- a/community/samples/serving/helloworld-vertx/README.md
+++ b/community/samples/serving/helloworld-vertx/README.md
@@ -233,7 +233,7 @@ To verify that your sample app has been successfully deployed:
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-vertx.default.1.2.3.4.xip.io

--- a/contributing/_index.md
+++ b/contributing/_index.md
@@ -12,4 +12,4 @@ Learn how to join the community of Knative contributors.
 Also see our [Community page](../community) for links to Knative chats,
 discussions, or Q&A.
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ focus on solving mundane but difficult tasks such as:
 
 - [Deploying a container](./serving/getting-started-knative-app.md)
 - [Routing and managing traffic with blue/green deployment](./serving/samples/blue-green-deployment.md)
-- [Scaling automatically and sizing workloads based on demand](./serving/autoscaling.md)
+- [Scaling automatically and sizing workloads based on demand](./serving/configuring-autoscaling.md)
 - [Binding running services to eventing ecosystems](./eventing/samples/kubernetes-event-source/)
 
 Developers on Knative can use familiar idioms, languages, and frameworks to

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -5,4 +5,4 @@ weight: 10
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -75,7 +75,7 @@ a
 Each channel is a separate Kubernetes [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 Events are delivered to Services or forwarded to other channels
 (possibly of a different type) using
-[Subscriptions](https://github.com/knative/eventing/blob/master/pkg/apis/eventing/v1alpha1/subscription_types.go#L35).
+[Subscriptions](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1alpha1/subscription_types.go).
 This allows message delivery in a cluster to vary based on requirements, so that
 some events might be handled by an in-memory implementation while others would
 be persisted using Apache Kafka or NATS Streaming.
@@ -117,7 +117,7 @@ The eventing infrastructure supports two forms of event delivery at the moment:
    using
    [Channels](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1alpha1/channel_types.go#L57)
    and
-   [Subscriptions](https://github.com/knative/eventing/blob/master/pkg/apis/eventing/v1alpha1/subscription_types.go#L35).
+   [Subscriptions](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1alpha1/subscription_types.go).
    In this case, the Channel implementation ensures that messages are delivered
    to the requested destinations and should buffer the events if the destination
    Service is unavailable.

--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -311,7 +311,7 @@ Knative Serving application so that they can be consumed.
       certificate.
 
 See the
-[Kafka Source](https://github.com/knative/eventing-contrib/tree/{{< branch >}}/kafka/source)
+[Kafka Source](https://github.com/knative/eventing-contrib/tree/master/kafka/source)
 example.
 
 ### CamelSource
@@ -341,7 +341,7 @@ to be installed into the current namespace.
   development purposes.
 
 See the
-[CamelSource](https://github.com/knative/eventing-contrib/tree/{{< branch >}}/camel/source/samples)
+[CamelSource](https://github.com/knative/eventing-contrib/tree/master/camel/source/samples)
 example.
 
 ## Getting Started

--- a/docs/eventing/_index.md
+++ b/docs/eventing/_index.md
@@ -5,4 +5,4 @@ weight: 60
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/channels/README.md
+++ b/docs/eventing/channels/README.md
@@ -1,4 +1,4 @@
-Channels are Kubernetes [Custom Resources]((https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) which define a single event forwarding
+Channels are Kubernetes [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) which define a single event forwarding
 and persistence layer. Messaging implementations may provide implementations of
 Channels via a Kubernetes Custom Resource, supporting different technologies, such as Apache Kafka or NATS
 Streaming.

--- a/docs/eventing/channels/_index.md
+++ b/docs/eventing/channels/_index.md
@@ -6,4 +6,4 @@ type: "docs"
 showlandingtoc: "true"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/debugging/example.yaml
+++ b/docs/eventing/debugging/example.yaml
@@ -40,7 +40,7 @@ metadata:
 
 # The Subscription to the InMemoryChannel.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: sub

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -8,7 +8,7 @@ type: "docs"
 
 The Event Registry maintains a catalog of the event types that can be consumed
 from the different Brokers. It introduces a new
-[EventType](../reference/eventing/eventing.md) CRD in order to persist the event
+[EventType](../reference/eventing/) CRD in order to persist the event
 type's information in the cluster's data store.
 
 ## Before you begin

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -258,7 +258,7 @@ the next topic: How do we actually populate the registry in the first place?
 
   If you are interested in more information regarding configuration options of a
   KafkaSource, please refer to the
-  [KafKaSource example](https://github.com/knative/eventing-contrib/tree/{{< branch >}}/kafka/source/samples).
+  [KafKaSource sample](./samples/kafka/).
 
   For this discussion, the relevant information from the yaml above are the
   `sink` and the `topics`. We observe that the `sink` is of kind `Broker`. We

--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -498,7 +498,7 @@ After sending events, verify that your events were received by the appropriate `
 
 After you finish this guide, delete your namespace to conserve resources if you do not plan to use them.
 
-Note: If you plan to continue learning about Knative Eventing with one of our [code samples](./samples/_index.md), check the requirements of the sample and make sure you do not need a namespace before you delete `event-example`. You can always reuse your namespaces.
+Note: If you plan to continue learning about Knative Eventing with one of our [code samples](./samples/), check the requirements of the sample and make sure you do not need a namespace before you delete `event-example`. You can always reuse your namespaces.
 
 Run the following command to delete `event-example`:
 

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -108,7 +108,7 @@ CamelSources from the namespace:
 kubectl delete camelsource --all
 ```
 
-Install the [mqtt CamelSource](mqtt_telegram.yaml):
+Install the [mqtt CamelSource](source_telegram.yaml):
 
 ```shell
 kubectl apply -f source_mqtt.yaml

--- a/docs/eventing/samples/helloworld/README.md
+++ b/docs/eventing/samples/helloworld/README.md
@@ -1,10 +1,18 @@
-Following examples include a simple web app written in the language of your choice that you can use to test knative eventing. It shows how to consume a [CloudEvent](https://cloudevents.io/) in Knative eventing, and optionally how to respond back with another CloudEvent in the http response.
+Following examples include a simple web app written in the language of your choice that you can
+use to test knative eventing. It shows how to consume a [CloudEvent](https://cloudevents.io/)
+in Knative eventing, and optionally how to respond back with another CloudEvent in the HTTP response.
 
-We will deploy the app as a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) along with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/). However, you can also deploy the app as a [Knative Serving Service](../../../serving/README.md)
+We will deploy the app as a
+[Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+along with a
+[Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
+However, you can also deploy the app as a [Knative Serving Service](../../../serving/README.md)
 
 ## Prerequisites
 
-- A Kubernetes cluster with [Knative Eventing](../../getting-started.md#installing-knative-eventing) installed.
-  - If you decide to deploy the app as a Knative Serving Service then you will have to install [Knative Serving](../../../install/README.md).
+- A Kubernetes cluster with [Knative Eventing](../../getting-started.md#installing-knative-eventing)
+  installed.
+  - If you decide to deploy the app as a Knative Serving Service then you will have to install
+    [Knative Serving](../../../install/README.md).
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/eventing/samples/helloworld/_index.md
+++ b/docs/eventing/samples/helloworld/_index.md
@@ -5,4 +5,4 @@ weight: 10
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/samples/helloworld/helloworld-go/_index.md
+++ b/docs/eventing/samples/helloworld/helloworld-go/_index.md
@@ -5,4 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/samples/kafka/_index.md
+++ b/docs/eventing/samples/kafka/_index.md
@@ -5,4 +5,4 @@ weight: 10
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -47,7 +47,9 @@ You can now set the `KafkaChannel` CRD as the default channel configuration.
 
 ## Specifying the default channel configuration
 
-To configure the usage of the `KafkaChannel` CRD as the [default channel configuration](../../../channels/default-channels.md), edit the `default-ch-webhook` ConfigMap as follows:
+To configure the usage of the `KafkaChannel` CRD as the 
+[default channel configuration](../../../channels/default-channels.md), 
+edit the `default-ch-webhook` ConfigMap as follows:
 
 ```
 cat <<-EOF | kubectl apply -f -

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -1,11 +1,9 @@
 ---
 title: "Apache Kafka Channel Example"
-linkTitle: "Apache Kafka Channel Example"
+linkTitle: "Channel Example"
 weight: 20
 type: "docs"
 ---
-
-# Apache Kafka CRD default channel
 
 You can install and configure the Apache Kafka CRD (`KafkaChannel`) as the default channel configuration in Knative Eventing. 
 

--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -1,11 +1,9 @@
 ---
 title: "Apache Kafka Source Example"
-linkTitle: "Apache Kafka Source Example"
+linkTitle: "Source Example"
 weight: 20
 type: "docs"
 ---
-
-# Apache Kafka - Source Example
 
 Tutorial on how to build and deploy a `KafkaSource` [Eventing source](../../../sources/README.md) using a Knative Serving `Service`.
 

--- a/docs/eventing/samples/parallel/_index.md
+++ b/docs/eventing/samples/parallel/_index.md
@@ -5,4 +5,4 @@ weight: 10
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/samples/parallel/multiple-branches/_index.md
+++ b/docs/eventing/samples/parallel/multiple-branches/_index.md
@@ -5,4 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/samples/parallel/mutual-exclusivity/_index.md
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/_index.md
@@ -5,4 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -12,7 +12,7 @@ taking the output of that `Sequence` and displaying the resulting output.
 ![Logical Configuration](./sequence-reply-to-event-display.png)
 
 The functions used in these examples live in
-(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
 
 ## Prerequisites
 

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -13,7 +13,7 @@ finally displaying the resulting output.
 ![Logical Configuration](./sequence-reply-to-sequence.png)
 
 The functions used in these examples live in
-(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
 
 ## Prerequisites
 

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -12,7 +12,7 @@ can then do either external work, or out of band create additional events.
 ![Logical Configuration](./sequence-terminal.png)
 
 The functions used in these examples live in
-(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
 
 ## Prerequisites
 

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -24,7 +24,7 @@ If you want to use different type of `Channel`, you will have to modify the
 ![Logical Configuration](./sequence-with-broker-trigger.png)
 
 The functions used in these examples live in
-(https://github.com/vaikas/transformer)[https://github.com/vaikas/transformer]
+[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
 
 ## Setup
 

--- a/docs/eventing/samples/writing-a-source/01-bootstrap.md
+++ b/docs/eventing/samples/writing-a-source/01-bootstrap.md
@@ -29,7 +29,7 @@ git commit -m "Initial commit" --allow-empty
 ## Create a Kubebuilder project
 
 _When in doubt, the
-[Kubebuilder Quick Start docs](https://book.kubebuilder.io/quick_start.html) are
+[Kubebuilder Quick Start docs](https://book.kubebuilder.io/quick-start.html) are
 likely more current than these instructions._
 
 Use the `kubebuilder init` command in the repo root directory to create the

--- a/docs/eventing/samples/writing-a-source/02-define-source.md
+++ b/docs/eventing/samples/writing-a-source/02-define-source.md
@@ -13,7 +13,7 @@ to learn more about Kubebuilder.
 ## Create the Source CRD Skeleton
 
 _When in doubt, the
-[Kubebuilder Quick Start docs](https://book.kubebuilder.io/quick_start.html) are
+[Kubebuilder Quick Start docs](https://book.kubebuilder.io/quick-start.html) are
 likely more current than these instructions._
 
 Use the `kubebuilder create api` command to create the API definition for a new

--- a/docs/eventing/samples/writing-a-source/_index.md
+++ b/docs/eventing/samples/writing-a-source/_index.md
@@ -5,4 +5,4 @@ weight: 60
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/install/Knative-custom-install.md
+++ b/docs/install/Knative-custom-install.md
@@ -3,7 +3,6 @@ title: "Performing a Custom Knative Installation"
 linkTitle: "Customizing your install"
 weight: 15
 type: "docs"
-markup: "mmark"
 ---
 
 Use this guide to perform a custom installation of Knative on an existing

--- a/docs/install/Knative-with-MicroK8s.md
+++ b/docs/install/Knative-with-MicroK8s.md
@@ -5,7 +5,7 @@ weight: 10
 type: "docs"
 ---
 
-[MicroK8s](https://microk8s.io) is a lightweight, powerful fully-conformant Kubernetes that tracks upstream releases and makes clustering trivial. It can run on any flavor of Linux that supports [Snap](https://snapcraft.io) packages. It can run on Windows and Mac OS using [Mutlipass](https://multipass.run).
+[MicroK8s](https://microk8s.io) is a lightweight, powerful fully-conformant Kubernetes that tracks upstream releases and makes clustering trivial. It can run on any flavor of Linux that supports [Snap](https://snapcraft.io) packages. It can run on Windows and Mac OS using [Multipass](https://multipass.run).
 This guide walks you through the installation of Knative using MicroK8s.
 
 If you need help or support please reach out on the [Kubernetes forum](https://discuss.kubernetes.io/tags/microk8s) or Kubernetes.slack.com channel #microk8s.

--- a/docs/install/_index.md
+++ b/docs/install/_index.md
@@ -5,4 +5,4 @@ weight: 05
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/reference/eventing/_index.md
+++ b/docs/reference/eventing/_index.md
@@ -5,4 +5,4 @@ weight: 30
 type: "docs"
 ---
 
-{{< readfile file="eventing.md" relative="true" >}}
+{{< readfile file="eventing.md" >}}

--- a/docs/reference/eventing/eventing-contrib-api.md
+++ b/docs/reference/eventing/eventing-contrib-api.md
@@ -5,4 +5,4 @@ weight: 50
 type: "docs"
 ---
 
-{{< readfile file="eventing-contrib.md" relative="true" >}}
+{{< readfile file="eventing-contrib.md" >}}

--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -1,4 +1,4 @@
 
-<p>See the <a href="https://github.com/knative/eventing/tree/{{< branch >}}/pkg/apis">Knative Eventing repo</a> for the API.</p>
+<p>See the <a href="https://github.com/knative/eventing/tree/master/pkg/apis">Knative Eventing repo</a> for the API.</p>
 
 <p>There is currently an <a href="https://github.com/knative/docs/issues/1661">API doc build tool issue</a> that we hope to resolve soon.</p>

--- a/docs/reference/serving-api.md
+++ b/docs/reference/serving-api.md
@@ -5,4 +5,4 @@ weight: 50
 type: "docs"
 ---
 
-{{< readfile file="serving.md" relative="true" >}}
+{{< readfile file="serving.md" >}}

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1,4 +1,4 @@
 
-<p>See the <a href="https://github.com/knative/serving/tree/{{< branch >}}/pkg/apis">Knative Serving repo</a> for the API.</p>
+<p>See the <a href="https://github.com/knative/serving/tree/master/pkg/apis">Knative Serving repo</a> for the API.</p>
 
 <p>There is currently an <a href="https://github.com/knative/docs/issues/1661">API doc build tool issue</a> that we hope to resolve soon.</p>

--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -36,7 +36,7 @@ serverless workload behaves on the cluster:
   are immutable objects and can be retained for as long as useful. Knative
   Serving Revisions can be automatically scaled up and down according to
   incoming traffic. See
-  [Configuring the Autoscaler](./configuring-the-autoscaler.md) for more
+  [Configuring the Autoscaler](./configuring-autoscaling.md) for more
   information.
 
 ![Diagram that displays how the Serving resources coordinate with each other.](https://github.com/knative/serving/raw/master/docs/spec/images/object_model.png)

--- a/docs/serving/_index.md
+++ b/docs/serving/_index.md
@@ -5,4 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/serving/fluentd-requirements.md
+++ b/docs/serving/fluentd-requirements.md
@@ -30,7 +30,7 @@ includes the desired output plugin. Two examples below:
 ### Send logs to Elasticsearch
 
 Operators can use
-[k8s.gcr.io/fluentd-elasticsearch:v2.0.4](https://github.com/kubernetes/kubernetes/tree/{{< branch >}}/cluster/addons/fluentd-elasticsearch/fluentd-es-image)
+[k8s.gcr.io/fluentd-elasticsearch:v2.0.4](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch/fluentd-es-image)
 which includes
 [fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch)
 that allows sending logs to a Elasticsearch service.
@@ -38,7 +38,7 @@ that allows sending logs to a Elasticsearch service.
 ### Send logs to Stackdriver
 
 This sample [Dockerfile](./stackdriver/Dockerfile) is based on
-[k8s.gcr.io/fluentd-elasticsearch:v2.0.4](https://github.com/kubernetes/kubernetes/tree/{{< branch >}}/cluster/addons/fluentd-elasticsearch).
+[k8s.gcr.io/fluentd-elasticsearch:v2.0.4](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/fluentd-elasticsearch).
 It additionally adds one more plugin -
 [fluent-plugin-google-cloud](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud)
 which allows sending logs to Stackdriver.

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -134,3 +134,9 @@ To remove the sample app from your cluster, delete the service record:
 ```shell
 kubectl delete --filename service.yaml
 ```
+
+Alternatively, delete the service by name:
+
+```shell
+kubectl delete kservice helloworld-go
+```

--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -93,5 +93,5 @@ The networking-istio deployment reconciles a cluster's ingress into an
   click
   [here](https://github.com/knative/serving/blob/master/docs/spec/overview.md#service).
 - For a high-level analysis of Serving, look at the [documentation here](./).
-- Check out the Knative Seriving code samples [here](./samples/) for more
+- Check out the Knative Serving code samples [here](./samples/) for more
   hands-on tutorials.

--- a/docs/serving/samples/_index.md
+++ b/docs/serving/samples/_index.md
@@ -5,4 +5,4 @@ weight: 100
 type: "docs"
 ---
 
-{{% readfile file="README.md" relative="true" markdown="true" %}}
+{{% readfile file="README.md" %}}

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -179,7 +179,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-csharp.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -177,7 +177,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-go.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-java-spark/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/README.md
@@ -136,7 +136,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-java.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -186,7 +186,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-java-spring.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -206,7 +206,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-kotlin.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-nodejs/README.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/README.md
@@ -189,7 +189,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-nodejs.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-php/README.md
+++ b/docs/serving/samples/hello-world/helloworld-php/README.md
@@ -135,7 +135,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-php.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -151,7 +151,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-python.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-ruby/README.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/README.md
@@ -148,7 +148,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-ruby.default.1.2.3.4.xip.io

--- a/docs/serving/samples/hello-world/helloworld-shell/README.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/README.md
@@ -187,7 +187,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://helloworld-shell.default.1.2.3.4.xip.io

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -56,7 +56,7 @@ cd knative-docs/serving/samples/secrets-go
     log.Print("Secrets sample started.")
 
     // This sets up the standard GCS storage client, which will pull
-    // credentials from GOOGLE_APPLICATION_DEFAULT if specified.
+    // credentials from GOOGLE_APPLICATION_CREDENTIALS if specified.
     ctx := context.Background()
     client, err := storage.NewClient(ctx)
     if err != nil {
@@ -184,7 +184,7 @@ cd knative-docs/serving/samples/secrets-go
                #  - `robot.json` is determined by the "key" that is used to hold the
                #   secret content in the Kubernetes secret.  This can be changed
                #   if both places are changed.
-               - name: GOOGLE_APPLICATION_DEFAULT
+               - name: GOOGLE_APPLICATION_CREDENTIALS
                  value: /var/secret/robot.json
 
              # This section specified where in the container we want the

--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -248,7 +248,7 @@ folder) you're ready to build and deploy the sample app.
    ```
 
 1. Now you can make a request to your app and see the result. Replace
-   the URL below the with URL returned in the previous command.
+   the URL below with the URL returned in the previous command.
 
    ```shell
    curl http://secrets-go.default.1.2.3.4.xip.io


### PR DESCRIPTION
- Fixed some missed 404s
- Update the syntax for the readfile (prevent others from copying the outdated syntax)
- Add all the back-log of cherry picks that were add to only 0.10 and never pushed into master. 
   See commits for details.