### PR TITLE
Removing pipe from KafkaChannel spec

### DIFF
--- a/docs/eventing/channel-based-broker.md
+++ b/docs/eventing/channel-based-broker.md
@@ -46,7 +46,7 @@ data:
   channelTemplateSpec: |
     apiVersion: messaging.knative.dev/v1alpha1
     kind: KafkaChannel
-    spec: |
+    spec:
       numPartitions: 3
       replicationFactor: 1
 ```


### PR DESCRIPTION
Removing pipe from KafkaChannel spec due to the following error on broker initialization:

`- Failed to reconcile trigger channel: json: cannot unmarshal string into Go struct field Channelable.spec of type v1alpha1.ChannelableSpec`

Which prevents the broker to initialize.