### PR TITLE
Using Destination API on source examples

### DIFF
--- a/docs/eventing/samples/container-source/README.md
+++ b/docs/eventing/samples/container-source/README.md
@@ -100,9 +100,10 @@ spec:
             - name: POD_NAMESPACE
               value: "event-test"
   sink:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display
 ```
 
 Use the following command to create the event source from

--- a/docs/eventing/samples/container-source/heartbeats-source.yaml
+++ b/docs/eventing/samples/container-source/heartbeats-source.yaml
@@ -18,6 +18,7 @@ spec:
             - name: POD_NAMESPACE
               value: "event-test"
   sink:
-    apiVersion: serving.knative.dev/v1alpha1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display

--- a/docs/eventing/samples/cronjob-source/README.md
+++ b/docs/eventing/samples/cronjob-source/README.md
@@ -54,9 +54,10 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display
 ```
 
 Use following command to create the event source from `cronjob-source.yaml`:

--- a/docs/eventing/samples/cronjob-source/cronjob-source.yaml
+++ b/docs/eventing/samples/cronjob-source/cronjob-source.yaml
@@ -6,6 +6,7 @@ spec:
   schedule: "*/2 * * * *"
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    name: event-display
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display


### PR DESCRIPTION
Most examples are already using the Destination API syntax, like:

```yaml
...
  sink:
    ref:
      apiVersion: serving.knative.dev/v1
      kind: Service
      name: event-display
```

but some examples did actually lack those :disappointed:  

This PR fixes this.... 


as well as using `apiVersion: serving.knative.dev/v1` instead of `apiVersion: serving.knative.dev/v1alpha1`  this 

