### PR TITLE
Add instruction in how to install Knative with Knative operators

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,3 +2,5 @@
 To install Knative components on your Kubernetes cluster, follow our [installation guide](./any-kubernetes-cluster.md).
 
 To install the Knative CLI, follow our [installation guide](./install-kn.md).
+
+To install Knative components with Knative Operators, follow our [installation guide with Knative Operators](./knative-with-operators.md).

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,6 +1,5 @@
 
-To install Knative components on your Kubernetes cluster, follow our [installation guide](./any-kubernetes-cluster.md).
+To install Knative components on your Kubernetes cluster, follow our [installation guide](./any-kubernetes-cluster.md) or
+[installation guide with Knative Operators](./knative-with-operators.md).
 
 To install the Knative CLI, follow our [installation guide](./install-kn.md).
-
-To install Knative components with Knative Operators, follow our [installation guide with Knative Operators](./knative-with-operators.md).

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,5 +1,5 @@
 
-To install Knative components on your Kubernetes cluster, follow our [installation guide](./any-kubernetes-cluster.md) or
+To install Knative components on your Kubernetes cluster, follow the [installation guide](./any-kubernetes-cluster.md) or
 [installation guide with Knative Operators](./knative-with-operators.md).
 
-To install the Knative CLI, follow our [installation guide](./install-kn.md).
+To install the Knative CLI, follow the [installation guide](./install-kn.md).

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -4,7 +4,7 @@ weight: 10
 type: "docs"
 ---
 
-# Knative installations with Knative Operators
+# Installing Knative components using Operators
 
 Knative provides operators as tools to install, configure and manage Knative. This guide explains how to install and
 uninstall Knative using Knative operators.
