### PR TITLE
knative-monitoring namespace needs to exist

### DIFF
--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -523,7 +523,7 @@ You can find a number of sample on how to get started with Knative Eventing [her
 
 ## Installing the Monitoring bundle
 
-Knative provides a bundle of monitoring components that can be used to make the Serving and Eventing components more observable.
+Knative provides a bundle of monitoring components that can be used to make the Serving and Eventing components more observable. You will need to have a ```knative-monitoring``` namespace set up for installing the monitoring components. 
 
 - Install [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/) for metrics:
 


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number

## Proposed Changes

If you do not have an existing Knative-monitoring namespace then the commands in the Installing Knative (monitoring) section will return an error as they are expecting the namespace to exist. 
