### PR TITLE
Adding PubSub Channel

### DIFF
--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -398,6 +398,18 @@ To learn more about the Apache Kafka channel, try [our sample](../eventing/sampl
 
 {{< /tab >}}
 
+{{% tab name="Google Cloud Pub/Sub Channel" %}}
+
+1. Install the Google Cloud Pub/Sub Channel:
+
+   ```bash
+   kubectl apply --filename {{< artifact repo="knative-gcp" file="cloud-run-events.yaml" >}}
+   ```
+
+To learn more about the Google Cloud Pub/Sub Channel, try [our sample](https://github.com/google/knative-gcp/blob/master/docs/examples/channel/README.md)
+
+{{< /tab >}}
+
 {{% tab name="In-Memory (standalone)" %}}
 
 {{< feature-state version="v0.2" state="alpha" >}}
@@ -423,7 +435,6 @@ The following command installs an implementation of Channel that runs in-memory.
 {{< /tab >}}
 
 <!-- TODO(https://github.com/knative/docs/issues/2153): Add more Channels here -->
-<!-- TODO: GCP Pub/Sub Channel -->
 
 {{< /tabs >}}
 

--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -403,7 +403,8 @@ To learn more about the Apache Kafka channel, try [our sample](../eventing/sampl
 1. Install the Google Cloud Pub/Sub Channel:
 
    ```bash
-   kubectl apply --filename {{< artifact repo="knative-gcp" file="cloud-run-events.yaml" >}}
+   # This installs both the Channel and the Source.
+   kubectl apply --filename {{< artifact org="google" repo="knative-gcp" file="cloud-run-events.yaml" >}}
    ```
 
 To learn more about the Google Cloud Pub/Sub Channel, try [our sample](https://github.com/google/knative-gcp/blob/master/docs/examples/channel/README.md)
@@ -558,7 +559,7 @@ The following command installs the GCP Pub/Sub Source:
 
    ```bash
    # This installs both the Source and the Channel.
-   kubectl apply --filename https://github.com/google/knative-gcp/releases/download/{{< version >}}/cloud-run-events.yaml
+   kubectl apply --filename {{< artifact org="google" repo="knative-gcp" file="cloud-run-events.yaml" >}}
    ```
 
 To learn more about the GCP Pub/Sub source, try [our sample](../eventing/samples/gcp-pubsub-source/README.md)


### PR DESCRIPTION
<!-- General PR guidelines:

New contributors:

If you are new to Git/GitHub and want to make a quick fix to the docs,
open your PR against the release branch where you found the error, such as
"release-0.5".

Regular contributors:

Most PRs should be opened against the master branch.

If the change should also be in the most recent numbered release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes https://github.com/knative/eventing-contrib/issues/895
Helps with https://github.com/knative/docs/issues/2153

## Proposed Changes

- Adding PubSub channel to new installation docs
- @matzew do you know how {{< artifact repo="knative-gcp" file="cloud-run-events.yaml" >}} gets replaced? It will probably point somewhere else...
