### PR TITLE
update examples to use new image locations

### DIFF
--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -12,7 +12,7 @@ taking the output of that `Sequence` and displaying the resulting output.
 ![Logical Configuration](./sequence-reply-to-event-display.png)
 
 The functions used in these examples live in
-[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
+[https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go](https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go).
 
 ## Prerequisites
 
@@ -40,10 +40,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "0"
+            - name: MESSAGE
+              value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -54,10 +54,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "1"
+            - name: MESSAGE
+              value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -67,10 +67,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "2"
+            - name: MESSAGE
+              value: " - Handled by 2"
 ---
 
 ```
@@ -132,7 +132,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+        - image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display
 ```
 
 Change `default` below to create the `Sequence` in the Namespace where you want

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/event-display.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/event-display.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/steps.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "0"
+        - name: MESSAGE
+          value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -20,10 +20,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "1"
+        - name: MESSAGE
+          value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -33,8 +33,8 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "2"
+        - name: MESSAGE
+          value: " - Handled by 2"
 ---

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -13,7 +13,7 @@ finally displaying the resulting output.
 ![Logical Configuration](./sequence-reply-to-sequence.png)
 
 The functions used in these examples live in
-[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
+[https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go](https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go).
 
 ## Prerequisites
 
@@ -41,10 +41,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "0"
+            - name: MESSAGE
+              value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -55,10 +55,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "1"
+            - name: MESSAGE
+              value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -68,10 +68,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "2"
+            - name: MESSAGE
+              value: " - Handled by 2"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -81,10 +81,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "3"
+            - name: MESSAGE
+              value: " - Handled by 3"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -95,10 +95,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "4"
+            - name: MESSAGE
+              value: " - Handled by 4"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -108,10 +108,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "5"
+            - name: MESSAGE
+              value: " - Handled by 5"
 ---
 
 ```
@@ -208,7 +208,7 @@ spec:
   template:
     spec:
       containerers:
-        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+        - image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display
 ```
 
 Change `default` below to create the `Sequence` in the Namespace where you want

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/event-display.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/event-display.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/steps.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "0"
+        - name: MESSAGE
+          value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -20,10 +20,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "1"
+        - name: MESSAGE
+          value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -33,10 +33,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "2"
+        - name: MESSAGE
+          value: " - Handled by 2"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -47,10 +47,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "3"
+        - name: MESSAGE
+          value: " - Handled by 3"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -60,10 +60,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "4"
+        - name: MESSAGE
+          value: " - Handled by 4"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -73,8 +73,8 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "5"
+        - name: MESSAGE
+          value: " - Handled by 5"
 ---

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -12,7 +12,7 @@ can then do either external work, or out of band create additional events.
 ![Logical Configuration](./sequence-terminal.png)
 
 The functions used in these examples live in
-[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
+[https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go](https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go).
 
 ## Prerequisites
 
@@ -39,10 +39,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "0"
+            - name: MESSAGE
+              value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -53,10 +53,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "1"
+            - name: MESSAGE
+              value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -66,10 +66,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "2"
+            - name: MESSAGE
+              value: " - Handled by 2"
 ---
 
 ```

--- a/docs/eventing/samples/sequence/sequence-terminal/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/steps.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "0"
+        - name: MESSAGE
+          value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -20,10 +20,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "1"
+        - name: MESSAGE
+          value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -33,8 +33,8 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "2"
+        - name: MESSAGE
+          value: " - Handled by 2"
 ---

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -24,7 +24,7 @@ If you want to use different type of `Channel`, you will have to modify the
 ![Logical Configuration](./sequence-with-broker-trigger.png)
 
 The functions used in these examples live in
-[https://github.com/vaikas/transformer](https://github.com/vaikas/transformer).
+[https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go](https://github.com/knative/eventing-contrib/blob/master/cmd/appender/main.go).
 
 ## Setup
 
@@ -42,10 +42,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "0"
+            - name: MESSAGE
+              value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -56,10 +56,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "1"
+            - name: MESSAGE
+              value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -69,10 +69,10 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
           env:
-            - name: STEP
-              value: "2"
+            - name: MESSAGE
+              value: " - Handled by 2"
 
 ---
 
@@ -194,7 +194,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
 ---
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Trigger

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display
 ---
 apiVersion: eventing.knative.dev/v1alpha1
 kind: Trigger

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/steps.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/steps.yaml
@@ -6,10 +6,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "0"
+        - name: MESSAGE
+          value: " - Handled by 0"
 
 ---
 apiVersion: serving.knative.dev/v1
@@ -20,10 +20,10 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "1"
+        - name: MESSAGE
+          value: " - Handled by 1"
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -33,9 +33,9 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/vaikas-knative/cmd-736bbd9d5a42b6282732cf4569e3c0ff@sha256:f069e4e58d6b420d66304d3bbde019160eb12ca17bb98fc3b88e0de5ad2cacd1
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
         env:
-        - name: STEP
-          value: "2"
+        - name: MESSAGE
+          value: " - Handled by 2"
 
 ---


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

## Proposed Changes

- I moved the example code from vaikas/transformer to knative/eventing-contrib, so update docs
- Use the newly released artifact from knative/eventing-contrib releases
- Update event-display container to use shorter vanity name.
