### PR TITLE
Updated secret sample path

### DIFF
--- a/docs/serving/samples/secrets-go/README.md
+++ b/docs/serving/samples/secrets-go/README.md
@@ -16,7 +16,7 @@ following commands:
 
 ```shell
 git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
-cd knative-docs/serving/samples/secrets-go
+cd knative-docs/docs/serving/samples/secrets-go
 ```
 
 ## Before you begin


### PR DESCRIPTION
Fixes issues with old paths for samples. It's knative/docs/serving now.

## Proposed Changes 

- Adds docs/ to a path to fix a sample code example