@@ -25,11 +25,6 @@ Disk storage to at least 30 GB. If you have multiple nodes for your cluster, set
     - [Download and install Istio](https://knative.dev/development/install/installing-istio/#downloading-istio-and-installing-crds). Go through all the 4 sub-steps.
     - [Update your Istio to use cluster local gateway](https://knative.dev/development/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway).
 
-Knative operators are still in Alpha phase. They focus on installation on a generic Kubernetes platform, such as
-Docker Desktop, Minikube, or kubeadm clusters, and the operators do not perform any platform specific customization.
-If you are not sure the customization of the Knative operators for vendor-specific platforms, use the generic Kubernetes
-platform.
-
 ## Limitations of Knative Operators:
 
 Knative Operators use custom resources (CRs) to configure your Knative deployment.
@@ -41,7 +36,7 @@ Knative Operators use custom resources (CRs) to configure your Knative deploymen
 
 Information about Knative Serving Operator releases can be found on the [Releases page](https://github.com/knative/serving-operator/releases).
 
-### Installling the Knative Serving Operator
+### Installing the Knative Serving Operator
 
 __From releases__:
 
@@ -128,7 +123,7 @@ webhook            1/1     1            1           19h
 
 Information about Knative Eventing Operator releases can be found on the [Releases page](https://github.com/knative/eventing-operator/releases).
 
-### Installling the Knative Eventing Operator
+### Installing the Knative Eventing Operator
 
 __From releases__:
 

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -1,0 +1,238 @@
+---
+title: "Installing Knative with Knative Operators"
+weight: 10
+type: "docs"
+---
+
+# Knative installations with Knative Operators
+
+As of v0.10.0, Knative started to release Knative operators as tools to install, configure and manage Knative. This
+guide will explain how to install and uninstall Knative with Knative operators.
+
+There are two major components in Knative: Serving and Eventing. There are two operators: [Knative Serving Operator](https://github.com/knative/serving-operator)
+and [Knative Eventing Operator](https://github.com/knative/eventing-operator), respectively dedicated to each of them. Please make sure you have set up a Kubernetes
+cluster accessible to your local workstation.
+
+## Limitations of Knative Operators:
+
+Knative operators are still in Alpha phase. They only focus on Knative installation for the generic Kubernetes platform,
+which means Docker-Desktop Kubernetes on Mac and Minikube can be directly used as the Kubernetes clusters for you to install
+Knative with Knative operators, without any additional configuration out of the scope of the operator custom resource,
+but vendor-specific Kubernetes services, like Google Kubernetes Engine, IBM Kubernetes Service, OpenShift, etc, may need
+some additional configurations to work after the Knative is installed by the operator. In short, the Knative operators of
+the open source version only supports the following Kubernetes services, without additional configurations:
+
+   * Docker-Desktop Kubernetes on Mac
+   * Minikube
+
+The same to any other Kubernetes operator, Knative operators use custom resources as the sources of truth to configure
+your Knative. The current custom resources still have limited capabilities, which can not cover all the scenarios of
+how we can configure Knative to meet our needs, but Knative operators are making progress in extending their capabilities.
+One of the major missing points is that operators still lack of APIs for us to specify the parameters for high availability.
+If you rely on the HA capability, Knative operators are currently not helping with that.
+
+The open source versions of Knative operators have not been tested on any existing production environment. Please use
+them for development or test purpose. However, we encourage you to experiment Knative operators on top of the Kubernetes
+cluster for your production environment, helping us find out what we can potentially improve in Knative operators by
+reporting your issues.
+
+## Prerequisites:
+
+Knative Serving needs an ingress or gateway to route inbound network traffic to the services. There are multiple options
+that can be used as the ingress candidates: Istio, Ambassador, Contour, Gloo, Kourier, etc. However, to install Knative
+with operators, we only support Istio as the ingress for now. Knative Operators are currently working on enabling the
+support for more ingress options. Since we talk about the installation on generic Kubernetes service, Istio can be
+installed with the following steps:
+
+1. [Download and install Istio](https://knative.dev/development/install/installing-istio/#downloading-istio-and-installing-crds). Go through all the 4 sub-steps.
+2. [Update your Istio to use cluster local gateway](https://knative.dev/development/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway).
+
+## Install Knative Serving with Operator:
+
+All the releases for Knative Serving Operator can be found on [this page](https://github.com/knative/serving-operator/releases).
+
+### From releases:
+
+Replace \<version\> with the latest version or the version you would like to install, and run the following command to
+install Knative Serving Operator:
+
+```
+kubectl apply -f https://github.com/knative/serving-operator/releases/download/<version>/serving-operator.yaml
+```
+
+### From source code:
+
+The source code is available on this page. You need to install the building tool [ko](https://github.com/google/ko) first. After downloading the
+source code, you can install the operator in the root directory of the source code with the following command:
+
+```
+ko apply -f config/
+```
+
+Verify the installation of Knative Serving Operator with the command:
+
+```
+kubectl get deployment knative-serving-operator
+```
+
+You should see the deployment is ready, if the operator is installed.
+
+Use the following command to track the log of the operator:
+
+```
+kubectl logs -f $(kubectl get pods -l name=knative-serving-operator -o name)
+```
+
+If everything goes fine, it is time to install Knative Serving by installing the custom resource of Knative Serving
+operator. Operator supports to install Knative Serving under any namespace, which needs to be created as well. Then,
+we can create a custom resource with empty spec section. Technically, you can use any namespace, but we recommend you
+to use knative-serving. In the rest of this tutorial, we keep on using knative-servingas the namespace to create the
+Serving operator CR and all the other namspaced Serving resources. To create the CR, you can run the following command:
+
+```
+cat <<-EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: knative-serving
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+EOF
+```
+
+Wait some time for Knative Serving is to become ready. Check the Knative Serving deployment with the following command:
+
+```
+kubectl get deployment -n knative-serving
+```
+
+You will receive the status of Knative serving deployments. If Knative Serving has been successfully deployed, you will
+see all the deployments of the Knative Serving have reached READY status.
+
+## Install Knative Eventing with Operator:
+
+All the releases for Knative Eventing Operator can be found on [this page](https://github.com/knative/eventing-operator/releases).
+
+### From releases:
+
+Replace \<version\> with the latest version or the version you would like to install, and run the following command to
+install Knative Eventing Operator:
+
+```
+kubectl apply -f https://github.com/knative/serving-operator/releases/download/<version>/eventing-operator.yaml
+```
+
+### From source code:
+
+The source code is available on this page. You need to install the building tool [ko](https://github.com/google/ko) first. After downloading the source
+code, you can install the operator in the root directory of the source code with the following command:
+
+```
+ko apply -f config/
+```
+
+Verify the installation of Knative Eventing Operator with the command:
+
+```
+kubectl get deployment knative-eventing-operator
+```
+
+You should see the deployment is ready, if the operator is installed. Use the following command to track the log of
+the operator:
+
+```
+kubectl logs -f $(kubectl get pods -l name=knative-eventing-operator -o name)
+```
+
+If deployment of Knative Eventing operator is ready, it is time to install Knative Evenintg by installing the custom
+resource of Knative Eventing operator. The same to Knative Serving operator, you can use any namespace, but we recommend
+you to use knative-eventing for Knative eventing. In the rest of this tutorial, we keep on using knative-eventingas the
+namespace to create the Eventing operator CR and all the other namspaced Eventing resources. Run the following command:
+
+```
+cat <<-EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: knative-eventing
+---
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+EOF
+```
+
+Wait some time for Knative Eventing to become ready. Check the Knative Eventing deployments with the following command:
+
+```
+kubectl get deployment -n knative-eventing
+```
+
+We should see a list of Knative Eventing deployments up and running. If Knative Eventing has been successfully deployed,
+you should see all the deployments of Knative Eventing are up and running.
+
+## Uninstall Knative Serving with Operator:
+
+### To remove Knative Serving component:
+
+All the resources of Knative Serving are owned by the Knative Serving operator custom resource. To uninstall your Knative
+Serving, you only need to remove the operator CR with the command:
+
+```
+kubectl delete KnativeServing knative-serving -n knative-serving
+```
+
+Knative Serving operator prevents unsafe removal of Knative serving resources. Even if the operator CR is successfully
+removed, all the CRDs in Knative Serving are still kept in the cluster. All your resources relying on Knative CRDs
+can still work.
+
+### To remove Knative Serving Operator:
+
+If you install from releases, run the following command:
+
+```
+kubectl delete -f https://github.com/knative/serving-operator/releases/download/<version>/serving-operator.yaml
+```
+
+Replace <version> with the version number of Knative Serving, you have installed.
+
+If you install from source code, run the following command in the root directory of your source code:
+
+```
+ko delete -f config/
+```
+
+## Uninstall Knative Eventing with Operator:
+
+### To remove Knative Eventing component:
+
+All the resources of Knative Eventing are owned by the Knative Eventing operator custom resource. You can uninstall your
+Knative Eventing, by removing the operator CR with the command:
+
+```
+kubectl delete KnativeEventing knative-eventing -n knative-eventing
+```
+
+Knative Eventing operator also prevents unsafe removal of Knative Eventing resources by keeping the Knative Eventing CRDs.
+
+### To remove Knative Eventing Operator:
+
+If you install from releases, run the following command:
+
+```
+kubectl delete -f https://github.com/knative/eventing-operator/releases/download/<version>/serving-operator.yaml
+```
+
+Replace <version> with the version number of Knative Eventing, you have installed.
+
+If you install from source code, run the following command in the root directory of your source code:
+
+```
+ko delete -f config/
+```

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -6,46 +6,52 @@ type: "docs"
 
 # Knative installations with Knative Operators
 
-As of v0.10.0, Knative started to release Knative operators as tools to install, configure and manage Knative. This
-guide will explain how to install and uninstall Knative with Knative operators.
+Knative provides operators as tools to install, configure and manage Knative. This guide explains how to install and
+uninstall Knative using Knative operators.
 
-There are two major components in Knative: Serving and Eventing. There are two operators: [Knative Serving Operator](https://github.com/knative/serving-operator)
-and [Knative Eventing Operator](https://github.com/knative/eventing-operator), respectively dedicated to each of them. Please make sure you have set up a Kubernetes
-cluster accessible to your local workstation.
-
-## Limitations of Knative Operators:
-
-Knative operators are still in Alpha phase. They only focus on Knative installation for the generic Kubernetes platform,
-which means Docker-Desktop Kubernetes on Mac and Minikube can be directly used as the Kubernetes clusters for you to install
-Knative with Knative operators, without any additional configuration out of the scope of the operator custom resource,
-but vendor-specific Kubernetes services, like Google Kubernetes Engine, IBM Kubernetes Service, OpenShift, etc, may need
-some additional configurations to work after the Knative is installed by the operator. In short, the Knative operators of
-the open source version only supports the following Kubernetes services, without additional configurations:
-
-   * Docker-Desktop Kubernetes on Mac
-   * Minikube
-
-The same to any other Kubernetes operator, Knative operators use custom resources as the sources of truth to configure
-your Knative. The current custom resources still have limited capabilities, which can not cover all the scenarios of
-how we can configure Knative to meet our needs, but Knative operators are making progress in extending their capabilities.
-One of the major missing points is that operators still lack of APIs for us to specify the parameters for high availability.
-If you rely on the HA capability, Knative operators are currently not helping with that.
-
-The open source versions of Knative operators have not been tested on any existing production environment. Please use
-them for development or test purpose. However, we encourage you to experiment Knative operators on top of the Kubernetes
-cluster for your production environment, helping us find out what we can potentially improve in Knative operators by
-reporting your issues.
+Each component in Knative has a separate operator for installation and configuration. This means that there is a [Serving operator](https://github.com/knative/serving-operator)
+and an [Eventing operator](https://github.com/knative/eventing-operator), and you can choose to install one or both independently.
 
 ## Prerequisites:
 
-Knative Serving needs an ingress or gateway to route inbound network traffic to the services. There are multiple options
-that can be used as the ingress candidates: Istio, Ambassador, Contour, Gloo, Kourier, etc. However, to install Knative
-with operators, we only support Istio as the ingress for now. Knative Operators are currently working on enabling the
-support for more ingress options. Since we talk about the installation on generic Kubernetes service, Istio can be
-installed with the following steps:
+### Set up a Kubernetes cluster
+
+Knative operators are still in Alpha phase. They focus on installation on a generic Kubernetes platform, such as
+Docker Desktop, Minikube, or kubeadm clusters, and the operators do not perform any platform specific customization.
+If you are not sure the customization of the Knative operators for vendor-specific platforms, use the generic Kubernetes
+platform.
+
+If you have only one node for your cluster, set CPUs to at least 6, Memory to at least 6.0 GB, Disk storage to at
+least 30 GB. If you have multiple nodes for your cluster, set CPUs to at least 2, Memory to at least 4.0 GB, Disk storage
+to at least 20 GB for each node.
+
+You need to make sure that your Kubernetes cluster is able to access the internet, since Knative operators download
+images online.
+
+Vendor-specific Kubernetes services, such as Google Kubernetes Engine, IBM Kubernetes Service, or OpenShift, may need
+some additional configurations, after the Knative is installed using the operators. In this tutorial, we do not introduce
+the customization or additional configurations, that may vary from platform to platform.
+
+### Install Istio
+
+Knative Serving needs an ingress or gateway to route inbound network traffic to the services. Knative Operators only support
+Istio in this release. Since we talk about the installation on generic Kubernetes service, Istio can be installed with
+the following steps:
 
 1. [Download and install Istio](https://knative.dev/development/install/installing-istio/#downloading-istio-and-installing-crds). Go through all the 4 sub-steps.
 2. [Update your Istio to use cluster local gateway](https://knative.dev/development/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway).
+
+## Limitations of Knative Operators:
+
+Knative operators use custom resources as the sources of truth to configure your Knative. The current custom resources
+still have limited capabilities, which can not configure everything to meet Knative needs, but Knative operators are
+making progress in extending their capabilities. One of the major missing points is that Knative operators do not currently
+provide HA capabilities.
+
+The open source versions of Knative operators have not been tested on any existing production environment, so use
+them for development or test purpose. However, we encourage you to experiment Knative operators on top of the Kubernetes
+cluster for your production environment, helping us find out what we can potentially improve in Knative operators by
+reporting your issues.
 
 ## Install Knative Serving with Operator:
 
@@ -86,8 +92,8 @@ kubectl logs -f $(kubectl get pods -l name=knative-serving-operator -o name)
 If everything goes fine, it is time to install Knative Serving by installing the custom resource of Knative Serving
 operator. Operator supports to install Knative Serving under any namespace, which needs to be created as well. Then,
 we can create a custom resource with empty spec section. Technically, you can use any namespace, but we recommend you
-to use knative-serving. In the rest of this tutorial, we keep on using knative-servingas the namespace to create the
-Serving operator CR and all the other namspaced Serving resources. To create the CR, you can run the following command:
+to use `knative-serving`. In the rest of this tutorial, we keep on using `knative-serving` as the namespace to create the
+Serving operator CR and all the other namespaced Serving resources. To create the CR, you can run the following command:
 
 ```
 cat <<-EOF | kubectl apply -f -
@@ -150,8 +156,8 @@ kubectl logs -f $(kubectl get pods -l name=knative-eventing-operator -o name)
 
 If deployment of Knative Eventing operator is ready, it is time to install Knative Evenintg by installing the custom
 resource of Knative Eventing operator. The same to Knative Serving operator, you can use any namespace, but we recommend
-you to use knative-eventing for Knative eventing. In the rest of this tutorial, we keep on using knative-eventingas the
-namespace to create the Eventing operator CR and all the other namspaced Eventing resources. Run the following command:
+you to use `knative-eventing` for Knative eventing. In the rest of this tutorial, we keep on using `knative-eventing` as the
+namespace to create the Eventing operator CR and all the other namespaced Eventing resources. Run the following command:
 
 ```
 cat <<-EOF | kubectl apply -f -

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -1,5 +1,5 @@
 ---
-title: "Installing Knative with Knative Operators"
+title: "Installing Knative components using Operators"
 weight: 10
 type: "docs"
 ---
@@ -12,52 +12,38 @@ uninstall Knative using Knative operators.
 Each component in Knative has a separate operator for installation and configuration. This means that there is a [Serving operator](https://github.com/knative/serving-operator)
 and an [Eventing operator](https://github.com/knative/eventing-operator), and you can choose to install one or both independently.
 
-## Prerequisites:
+## Before you begin
 
-### Set up a Kubernetes cluster
+Knative installation using Operators requires the following:
+
+- A Kubernetes cluster v1.15 or newer, as well as a compatible kubectl. This guide assumes that you've already created
+a Kubernetes cluster. If you have only one node for your cluster, set CPUs to at least 6, Memory to at least 6.0 GB,
+Disk storage to at least 30 GB. If you have multiple nodes for your cluster, set CPUs to at least 2, Memory to at least
+4.0 GB, Disk storage to at least 20 GB for each node.
+- The Kubernetes cluster must be able to access the internet, since Knative operators download images online.
+- Istio:
+    - [Download and install Istio](https://knative.dev/development/install/installing-istio/#downloading-istio-and-installing-crds). Go through all the 4 sub-steps.
+    - [Update your Istio to use cluster local gateway](https://knative.dev/development/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway).
 
 Knative operators are still in Alpha phase. They focus on installation on a generic Kubernetes platform, such as
 Docker Desktop, Minikube, or kubeadm clusters, and the operators do not perform any platform specific customization.
 If you are not sure the customization of the Knative operators for vendor-specific platforms, use the generic Kubernetes
 platform.
 
-If you have only one node for your cluster, set CPUs to at least 6, Memory to at least 6.0 GB, Disk storage to at
-least 30 GB. If you have multiple nodes for your cluster, set CPUs to at least 2, Memory to at least 4.0 GB, Disk storage
-to at least 20 GB for each node.
-
-You need to make sure that your Kubernetes cluster is able to access the internet, since Knative operators download
-images online.
-
-Vendor-specific Kubernetes services, such as Google Kubernetes Engine, IBM Kubernetes Service, or OpenShift, may need
-some additional configurations, after the Knative is installed using the operators. In this tutorial, we do not introduce
-the customization or additional configurations, that may vary from platform to platform.
-
-### Install Istio
-
-Knative Serving needs an ingress or gateway to route inbound network traffic to the services. Knative Operators only support
-Istio in this release. Since we talk about the installation on generic Kubernetes service, Istio can be installed with
-the following steps:
-
-1. [Download and install Istio](https://knative.dev/development/install/installing-istio/#downloading-istio-and-installing-crds). Go through all the 4 sub-steps.
-2. [Update your Istio to use cluster local gateway](https://knative.dev/development/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway).
-
 ## Limitations of Knative Operators:
 
-Knative operators use custom resources as the sources of truth to configure your Knative. The current custom resources
-still have limited capabilities, which can not configure everything to meet Knative needs, but Knative operators are
-making progress in extending their capabilities. One of the major missing points is that Knative operators do not currently
-provide HA capabilities.
+Knative Operators use custom resources (CRs) to configure your Knative deployment.
 
-The open source versions of Knative operators have not been tested on any existing production environment, so use
-them for development or test purpose. However, we encourage you to experiment Knative operators on top of the Kubernetes
-cluster for your production environment, helping us find out what we can potentially improve in Knative operators by
-reporting your issues.
+ - Currently, the CRs included with Knative Operators do not provide high availability (HA) capabilities.
+ - Knative Operators have not been tested in a production environment, and should be used for development or test purposes only.
 
 ## Install Knative Serving with Operator:
 
-All the releases for Knative Serving Operator can be found on [this page](https://github.com/knative/serving-operator/releases).
+Information about Knative Serving Operator releases can be found on the [Releases page](https://github.com/knative/serving-operator/releases).
 
-### From releases:
+### Installling the Knative Serving Operator
+
+__From releases__:
 
 Replace \<version\> with the latest version or the version you would like to install, and run the following command to
 install Knative Serving Operator:
@@ -66,22 +52,33 @@ install Knative Serving Operator:
 kubectl apply -f https://github.com/knative/serving-operator/releases/download/<version>/serving-operator.yaml
 ```
 
-### From source code:
+__From source code__:
 
-The source code is available on this page. You need to install the building tool [ko](https://github.com/google/ko) first. After downloading the
-source code, you can install the operator in the root directory of the source code with the following command:
+You can also install Knative Operators from source using `ko`.
+
+1. Install the [ko]((https://github.com/google/ko)) build tool.
+1. Install the operator in the root directory of the source using the following command:
 
 ```
 ko apply -f config/
 ```
 
-Verify the installation of Knative Serving Operator with the command:
+### Verify the operator installation
+
+Verify the installation of Knative Serving Operator using the command:
 
 ```
 kubectl get deployment knative-serving-operator
 ```
 
-You should see the deployment is ready, if the operator is installed.
+If the operator is installed correctly, the deployment should show a `Ready` status. Here is a sample output:
+
+```
+NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+knative-serving-operator   1/1     1            1           19h
+```
+
+### Track the log
 
 Use the following command to track the log of the operator:
 
@@ -89,11 +86,9 @@ Use the following command to track the log of the operator:
 kubectl logs -f $(kubectl get pods -l name=knative-serving-operator -o name)
 ```
 
-If everything goes fine, it is time to install Knative Serving by installing the custom resource of Knative Serving
-operator. Operator supports to install Knative Serving under any namespace, which needs to be created as well. Then,
-we can create a custom resource with empty spec section. Technically, you can use any namespace, but we recommend you
-to use `knative-serving`. In the rest of this tutorial, we keep on using `knative-serving` as the namespace to create the
-Serving operator CR and all the other namespaced Serving resources. To create the CR, you can run the following command:
+### Installing the Knative Serving component
+
+1. Create and apply the Knative Serving CR:
 
 ```
 cat <<-EOF | kubectl apply -f -
@@ -110,54 +105,77 @@ metadata:
 EOF
 ```
 
-Wait some time for Knative Serving is to become ready. Check the Knative Serving deployment with the following command:
+2. Verify the Knative Serving deployment:
 
 ```
 kubectl get deployment -n knative-serving
 ```
 
-You will receive the status of Knative serving deployments. If Knative Serving has been successfully deployed, you will
-see all the deployments of the Knative Serving have reached READY status.
+If Knative Serving has been successfully deployed, all deployments of the Knative Serving will show `READY` status. Here
+is a sample output:
+
+```
+NAME               READY   UP-TO-DATE   AVAILABLE   AGE
+activator          1/1     1            1           19h
+autoscaler         1/1     1            1           19h
+autoscaler-hpa     1/1     1            1           19h
+controller         1/1     1            1           19h
+networking-istio   1/1     1            1           19h
+webhook            1/1     1            1           19h
+```
 
 ## Install Knative Eventing with Operator:
 
-All the releases for Knative Eventing Operator can be found on [this page](https://github.com/knative/eventing-operator/releases).
+Information about Knative Eventing Operator releases can be found on the [Releases page](https://github.com/knative/eventing-operator/releases).
 
-### From releases:
+### Installling the Knative Eventing Operator
+
+__From releases__:
 
 Replace \<version\> with the latest version or the version you would like to install, and run the following command to
 install Knative Eventing Operator:
 
 ```
-kubectl apply -f https://github.com/knative/serving-operator/releases/download/<version>/eventing-operator.yaml
+kubectl apply -f https://github.com/knative/eventing-operator/releases/download/<version>/eventing-operator.yaml
 ```
 
-### From source code:
+__From source code__:
 
-The source code is available on this page. You need to install the building tool [ko](https://github.com/google/ko) first. After downloading the source
-code, you can install the operator in the root directory of the source code with the following command:
+You can also install Knative Operators from source using `ko`.
+
+- Install the [ko]((https://github.com/google/ko)) build tool.
+- Install the operator in the root directory of the source using the following command:
 
 ```
 ko apply -f config/
 ```
 
-Verify the installation of Knative Eventing Operator with the command:
+### Verify the operator installation
+
+Verify the installation of Knative Eventing Operator using the command:
 
 ```
 kubectl get deployment knative-eventing-operator
 ```
 
-You should see the deployment is ready, if the operator is installed. Use the following command to track the log of
-the operator:
+If the operator is installed correctly, the deployment should show a `Ready` status. Here is a sample output:
+
+```
+NAME                       READY   UP-TO-DATE   AVAILABLE   AGE
+knative-eventing-operator   1/1     1            1           19h
+```
+
+### Track the log
+
+Use the following command to track the log of the operator:
 
 ```
 kubectl logs -f $(kubectl get pods -l name=knative-eventing-operator -o name)
 ```
 
-If deployment of Knative Eventing operator is ready, it is time to install Knative Evenintg by installing the custom
-resource of Knative Eventing operator. The same to Knative Serving operator, you can use any namespace, but we recommend
-you to use `knative-eventing` for Knative eventing. In the rest of this tutorial, we keep on using `knative-eventing` as the
-namespace to create the Eventing operator CR and all the other namespaced Eventing resources. Run the following command:
+### Installing the Knative Eventing component
+
+1. Create and apply the Knative eventing CR:
 
 ```
 cat <<-EOF | kubectl apply -f -
@@ -174,21 +192,29 @@ metadata:
 EOF
 ```
 
-Wait some time for Knative Eventing to become ready. Check the Knative Eventing deployments with the following command:
+2. Verify the Knative Eventing deployment:
 
 ```
 kubectl get deployment -n knative-eventing
 ```
 
-We should see a list of Knative Eventing deployments up and running. If Knative Eventing has been successfully deployed,
-you should see all the deployments of Knative Eventing are up and running.
+If Knative Eventing has been successfully deployed, all deployments of the Knative Eventing will show `READY` status. Here
+is a sample output:
 
-## Uninstall Knative Serving with Operator:
+```
+NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+broker-controller     1/1     1            1           42h
+eventing-controller   1/1     1            1           42h
+eventing-webhook      1/1     1            1           42h
+imc-controller        1/1     1            1           42h
+imc-dispatcher        1/1     1            1           42h
+```
 
-### To remove Knative Serving component:
+## Uninstall Knative
 
-All the resources of Knative Serving are owned by the Knative Serving operator custom resource. To uninstall your Knative
-Serving, you only need to remove the operator CR with the command:
+### Removing the Knative Serving component
+
+Remove the Knative Serving CR:
 
 ```
 kubectl delete KnativeServing knative-serving -n knative-serving
@@ -198,28 +224,26 @@ Knative Serving operator prevents unsafe removal of Knative serving resources. E
 removed, all the CRDs in Knative Serving are still kept in the cluster. All your resources relying on Knative CRDs
 can still work.
 
-### To remove Knative Serving Operator:
+### Removing the Knative Serving Operator:
 
-If you install from releases, run the following command:
+If you have installed Knative Serving using the Release page, remove the operator using the following command:
 
 ```
 kubectl delete -f https://github.com/knative/serving-operator/releases/download/<version>/serving-operator.yaml
 ```
 
-Replace <version> with the version number of Knative Serving, you have installed.
+Replace <version> with the version number of Knative Serving you have installed.
 
-If you install from source code, run the following command in the root directory of your source code:
+If you have installed Knative Serving from source, uninstall it using the following command while in the root directory
+for the source:
 
 ```
 ko delete -f config/
 ```
 
-## Uninstall Knative Eventing with Operator:
+### Removing Knative Eventing component
 
-### To remove Knative Eventing component:
-
-All the resources of Knative Eventing are owned by the Knative Eventing operator custom resource. You can uninstall your
-Knative Eventing, by removing the operator CR with the command:
+Remove the Knative Eventing CR:
 
 ```
 kubectl delete KnativeEventing knative-eventing -n knative-eventing
@@ -227,17 +251,18 @@ kubectl delete KnativeEventing knative-eventing -n knative-eventing
 
 Knative Eventing operator also prevents unsafe removal of Knative Eventing resources by keeping the Knative Eventing CRDs.
 
-### To remove Knative Eventing Operator:
+### Removing Knative Eventing Operator:
 
-If you install from releases, run the following command:
+If you have installed Knative Eventing using the Release page, remove the operator using the following command:
 
 ```
-kubectl delete -f https://github.com/knative/eventing-operator/releases/download/<version>/serving-operator.yaml
+kubectl delete -f https://github.com/knative/eventing-operator/releases/download/<version>/eventing-operator.yaml
 ```
 
-Replace <version> with the version number of Knative Eventing, you have installed.
+Replace <version> with the version number of Knative Eventing you have installed.
 
-If you install from source code, run the following command in the root directory of your source code:
+If you have installed Knative Eventing from source, uninstall it using the following command while in the root directory
+for the source:
 
 ```
 ko delete -f config/


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2260
The outline of this page can be found here: https://github.com/houshengbo/docs/blob/add-doc-operator/docs/install/knative-with-operators.md

## Proposed Changes <!-- Describe the changes the PR makes. -->

- This PR adds the instruction on how to install and uninstall knative with operators.

