### PR TITLE
Added go mod init so that docker can build

### DIFF
--- a/docs/serving/samples/cloudevents/cloudevents-go/Dockerfile
+++ b/docs/serving/samples/cloudevents/cloudevents-go/Dockerfile
@@ -6,17 +6,17 @@ FROM golang:1.13 as builder
 # Create and change to the app directory.
 WORKDIR /app
 
-# Retrieve application dependencies using go modules.
-# Allows container builds to reuse downloaded dependencies.
-COPY go.* ./
-RUN go mod download
-
 # Copy local code to the container image.
 COPY . ./
 
-# Build the binary.
-# -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
+# Ensure Go modules are on and create the go.mod and go.sum files.
+# Also builds the binary
+ENV GO111MODULE=on
+RUN go mod init cloudevents.go \
+    && CGO_ENABLED=0 GOOS=linux go build -v -o server
+
+# Allows the container builds to reuse downloaded dependencies.
+RUN go mod download
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine

--- a/docs/serving/samples/cloudevents/cloudevents-go/README.md
+++ b/docs/serving/samples/cloudevents/cloudevents-go/README.md
@@ -27,6 +27,14 @@ git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/cloudevents/cloudevents-go
 ```
 
+After getting the sample code the go.mod and go.sum files need to be created so that the
+Dockerfile build will work.
+
+```shell
+go mod init cloudevents.go
+go test
+```
+
 ## Before you begin
 
 - A Kubernetes cluster with Knative installed and DNS configured. Follow the

--- a/docs/serving/samples/cloudevents/cloudevents-go/README.md
+++ b/docs/serving/samples/cloudevents/cloudevents-go/README.md
@@ -27,14 +27,6 @@ git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/cloudevents/cloudevents-go
 ```
 
-After getting the sample code the go.mod and go.sum files need to be created so that the
-Dockerfile build will work.
-
-```shell
-go mod init cloudevents.go
-go test
-```
-
 ## Before you begin
 
 - A Kubernetes cluster with Knative installed and DNS configured. Follow the


### PR DESCRIPTION
Looking for advice on this one. Should the go mod init and test go in the Dockerfile so the end user doesn't have to run it? This issue prob causes problems when trying to ko apply. I got an error using ko apply further down, but wasn't sure if it was due to the image not building. 

Also looking for help on wording if it could be worded in a better way. 

Fixes #2101 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Added information about using go mod init to create the go.mod and go. sum files. Otherwise the docker build fails since it expects mod/sum files. 
