### PR TITLE
Remove the additional title for install knative using operators

### DIFF
--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -49,7 +49,7 @@ __From source code__:
 
 You can also install Knative Operators from source using `ko`.
 
-1. Install the [ko]((https://github.com/google/ko)) build tool.
+1. Install the [ko](https://github.com/google/ko) build tool.
 1. Install the operator in the root directory of the source using the following command:
 
 ```
@@ -136,8 +136,8 @@ __From source code__:
 
 You can also install Knative Operators from source using `ko`.
 
-- Install the [ko]((https://github.com/google/ko)) build tool.
-- Install the operator in the root directory of the source using the following command:
+1. Install the [ko](https://github.com/google/ko) build tool.
+1. Install the operator in the root directory of the source using the following command:
 
 ```
 ko apply -f config/

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -4,8 +4,6 @@ weight: 10
 type: "docs"
 ---
 
-# Installing Knative components using Operators
-
 Knative provides operators as tools to install, configure and manage Knative. This guide explains how to install and
 uninstall Knative using Knative operators.
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Remove the additional title for operator installation guide.
- Correct the link to the `ko`.
