### PR TITLE
An update to the install instructions that make use of tabbing.

### DIFF
--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -1,6 +1,5 @@
 ---
 title: "Installing Knative"
-linkTitle: "Installing Knative"
 weight: 15
 type: "docs"
 ---
@@ -17,7 +16,7 @@ Knative also has a [**Monitoring bundle**](#installing-the-monitoring-bundle)(_a
 
 ## Before you begin
 
-This guide assumes that you want to install an upstream Knative release on a Kubernetes cluster. A growing number of vendors have managed Knative offerings, see [here](../knative-offerings.md) for the known list.
+This guide assumes that you want to install an upstream Knative release on a Kubernetes cluster. A growing number of vendors have managed Knative offerings; see the [Knative Offerings](../knative-offerings.md) page for a full list.
 
 Knative {{< version >}} requires a Kubernetes cluster v1.15 or newer, as well as a compatible
 `kubectl`. This guide assumes that you've already created a Kubernetes cluster,
@@ -49,7 +48,7 @@ The following commands install the Knative Serving component.
    {{< tabs name="serving_networking" default="Istio" >}}
 {{% tab name="Ambassador" %}}
 
-The following commands install Ambassador and enable its Knative integration:
+The following commands install Ambassador and enable its Knative integration.
 
 1. Create a namespace to install Ambassador in:
 
@@ -57,7 +56,7 @@ The following commands install Ambassador and enable its Knative integration:
    kubectl create namespace ambassador
    ```
 
-2. Install Ambassador:
+1. Install Ambassador:
 
    ```bash
    kubectl apply --namespace ambassador \
@@ -65,19 +64,19 @@ The following commands install Ambassador and enable its Knative integration:
      --filename https://getambassador.io/yaml/ambassador/ambassador-service.yaml
    ```
 
-3. Give Ambassador the required permissions:
+1. Give Ambassador the required permissions:
 
    ```bash
    kubectl patch clusterrolebinding ambassador -p '{"subjects":[{"kind": "ServiceAccount", "name": "ambassador", "namespace": "ambassador"}]}'
    ```
 
-4. Enable Knative support in Ambassador:
+1. Enable Knative support in Ambassador:
 
    ```bash
    kubectl set env --namespace ambassador  deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
    ```
 
-5. To configure Knative Serving to use Ambassador by default:
+1. To configure Knative Serving to use Ambassador by default:
 
     ```bash
     kubectl patch configmap/config-network \
@@ -86,7 +85,7 @@ The following commands install Ambassador and enable its Knative integration:
       --patch '{"data":{"ingress.class":"ambassador.ingress.networking.knative.dev"}}'
     ```
 
-6. Fetch the External IP or CNAME
+1. Fetch the External IP or CNAME:
 
    ```bash
    kubectl --namespace ambassador get service ambassador
@@ -97,7 +96,7 @@ The following commands install Ambassador and enable its Knative integration:
 {{< /tab >}}
 
 {{% tab name="Contour" %}}
-The following commands install Contour and enables its Knative integration:
+The following commands install Contour and enable its Knative integration.
 
 1. Install the Knative Contour controller (includes Contour):
 
@@ -105,7 +104,7 @@ The following commands install Contour and enables its Knative integration:
    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/{{< version >}}/third_party/contour-latest/contour.yaml
    ```
 
-2. To configure Knative Serving to use Contour by default:
+1. To configure Knative Serving to use Contour by default:
 
     ```bash
     kubectl patch configmap/config-network \
@@ -114,7 +113,7 @@ The following commands install Contour and enables its Knative integration:
       --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
     ```
 
-3. Fetch the External IP or CNAME
+1. Fetch the External IP or CNAME:
 
    ```bash
    kubectl --namespace projectcontour get service envoy-external
@@ -125,9 +124,9 @@ The following commands install Contour and enables its Knative integration:
 {{< /tab >}}
 
 {{% tab name="Gloo" %}}
-_For a detailed guide on Gloo integration, see [here](https://docs.solo.io/gloo/latest/installation/knative/)_
+_For a detailed guide on Gloo integration, see [Installing Gloo for Knative](https://docs.solo.io/gloo/latest/installation/knative/) in the Gloo documentation._
 
-The following commands install Gloo and enables its Knative integration:
+The following commands install Gloo and enable its Knative integration.
 
 1. Make sure `glooctl` is installed (version 1.3.x and higher recommended):
 
@@ -137,13 +136,13 @@ The following commands install Gloo and enables its Knative integration:
 
    If it is not installed, follow the instructions [here](https://docs.solo.io/gloo/latest/installation/knative/#install-command-line-tool-cli)
 
-2. Install Gloo and the Knative integration:
+1. Install Gloo and the Knative integration:
 
     ```bash
     glooctl install knative --install-knative=false
     ```
 
-3. Fetch the External IP or CNAME
+1. Fetch the External IP or CNAME:
 
    ```bash
    kubectl get svc -ngloo-system knative-external-proxy
@@ -154,19 +153,19 @@ The following commands install Gloo and enables its Knative integration:
 {{< /tab >}}
 
 {{% tab name="Istio" %}}
-The following commands install Istio and enables its Knative integration:
+The following commands install Istio and enable its Knative integration.
 
 <!-- TODO(https://github.com/knative/docs/issues/2166): Create streamlined instructions to inline -->
 
 1. [Installing Istio for Knative](./installing-istio.md)
 
-2. Install the Knative Istio controller:
+1. Install the Knative Istio controller:
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-istio.yaml
    ```
 
-3. Fetch the External IP or CNAME
+1. Fetch the External IP or CNAME:
 
    ```bash
    kubectl --namespace istio-system get service istio-ingressgateway
@@ -177,7 +176,7 @@ The following commands install Istio and enables its Knative integration:
 {{< /tab >}}
 
 {{% tab name="Kourier" %}}
-The following commands install Kourier and enables its Knative integration:
+The following commands install Kourier and enable its Knative integration.
 
 1. Install the Knative Kourier controller:
 
@@ -185,7 +184,7 @@ The following commands install Kourier and enables its Knative integration:
    kubectl apply --filename https://raw.githubusercontent.com/knative/serving/{{< version >}}/third_party/kourier-latest/kourier.yaml
    ```
 
-2. To configure Knative Serving to use Kourier by default:
+1. To configure Knative Serving to use Kourier by default:
 
     ```bash
     kubectl patch configmap/config-network \
@@ -194,7 +193,7 @@ The following commands install Kourier and enables its Knative integration:
       --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
     ```
 
-3. Fetch the External IP or CNAME
+1. Fetch the External IP or CNAME:
 
    ```bash
    kubectl --namespace kourier-system get service kourier
@@ -223,7 +222,7 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/{{
 {{% tab name="Real DNS" %}}
 To configure DNS for Knative, take the External IP or CNAME from setting up networking, and configure it with your DNS provider as follows:
 
-- If the networking layer produced an External IP address, then configure a wildcard A record for the domain:
+- If the networking layer produced an External IP address, then configure a wildcard `A` record for the domain:
 
     ```
     # Here knative.example.com is the domain suffix for your cluster
@@ -237,7 +236,7 @@ To configure DNS for Knative, take the External IP or CNAME from setting up netw
     *.knative.example.com == CNAME a317a278525d111e89f272a164fd35fb-1510370581.eu-central-1.elb.amazonaws.com
     ```
 
-Once your DNS provider has been configured, direct Knative to use that domain with:
+Once your DNS provider has been configured, direct Knative to use that domain:
 
 ```bash
 # Replace knative.example.com with your domain suffix
@@ -278,7 +277,7 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/{{
 
 {{% tab name="TLS with cert-manager" %}}
 
-Knative supports automatically provisioning TLS certificates via cert-manager.  The following commands will install the components needed to support the provisioning of TLS certificates via cert-manager:
+Knative supports automatically provisioning TLS certificates via [cert-manager](https://cert-manager.io/docs/).  The following commands will install the components needed to support the provisioning of TLS certificates via cert-manager.
 
 1. First, install [cert-manager version `0.12.0` or higher](../serving/installing-cert-manager.md)
 

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -9,10 +9,10 @@ This guide walks you through the installation of the latest version of Knative.
 Knative has two components, which can be installed and used independently or together.
 To help you pick and choose the pieces that are right for you, here is a brief
 description of each:
- - [**Serving**](#installing-the-serving-component)(_stable_) provides an abstraction for stateless request-based scale-to-zero services.
- - [**Eventing**](#installing-the-eventing-component)(_alpha_) provides abstractions to enable binding event sources (e.g. Github Webhooks, Kafka) and consumers (e.g. Kubernetes or Knative Services).
+ - [**Serving**](#installing-the-serving-component) (_stable_) provides an abstraction for stateless request-based scale-to-zero services.
+ - [**Eventing**](#installing-the-eventing-component) (_alpha_) provides abstractions to enable binding event sources (e.g. Github Webhooks, Kafka) and consumers (e.g. Kubernetes or Knative Services).
 
-Knative also has a [**Monitoring bundle**](#installing-the-monitoring-bundle)(_alpha_) which provides standard tooling that can be used to get visibility into the health of the software running on Knative.
+Knative also has a [**Monitoring bundle**](#installing-the-monitoring-bundle) (_alpha_) which provides standard tooling that can be used to get visibility into the health of the software running on Knative.
 
 ## Before you begin
 

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -7,18 +7,19 @@ type: "docs"
 
 This guide walks you through the installation of the latest version of Knative.
 
-Knative has several pieces, which can be installed and used independently or together.
+Knative has two components, which can be installed and used independently or together.
 To help you pick and choose the pieces that are right for you, here is a brief
 description of each:
  - [**Serving**](#installing-the-serving-component)(_stable_) provides an abstraction for stateless request-based scale-to-zero services.
  - [**Eventing**](#installing-the-eventing-component)(_alpha_) provides abstractions to enable binding event sources (e.g. Github Webhooks, Kafka) and consumers (e.g. Kubernetes or Knative Services).
- - [**Monitoring**](#installing-the-monitoring-bundle)(_alpha_) provides a bundle of standard tooling that can be used to get visibility into the health of the software running on Knative.
+
+Knative also has a [**Monitoring bundle**](#installing-the-monitoring-bundle)(_alpha_) which provides standard tooling that can be used to get visibility into the health of the software running on Knative.
 
 ## Before you begin
 
 This guide assumes that you want to install an upstream Knative release on a Kubernetes cluster. A growing number of vendors are offering managed Knative services, see [here](./vendor-options.md) for a list of the known offerings.
 
-Knative requires a Kubernetes cluster v1.15 or newer, as well as a compatible
+Knative {{< version >}} requires a Kubernetes cluster v1.15 or newer, as well as a compatible
 `kubectl`. This guide assumes that you've already created a Kubernetes cluster,
 and that you are using bash in a Mac or Linux environment; some commands will
 need to be adjusted for use in a Windows environment.
@@ -29,7 +30,7 @@ need to be adjusted for use in a Windows environment.
 
 The following commands install the Knative Serving component.
 
-1. Install the Custom Resource Definitions (aka CRDs):
+1. Install the [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (aka CRDs):
 
    ```bash
    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-crds.yaml
@@ -42,6 +43,7 @@ The following commands install the Knative Serving component.
    ```
 
 1. Pick a networking layer (alphabetical):
+   <!-- TODO: Link to document/diagram describing what is a networking layer.  -->
 
    <!-- This indentation is important for things to render properly. -->
    {{< tabs name="serving_networking" default="Istio" >}}
@@ -154,6 +156,8 @@ The following commands install Gloo and enables its Knative integration:
 {{% tab name="Istio" %}}
 The following commands install Istio and enables its Knative integration:
 
+<!-- TODO(https://github.com/knative/docs/issues/2166): Create streamlined instructions to inline -->
+
 1. [Installing Istio for Knative](./installing-istio.md)
 
 2. Install the Knative Istio controller:
@@ -212,7 +216,7 @@ We ship a simple Kubernetes Job called "default domain" that will (see caveats) 
 kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-default-domain.yaml
 ```
 
-**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Using a real DNS record" (below).
+**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS".
 {{< /tab >}}
 
 
@@ -308,7 +312,7 @@ Deploy your first app with the [getting started with Knative app deployment](../
 
 The following commands install the Knative Eventing component.
 
-1. Install the Custom Resource Definitions (aka CRDs):
+1. Install the [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (aka CRDs):
 
    ```bash
    kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing-crds.yaml

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -134,7 +134,14 @@ The following commands install Gloo and enable its Knative integration.
    glooctl version
    ```
 
-   If it is not installed, follow the instructions [here](https://docs.solo.io/gloo/latest/installation/knative/#install-command-line-tool-cli)
+   If it is not installed, you can install the latest version using:
+
+   ```bash
+   curl -sL https://run.solo.io/gloo/install | sh
+   export PATH=$HOME/.gloo/bin:$PATH
+   ```
+
+   Or following the [Gloo CLI install instructions](https://docs.solo.io/gloo/latest/installation/knative/#install-command-line-tool-cli).
 
 1. Install Gloo and the Knative integration:
 
@@ -145,7 +152,7 @@ The following commands install Gloo and enable its Knative integration.
 1. Fetch the External IP or CNAME:
 
    ```bash
-   kubectl get svc -ngloo-system knative-external-proxy
+   glooctl proxy url --name knative-external-proxy
    ```
 
    Save this for configuring DNS below.

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -17,7 +17,7 @@ Knative also has a [**Monitoring bundle**](#installing-the-monitoring-bundle)(_a
 
 ## Before you begin
 
-This guide assumes that you want to install an upstream Knative release on a Kubernetes cluster. A growing number of vendors are offering managed Knative services, see [here](./vendor-options.md) for a list of the known offerings.
+This guide assumes that you want to install an upstream Knative release on a Kubernetes cluster. A growing number of vendors have managed Knative offerings, see [here](../knative-offerings.md) for the known list.
 
 Knative {{< version >}} requires a Kubernetes cluster v1.15 or newer, as well as a compatible
 `kubectl`. This guide assumes that you've already created a Kubernetes cluster,

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -1,89 +1,470 @@
 ---
-title: "Install on a Kubernetes cluster"
-linkTitle: "On existing cluster"
+title: "Installing Knative"
+linkTitle: "Installing Knative"
 weight: 15
 type: "docs"
 ---
 
-This guide walks you through the installation of the latest version of Knative
-using pre-built images.
+This guide walks you through the installation of the latest version of Knative.
+
+Knative has several pieces, which can be installed and used independently or together.
+To help you pick and choose the pieces that are right for you, here is a brief
+description of each:
+ - [**Serving**](#installing-the-serving-component)(_stable_) provides an abstraction for stateless request-based scale-to-zero services.
+ - [**Eventing**](#installing-the-eventing-component)(_alpha_) provides abstractions to enable binding event sources (e.g. Github Webhooks, Kafka) and consumers (e.g. Kubernetes or Knative Services).
+ - [**Monitoring**](#installing-the-monitoring-bundle)(_alpha_) provides a bundle of standard tooling that can be used to get visibility into the health of the software running on Knative.
 
 ## Before you begin
 
+This guide assumes that you want to install an upstream Knative release on a Kubernetes cluster. A growing number of vendors are offering managed Knative services, see [here](./vendor-options.md) for a list of the known offerings.
+
 Knative requires a Kubernetes cluster v1.15 or newer, as well as a compatible
-`kubectl`. This guide assumes that you've already created a Kubernetes cluster
-which you're comfortable installing _alpha_ software on.
+`kubectl`. This guide assumes that you've already created a Kubernetes cluster,
+and that you are using bash in a Mac or Linux environment; some commands will
+need to be adjusted for use in a Windows environment.
 
-This guide assumes you are using bash in a Mac or Linux environment; some
-commands will need to be adjusted for use in a Windows environment.
+<!-- TODO: Link to provisioning guide for advanced installation -->
 
-## Installing Istio
+## Installing the Serving component
 
-Knative depends on Istio. If your cloud platform offers a managed Istio
-installation, we recommend installing Istio that way, unless you need the
-ability to customize your installation. For example, the
-[GKE Install Guide](./Knative-with-GKE.md) includes the instructions for
-installing Istio on your cluster using `gcloud`.
+The following commands install the Knative Serving component.
 
-If you prefer to install Istio manually, if your cloud provider doesn't offer a
-managed Istio installation, or if you're installing Knative locally using
-Minkube or similar, see the
-[Installing Istio for Knative guide](./installing-istio.md).
-
-You must install Istio on your Kubernetes cluster before continuing with these
-instructions to install Knative.
-
-## Installing `cluster-local-gateway` for serving cluster-internal traffic
-
-If you installed Istio, you can install a `cluster-local-gateway` within your Knative cluster so that you can serve cluster-internal traffic. If you want to configure your revisions to use routes that are visible only within your cluster, [install and use the `cluster-local-gateway`](./installing-istio.md#updating-your-install-to-use-cluster-local-gateway).
-
-## Installing Knative
-
-The following commands install all available Knative components. To customize
-your Knative installation, see
-[Performing a Custom Knative Installation](./Knative-custom-install.md).
-
-1. To install Knative, first install the CRDs by running the `kubectl apply`
-   command once with the `-l knative.dev/crd-install=true` flag. This prevents
-   race conditions during the install, which cause intermittent errors:
+1. Install the Custom Resource Definitions (aka CRDs):
 
    ```bash
-   kubectl apply --selector knative.dev/crd-install=true \
-   --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
-   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-crds.yaml
    ```
 
-1. To complete the install of Knative and its dependencies, run the
-   `kubectl apply` command again, this time without the `--selector` flag, to
-   complete the install of Knative and its dependencies:
+1. Install the core components of Serving (see below for optional extensions):
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving.yaml \
-   --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml \
-   --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring.yaml
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-core.yaml
    ```
+
+1. Pick a networking layer (alphabetical):
+
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="serving_networking" default="Istio" >}}
+{{% tab name="Ambassador" %}}
+
+The following commands install Ambassador and enable its Knative integration:
+
+1. Create a namespace to install Ambassador in:
+
+   ```bash
+   kubectl create namespace ambassador
+   ```
+
+2. Install Ambassador:
+
+   ```bash
+   kubectl apply --namespace ambassador \
+     --filename https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
+     --filename https://getambassador.io/yaml/ambassador/ambassador-service.yaml
+   ```
+
+3. Give Ambassador the required permissions:
+
+   ```bash
+   kubectl patch clusterrolebinding ambassador -p '{"subjects":[{"kind": "ServiceAccount", "name": "ambassador", "namespace": "ambassador"}]}'
+   ```
+
+4. Enable Knative support in Ambassador:
+
+   ```bash
+   kubectl set env --namespace ambassador  deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
+   ```
+
+5. To configure Knative Serving to use Ambassador by default:
+
+    ```bash
+    kubectl patch configmap/config-network \
+      --namespace knative-serving \
+      --type merge \
+      --patch '{"data":{"ingress.class":"ambassador.ingress.networking.knative.dev"}}'
+    ```
+
+6. Fetch the External IP or CNAME
+
+   ```bash
+   kubectl --namespace ambassador get service ambassador
+   ```
+
+   Save this for configuring DNS below.
+
+{{< /tab >}}
+
+{{% tab name="Contour" %}}
+The following commands install Contour and enables its Knative integration:
+
+1. Install the Knative Contour controller (includes Contour):
+
+   ```bash
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/{{< version >}}/third_party/contour-latest/contour.yaml
+   ```
+
+2. To configure Knative Serving to use Contour by default:
+
+    ```bash
+    kubectl patch configmap/config-network \
+      --namespace knative-serving \
+      --type merge \
+      --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
+    ```
+
+3. Fetch the External IP or CNAME
+
+   ```bash
+   kubectl --namespace projectcontour get service envoy-external
+   ```
+
+   Save this for configuring DNS below.
+
+{{< /tab >}}
+
+{{% tab name="Gloo" %}}
+_For a detailed guide on Gloo integration, see [here](https://docs.solo.io/gloo/latest/installation/knative/)_
+
+The following commands install Gloo and enables its Knative integration:
+
+1. Make sure `glooctl` is installed (version 1.3.x and higher recommended):
+
+   ```bash
+   glooctl version
+   ```
+
+   If it is not installed, follow the instructions [here](https://docs.solo.io/gloo/latest/installation/knative/#install-command-line-tool-cli)
+
+2. Install Gloo and the Knative integration:
+
+    ```bash
+    glooctl install knative --install-knative=false
+    ```
+
+3. Fetch the External IP or CNAME
+
+   ```bash
+   kubectl get svc -ngloo-system knative-external-proxy
+   ```
+
+   Save this for configuring DNS below.
+
+{{< /tab >}}
+
+{{% tab name="Istio" %}}
+The following commands install Istio and enables its Knative integration:
+
+1. [Installing Istio for Knative](./installing-istio.md)
+
+2. Install the Knative Istio controller:
+
+   ```bash
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-istio.yaml
+   ```
+
+3. Fetch the External IP or CNAME
+
+   ```bash
+   kubectl --namespace istio-system get service istio-ingressgateway
+   ```
+
+   Save this for configuring DNS below.
+
+{{< /tab >}}
+
+{{% tab name="Kourier" %}}
+The following commands install Kourier and enables its Knative integration:
+
+1. Install the Knative Kourier controller:
+
+   ```bash
+   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/{{< version >}}/third_party/kourier-latest/kourier.yaml
+   ```
+
+2. To configure Knative Serving to use Kourier by default:
+
+    ```bash
+    kubectl patch configmap/config-network \
+      --namespace knative-serving \
+      --type merge \
+      --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+    ```
+
+3. Fetch the External IP or CNAME
+
+   ```bash
+   kubectl --namespace kourier-system get service kourier
+   ```
+
+   Save this for configuring DNS below.
+
+{{< /tab >}}
+{{< /tabs >}}
+
+1. Configure DNS
+
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="serving_dns" >}}
+{{% tab name="Magic DNS (xip.io)" %}}
+We ship a simple Kubernetes Job called "default domain" that will (see caveats) configure Knative Serving to use <a href="http://xip.io">xip.io</a> as the default DNS suffix.
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-default-domain.yaml
+```
+
+**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Using a real DNS record" (below).
+{{< /tab >}}
+
+
+{{% tab name="Real DNS" %}}
+To configure DNS for Knative, take the External IP or CNAME from setting up networking, and configure it with your DNS provider as follows:
+
+- If the networking layer produced an External IP address, then configure a wildcard A record for the domain:
+
+    ```
+    # Here knative.example.com is the domain suffix for your cluster
+    *.knative.example.com == A 35.233.41.212
+    ```
+
+- If the networking layer produced a CNAME, then configure a CNAME record for the domain:
+
+    ```
+    # Here knative.example.com is the domain suffix for your cluster
+    *.knative.example.com == CNAME a317a278525d111e89f272a164fd35fb-1510370581.eu-central-1.elb.amazonaws.com
+    ```
+
+Once your DNS provider has been configured, direct Knative to use that domain with:
+
+```bash
+# Replace knative.example.com with your domain suffix
+kubectl patch configmap/config-domain \
+  --namespace knative-serving \
+  --type merge \
+  --patch '{"data":{"knative.example.com":""}}'
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+1. Monitor the Knative components until all of the components show a `STATUS` of `Running` or `Completed`:
+
+   ```bash
+   kubectl get pods --namespace knative-serving
+   ```
+
+At this point, you have a basic installation of Knative Serving!
+
+
+### Optional Serving extensions
+
+{{< tabs name="serving_extensions" >}}
+{{% tab name="HPA autoscaling" %}}
+
+Knative also supports the use of the Kubernetes Horizontal Pod Autoscaler (HPA)
+for driving autoscaling decisions.  The following command will install the
+components needed to support HPA-class autoscaling:
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-hpa.yaml
+```
+
+<!-- TODO(https://github.com/knative/docs/issues/2152): Link to a more in-depth guide on HPA-class autoscaling -->
+
+{{< /tab >}}
+
+{{% tab name="TLS with cert-manager" %}}
+
+Knative supports automatically provisioning TLS certificates via cert-manager.  The following commands will install the components needed to support the provisioning of TLS certificates via cert-manager:
+
+1. First, install [cert-manager version `0.12.0` or higher](../serving/installing-cert-manager.md)
+
+2. Next, install the component that integrates Knative with cert-manager:
+
+    ```bash
+    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-cert-manager.yaml
+    ```
+
+3. Now configure Knative to [automatically configure TLS certificates](../serving/using-auto-tls.md).
+{{< /tab >}}
+
+{{% tab name="TLS wildcard support" %}}
+
+If you plan to use cert-manager's support for provisioning wildcard certificates, then the most efficient way to provision certificates is with the namespace wildcard certificate controller.  The following command will install the components needed to provision wildcard certificates in each namespace:
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-nscert.yaml
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+
+### Getting started with Serving
+
+Deploy your first app with the [getting started with Knative app deployment](../serving/getting-started-knative-app.md) guide.  You can also find a number of samples for Knative Serving [here](../eventing/samples/).
+
+
+## Installing the Eventing component
+
+The following commands install the Knative Eventing component.
+
+1. Install the Custom Resource Definitions (aka CRDs):
+
+   ```bash
+   kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing-crds.yaml
+   ```
+
+1. Install the core components of Eventing (see below for optional extensions):
+
+   ```bash
+   kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing-core.yaml
+   ```
+
+1. Install a default Channel (messaging) layer.
+
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="eventing_channels" default="In-Memory (standalone)" >}}
+{{% tab name="In-Memory (standalone)" %}}
+The following command installs an implementation of Channel that runs in-memory.  This implementation is nice because it is simple and standalone, but it is unsuitable for production use cases.
+
+   ```bash
+   kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel.yaml
+   ```
+
+{{< /tab >}}
+
+<!-- TODO(https://github.com/knative/docs/issues/2153): Add more Channels here -->
+
+{{< /tabs >}}
+
+1. Install a default Broker (eventing) layer into a namespace (in this example, default):
+
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="eventing_brokers" default="Channel-based" >}}
+{{% tab name="Channel-based" %}}
+
+The core install above includes an implementation of Broker that uses Channels.
+
+To customize which channel implementation is used, update the following ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-ch-webhook
+  namespace: knative-eventing
+data:
+  default-ch-config: |
+    # This is the cluster-wide default channel.
+    clusterDefault:
+      apiVersion: messaging.knative.dev/v1alpha1
+      kind: InMemoryChannel
+
+    namespaceDefaults:
+      # This allows you to specify different defaults per-namespace,
+      # in this case the "some-namespace" namespace will use the Kafka
+      # channel by default.
+      some-namespace:
+        apiVersion: messaging.knative.dev/v1alpha1
+        kind: KafkaChannel
+        spec:
+          numPartitions: 2
+          replicationFactor: 1
+```
+
+{{< /tab >}}
+
+<!-- TODO: Add more Brokers here, once they exist -->
+
+{{< /tabs >}}
 
 1. Monitor the Knative components until all of the components show a `STATUS` of
    `Running`:
 
    ```bash
-   kubectl get pods --namespace knative-serving
    kubectl get pods --namespace knative-eventing
-   kubectl get pods --namespace knative-monitoring
    ```
 
-## What's next
+At this point, you have a basic installation of Knative Eventing!
 
-Now that your cluster has Knative installed, you can see what Knative has to
-offer.
 
-To deploy your first app with the
-[Getting Started with Knative App Deployment](../serving/getting-started-knative-app.md)
-guide.
+### Optional Eventing extensions
 
-Get started with Knative Eventing by walking through one of the
-[Eventing Samples](../eventing/samples/).
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="eventing_extensions" >}}
+{{% tab name="Enable Broker" %}}
+The following command enables the default Broker on a namespace (here `default`):
 
-[Install Cert-Manager](../serving/installing-cert-manager.md) if you want to use the
-[automatic TLS cert provisioning feature](../serving/using-auto-tls.md).
+   ```bash
+   kubectl label namespace default knative-eventing-injection=enabled
+   ```
+
+{{< /tab >}}
+
+<!-- TODO(https://github.com/knative/docs/issues/2154): Add sources and other stuff here. -->
+
+{{< /tabs >}}
+
+
+### Getting started with Eventing
+
+You can find a number of sample on how to get started with Knative Eventing [here](../eventing/eventing/).
+
+
+## Installing the Monitoring bundle
+
+Knative provides a bundle of monitoring components that can be used to make the Serving and Eventing components more observable.
+
+- Install Prometheus and Grafana for metrics:
+
+   ```bash
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
+   ```
+
+- Install the ELK stack (Elasticsearch, Logstash and Kibana) for logs:
+
+   ```bash
+   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
+   ```
+
+- Install Jaeger for distributed tracing
+
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="jaeger" default="In-Memory (standalone)" >}}
+{{% tab name="In-Memory (standalone)" %}}
+To install the in-memory (standalone) version of Jaeger, run the following command:
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
+```
+{{< /tab >}}
+
+{{% tab name="ELK stack" %}}
+To install the ELK version of Jaeger (needs the ELK install above), run the following command:
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+- Install Zipkin for distributed tracing
+
+   <!-- This indentation is important for things to render properly. -->
+   {{< tabs name="zipkin" default="In-Memory (standalone)" >}}
+{{% tab name="In-Memory (standalone)" %}}
+To install the in-memory (standalone) version of Zipkin, run the following command:
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
+```
+{{< /tab >}}
+
+{{% tab name="ELK stack" %}}
+To install the ELK version of Zipkin (needs the ELK install above), run the following command:
+
+```bash
+kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
+```
+{{< /tab >}}
+{{< /tabs >}}

--- a/docs/install/Knative-with-any-k8s.md
+++ b/docs/install/Knative-with-any-k8s.md
@@ -408,7 +408,7 @@ The following command enables the default Broker on a namespace (here `default`)
 
 ### Getting started with Eventing
 
-You can find a number of sample on how to get started with Knative Eventing [here](../eventing/eventing/).
+You can find a number of sample on how to get started with Knative Eventing [here](../eventing/).
 
 
 ## Installing the Monitoring bundle


### PR DESCRIPTION
This attempts to consolidate our install instructions into a single source of truth.

/assign @samodell 

Networking bits: cc @ilackarms @tcnghia @concaf @bbrowning 
Eventing bits: cc @vaikas @lionelvillard 
General: @rgregg @duglin @pmorie 

This depends on: https://github.com/knative/website/pull/124
This links to the WIP: https://github.com/knative/docs/pull/2150

/hold
As this needs a number of eyeballs on it...


For those who haven't been following along the tabs saga, here's roughly how it looks in hugo locally: 
![image](https://user-images.githubusercontent.com/2442466/73480124-2d9d1200-434e-11ea-96a7-60390f04a602.png)
