### PR TITLE
Updated secret creation for private registries

### DIFF
--- a/docs/serving/deploying/private-registry.md
+++ b/docs/serving/deploying/private-registry.md
@@ -27,7 +27,7 @@ You need:
 1. Create a `imagePullSecrets` that contains your credentials as a list of secrets:
 
     ```shell
-    kubectl create secret [REGISTRY-CRED-SECRETS] \
+    kubectl create secret docker-registry [REGISTRY-CRED-SECRETS] \
       --docker-server=[PRIVATE_REGISTRY_SERVER_URL] \
       --docker-email=[PRIVATE_REGISTRY_EMAIL] \
       --docker-username=[PRIVATE_REGISTRY_USER] \


### PR DESCRIPTION
Fixes #2141 

## Proposed Changes 

- Added "docker-registry" to the secret creation based on K8s docs and the recommendation of the user

https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-secret-by-providing-credentials-on-the-command-line
