### PR TITLE
Switch support status for triggermesh external sources

### DIFF
--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -69,12 +69,12 @@ These are containers intended to be used with `ContainerSource`.
 
 Name | Status | Support | Description
 --- | --- | --- | ---
-[AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Active Development | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
-[AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito) | Active Development | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.
-[AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb) | Active Development | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
-[AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis) | Active Development | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
-[AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns) | Active Development | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.
-[AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs) | Active Development | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.
+[AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Supported | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
+[AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito) | Supported | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.
+[AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb) | Supported | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
+[AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis) | Supported | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
+[AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns) | Supported | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.
+[AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs) | Supported | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.
 [FTP / SFTP](https://github.com/vaikas-google/ftp) | Proof of concept | None | Watches for files being uploaded into a FTP/SFTP and generates events for those.
 [Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source) | Proof of Concept | None | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure.
 [Heartbeats](https://github.com/knative/eventing-contrib/tree/{{< branch >}}/cmd/heartbeats) | Proof of Concept | None | Uses an in-memory timer to produce events at the specified interval.

--- a/docs/eventing/sources/sources.yaml
+++ b/docs/eventing/sources/sources.yaml
@@ -148,37 +148,37 @@ containers:
       for underlying infrastructure.
   - name: AWS CodeCommit
     url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit
-    status: Active Development
+    status: Supported
     support: TriggerMesh
     description: >
       Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
   - name: AWS Cognito
     url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito
-    status: Active Development
+    status: Supported
     support: TriggerMesh
     description: >
       Registers for AWS Cognito events. Brings those events into Knative.
   - name: AWS DynamoDB
     url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb
-    status: Active Development
+    status: Supported
     support: TriggerMesh
     description: >
       Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
   - name: AWS Kinesis
     url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis
-    status: Active Development
+    status: Supported
     support: TriggerMesh
     description: >
       Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
   - name: AWS SQS
     url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs
-    status: Active Development
+    status: Supported
     support: TriggerMesh
     description: >
       Registers for events of the specified AWS SQS queue. Brings those events into Knative.
   - name: AWS SNS
     url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns
-    status: Active Development
+    status: Supported
     support: TriggerMesh
     description: >
       Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Switch the status of TriggerMesh external sources to "supported" since we now offer support.
