### PR TITLE
added github.com/maximilien/knfun as a Knative client demo sample

### DIFF
--- a/community/samples/README.md
+++ b/community/samples/README.md
@@ -4,7 +4,7 @@ contributed and maintained by members of the Knative community.
 Note: It is possible that one or more samples might become outdated or the
 original author is unable to maintain their contribution. If you find that
 something isn't working, lend a helping hand and fix it in a PR.
-[Learn more about the lifespan of samples](../../contributing/DOCS-CONTRIBUTING.md).
+[Learn more about the lifespan of samples](https://github.com/knative/community/blob/master/DOCS-CONTRIBUTING.md).
 
 [**See all Knative code samples**](../../docs/samples.md)
 
@@ -16,8 +16,15 @@ Knative Serving sample apps.
 | ----------- | ----------- | ----------- |
 | Hello World | A quick introduction to Knative Serving that highlights how to deploy an app. | [Clojure](./serving/helloworld-clojure/README.md), [Dart](./serving/helloworld-dart/README.md), [Elixir](./serving/helloworld-elixir/README.md), [Haskell](./serving/helloworld-haskell/README.md), [Java - Micronaut](./serving/helloworld-java-micronaut/README.md), [Java - Quarkus](./serving/helloworld-java-quarkus/README.md), [R - Go Server](./serving/helloworld-r/README.md), [Rust](./serving/helloworld-rust/README.md), [Swift](./serving/helloworld-swift/README.md), [Vertx](./serving/helloworld-vertx/README.md) |
 
-
 #### Eventing and Eventing Resources samples
 
 - _Be the first to contribute an Eventing or Eventing Sources code sample to the
   community collection._
+
+### Client samples
+
+Knative `kn` Client sample workflows and apps.
+
+| Sample Name | Description |
+| ----------- | ----------- |
+| [knfun](https://github.com/maximilien/knfun) | Knative micro-functions (Twitter and Watson APIs) demo using the `kn` client. |


### PR DESCRIPTION
Fixes #2131

## Proposed Changes
- create new `kn` client section in community samples
- add [knfun](https://github.com/maximilien/knfun) to the community samples