### PR TITLE
Fix wording to address bug #2023 plus small formatting updates

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -58,7 +58,10 @@ If the `knative-eventing` namespace or the `imc-controller-*` does not exist, us
     kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
     ```
 
-   Installing the CRDs first can prevent race conditions and failures during the install.
+   Installing the CRDs first can prevent race conditions, which may cause failures during the install.
+   Race conditions exist during install because a CRD must be defined before an instance of that
+   resource can be created. Defining all CRDs before continuing with the rest of the installation
+   prevents this problem.
 
 1. Confirm that Knative Eventing is correctly installed by running the following command:
 

--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -8,8 +8,11 @@ type: "docs"
 Use this guide to learn how to create, send, and verify events in Knative. The steps in this guide demonstrate a basic developer flow for managing events in Knative, including:
 
 1. [Installing the Knative Eventing component](#installing-knative-eventing)
+
 1. [Creating and configuring Knative Eventing Resources](#setting-up-knative-eventing-resources)
+
 1. [Sending events with HTTP requests](#sending-events-to-the-broker)
+
 1. [Verifying events were sent correctly](#verifying-events-were-received)
 
 ## Before you begin
@@ -17,9 +20,13 @@ Use this guide to learn how to create, send, and verify events in Knative. The s
 To complete this guide, you will need the following installed and running:
 
 - A [Kubernetes cluster](https://kubernetes.io/docs/concepts/cluster-administration/cluster-administration-overview/) running v1.14 or higher
+
 - [`kubectl` CLI tool](https://kubernetes.io/docs/reference/kubectl/overview/) within a minor version of your Kubernetes cluster.
+
 - [curl v7.65 or higher](https://curl.haxx.se/download.html)
+
 - Knative Eventing Component
+
    - Knative Eventing In-memory channel 
 
 ### Installing Knative Eventing 
@@ -33,22 +40,27 @@ kubectl get pods --namespace knative-eventing
 If the `knative-eventing` namespace or the `imc-controller-*` does not exist, use the following steps to install Knative Eventing with the in-memory channel:
 
 1. Make sure that you have a functioning Kubernetes cluster. See the [Comprehensive Install guide](../install) for more information.
+
    - Old versions of Knative Serving doesn't necessarily work well with latest Knative Eventing, so try to install the latest version of Knative Serving.
+
    - If your Kubernetes cluster comes with pre-installed Istio, make sure it has `cluster-local-gateway` [deployed](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#deploy-istio). Depending on which Istio version you have, you'd need to apply the `istio-knative-extras.yaml` in the corresponding version folder at [here](https://github.com/knative/serving/tree/{{< branch >}}/third_party).
-2. Install the Eventing CRDs by running the following command:
+
+1. Install the Eventing CRDs by running the following command:
 
     ```sh
     kubectl apply --selector knative.dev/crd-install=true \
     --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
     ```
 
-3. Install the Eventing sources by running the following command:
+1. Finish installing Eventing resources by running the following command:
 
     ```sh
     kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
     ```
 
-4. Confirm that Knative Eventing is correctly installed by running the following command:
+   Installing the CRDs first can prevent race conditions and failures during the install.
+
+1. Confirm that Knative Eventing is correctly installed by running the following command:
 
     ```sh
     kubectl get pods --namespace knative-eventing
@@ -81,7 +93,7 @@ In this section you create the `event-example` namespace and then add the `knati
 
     This creates an empty namespace called `event-example`.
 
-2. Add a label to your namespace with the following command:
+1. Add a label to your namespace with the following command:
 
     ```sh
     kubectl label namespace event-example knative-eventing-injection=enabled
