### PR TITLE
Add note for 0% of traffic for obsolete revision

### DIFF
--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -237,6 +237,10 @@ spec:
       # Named route for v2 has been removed, since we don't need it anymore
 ```
 
+> Note: You can remove the first revision blue-green-demo-lcfrd instead of 0% of traffic
+> when you will not roll back the revision anymore.
+> Then the non-routeable revision object will be garbage collected.
+
 Save the file, then apply the updated route to your cluster:
 
 ```bash


### PR DESCRIPTION
## Proposed Changes

This patch adds note for 0% of traffic for old revision.
Current non-routeable makes a few confusion like:

* Until when users should keep setting 0% traffic.
* With 0% traffic setting, the revision is not garbage collected.

Hence, this patch adds the note.
