### PR TITLE
The yaml was not matching the text in the README

### DIFF
--- a/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
@@ -11,6 +11,6 @@ spec:
     kind: Event
   sink:
     ref:
-      apiVersion: serving.knative.dev/v1alpha1
-      kind: Service
-      name: event-display
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default


### PR DESCRIPTION
## Proposed Changes

- the `README` talk about the Broker, but the yaml used `ksvc`, which is wrong
