### PR TITLE
Update the instruction on how to use cluster local gateway

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -144,18 +144,22 @@ EOF
 **Note:** This method is only for development purposes. The production readiness of the above 
 installation method is not ensured. For a production-ready installation, see the `helm` installation method above.
 
-If you follow either of the above steps, your service and deployment for the local gateway are both named `cluster-local-gateway`,
-and you do not need to update gateway configmap `config-istio` under `knative-serving` namespace, because Knative Serving
-can by default use the local gateway with the name `cluster-local-gateway`.
+After you install the cluster local gateway, your service and deployment for the local gateway are both named `cluster-local-gateway`.
+You do not need to update the `config-istio` configmap under `knative-serving` namespace, because Knative Serving can use
+this local gateway cluster-local-gateway by default.
+
+### Updating the `config-istio` configmap to use a non-default local gateway
 
 However, if you create custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
-need to update gateway configmap `config-istio` under `knative-serving` namespace. Run the following command:
+need to update gateway configmap `config-istio` under `knative-serving` namespace.
+
+1. Run the following command:
 
 ```shell
 kubectl edit configmap config-istio -n knative-serving
 ```
 
-Replace the `local-gateway.knative-serving.cluster-local-gateway` field with the custom service. If you name both
+2. Replace the `local-gateway.knative-serving.cluster-local-gateway` field with the custom service. If you name both
 of the service and deployment after `custom-local-gateway` under the namespace `istio-system`, it should be updated to:
 
 ```

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -150,6 +150,8 @@ this local gateway cluster-local-gateway by default.
 
 ### Updating the `config-istio` configmap to use a non-default local gateway
 
+#### Update Gateway Configmap
+
 If you create custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
 need to update gateway configmap `config-istio` under `knative-serving` namespace.
 
@@ -165,6 +167,30 @@ of the service and deployment after `custom-local-gateway` under the namespace `
 ```
 custom-local-gateway.istio-system.svc.cluster.local
 ```
+
+#### Update Knative Gateway
+
+If both of the custom service and deployment are labeled with `custom: custom-local-gateway`, not the default
+`istio: cluster-local-gateway`, you need to update gateway instance `cluster-local-gateway` in `knative-serving` namespace:
+
+```shell
+kubectl edit gateway cluster-local-gateway -n knative-serving
+```
+
+Replace the label selector with the label of your service:
+
+```
+istio: cluster-local-gateway
+```
+
+For the service above, it should be updated to:
+
+```
+custom: custom-local-gateway
+```
+
+If there is a change in service ports (compared with that of
+`cluster-local-gateway`), update the port info in the gateway accordingly.
 
 ### Verifying your Istio install
 

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -150,7 +150,7 @@ this local gateway cluster-local-gateway by default.
 
 ### Updating the `config-istio` configmap to use a non-default local gateway
 
