### PR TITLE
Update template to avoid branch confusion

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,17 +1,9 @@
 <!-- General PR guidelines:
 
-New contributors:
-
-If you are new to Git/GitHub and want to make a quick fix to the docs,
-open your PR against the release branch where you found the error, such as
-"release-0.5".
-
-Regular contributors:
-
 Most PRs should be opened against the master branch.
 
-If the change should also be in the most recent numbered release, add the
-corresponding "cherrypick-0.X" label; for example, "cherrypick-0.5", to the
+If the change should also be in the most recent release, add the
+corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
 original PR. Best practice is to open a PR for the cherry-pick yourself after
 your original PR has been merged into the master branch. Once the cherry-pick PR
 has merged, remove the cherry-pick label from the original PR.
@@ -21,9 +13,9 @@ https://www.knative.dev/community/contributing/
 
  -->
 
-Fixes #issue-number
+Fixes #issue-number or description of the problem the PR solves
 
-## Proposed Changes
+## Proposed Changes <!-- Describe the changes the PR makes. -->
 
 -
 -


### PR DESCRIPTION
Fixes old, confusing instructions that tell users to open PRs against the release branches

## Proposed Changes

- Removes guidance about contributing directly to release branches
- Adds more prompting to describe what the PR does and why
