### PR TITLE
Apache Kafka channel install

### DIFF
--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -364,8 +364,23 @@ The following command installs an implementation of Channel that runs in-memory.
 
 {{< /tab >}}
 
+{{% tab name="Apache Kafka Channel" %}}
+
+1. [Installing Apache Kafka for Kubernetes](../eventing/samples/kafka/README.md)
+
+1. Install the Apache Kafka Channel:
+
+   ```bash
+   curl -L "https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka-channel.yaml" \
+    | sed 's/REPLACE_WITH_CLUSTER_URL/my-cluster-kafka-bootstrap.kafka:9092/' \
+    | kubectl apply --filename -
+   ```
+
+To learn more about the Apache Kafka channel, try [our sample](../eventing/samples/kafka/channel/README.md)
+
+{{< /tab >}}
+
 <!-- TODO(https://github.com/knative/docs/issues/2153): Add more Channels here -->
-<!-- TODO: Kafka Channel -->
 <!-- TODO: NATSS Channel -->
 <!-- TODO: GCP Pub/Sub Channel -->
 

--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -368,7 +368,7 @@ The following command installs an implementation of Channel that runs in-memory.
 
 1. First, [Install Apache Kafka for Kubernetes](../eventing/samples/kafka/README.md)
 
-1. Install the Apache Kafka Channel:
+1. Then install the Apache Kafka Channel:
 
    ```bash
    curl -L "https://github.com/knative/eventing-contrib/releases/download/{{< version >}}/kafka-channel.yaml" \

--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -366,7 +366,7 @@ The following command installs an implementation of Channel that runs in-memory.
 
 {{% tab name="Apache Kafka Channel" %}}
 
-1. [Installing Apache Kafka for Kubernetes](../eventing/samples/kafka/README.md)
+1. First, [Install Apache Kafka for Kubernetes](../eventing/samples/kafka/README.md)
 
 1. Install the Apache Kafka Channel:
 


### PR DESCRIPTION
based on changes from #2193 - let's get that in first!

/assign @mattmoor 

A couple of thoughts....  

Should we separate this into three different aspects? 

* Broker enablement (well, atm there is just one, but we could show the install of a custom one, w/o the labeling?
* Full dedicated section on Sources _and_ one that covers channels.

Currently we mix all in one, but as soon we have more content there, it might be better to separate things!  Happy to help on that.


