### PR TITLE
(bug-fix): Add missing configmap command

### DIFF
--- a/docs/install/Knative-with-Contour.md
+++ b/docs/install/Knative-with-Contour.md
@@ -63,7 +63,7 @@ data:
 
 Enter the following command to add the key:
 
-        kubectl edit --namespace knative-serving config-network
+        kubectl edit --namespace knative-serving configmap/config-network
 
 
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number

## Proposed Changes

- Add missing configmap command
- `kubectl edit --namespace knative-serving config-network` to `kubectl edit --namespace knative-serving configmap/config-network`