### PR TITLE
Use the new api group for SinkBinding.

### DIFF
--- a/docs/eventing/samples/sinkbinding/README.md
+++ b/docs/eventing/samples/sinkbinding/README.md
@@ -82,7 +82,7 @@ In order to direct events to our Event Display, we will first create a
 SinkBinding that will inject `$K_SINK` into select `Jobs`:
 
 ```yaml
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat
@@ -197,7 +197,7 @@ together.  For example, the [`cloudevents-go`
 sample](../../../serving/samples/cloudevents/cloudevents-go) may be bound with:
 
 ```yaml
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat

--- a/docs/eventing/samples/sinkbinding/sinkbinding.yaml
+++ b/docs/eventing/samples/sinkbinding/sinkbinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat


### PR DESCRIPTION
Pending on https://github.com/knative/eventing/pull/2369

Related to https://github.com/knative/eventing/issues/1500

## Proposed Changes

- SinkBinding is moving the ApiGroup it lives in: `sources.eventing.knative.dev` becomes `sources.knative.dev`.
