### PR TITLE
Update configuring-autoscaling.md

### DIFF
--- a/docs/serving/configuring-autoscaling.md
+++ b/docs/serving/configuring-autoscaling.md
@@ -19,7 +19,7 @@ namespace.
 
 You can view the default contents of this ConfigMap using the following command.
 
-`kubectl -n knative-serving get cm config-autoscaler`
+`kubectl -n knative-serving describe cm config-autoscaler`
 
 ## Example of the default Kubernetes ConfigMap
 


### PR DESCRIPTION
The description says:

> You can view the default contents of this ConfigMap using the following command.

To view the contents of the ConfigMap you actually want to `describe` the resource, not `get`.