@@ -110,7 +122,7 @@ The [`Broker`](./broker-trigger.md#broker) ensures that every event sent by even
 
     When the `Broker` has the `READY=True` state, it can begin to manage any events it receives.
 
-2. If `READY=False`, wait 2 minutes and re-run the command. If you continue to receive the `READY=False`, see the [Debugging Guide](./debugging/README.md) to help troubleshoot the issue.
+1. If `READY=False`, wait 2 minutes and re-run the command. If you continue to receive the `READY=False`, see the [Debugging Guide](./debugging/README.md) to help troubleshoot the issue.
 
 Now that your `Broker` is ready to manage events, you can create and configure your event producers and consumers.
 
@@ -158,7 +170,7 @@ Your event consumers receive the events sent by event producers. In this step, y
     END
     ```
 
-2. To deploy the `goodbye-display` consumer to your cluster, run the following command:
+1. To deploy the `goodbye-display` consumer to your cluster, run the following command:
 
     ```sh
     kubectl --namespace event-example apply --filename - << END
@@ -198,7 +210,7 @@ Your event consumers receive the events sent by event producers. In this step, y
     END
     ```
 
-3. Just like you did with the `Broker`, verify that your event consumers are working by running the following command:
+1. Just like you did with the `Broker`, verify that your event consumers are working by running the following command:
 
     ```sh
     kubectl --namespace event-example get deployments hello-display goodbye-display
@@ -243,7 +255,7 @@ to receive. Your `Broker` uses triggers to forward events to the right consumers
 
    The command creates a trigger that sends all events of type `greeting` to your event consumer named `hello-display`.
 
-2. To add the second `Trigger`, run the following command:
+1. To add the second `Trigger`, run the following command:
 
     ```sh
     kubectl --namespace event-example apply --filename - << END
@@ -265,7 +277,7 @@ to receive. Your `Broker` uses triggers to forward events to the right consumers
 
    The command creates a trigger that sends all events of source `sendoff` to your event consumer named `goodbye-display`.
 
-3. Verify that the triggers are working correctly by running the following command:
+1. Verify that the triggers are working correctly by running the following command:
 
     ```sh
     kubectl --namespace event-example get triggers
@@ -358,7 +370,7 @@ To show the various types of events you can send, you will make three requests:
     ```
 
 
-2. To make the second request, which creates an event that has the `source` `sendoff`, run the following in the SSH terminal:
+1. To make the second request, which creates an event that has the `source` `sendoff`, run the following in the SSH terminal:
 
     ```sh
     curl -v "http://default-broker.event-example.svc.cluster.local" \
@@ -381,7 +393,7 @@ To show the various types of events you can send, you will make three requests:
     < Date: Mon, 12 Aug 2019 19:48:18 GMT
     ```
 
-3. To make the third request, which creates an event that has the `type` `greeting` and the`source` `sendoff`, run the following in the SSH terminal:
+1. To make the third request, which creates an event that has the `type` `greeting` and the`source` `sendoff`, run the following in the SSH terminal:
 
     ```sh
     curl -v "http://default-broker.event-example.svc.cluster.local" \
@@ -453,7 +465,7 @@ After sending events, verify that your events were received by the appropriate `
      }
     ```
 
-2. Look at the logs for the `goodbye-display` event consumer by running the following command:
+1. Look at the logs for the `goodbye-display` event consumer by running the following command:
 
     ```sh
     kubectl --namespace event-example logs -l app=goodbye-display --tail=100

--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -58,7 +58,7 @@ If the `knative-eventing` namespace or the `imc-controller-*` does not exist, us
     kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/release.yaml
     ```
 
-   Installing the CRDs first can prevent race conditions, which may cause failures during the install.
+   Installing the CRDs first can prevent race conditions, which might cause failures during the install.
    Race conditions exist during install because a CRD must be defined before an instance of that
    resource can be created. Defining all CRDs before continuing with the rest of the installation
    prevents this problem.


### PR DESCRIPTION
Fixes #2023 

## Proposed Changes

- Update wording to reflect what's actually happening during install (the guide doesn't actually need to install Eventing sources; the install is just split into two steps so that the CRDs are installed first and then everything else is installed on the second pass)

- Update formatting to add whitespace and use automatic numbering
