### PR TITLE
Repair sample 'telemetry-go'

### DIFF
--- a/docs/serving/samples/telemetry-go/Dockerfile
+++ b/docs/serving/samples/telemetry-go/Dockerfile
@@ -14,14 +14,15 @@
 
 FROM golang AS builder
 
-WORKDIR /go/src/github.com/knative/docs/docs/
-ADD . /go/src/github.com/knative/docs/
+WORKDIR /go/src/github.com/knative/docs/
+ADD . .
 
-RUN CGO_ENABLED=0 go build ./serving/samples/telemetry-go/
+RUN go get -d -v ./... && \
+    CGO_ENABLED=0 go build telemetrysample.go
 
 FROM gcr.io/distroless/base
 
 EXPOSE 8080
-COPY --from=builder /go/src/github.com/knative/docs/docs/telemetry-go /sample
+COPY --from=builder /go/src/github.com/knative/docs/telemetrysample /sample
 
 ENTRYPOINT ["/sample"]

--- a/docs/serving/samples/telemetry-go/telemetrysample.go
+++ b/docs/serving/samples/telemetry-go/telemetrysample.go
@@ -29,8 +29,8 @@ import (
 	openzipkin "github.com/openzipkin/zipkin-go"
 	httpreporter "github.com/openzipkin/zipkin-go/reporter/http"
 
-	"go.opencensus.io/exporter/prometheus"
-	"go.opencensus.io/exporter/zipkin"
+	"contrib.go.opencensus.io/exporter/prometheus"
+	"contrib.go.opencensus.io/exporter/zipkin"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/stats"


### PR DESCRIPTION
Fix Dockerfile & imports in 'telemetrysample.go'
## Command 'docker build -t telemetry-go:0.11.0 .'  failed.Error outputs below
```
==========================================
[docker build stage begin.]
Sending build context to Docker daemon 26.11kB
Step 1/8 : FROM golang AS builder
latest: Pulling from library/golang
Digest: sha256:2df96417dca0561bf1027742dcc5b446a18957cd28eba6aa79269f23f1846d3f
Status: Downloaded newer image for golang:latest
---> 272e3f68338f
Step 2/8 : WORKDIR /go/src/github.com/knative/docs/docs/
---> 2ba2c1a0b507
Removing intermediate container 366590cb6264
Step 3/8 : ADD . /go/src/github.com/knative/docs/
---> 809f650b82da
Removing intermediate container ab10509bf0a6
Step 4/8 : RUN CGO_ENABLED=0 go build ./serving/samples/telemetry-go/
---> Running in 72e97bf3c5e4
can't load package: package github.com/knative/docs/docs/serving/samples/telemetry-go: cannot find package "github.com/knative/docs/docs/serving/samples/telemetry-go" in any of:
/usr/local/go/src/github.com/knative/docs/docs/serving/samples/telemetry-go (from $GOROOT)
/go/src/github.com/knative/docs/docs/serving/samples/telemetry-go (from $GOPATH)
The command '/bin/sh -c CGO_ENABLED=0 go build ./serving/samples/telemetry-go/' returned a non-zero code: 1
{"exitCode":8, "message":"docker build failed or timeout "}
```