### PR TITLE
Godoc seem seems to go away

### DIFF
--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -44,7 +44,7 @@ The `deadLetterSink` specifies where to send events that failed be consumed by `
 When present, events that failed to be consumed are sent to the `deadLetterSink`.
 In case of failure, the event is dropped and an error is logged into the system.
 
-The `deadLetterSink` value must be a [Destination](https://godoc.org/knative.dev/pkg/apis/duck/v1#Destination).
+The `deadLetterSink` value must be a [Destination](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination).
 
 ```yaml
 spec:

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -836,7 +836,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 <p>Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
 by a backend. An Ingress can be configured to give services externally-reachable URLs, load
 balance traffic, offer name based virtual hosting, etc.</p>
-<p>This is heavily based on K8s Ingress <a href="https://godoc.org/k8s.io/api/networking/v1beta1#Ingress">https://godoc.org/k8s.io/api/networking/v1beta1#Ingress</a>
+<p>This is heavily based on K8s Ingress <a href="https://pkg.go.dev/k8s.io/api/networking/v1beta1#Ingress">https://pkg.go.dev/k8s.io/api/networking/v1beta1#Ingress</a>
 which some highlighted modifications.</p>
 </p>
 <table>
@@ -1342,7 +1342,7 @@ before forwarding a request to the destination service.</p>
 <td>
 <code>timeout</code></br>
 <em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
 Kubernetes meta/v1.Duration
 </a>
 </em>
@@ -1439,7 +1439,7 @@ int
 <td>
 <code>perTryTimeout</code></br>
 <em>
-<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+<a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
 Kubernetes meta/v1.Duration
 </a>
 </em>

--- a/docs/serving/configuring-autoscaling.md
+++ b/docs/serving/configuring-autoscaling.md
@@ -9,7 +9,7 @@ aliases:
 Knative uses a single shared autoscaler. This is, by default, the Knative Pod Autoscaler (KPA), which
 provides fast, request-based autoscaling capabilities out of the box.
 
-You can also configure Knative to use Horizontal Pod Autoscaler (HPA), or use your own autoscaler, by creating a [controller](https://kubernetes.io/docs/concepts/architecture/controller/) (also referred to as a [reconciler](https://godoc.org/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler)) for the Pod Autoscaler custom resource.
+You can also configure Knative to use Horizontal Pod Autoscaler (HPA), or use your own autoscaler, by creating a [controller](https://kubernetes.io/docs/concepts/architecture/controller/) (also referred to as a [reconciler](https://pkg.go.dev/k8s.io/kubernetes/pkg/controller/volume/attachdetach/reconciler)) for the Pod Autoscaler custom resource.
 
 # Modifying the ConfigMap for KPA
 

--- a/docs/serving/samples/telemetry-go/telemetrysample.go
+++ b/docs/serving/samples/telemetry-go/telemetrysample.go
@@ -41,7 +41,7 @@ import (
 
 var (
 	// Create a measurement to keep track of incoming request counts.
-	// For more information on measurements, see https://godoc.org/go.opencensus.io/stats
+	// For more information on measurements, see https://pkg.go.dev/go.opencensus.io/stats
 	requestCount = stats.Int64("request_count", "Total number of requests.", stats.UnitNone)
 
 	// Create a measurement to keep track of request durations.
@@ -49,7 +49,7 @@ var (
 
 	// Capture the HTTP response code in a tag so that we can aggregate and visualize
 	// this metric based on different response codes (see count of all 400 vs 200 for example).
-	// For more information on tags, see https://godoc.org/go.opencensus.io/tag
+	// For more information on tags, see https://pkg.go.dev/go.opencensus.io/tag
 	requestStatusTagKey tag.Key
 )
 


### PR DESCRIPTION
liinks to godoc seem to be deprecated.

See

> Pkg.go.dev is a new destination for Go discovery & docs. Check it out at pkg.go.dev/knative.dev/pkg/apis/duck/v1 and share your feedback.

warning on their site 

/assing @mattmoor 
/assign @samodell 