-However, if you create custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
+If you create custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
 need to update gateway configmap `config-istio` under `knative-serving` namespace.
 
 1. Run the following command:

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -264,3 +264,4 @@ See the [Uninstall Istio](https://istio.io/docs/setup/install/istioctl/#uninstal
   https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#automatic-sidecar-injection
 [3]: https://istio.io/docs/concepts/security/#mutual-tls-authentication
 [4]: https://istio.io/docs/tasks/security/authz-http/
+[4]: https://istio.io/docs/concepts/security/#mutual-tls-authentication

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -141,7 +141,7 @@ spec:
 EOF
 ```
 
-__Note:__ This installation method is not production ready and is for development purposes only. For a more stable method,
+**Note:** This installation method is not production ready and is for development purposes only. For a more stable method,
 use Helm. For more information about the Helm installation method, see [Installing Helm](https://helm.sh/docs/intro/install/).
 
 After you install the cluster local gateway, your service and deployment for the local gateway are both named `cluster-local-gateway`.
@@ -167,7 +167,7 @@ custom-local-gateway.istio-system.svc.cluster.local
 ```
 
 If both the custom service and deployment are labeled with `custom: custom-local-gateway`, not the default
-`istio: cluster-local-gateway`, you need to update gateway instance `cluster-local-gateway` in `knative-serving` namespace:
+`istio: cluster-local-gateway`, you need to update gateway instance `cluster-local-gateway` in the `knative-serving` namespace:
 
 ```shell
 kubectl edit gateway cluster-local-gateway -n knative-serving
@@ -203,10 +203,9 @@ kubectl get pods --namespace istio-system
 
 ### Configuring DNS
 
-Knative dispatches to different services based on their hostname, so it greatly
-simplifies things to have DNS properly configured. For this, we must look up the
-external IP address that Istio received. This can be done with the following
-command:
+You must configure your DNS settings to allow Knative to dispatch services based on
+their hostname. To do this, you must look up the external IP address received by Istio
+by entering the following command:
 
 ```
 $ kubectl get svc -nistio-system

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -141,36 +141,32 @@ spec:
 EOF
 ```
 
-**Note:** This method is only for development purposes. The production readiness of the above 
-installation method is not ensured. For a production-ready installation, see the `helm` installation method above.
+__Note:__ This installation method is not production ready and is for development purposes only. For a more stable method,
+use Helm. For more information about the Helm installation method, see [Installing Helm](https://helm.sh/docs/intro/install/).
 
 After you install the cluster local gateway, your service and deployment for the local gateway are both named `cluster-local-gateway`.
-You do not need to update the `config-istio` configmap under `knative-serving` namespace, because Knative Serving can use
-this local gateway cluster-local-gateway by default.
+You do not need to update the `config-istio` configmap under the `knative-serving` namespace, because Knative Serving can use
+the local gateway cluster-local-gateway by default.
 
 ### Updating the `config-istio` configmap to use a non-default local gateway
 
-#### Update Gateway Configmap
+If you create a custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
+need to update gateway configmap `config-istio` under the `knative-serving` namespace.
 
-If you create custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
-need to update gateway configmap `config-istio` under `knative-serving` namespace.
-
-1. Run the following command:
+1. Edit the 1config-istio1 configmap:
 
 ```shell
 kubectl edit configmap config-istio -n knative-serving
 ```
 
 2. Replace the `local-gateway.knative-serving.cluster-local-gateway` field with the custom service. If you name both
-of the service and deployment after `custom-local-gateway` under the namespace `istio-system`, it should be updated to:
+the service and deployment `custom-local-gateway` under the namespace `istio-system`, it should be updated to:
 
 ```
 custom-local-gateway.istio-system.svc.cluster.local
 ```
 
-#### Update Knative Gateway
-
-If both of the custom service and deployment are labeled with `custom: custom-local-gateway`, not the default
+If both the custom service and deployment are labeled with `custom: custom-local-gateway`, not the default
 `istio: cluster-local-gateway`, you need to update gateway instance `cluster-local-gateway` in `knative-serving` namespace:
 
 ```shell
@@ -189,7 +185,7 @@ For the service above, it should be updated to:
 custom: custom-local-gateway
 ```
 
-If there is a change in service ports (compared with that of
+If there is a change in service ports (compared to that of
 `cluster-local-gateway`), update the port info in the gateway accordingly.
 
 ### Verifying your Istio install

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -141,9 +141,6 @@ spec:
 EOF
 ```
 
-**Note:** This installation method is not production ready and is for development purposes only. For a more stable method,
-use Helm. For more information about the Helm installation method, see [Installing Helm](https://helm.sh/docs/intro/install/).
-
 After you install the cluster local gateway, your service and deployment for the local gateway are both named `cluster-local-gateway`.
 You do not need to update the `config-istio` configmap under the `knative-serving` namespace, because Knative Serving can use
 the local gateway cluster-local-gateway by default.
@@ -203,9 +200,10 @@ kubectl get pods --namespace istio-system
 
 ### Configuring DNS
 
-You must configure your DNS settings to allow Knative to dispatch services based on
-their hostname. To do this, you must look up the external IP address received by Istio
-by entering the following command:
+Knative dispatches to different services based on their hostname, so it greatly
+simplifies things to have DNS properly configured. For this, we must look up the
+external IP address that Istio received. This can be done with the following
+command:
 
 ```
 $ kubectl get svc -nistio-system
@@ -264,4 +262,3 @@ See the [Uninstall Istio](https://istio.io/docs/setup/install/istioctl/#uninstal
   https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#automatic-sidecar-injection
 [3]: https://istio.io/docs/concepts/security/#mutual-tls-authentication
 [4]: https://istio.io/docs/tasks/security/authz-http/
-[4]: https://istio.io/docs/concepts/security/#mutual-tls-authentication

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -142,29 +142,27 @@ EOF
 ```
 
 After you install the cluster local gateway, your service and deployment for the local gateway are both named `cluster-local-gateway`.
-You do not need to update the `config-istio` configmap under the `knative-serving` namespace, because Knative Serving can use
-the local gateway cluster-local-gateway by default.
 
 ### Updating the `config-istio` configmap to use a non-default local gateway
 
 If you create a custom service and deployment for local gateway with a name other than `cluster-local-gateway`, you
 need to update gateway configmap `config-istio` under the `knative-serving` namespace.
 
-1. Edit the 1config-istio1 configmap:
+1. Edit the `config-istio` configmap:
 
 ```shell
 kubectl edit configmap config-istio -n knative-serving
 ```
 
-2. Replace the `local-gateway.knative-serving.cluster-local-gateway` field with the custom service. If you name both
+2. Replace the `local-gateway.knative-serving.cluster-local-gateway` field with the custom service. As an example, if you name both
 the service and deployment `custom-local-gateway` under the namespace `istio-system`, it should be updated to:
 
 ```
 custom-local-gateway.istio-system.svc.cluster.local
 ```
 
-If both the custom service and deployment are labeled with `custom: custom-local-gateway`, not the default
-`istio: cluster-local-gateway`, you need to update gateway instance `cluster-local-gateway` in the `knative-serving` namespace:
+As an example, if both the custom service and deployment are labeled with `custom: custom-local-gateway`, not the default
+`istio: cluster-local-gateway`, you must update gateway instance `cluster-local-gateway` in the `knative-serving` namespace:
 
 ```shell
 kubectl edit gateway cluster-local-gateway -n knative-serving
@@ -200,10 +198,9 @@ kubectl get pods --namespace istio-system
 
 ### Configuring DNS
 
-Knative dispatches to different services based on their hostname, so it greatly
-simplifies things to have DNS properly configured. For this, we must look up the
-external IP address that Istio received. This can be done with the following
-command:
+Knative dispatches to different services based on their hostname, so it is recommended to have DNS properly configured.
+
+To do this, begin by looking up the external IP address that Istio received:
 
 ```
 $ kubectl get svc -nistio-system
@@ -213,10 +210,10 @@ istio-ingressgateway    LoadBalancer   10.0.2.24    34.83.80.117   15020:32206/T
 istio-pilot             ClusterIP      10.0.3.27    <none>         15010/TCP,15011/TCP,8080/TCP,15014/TCP       2m14s
 ```
 
-This external IP can be used with your DNS provider with a wildcard `A` record;
-however, for a basic functioning DNS setup (not suitable for production!) this
-external IP address can be used with `xip.io` in the `config-domain` ConfigMap
-in `knative-serving`. You can edit this with the following command:
+This external IP can be used with your DNS provider with a wildcard `A` record. However, for a basic non-production set
+up, this external IP address can be used with `xip.io` in the `config-domain` ConfigMap in `knative-serving`.
+
+You can edit this by using the following command:
 
 ```
 kubectl edit cm config-domain --namespace knative-serving

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -7,7 +7,7 @@ type: "docs"
 
 Knative uses a shared ingress Gateway to serve all incoming traffic within
 Knative service mesh, which is the `knative-ingress-gateway` Gateway under
-`knative-serving` namespace. By default, we use Istio gateway service
+the `knative-serving` namespace. By default, we use Istio gateway service
 `istio-ingressgateway` under `istio-system` namespace as its underlying service.
 You can replace the service with that of your own as follows.
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #1402

## Proposed Changes

- This PR adds the instruction of updating the configmap `config-istio` under the namespace `knative-serving`, if the service name for the local gateway is not `cluster-local-gateway`.

