### PR TITLE
update cert manager version for using on gcp

### DIFF
--- a/docs/serving/using-cert-manager-on-gcp.md
+++ b/docs/serving/using-cert-manager-on-gcp.md
@@ -129,7 +129,7 @@ TLS certificates and how the requests are validated with Cloud DNS.
                 serviceAccountSecretRef:
                   name: cloud-dns-key
                   key: key.json
-    EOF  
+    EOF
    ```
 
 1. Ensure that `letsencrypt-issuer` is created successfully by running the


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->



## Proposed Changes <!-- Describe the changes the PR makes. -->

- Changed examples to show certificates and issuers using the latest cert manager version

