### PR TITLE
Fixed indentation of Service YAML in Documentation

### DIFF
--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -135,9 +135,9 @@ spec:
   template:
     spec:
       containers:
-      -  # This corresponds to
-         # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display
-         - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a214514d6ba674d7393ec8448dd272472b2956207acb3f83152d3071f0ab1911
+       # This corresponds to
+       # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display
+       - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a214514d6ba674d7393ec8448dd272472b2956207acb3f83152d3071f0ab1911
 ```
 
 ### Trigger


### PR DESCRIPTION
Fixes indentation of Service YAML in Documentation

## Proposed Changes 

File had incorrect indentation, which now has been corrected.