### PR TITLE
Update broker installation doc to include ConfigMapPropagation.

### DIFF
--- a/docs/eventing/channel-based-broker.md
+++ b/docs/eventing/channel-based-broker.md
@@ -134,21 +134,23 @@ installed with Knative Eventing
 The `ServiceAccount` was created two commands prior. The `RoleBinding` is
 created with this command.
 
-Create RBAC permissions granting access to shared configmaps for logging,
-tracing, and metrics configuration.
-
-_These commands assume the shared Knative Eventing components are installed in
-the `knative-eventing` namespace. If you installed the shared Knative Eventing
-components in a different namespace, replace `knative-eventing` with the name of
-that namespace._
-
+The broker expects 3 configmaps to run properly: `eventing-config-logging`, `eventing-config-observability`
+and `eventing-config-tracing`. You can copy the corresponding configmaps under [`eventing/config/`](https://github.com/knative/eventing/tree/master/config).
+An easier way is to create a `ConfigMapPropagation` object and the configmaps will be automatically
+be propagated. To do so,
 ```shell
-kubectl -n knative-eventing create rolebinding eventing-config-reader-default-eventing-broker-ingress \
-  --clusterrole=eventing-config-reader \
-  --serviceaccount=default:eventing-broker-ingress
-kubectl -n knative-eventing create rolebinding eventing-config-reader-default-eventing-broker-filter \
-  --clusterrole=eventing-config-reader \
-  --serviceaccount=default:eventing-broker-filter
+cat << EOF | kubectl apply -f -
+apiVersion: configs.internal.knative.dev/v1alpha1
+kind: ConfigMapPropagation
+metadata:
+  namespace: default
+  name: eventing
+spec:
+  originalNamespace: knative-eventing
+  selector:
+    matchLabels:
+      knative.dev/config-category: eventing
+EOF
 ```
 
 Now we can create the `Broker`. Note that this example uses the name `default`,


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The instruction to create RBACs for reading configmaps from the system namespace is removed since we now copy configmaps into user namespace.
- Added instruction to propagate  the required configmaps to user namespace.
-

cc @grac3gao 