### PR TITLE
adding in default config map required values

### DIFF
--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -63,6 +63,8 @@ data:
     clusterDefault:
       apiVersion: messaging.knative.dev/v1alpha1
       kind: KafkaChannel
+        numPartitions: 3
+        replicationFactor: 1
 EOF
 ```
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Fixing the config map for default channel to include partitions and replication factor. Failing to include these values in the config map for default channels will cause an error for default channels about partitions not being allowed to be set to 0.
