### PR TITLE
Use the new api group for ApiServerSource.

### DIFF
--- a/docs/eventing/debugging/example.yaml
+++ b/docs/eventing/debugging/example.yaml
@@ -11,7 +11,7 @@ metadata:
 
 # The event source.
 
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: ApiServerSource
 metadata:
   name: src

--- a/docs/eventing/debugging/example.yaml
+++ b/docs/eventing/debugging/example.yaml
@@ -23,9 +23,10 @@ spec:
     - apiVersion: v1
       kind: Event
   sink:
-    apiVersion: messaging.knative.dev/v1alpha1
-    kind: InMemoryChannel
-    name: chan
+    ref:
+      apiVersion: messaging.knative.dev/v1alpha1
+      kind: InMemoryChannel
+      name: chan
 
 ---
 

--- a/docs/eventing/samples/kafka/channel/020-k8s-events.yaml
+++ b/docs/eventing/samples/kafka/channel/020-k8s-events.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: ApiServerSource
 metadata:
   name: testevents-kafka-03

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -94,7 +94,7 @@ kubectl apply --filename serviceaccount.yaml
    block below into it.
 
 ```yaml
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: ApiServerSource
 metadata:
   name: testevents

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -106,9 +106,10 @@ spec:
     - apiVersion: v1
       kind: Event
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: Broker
-    name: default
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default
 ```
 
 If you want to consume events from a different namespace or use a different

--- a/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: ApiServerSource
 metadata:
   name: testevents

--- a/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
@@ -10,6 +10,7 @@ spec:
   - apiVersion: v1
     kind: Event
   sink:
-    apiVersion: serving.knative.dev/v1alpha1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1alpha1
+      kind: Service
+      name: event-display


### PR DESCRIPTION
Pending on https://github.com/knative/eventing/pull/2368

Related to https://github.com/knative/eventing/issues/1500

## Proposed Changes

- ApiServerSource is moving the ApiGroup it lives in: `sources.eventing.knative.dev` becomes `sources.knative.dev`.
