### PR TITLE
deleted duplicate cloud scheduler and cloud storage source

### DIFF
--- a/docs/eventing/samples/cloud-audit-logs-source/README.md
+++ b/docs/eventing/samples/cloud-audit-logs-source/README.md
@@ -5,6 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-# CloudAuditLogsSource Example
-
 Please refer to the [example](https://github.com/google/knative-gcp/blob/master/docs/examples/cloudauditlogssource/README.md) in knative-gcp.

--- a/docs/eventing/samples/cloud-pubsub-source/README.md
+++ b/docs/eventing/samples/cloud-pubsub-source/README.md
@@ -7,6 +7,4 @@ aliases:
   - /docs/eventing/samples/gcp-pubsub-source/README.md
 ---
 
-# CloudPubSubSource Example
-
 Please refer to the [example](https://github.com/google/knative-gcp/blob/master/docs/examples/cloudpubsubsource/README.md) in knative-gcp.

--- a/docs/eventing/samples/cloud-scheduler-source/README.md
+++ b/docs/eventing/samples/cloud-scheduler-source/README.md
@@ -5,6 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-# CloudSchedulerSource Example
-
 Please refer to the [example](https://github.com/google/knative-gcp/blob/master/docs/examples/cloudschedulersource/README.md) in knative-gcp.

--- a/docs/eventing/samples/cloud-storage-source/README.md
+++ b/docs/eventing/samples/cloud-storage-source/README.md
@@ -5,6 +5,4 @@ weight: 20
 type: "docs"
 ---
 
-# CloudStorageSource Example
-
 Please refer to the [example](https://github.com/google/knative-gcp/blob/master/docs/examples/cloudstoragesource/README.md) in knative-gcp.

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -59,7 +59,7 @@ Name | Status | Support | Description
 [Auto Container Source](https://github.com/Harwayne/auto-container-source) | Proof of Concept | None | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure.
 [Container Source](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.
 [Kubebuilder Sample Source](https://github.com/grantr/sample-source) | Proof of Concept | None | Kubebuilder SampleSource is a kubebuilder based implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).
-[Sample Source](https://github.com/knative/sample-source) | Active Development | Knative | Used as reference implementation supporting [Writing an Event Source from Scratch tutorial](../samples/writing-ra-source).
+[Sample Source](https://github.com/knative/sample-source) | Active Development | Knative | Used as reference implementation supporting [Writing an Event Source from Scratch tutorial](../samples/writing-receive-adapter-source).
 
 
 

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Knative Eventing sources"
-linkTitle: "Sources"
-weight: 10
+linkTitle: "Eventing sources"
+weight: 20
 type: "docs"
 ---
 
@@ -46,8 +46,6 @@ Name | Status | Support | Description
 [Cron Job](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/cron_job_types.go) | Proof of Concept | None | Uses an in-memory timer to produce events on the specified Cron schedule.
 [GitHub](https://github.com/knative/eventing-contrib/blob/master/github/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
 [GitLab](https://gitlab.com/triggermesh/gitlabsource) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
-[Google Cloud Scheduler](https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/scheduler_types.go) | Active Development | None | Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/) Jobs. When those jobs are triggered, receive the event inside Knative.
-[Google Cloud Storage](https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/storage_types.go) | Active Development | None | Registers for events of the specified types on the specified Google Cloud Storage bucket and optional object prefix. Brings those events into Knative.
 [Kubernetes](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/apiserver_types.go) | Active Development | Knative | Brings Kubernetes API server events into Knative.
 
 
@@ -61,7 +59,7 @@ Name | Status | Support | Description
 [Auto Container Source](https://github.com/Harwayne/auto-container-source) | Proof of Concept | None | AutoContainerSource is a controller that allows the Source CRDs _without_ needing a controller. It notices CRDs with a specific label and starts controlling resources of that type. It utilizes Container Source as underlying infrastructure.
 [Container Source](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/containersource_types.go) | Active Development | Knative | Container Source is a generic controller. Given an Image URL, it will keep a single `Pod` running with the specified image, environment, and arguments. It is used by multiple other Sources as underlying infrastructure.
 [Kubebuilder Sample Source](https://github.com/grantr/sample-source) | Proof of Concept | None | Kubebuilder SampleSource is a kubebuilder based implementation supporting the [Writing an Event Source the Hard Way tutorial](../samples/writing-a-source).
-[Sample Source](https://github.com/knative/sample-source) | Active Development | Knative | Used as reference implementation supporting [Writing an Event Source from Scratch tutorial](../samples/writing-receive-adapter-source).
+[Sample Source](https://github.com/knative/sample-source) | Active Development | Knative | Used as reference implementation supporting [Writing an Event Source from Scratch tutorial](../samples/writing-ra-source).
 
 
 

--- a/docs/eventing/sources/sources.yaml
+++ b/docs/eventing/sources/sources.yaml
@@ -104,20 +104,6 @@ sources:
     support: Knative
     description: >
       Brings Kubernetes API server events into Knative.
-  - name: Google Cloud Scheduler
-    url: https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/scheduler_types.go
-    status: Active Development
-    support: None
-    description: >
-      Create, update, and delete [Google Cloud Scheduler](https://cloud.google.com/scheduler/)
-      Jobs. When those jobs are triggered, receive the event inside Knative.
-  - name: Google Cloud Storage
-    url: https://github.com/google/knative-gcp/blob/master/pkg/apis/events/v1alpha1/storage_types.go
-    status: Active Development
-    support: None
-    description: >
-      Registers for events of the specified types on the specified Google Cloud Storage bucket and
-      optional object prefix. Brings those events into Knative.
   - name: Apache Kafka
     url: https://github.com/knative/eventing-contrib/blob/master/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go
     status: Proof of Concept

--- a/docs/eventing/sources/sources.yaml
+++ b/docs/eventing/sources/sources.yaml
@@ -30,7 +30,7 @@ metaSources:
     support: Knative
     description: >
       Used as reference implementation supporting
-      [Writing an Event Source from Scratch tutorial](../samples/writing-ra-source).
+      [Writing an Event Source from Scratch tutorial](../samples/writing-receive-adapter-source).
 
 
 # Sources are event sources that users can install and use directly.

--- a/docs/install/knative-with-any-k8s.md
+++ b/docs/install/knative-with-any-k8s.md
@@ -562,10 +562,13 @@ The following command installs the GCP Sources:
    kubectl apply --filename {{< artifact repo="knative-gcp" file="cloud-run-events.yaml" >}}
    ```
 
-To learn more about the Cloud Pub/Sub source, try [our sample](../eventing/samples/cloud-pubsub-source/README.md)
-To learn more about the Cloud Storage source, try [our sample](../eventing/samples/cloud-storage-source/README.md)
-To learn more about the Cloud Scheduler source, try [our sample](../eventing/samples/cloud-scheduler-source/README.md)
-To learn more about the Cloud Audit Logs source, try [our sample](../eventing/samples/cloud-audit-logs-source/README.md)
+To learn more about the Cloud Pub/Sub source, try [our sample](../eventing/samples/cloud-pubsub-source/README.md).
+
+To learn more about the Cloud Storage source, try [our sample](../eventing/samples/cloud-storage-source/README.md).
+
+To learn more about the Cloud Scheduler source, try [our sample](../eventing/samples/cloud-scheduler-source/README.md).
+
+To learn more about the Cloud Audit Logs source, try [our sample](../eventing/samples/cloud-audit-logs-source/README.md).
 
 {{< /tab >}}
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- deleted duplicate cloud scheduler and cloud storage source
-
-
