### PR TITLE
This adopts the "artifact" shortcode.

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -49,13 +49,13 @@ If the `knative-eventing` namespace or the `imc-controller-*` does not exist, us
 
     ```sh
     kubectl apply --selector knative.dev/crd-install=true \
-    --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
+    --filename {{< artifact repo="eventing" file="eventing.yaml" >}}
     ```
 
 1. Finish installing Eventing resources by running the following command:
 
     ```sh
-    kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing.yaml
+    kubectl apply --filename {{< artifact repo="eventing" file="eventing.yaml" >}}
     ```
 
    Installing the CRDs first can prevent race conditions, which might cause failures during the install.

--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -45,13 +45,13 @@ The following commands install the Knative Serving component.
 1. Install the [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (aka CRDs):
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-crds.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="serving-crds.yaml" >}}
    ```
 
 1. Install the core components of Serving (see below for optional extensions):
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-core.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="serving-core.yaml" >}}
    ```
 
 1. Pick a networking layer (alphabetical):
@@ -114,7 +114,7 @@ The following commands install Contour and enable its Knative integration.
 1. Install a properly configured Contour:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/net-contour/releases/download/{{< version >}}/contour.yaml
+   kubectl apply --filename {{< artifact repo="net-contour" file="contour.yaml" >}}
    ```
 
    <!-- TODO(https://github.com/knative/net-contour/issues/11): We need a guide on how to use/modify a pre-existing install. -->
@@ -122,7 +122,7 @@ The following commands install Contour and enable its Knative integration.
 1. Install the Knative Contour controller:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/net-contour/releases/download/{{< version >}}/net-contour.yaml
+   kubectl apply --filename {{< artifact repo="net-contour" file="net-contour.yaml" >}}
    ```
 
 1. To configure Knative Serving to use Contour by default:
@@ -190,7 +190,7 @@ The following commands install Istio and enable its Knative integration.
 1. Install the Knative Istio controller:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-istio.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="serving-istio.yaml" >}}
    ```
 
 1. Fetch the External IP or CNAME:
@@ -240,7 +240,7 @@ The following commands install Kourier and enable its Knative integration.
 We ship a simple Kubernetes Job called "default domain" that will (see caveats) configure Knative Serving to use <a href="http://xip.io">xip.io</a> as the default DNS suffix.
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-default-domain.yaml
+kubectl apply --filename {{< artifact repo="serving" file="serving-default-domain.yaml" >}}
 ```
 
 **Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS".
@@ -296,7 +296,7 @@ for driving autoscaling decisions.  The following command will install the
 components needed to support HPA-class autoscaling:
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-hpa.yaml
+kubectl apply --filename {{< artifact repo="serving" file="serving-hpa.yaml" >}}
 ```
 
 <!-- TODO(https://github.com/knative/docs/issues/2152): Link to a more in-depth guide on HPA-class autoscaling -->
@@ -312,7 +312,7 @@ Knative supports automatically provisioning TLS certificates via [cert-manager](
 2. Next, install the component that integrates Knative with cert-manager:
 
     ```bash
-    kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-cert-manager.yaml
+    kubectl apply --filename {{< artifact repo="serving" file="serving-cert-manager.yaml" >}}
     ```
 
 3. Now configure Knative to [automatically configure TLS certificates](../serving/using-auto-tls.md).
@@ -323,7 +323,7 @@ Knative supports automatically provisioning TLS certificates via [cert-manager](
 If you plan to use cert-manager's support for provisioning wildcard certificates, then the most efficient way to provision certificates is with the namespace wildcard certificate controller.  The following command will install the components needed to provision wildcard certificates in each namespace:
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/serving-nscert.yaml
+kubectl apply --filename {{< artifact repo="serving" file="serving-nscert.yaml" >}}
 ```
 
 {{< /tab >}}
