### PR TITLE
call version with using '--'

### DIFF
--- a/docs/install/Knative-with-Gloo.md
+++ b/docs/install/Knative-with-Gloo.md
@@ -40,7 +40,7 @@ export PATH=$HOME/.gloo/bin:$PATH
 Verify the CLI is installed and running correctly with:
 
 ```shell
-glooctl --version
+glooctl version
 ```
 
 ### Deploying Gloo and Knative to your cluster


### PR DESCRIPTION
It seems that the `glooctl` changed and doesn't require prefixing the command with `--`. 


