### PR TITLE
Update Knative Eventing sample link

### DIFF
--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -507,7 +507,7 @@ To learn more about the GCP Pub/Sub source, try [our sample](../eventing/samples
 
 ### Getting started with Eventing
 
-You can find a number of sample on how to get started with Knative Eventing [here](../eventing/).
+You can find a number of samples for Knative Eventing [here](../eventing/samples/README.md). A quick-start guide is available [here](../eventing/getting-started.md).
 
 
 ## Installing the Monitoring bundle


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number

## Proposed Changes

In the docs it currently says "You can find a number of sample on how to get started with Knative Eventing here." 

This is confusing as it talks about both a link to samples and getting started (which are two different pages). Also, the existing link is to the general Knative Eventing overview. I have tried to make it more explicit. 
