### PR TITLE
fix default template so it works, use event display that works

### DIFF
--- a/docs/eventing/samples/kafka/channel/000-ksvc.yaml
+++ b/docs/eventing/samples/kafka/channel/000-ksvc.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display@sha256:1d6ddc00ab3e43634cd16b342f9663f9739ba09bc037d5dea175dc425a1bb955
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a214514d6ba674d7393ec8448dd272472b2956207acb3f83152d3071f0ab1911

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -63,6 +63,9 @@ data:
     clusterDefault:
       apiVersion: messaging.knative.dev/v1alpha1
       kind: KafkaChannel
+      spec:
+        numPartitions: 3
+        replicationFactor: 1
 EOF
 ```
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/contributing/docs-contributing/

 -->

Fixes #2134 

## Proposed Changes

- Set numPartitions and replicationFactor in the default Channel template spec. 
- Use a newer version of Event Display. The one in the instructions fails to decode the incoming message.
-
