### PR TITLE
key deserializer doc for kafka source

### DIFF
--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -202,3 +202,34 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
    $ kubectl delete -f kafka/source/samples/kafka-topic.yaml
    kafkatopic.kafka.strimzi.io "knative-demo-topic" deleted
    ```
+
+## (Optional) Specify the key deserializer
+
+When `KafkaSource` receives a message from Kafka, it dumps the key in the Event extension called `Key` and dumps Kafka message headers in the extensions starting with `kafkaheader`.
+
+You can specify the key deserializer among four types:
+
+* `string` (default) for UTF-8 encoded strings 
+* `int` for 32-bit & 64-bit signed integers
+* `float` for 32-bit & 64-bit floating points
+* `byte-array` for a Base64 encoded byte array
+
+To specify it, add the label `kafkasources.sources.eventing.knative.dev/key-type` to the `KafkaSource` definition like:
+
+```yaml
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: KafkaSource
+metadata:
+ name: kafka-source
+ labels:
+  kafkasources.sources.eventing.knative.dev/key-type: int
+spec:
+ consumerGroup: knative-group
+ bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092 #note the kafka namespace
+ topics: knative-demo-topic
+ sink:
+   ref:
+     apiVersion: serving.knative.dev/v1
+     kind: Service
+     name: event-display
+```


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

## Proposed Changes

- Added documentation for `KafkaSource` new label introduced by https://github.com/knative/eventing-contrib/pull/860
