### PR TITLE
Remove DNS pain point for new users

### DIFF
--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -1,12 +1,12 @@
 ---
-title: "Kubernetes event using the API Server Source"
+title: "API Server Source"
 linkTitle: "Kubernetes event"
 weight: 50
 type: "docs"
 ---
 
-This example shows how to wire [Kubernetes cluster events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#event-v1-core),
-using the API Server Source, for consumption by a function that has been implemented as a Knative Service.
+This example shows how to wire [Kubernetes cluster events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#event-v1-core), using the API Server Source, for
+consumption by a function that has been implemented as a Knative Service.
 
 ## Before you begin
 
@@ -16,7 +16,7 @@ using the API Server Source, for consumption by a function that has been impleme
    the repo by running:
 
    ```shell
-   git clone -b "release-0.13" https://github.com/knative/docs knative-docs
+   git clone -b "release-0.9" https://github.com/knative/docs knative-docs
    cd knative-docs/docs/eventing/samples/kubernetes-event-source
    ```
 
@@ -24,15 +24,14 @@ using the API Server Source, for consumption by a function that has been impleme
 
 ### Broker
 
-These instructions assume the namespace `default`, which you can change to your
-preferred namespace. If you use a different namespace, you will need to modify
-all the YAML files deployed in this sample to point at that namespace.
+1. Create the `default` Broker in your namespace. These instructions assume the
+   namespace `default`, feel free to change to any other namespace you would
+   like to use instead. If you use a different namespace, you will need to
+   modify all the YAML files deployed in this sample to point at that namespace.
 
-1. Create the `default` Broker in your namespace:
-
-   ```shell
-   kubectl label namespace default knative-eventing-injection=enabled
-   ```
+```shell
+kubectl label namespace default knative-eventing-injection=enabled
+```
 
 ### Service Account
 
@@ -41,51 +40,52 @@ all the YAML files deployed in this sample to point at that namespace.
    Knative Eventing Broker. Create a file named `serviceaccount.yaml` and copy
    the code block below into it.
 
-   ```yaml
-   apiVersion: v1
-   kind: ServiceAccount
-   metadata:
-     name: events-sa
-     namespace: default
-   
-   ---
-   apiVersion: rbac.authorization.k8s.io/v1
-   kind: ClusterRole
-   metadata:
-     name: event-watcher
-   rules:
-     - apiGroups:
-         - ""
-       resources:
-         - events
-       verbs:
-         - get
-         - list
-         - watch
-   
-   ---
-   apiVersion: rbac.authorization.k8s.io/v1
-   kind: ClusterRoleBinding
-   metadata:
-     name: k8s-ra-event-watcher
-   roleRef:
-     apiGroup: rbac.authorization.k8s.io
-     kind: ClusterRole
-     name: event-watcher
-   subjects:
-     - kind: ServiceAccount
-       name: events-sa
-       namespace: default
-   ```
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: events-sa
+  namespace: default
 
-   If you want to re-use an existing Service Account with the appropriate permissions,
-   you need to modify the `serviceaccount.yaml`.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: event-watcher
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 
-2. Enter the following command to create the service account from `serviceaccount.yaml`:
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-ra-event-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: event-watcher
+subjects:
+  - kind: ServiceAccount
+    name: events-sa
+    namespace: default
+```
 
-   ```shell
-   kubectl apply --filename serviceaccount.yaml
-   ```
+If you want to re-use an existing Service Account with the appropriate
+permissions, you need to modify the `serviceaccount.yaml`.
+
+Enter the following command to create the service account from
+`serviceaccount.yaml`:
+
+```shell
+kubectl apply --filename serviceaccount.yaml
+```
 
 ### Create Event Source for Kubernetes Events
 
@@ -93,33 +93,33 @@ all the YAML files deployed in this sample to point at that namespace.
    specific namespace. Create a file named `k8s-events.yaml` and copy the code
    block below into it.
 
-   ```yaml
-   apiVersion: sources.knative.dev/v1alpha1
-   kind: ApiServerSource
-   metadata:
-     name: testevents
-     namespace: default
-   spec:
-     serviceAccountName: events-sa
-     mode: Resource
-     resources:
-       - apiVersion: v1
-         kind: Event
-     sink:
-       ref:
-         apiVersion: eventing.knative.dev/v1alpha1
-         kind: Broker
-         name: default
-   ```
+```yaml
+apiVersion: sources.knative.dev/v1alpha1
+kind: ApiServerSource
+metadata:
+  name: testevents
+  namespace: default
+spec:
+  serviceAccountName: events-sa
+  mode: Resource
+  resources:
+    - apiVersion: v1
+      kind: Event
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: Broker
+      name: default
+```
 
-   If you want to consume events from a different namespace or use a
-   different `Service Account`, you need to modify `k8s-events.yaml` accordingly.
+If you want to consume events from a different namespace or use a different
+`Service Account`, you need to modify `k8s-events.yaml` accordingly.
 
-2. Enter the following command to create the event source:
+Enter the following command to create the event source:
 
-   ```shell
-   kubectl apply --filename k8s-events.yaml
-   ```
+```shell
+kubectl apply --filename k8s-events.yaml
+```
 
 ### Trigger
 
@@ -127,52 +127,52 @@ In order to check the `ApiServerSource` is fully working, we will create a
 simple Knative Service that dumps incoming messages to its log and creates a
 `Trigger` from the `Broker` to that Knative Service.
 
-1. Create a file named `trigger.yaml` and copy the code block below into it.
+Create a file named `trigger.yaml` and copy the code block below into it.
 
-   ```yaml
-   apiVersion: eventing.knative.dev/v1alpha1
-   kind: Trigger
-   metadata:
-     name: testevents-trigger
-     namespace: default
-   spec:
-     subscriber:
-       ref:
-         apiVersion: serving.knative.dev/v1
-         kind: Service
-         name: event-display
+```yaml
+apiVersion: eventing.knative.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: testevents-trigger
+  namespace: default
+spec:
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display
 
-   ---
-   # This is a very simple Knative Service that writes the input request to its log.
-   
-   apiVersion: serving.knative.dev/v1
-   kind: Service
-   metadata:
-     name: event-display
-     namespace: default
-   spec:
-     template:
-       spec:
-         containers:
-           - # This corresponds to
-             # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
-             image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
-   ```
+---
+# This is a very simple Knative Service that writes the input request to its log.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: event-display
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - # This corresponds to
+          # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
+          image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+```
 
 1. If the deployed `ApiServerSource` is pointing at a `Broker` other than
    `default`, modify `trigger.yaml` by adding `spec.broker` with the `Broker`'s
    name.
 
-1. Deploy `trigger.yaml`:
+1. Deploy `trigger.yaml`.
 
-   ```shell
-   kubectl apply --filename trigger.yaml
-   ```
+```shell
+kubectl apply --filename trigger.yaml
+```
 
 ### Create Events
 
-Create events by launching a pod in the default namespace. Create a `busybox`
-container and immediately delete it:
+Create events by launching a pod in the default namespace. Create a busybox
+container and immediately delete it.
 
 ```shell
 kubectl run busybox --image=busybox --restart=Never -- ls
@@ -183,8 +183,8 @@ kubectl delete pod busybox
 
 We will verify that the Kubernetes events were sent into the Knative eventing
 system by looking at our message dumper function logs. If you deployed the
-[Trigger](#trigger), continue using this section. If not, you will
-need to look downstream yourself:
+[Trigger](#trigger), then continue using this section. If not, then you will
+need to look downstream yourself.
 
 ```shell
 kubectl get pods
@@ -244,7 +244,7 @@ Data,
 ### Cleanup
 
 You can remove the `ServiceAccount`, `ClusterRoles`, `ClusterRoleBinding`,
-`ApiServerSource`, `Service` and `Trigger` using:
+`ApiServerSource`, `Service` and `Trigger` via:
 
 ```shell
 kubectl --namespace default delete --filename serviceaccount.yaml

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -1,12 +1,12 @@
 ---
-title: "API Server Source"
+title: "Kubernetes event using the API Server Source"
 linkTitle: "Kubernetes event"
 weight: 50
 type: "docs"
 ---
 
-This example shows how to wire [Kubernetes cluster events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#event-v1-core), using the API Server Source, for
-consumption by a function that has been implemented as a Knative Service.
+This example shows how to wire [Kubernetes cluster events](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#event-v1-core),
+using the API Server Source, for consumption by a function that has been implemented as a Knative Service.
 
 ## Before you begin
 
@@ -16,7 +16,7 @@ consumption by a function that has been implemented as a Knative Service.
    the repo by running:
 
    ```shell
-   git clone -b "release-0.9" https://github.com/knative/docs knative-docs
+   git clone -b "release-0.13" https://github.com/knative/docs knative-docs
    cd knative-docs/docs/eventing/samples/kubernetes-event-source
    ```
 
@@ -24,14 +24,15 @@ consumption by a function that has been implemented as a Knative Service.
 
 ### Broker
 
-1. Create the `default` Broker in your namespace. These instructions assume the
-   namespace `default`, feel free to change to any other namespace you would
-   like to use instead. If you use a different namespace, you will need to
-   modify all the YAML files deployed in this sample to point at that namespace.
+These instructions assume the namespace `default`, which you can change to your
+preferred namespace. If you use a different namespace, you will need to modify
+all the YAML files deployed in this sample to point at that namespace.
 
-```shell
-kubectl label namespace default knative-eventing-injection=enabled
-```
+1. Create the `default` Broker in your namespace:
+
+   ```shell
+   kubectl label namespace default knative-eventing-injection=enabled
+   ```
 
 ### Service Account
 
@@ -40,52 +41,51 @@ kubectl label namespace default knative-eventing-injection=enabled
    Knative Eventing Broker. Create a file named `serviceaccount.yaml` and copy
    the code block below into it.
 
-```yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: events-sa
-  namespace: default
+   ```yaml
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: events-sa
+     namespace: default
+   
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRole
+   metadata:
+     name: event-watcher
+   rules:
+     - apiGroups:
+         - ""
+       resources:
+         - events
+       verbs:
+         - get
+         - list
+         - watch
+   
+   ---
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: ClusterRoleBinding
+   metadata:
+     name: k8s-ra-event-watcher
+   roleRef:
+     apiGroup: rbac.authorization.k8s.io
+     kind: ClusterRole
+     name: event-watcher
+   subjects:
+     - kind: ServiceAccount
+       name: events-sa
+       namespace: default
+   ```
 
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: event-watcher
-rules:
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - watch
+   If you want to re-use an existing Service Account with the appropriate permissions,
+   you need to modify the `serviceaccount.yaml`.
 
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: k8s-ra-event-watcher
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: event-watcher
-subjects:
-  - kind: ServiceAccount
-    name: events-sa
-    namespace: default
-```
+2. Enter the following command to create the service account from `serviceaccount.yaml`:
 
-If you want to re-use an existing Service Account with the appropriate
-permissions, you need to modify the `serviceaccount.yaml`.
-
-Enter the following command to create the service account from
-`serviceaccount.yaml`:
-
-```shell
-kubectl apply --filename serviceaccount.yaml
-```
+   ```shell
+   kubectl apply --filename serviceaccount.yaml
+   ```
 
 ### Create Event Source for Kubernetes Events
 
@@ -93,33 +93,33 @@ kubectl apply --filename serviceaccount.yaml
    specific namespace. Create a file named `k8s-events.yaml` and copy the code
    block below into it.
 
-```yaml
-apiVersion: sources.knative.dev/v1alpha1
-kind: ApiServerSource
-metadata:
-  name: testevents
-  namespace: default
-spec:
-  serviceAccountName: events-sa
-  mode: Resource
-  resources:
-    - apiVersion: v1
-      kind: Event
-  sink:
-    ref:
-      apiVersion: eventing.knative.dev/v1alpha1
-      kind: Broker
-      name: default
-```
+   ```yaml
+   apiVersion: sources.knative.dev/v1alpha1
+   kind: ApiServerSource
+   metadata:
+     name: testevents
+     namespace: default
+   spec:
+     serviceAccountName: events-sa
+     mode: Resource
+     resources:
+       - apiVersion: v1
+         kind: Event
+     sink:
+       ref:
+         apiVersion: eventing.knative.dev/v1alpha1
+         kind: Broker
+         name: default
+   ```
 
-If you want to consume events from a different namespace or use a different
-`Service Account`, you need to modify `k8s-events.yaml` accordingly.
+   If you want to consume events from a different namespace or use a
+   different `Service Account`, you need to modify `k8s-events.yaml` accordingly.
 
-Enter the following command to create the event source:
+2. Enter the following command to create the event source:
 
-```shell
-kubectl apply --filename k8s-events.yaml
-```
+   ```shell
+   kubectl apply --filename k8s-events.yaml
+   ```
 
 ### Trigger
 
@@ -127,52 +127,52 @@ In order to check the `ApiServerSource` is fully working, we will create a
 simple Knative Service that dumps incoming messages to its log and creates a
 `Trigger` from the `Broker` to that Knative Service.
 
-Create a file named `trigger.yaml` and copy the code block below into it.
+1. Create a file named `trigger.yaml` and copy the code block below into it.
 
-```yaml
-apiVersion: eventing.knative.dev/v1alpha1
-kind: Trigger
-metadata:
-  name: testevents-trigger
-  namespace: default
-spec:
-  subscriber:
-    ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: event-display
+   ```yaml
+   apiVersion: eventing.knative.dev/v1alpha1
+   kind: Trigger
+   metadata:
+     name: testevents-trigger
+     namespace: default
+   spec:
+     subscriber:
+       ref:
+         apiVersion: serving.knative.dev/v1
+         kind: Service
+         name: event-display
 
----
-# This is a very simple Knative Service that writes the input request to its log.
-
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: event-display
-  namespace: default
-spec:
-  template:
-    spec:
-      containers:
-        - # This corresponds to
-          # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
-          image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
-```
+   ---
+   # This is a very simple Knative Service that writes the input request to its log.
+   
+   apiVersion: serving.knative.dev/v1
+   kind: Service
+   metadata:
+     name: event-display
+     namespace: default
+   spec:
+     template:
+       spec:
+         containers:
+           - # This corresponds to
+             # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
+             image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+   ```
 
 1. If the deployed `ApiServerSource` is pointing at a `Broker` other than
    `default`, modify `trigger.yaml` by adding `spec.broker` with the `Broker`'s
    name.
 
-1. Deploy `trigger.yaml`.
+1. Deploy `trigger.yaml`:
 
-```shell
-kubectl apply --filename trigger.yaml
-```
+   ```shell
+   kubectl apply --filename trigger.yaml
+   ```
 
 ### Create Events
 
-Create events by launching a pod in the default namespace. Create a busybox
-container and immediately delete it.
+Create events by launching a pod in the default namespace. Create a `busybox`
+container and immediately delete it:
 
 ```shell
 kubectl run busybox --image=busybox --restart=Never -- ls
@@ -183,8 +183,8 @@ kubectl delete pod busybox
 
 We will verify that the Kubernetes events were sent into the Knative eventing
 system by looking at our message dumper function logs. If you deployed the
-[Trigger](#trigger), then continue using this section. If not, then you will
-need to look downstream yourself.
+[Trigger](#trigger), continue using this section. If not, you will
+need to look downstream yourself:
 
 ```shell
 kubectl get pods
@@ -244,7 +244,7 @@ Data,
 ### Cleanup
 
 You can remove the `ServiceAccount`, `ClusterRoles`, `ClusterRoleBinding`,
-`ApiServerSource`, `Service` and `Trigger` via:
+`ApiServerSource`, `Service` and `Trigger` using:
 
 ```shell
 kubectl --namespace default delete --filename serviceaccount.yaml

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -261,7 +261,7 @@ We ship a simple Kubernetes Job called "default domain" that will (see caveats) 
 kubectl apply --filename {{< artifact repo="serving" file="serving-default-domain.yaml" >}}
 ```
 
-**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS" or "Temporary DNS".
+**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS".
 {{< /tab >}}
 
 
@@ -293,41 +293,6 @@ kubectl patch configmap/config-domain \
 ```
 
 {{< /tab >}}
-
-{{% tab name="Temporary DNS" %}}
-If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (xip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using, for example, minikube locally or IPv6 clusters.
-
-To access your application using `curl` using this method:
-
-1. After starting your application, get the URL of your application:
-
-    ```bash
-    kubectl get ksvc
-    ```
-
-   The output should be similar to:
-
-   ```bash
-   NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
-   helloworld-go   http://helloworld-go.default.example.com   helloworld-go-vqjlf   helloworld-go-vqjlf   True    
-   ```
-
-1. Instruct `curl` to connect to the External IP or CNAME defined by the networking layer in section 3 above, and use the `-H "Host:"` command-line option to specify the Knative application's host name. For example, if the networking layer defines your External IP and port to be `http://192.168.39.228:32198` and you wish to access the above `helloworld-go` application, use:
-
-   ```bash
-   curl -H "Host: helloworld-go.default.example.com" http://192.168.39.228:32198
-   ```
-
-   In the case of the provided `helloworld-go` sample application, the output should, using the default configuration, be:
-
-   ```
-   Hello Go Sample v1!
-   ```
-
-Refer to the "Real DNS" method for a permanent solution.
-
-{{< /tab >}}
-
 {{< /tabs >}}
 
 1. Monitor the Knative components until all of the components show a `STATUS` of `Running` or `Completed`:

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -261,7 +261,7 @@ We ship a simple Kubernetes Job called "default domain" that will (see caveats) 
 kubectl apply --filename {{< artifact repo="serving" file="serving-default-domain.yaml" >}}
 ```
 
-**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS".
+**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS" or "Temporary DNS".
 {{< /tab >}}
 
 
@@ -293,6 +293,41 @@ kubectl patch configmap/config-domain \
 ```
 
 {{< /tab >}}
+
+{{% tab name="Temporary DNS" %}}
+If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (xip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using, for example, minikube locally or IPv6 clusters.
+
+To access your application using `curl` using this temporary method:
+
+1. After starting your application, get the URL of your application:
+
+    ```bash
+    kubectl get ksvc
+    ```
+
+   The output should be similar to:
+
+   ```bash
+   NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
+   helloworld-go   http://helloworld-go.default.example.com   helloworld-go-vqjlf   helloworld-go-vqjlf   True    
+   ```
+
+1. Instruct `curl` to connect to the External IP or CNAME defined by the networking layer in section 3 above, and use the `-H "Host:"` command-line option to specify the Knative application's host name. For example, if the networking layer defines your External IP and port to be `http://192.168.39.228:32198` and you wish to access the above `helloworld-go` application, use:
+
+   ```bash
+   curl -H "Host: helloworld-go.default.example.com" http://192.168.39.228:32198
+   ```
+
+   In the case of the provided `helloworld-go` sample application, the output should, using the default configuration, be:
+
+   ```
+   Hello Go Sample v1!
+   ```
+
+Please refer to the "Real DNS" method for a more permanent solution.
+
+{{< /tab >}}
+
 {{< /tabs >}}
 
 1. Monitor the Knative components until all of the components show a `STATUS` of `Running` or `Completed`:

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -261,7 +261,7 @@ We ship a simple Kubernetes Job called "default domain" that will (see caveats) 
 kubectl apply --filename {{< artifact repo="serving" file="serving-default-domain.yaml" >}}
 ```
 
-**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS".
+**Caveat**: This will only work if the cluster LoadBalancer service exposes an IPv4 address, so it will not work with IPv6 clusters, AWS, or local setups like Minikube.  For these, see "Real DNS" or "Temporary DNS".
 {{< /tab >}}
 
 
@@ -293,6 +293,41 @@ kubectl patch configmap/config-domain \
 ```
 
 {{< /tab >}}
+
+{{% tab name="Temporary DNS" %}}
+If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (xip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using, for example, minikube locally or IPv6 clusters.
+
+To access your application using `curl` using this method:
+
+1. After starting your application, get the URL of your application:
+
+    ```bash
+    kubectl get ksvc
+    ```
+
+   The output should be similar to:
+
+   ```bash
+   NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
+   helloworld-go   http://helloworld-go.default.example.com   helloworld-go-vqjlf   helloworld-go-vqjlf   True    
+   ```
+
+1. Instruct `curl` to connect to the External IP or CNAME defined by the networking layer in section 3 above, and use the `-H "Host:"` command-line option to specify the Knative application's host name. For example, if the networking layer defines your External IP and port to be `http://192.168.39.228:32198` and you wish to access the above `helloworld-go` application, use:
+
+   ```bash
+   curl -H "Host: helloworld-go.default.example.com" http://192.168.39.228:32198
+   ```
+
+   In the case of the provided `helloworld-go` sample application, the output should, using the default configuration, be:
+
+   ```
+   Hello Go Sample v1!
+   ```
+
+Refer to the "Real DNS" method for a permanent solution.
+
+{{< /tab >}}
+
 {{< /tabs >}}
 
 1. Monitor the Knative components until all of the components show a `STATUS` of `Running` or `Completed`:

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -297,7 +297,7 @@ kubectl patch configmap/config-domain \
 {{% tab name="Temporary DNS" %}}
 If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (xip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using, for example, minikube locally or IPv6 clusters.
 
-To access your application using `curl` using this temporary method:
+To access your application using `curl` using this method:
 
 1. After starting your application, get the URL of your application:
 
@@ -324,7 +324,7 @@ To access your application using `curl` using this temporary method:
    Hello Go Sample v1!
    ```
 
-Please refer to the "Real DNS" method for a more permanent solution.
+Refer to the "Real DNS" method for a permanent solution.
 
 {{< /tab >}}
 


### PR DESCRIPTION
Stepping through the installation guide, I ran into a mild pain point using Minikube and Gloo and/or Istio at the DNS stage. The Magic DNS solution couldn't be used, and the Real DNS method seems perhaps a little heavy-handed - creating DNS entries for what may be dynamically assigned IP addresses - for just getting a Hello, Word application running to see if a cluster is configured correctly.

Judging from issues raised and questions asked online, others were also caught up on this stage, so I suggest the following addition to reduce friction post-installation.

## Proposed Changes <!-- Describe the changes the PR makes. -->
- The addition of another tab in the DNS section that explains how to use curl to specify the application when connecting to the external IP or CNAME. The rationale being most of the sample applications suggest using curl to communication with the software.
- The tab indicates the Real DNS solution is preferred for production deployments.

NB: The tab title "Temporary DNS" could be improved. The point I wanted to get across was, here's a way to interact immediately with the sample application without having to altering your DNS configuration.