### PR TITLE
Fix the CLI installation headings

### DIFF
--- a/docs/install/install-kn.md
+++ b/docs/install/install-kn.md
@@ -15,11 +15,11 @@ You must place the executable binary in your system path, and make sure that it 
 ## Install `kn` using Go
 1. Check out the [Client repository](https://github.com/knative/client).
 1. Run the command:
-  ```
+  ```bash
   go install ./cmd/kn
   ```
 
 ## `kn` container images
 The `kn` container images are available here:
-- [Nightly container image](gcr.io/knative-nightly/knative.dev/client/cmd/kn)
-- [Latest release](gcr.io/knative-releases/knative.dev/client/cmd/kn)
+- [Nightly container image](https://gcr.io/knative-nightly/knative.dev/client/cmd/kn)
+- [Latest release](https://gcr.io/knative-releases/knative.dev/client/cmd/kn)

--- a/docs/install/install-kn.md
+++ b/docs/install/install-kn.md
@@ -1,6 +1,5 @@
 ---
-title: "Installing the `kn` Client"
-linkTitle: "Installing the `kn` Client"
+title: "Installing the Knative CLI"
 weight: 10
 type: "docs"
 ---


### PR DESCRIPTION
As this is today, things don't look very good:
![image](https://user-images.githubusercontent.com/2442466/73797895-1606c480-4766-11ea-8bf3-bc55b851c876.png)
