### PR TITLE
Add a step for installing github source

### DIFF
--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -26,6 +26,15 @@ You will need:
    instructions also install the default eventing sources, including
    the `GitHubSource` we'll use.
 
+### Install Github Event Source
+
+Github Event source lives in the [knative/eventing-contrib](https://github.com/knative/eventing-contrib).
+You can install it by running the following (this is currently the latest released version (0.11.2))
+
+```shell
+kubectl apply -f https://github.com/knative/eventing-contrib/releases/download/v0.11.2/github.yaml
+```
+
 ### Create a Knative Service
 
 To verify the `GitHubSource` is working, we will create a simple Knative


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #2092 

## Proposed Changes

- In the Github source example, add a step that installs the Github Source CRD.
-
-
