### PR TITLE
Create overview.md

### DIFF
--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,5 +1,5 @@
 ---
-title:  "Quick Overview"
+title:  "Overview"
 weight: ?
 type: "docs"
 ---

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,0 +1,32 @@
+---
+title:  "Quick Overview"
+weight: ?
+type: "docs"
+---
+
+This document contains a quick overview of Knative, what it is and how it is used.
+
+Knative (pronounced kay-native) is a set of open source components for [Kubernetes](https://kubernetes.io) that implements
+functionality to:
+
+* run stateless workloads, such as microservices
+* support event subscription, delivery and handling 
+
+on Kubernetes clusters.
+
+Knative is implemented as a set of [controllers](https://kubernetes.io/docs/concepts/architecture/controller/) you install
+on your Kubernetes cluster. Knative registers its own API types to Kubernetes API, so working with it is not 
+too different from working with Kubernetes itself.
+
+Knative consists of two separate projects:
+
+* [Knative Serving](https://knative.dev/docs/serving/): Run stateless services more easily on Kubernetes, 
+   by making autoscaling, networking and rollouts easier. 
+
+* [Knative Eventing](https://knative.dev/docs/eventing/): Create subscriptions to event sources declaratively, 
+   and route events to Kubernetes endpoints. 
+
+You can use either one or both components in your cluster.
+
+**Note**: Earlier versions of Knative included a Build component.  That component has been broken out into its own
+project, [Tekton Pipelines](https://tekton.dev/).

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -15,7 +15,7 @@ functionality to:
 on Kubernetes clusters.
 
 Knative is implemented as a set of [controllers](https://kubernetes.io/docs/concepts/architecture/controller/) you install
-on your Kubernetes cluster. Knative registers its own API types to Kubernetes API, so working with it is not 
+on your Kubernetes cluster. Knative registers its own API types to the Kubernetes API, so working with it is not 
 too different from working with Kubernetes itself.
 
 Knative consists of two separate projects:

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -4,7 +4,7 @@ weight: 5
 type: "docs"
 ---
 
-This document contains a quick overview of Knative, what it is and how it is used.
+This document contains a quick overview of Knative.
 
 Knative (pronounced kay-native) is a set of open source components for [Kubernetes](https://kubernetes.io) that implements
 functionality to:

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -18,7 +18,7 @@ Knative is implemented as a set of [controllers](https://kubernetes.io/docs/conc
 on your Kubernetes cluster. Knative registers its own API types to the Kubernetes API, so working with it is not 
 too different from working with Kubernetes itself.
 
-Knative consists of two separate projects:
+Knative consists of two independent components that have their own GitHub projects:
 
 * [Knative Serving](https://knative.dev/docs/serving/): Run stateless services more easily on Kubernetes, 
    by making autoscaling, networking and rollouts easier. 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,6 +1,6 @@
 ---
 title:  "Overview"
-weight: ?
+weight: 5
 type: "docs"
 ---
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -10,7 +10,7 @@ Knative (pronounced kay-native) is a set of open source components for [Kubernet
 functionality to:
 
 * run stateless workloads, such as microservices
-* support event subscription, delivery and handling 
+* support event subscription, delivery, and handling 
 
 on Kubernetes clusters.
 


### PR DESCRIPTION
A document for the Concepts section that is purely a high level description of what the project is.  The main landing page for the site includes lots of market-y stuff and process stuff, and is likely to be confusing to someone who is really new to all this. Most of this is stolen, shamelessly, from knative.tips. It also points out that Build has been moved to its own project.  Since much of the documentation available on the wider web still indicates Build is part of Knative, it is valuable to explain where it went.

<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number

## Proposed Changes

-
-
-
