### PR TITLE
The github source was moved to sources.knative.dev APIgroup

### DIFF
--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -116,7 +116,7 @@ field to the spec specifying your GitHub enterprise API endpoint, see
 [here](../../README.md#githubsource)
 
 ```yaml
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: GitHubSource
 metadata:
   name: githubsourcesample

--- a/docs/eventing/samples/github-source/github-source.yaml
+++ b/docs/eventing/samples/github-source/github-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: GitHubSource
 metadata:
   name: githubsourcesample


### PR DESCRIPTION
See https://github.com/knative/eventing-contrib/issues/894

/assing @nachocano 

I've updated the apiGroup for the GH source in the sample doc

