### PR TITLE
Update docs to talk about CloudEvents Overrides

### DIFF
--- a/docs/eventing/samples/sinkbinding/README.md
+++ b/docs/eventing/samples/sinkbinding/README.md
@@ -79,7 +79,7 @@ event-display   http://event-display.default.1.2.3.4.xip.io   event-display-gqjb
 ### Create our SinkBinding
 
 In order to direct events to our Event Display, we will first create a
-SinkBinding that will inject `$K_SINK` into select `Jobs`:
+SinkBinding that will inject `$K_SINK` and "$K_CE_OVERRIDES" into select `Jobs`:
 
 ```yaml
 apiVersion: sources.knative.dev/v1alpha1
@@ -99,6 +99,9 @@ spec:
       apiVersion: serving.knative.dev/v1
       kind: Service
       name: event-display
+  ceOverrides:
+    extensions:
+      sink: bound
 ```
 
 In this case, we will bind any `Job` with the labels `app: heartbeat-cron`.
@@ -181,6 +184,7 @@ Context Attributes,
 Extensions,
   beats: true
   heart: yes
+  sink: bound
   the: 42
 Data,
   {


### PR DESCRIPTION
## Proposed Changes

- Document the addition of CloudEvents Overrides from SinkBinding.

Related to https://github.com/knative/eventing/pull/2481
