### PR TITLE
chore(resources): Remove link to knctl

### DIFF
--- a/docs/concepts/resources.md
+++ b/docs/concepts/resources.md
@@ -7,20 +7,6 @@ type: "docs"
 This page contains information about various tools and technologies that are
 useful to anyone developing on Knative.
 
-## Community Resources
-
-This section contains tools and technologies developed by members of the Knative
-community specifically for use with Knative.
-
-### [`knctl`](https://github.com/cppforlife/knctl)
-
-`knctl` is an under-development CLI for working with Knative.
-
-## Other Resources
-
-This section contains other tools and technologies that are useful when working
-with Knative.
-
 ### [`ko`](https://github.com/google/ko)
 
 `ko` is a tool designed to make development of Go apps on Kubernetes easier, by


### PR DESCRIPTION
knctl doesn't seem to be developed anymore (latest serving dependency: 0.2.1, latest commit: May 2019).
I think its fair to remove it from this page to not mislead potential users
(or at least don't call it 'under active development')

@cppforlife I hope this is ok for you. You did an awesome job to kick off the idea for a Knative client and you paved the way to `kn`. However, I think it would be a bit confusing for people if we give them the choice between `kn` and `knctl`. Please let me know if I'm wrong and you are planning to continue to work on `knctl`.

Thanks !
In general I question the value of the overall page is can be removed completely IMO.