### PR TITLE
update samples to not use deprecated fields in triggers

### DIFF
--- a/docs/eventing/channels/README.md
+++ b/docs/eventing/channels/README.md
@@ -1,4 +1,4 @@
-Channels are Kubernetes [Custom Resources]((https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)) which define a single event forwarding
+Channels are Kubernetes [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) which define a single event forwarding
 and persistence layer. Messaging implementations may provide implementations of
 Channels via a Kubernetes Custom Resource, supporting different technologies, such as Apache Kafka or NATS
 Streaming.

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -128,7 +128,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
    spec:
      broker: default
      filter:
-       sourceAndType:
+       attributes:
          type: dev.knative.source.github.push
      subscriber:
        ref:
@@ -153,7 +153,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
    spec:
      broker: default
      filter:
-       sourceAndType:
+       attributes:
          type: dev.knative.source.github.pull_request
          source: https://github.com/knative/eventing
      subscriber:
@@ -174,7 +174,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
    spec:
      broker: default
      filter:
-       sourceAndType:
+       attributes:
          type: dev.knative.kafka.event
          source: /apis/v1/namespaces/default/kafkasources/kafka-sample#knative-demo
      subscriber:
@@ -196,7 +196,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
    spec:
      broker: dev
      filter:
-       sourceAndType:
+       attributes:
          source: //pubsub.googleapis.com/knative/topics/testing
      subscriber:
        ref:

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -166,7 +166,7 @@ metadata:
   name: sequence-trigger
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: dev.knative.cronjob.event
   subscriber:
     ref:
@@ -202,7 +202,7 @@ metadata:
   name: display-trigger
 spec:
   filter:
-    sourceAndType:
+    attributes:
       type: samples.http.mod3
   subscriber:
     ref:

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   broker: default
   filter:
-    sourceAndType:
+    attributes:
       type: samples.http.mod3
   subscriber:
     ref:

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/trigger.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   broker: default
   filter:
-    sourceAndType:
+    attributes:
       type: dev.knative.cronjob.event
   subscriber:
     ref:


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Change deprecated sourceAndType Trigger examples to use attributes
- Fix one broken link.
-