@@ -342,13 +342,13 @@ The following commands install the Knative Eventing component.
 1. Install the [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (aka CRDs):
 
    ```bash
-   kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing-crds.yaml
+   kubectl apply --filename {{< artifact repo="eventing" file="eventing-crds.yaml" >}}
    ```
 
 1. Install the core components of Eventing (see below for optional extensions):
 
    ```bash
-   kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/eventing-core.yaml
+   kubectl apply --filename {{< artifact repo="eventing" file="eventing-core.yaml" >}}
    ```
 
 1. Install a default Channel (messaging) layer.
@@ -359,7 +359,7 @@ The following commands install the Knative Eventing component.
 The following command installs an implementation of Channel that runs in-memory.  This implementation is nice because it is simple and standalone, but it is unsuitable for production use cases.
 
    ```bash
-   kubectl apply --filename https://github.com/knative/eventing/releases/download/{{< version >}}/in-memory-channel.yaml
+   kubectl apply --filename {{< artifact repo="eventing" file="in-memory-channel.yaml" >}}
    ```
 
 {{< /tab >}}
@@ -437,7 +437,7 @@ The following command enables the default Broker on a namespace (here `default`)
 The following command installs the Github Source:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/github.yaml
+   kubectl apply --filename {{< artifact repo="eventing-contrib" file="github.yaml" >}}
    ```
 
 To learn more about the Github source, try [our sample](../eventing/samples/github-source/README.md)
@@ -448,7 +448,7 @@ To learn more about the Github source, try [our sample](../eventing/samples/gith
 The following command installs the Camel Source:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/camel.yaml
+   kubectl apply --filename {{< artifact repo="eventing-contrib" file="camel.yaml" >}}
    ```
 
 To learn more about the Camel source, try [our sample](../eventing/samples/apache-camel-source/README.md)
@@ -459,7 +459,7 @@ To learn more about the Camel source, try [our sample](../eventing/samples/apach
 The following command installs the Kafka Source:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka-source.yaml
+   kubectl apply --filename {{< artifact repo="eventing-contrib" file="kafka-source.yaml" >}}
    ```
 
 To learn more about the Kafka source, try [our sample](../eventing/samples/kafka/source/README.md)
@@ -499,13 +499,13 @@ Knative provides a bundle of monitoring components that can be used to make the 
 - Install [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/) for metrics:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="monitoring-metrics-prometheus.yaml" >}}
    ```
 
 - Install the [ELK stack](https://www.elastic.co/what-is/elk-stack) (Elasticsearch, Logstash and Kibana) for logs:
 
    ```bash
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="monitoring-logs-elasticsearch.yaml" >}}
    ```
 
 - Install [Jaeger](https://jaegertracing.io/) for distributed tracing
@@ -516,7 +516,7 @@ Knative provides a bundle of monitoring components that can be used to make the 
 To install the in-memory (standalone) version of Jaeger, run the following command:
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
+kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-jaeger-in-mem.yaml" >}}
 ```
 {{< /tab >}}
 
@@ -524,7 +524,7 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/{{
 To install the ELK version of Jaeger (needs the ELK install above), run the following command:
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
+kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-jaeger.yaml" >}}
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -537,7 +537,7 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/{{
 To install the in-memory (standalone) version of Zipkin, run the following command:
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
+kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-zipkin-in-mem.yaml" >}}
 ```
 {{< /tab >}}
 
@@ -545,7 +545,7 @@ kubectl apply --filename https://github.com/knative/serving/releases/download/{{
 To install the ELK version of Zipkin (needs the ELK install above), run the following command:
 
 ```bash
-kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
+kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-zipkin.yaml" >}}
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -31,7 +31,7 @@ sections to do so now.
 1. Run the following command to install Prometheus and Grafana:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-metrics-prometheus.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="monitoring-metrics-prometheus.yaml" >}}
    ```
 
 1. Ensure that the `grafana-*`, `kibana-logging-*`, `kube-state-metrics-*`,
@@ -90,7 +90,7 @@ install:
 1. Run the following command to install an ELK stack:
 
    ```shell
-   kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-logs-elasticsearch.yaml
+   kubectl apply --filename {{< artifact repo="serving" file="monitoring-logs-elasticsearch.yaml" >}}
    ```
 
 1. Ensure that the `elasticsearch-logging-*`, `fluentd-ds-*`, and
@@ -268,14 +268,14 @@ uninstall that tool before installing the new tool.
      end traces, run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin-in-mem.yaml
+     kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-zipkin-in-mem.yaml" >}}
      ```
 
    - If Elasticsearch is installed and you want to persist end to end traces,
      first run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-zipkin.yaml
+     kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-zipkin.yaml" >}}
      ```
 
 1. Create an Elasticsearch index for end to end traces:
@@ -303,14 +303,14 @@ end traces.
      end traces, run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger-in-mem.yaml
+     kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-jaeger-in-mem.yaml" >}}
      ```
 
    - If Elasticsearch is installed and you want to persist end to end traces,
      first run:
 
      ```shell
-     kubectl apply --filename https://github.com/knative/serving/releases/download/{{< version >}}/monitoring-tracing-jaeger.yaml
+     kubectl apply --filename {{< artifact repo="serving" file="monitoring-tracing-jaeger.yaml" >}}
      ```
 
 1. Create an Elasticsearch index for end to end traces:


### PR DESCRIPTION
I'm introducing this here: https://github.com/knative/website/pull/129 with the intention of enabling us to make the Pre-release pages show nightly builds, which are hosted completely differently.

/hold

Until the website PR merges.