### PR TITLE
fix the broker configmap example

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -454,8 +454,8 @@ The following command installs an implementation of Broker that utilizes Channel
    kubectl apply --filename {{< artifact repo="eventing" file="channel-broker.yaml" >}}
    ```
 
-To customize which channel implementation is used, update the following ConfigMap to
-specify which configurations are used for which namespaces:
+To customize which broker channel implementation is used, update the following
+ConfigMap to specify which configurations are used for which namespaces:
 
    ```yaml
    apiVersion: v1
@@ -465,7 +465,7 @@ specify which configurations are used for which namespaces:
      namespace: knative-eventing
    data:
      default-br-config: |
-       # This is the cluster-wide default channel configuration.
+       # This is the cluster-wide default broker channel.
        clusterDefault:
          apiVersion: v1
          kind: ConfigMap

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -363,7 +363,7 @@ Deploy your first app with the [getting started with Knative app deployment](../
 
 ## Installing the Eventing component
 
-{{< feature-state version="v0.2" state="alpha" >}}
+{{< feature-state version="v0.13" state="beta" >}}
 
 
 The following commands install the Knative Eventing component.
@@ -415,7 +415,7 @@ To learn more about the Google Cloud Pub/Sub Channel, try [our sample](https://g
 
 {{% tab name="In-Memory (standalone)" %}}
 
-{{< feature-state version="v0.2" state="alpha" >}}
+{{< feature-state version="v0.13" state="beta" >}}
 
 The following command installs an implementation of Channel that runs in-memory.  This implementation is nice because it is simple and standalone, but it is unsuitable for production use cases.
 
@@ -446,7 +446,7 @@ The following command installs an implementation of Channel that runs in-memory.
    <!-- This indentation is important for things to render properly. -->
    {{< tabs name="eventing_brokers" default="Channel-based" >}}
 {{% tab name="Channel-based" %}}
-{{< feature-state version="v0.5" state="alpha" >}}
+{{< feature-state version="v0.13" state="beta" >}}
 
 The following command installs an implementation of Broker that utilizes Channels:
 
@@ -454,31 +454,33 @@ The following command installs an implementation of Broker that utilizes Channel
    kubectl apply --filename {{< artifact repo="eventing" file="channel-broker.yaml" >}}
    ```
 
-To customize which channel implementation is used, update the following ConfigMap:
+To customize which channel implementation is used, update the following ConfigMap to
+specify which configurations are used for which namespaces:
 
    ```yaml
    apiVersion: v1
    kind: ConfigMap
    metadata:
-     name: default-ch-webhook
+     name: config-br-defaults
      namespace: knative-eventing
    data:
-     default-ch-config: |
-       # This is the cluster-wide default channel.
+     default-br-config: |
+       # This is the cluster-wide default channel configuration.
        clusterDefault:
-         apiVersion: messaging.knative.dev/v1alpha1
-         kind: InMemoryChannel
-
+         apiVersion: v1
+         kind: ConfigMap
+         name: imc-channel
+         namespace: knative-eventing
+       # This allows you to specify different defaults per-namespace,
+       # in this case the "some-namespace" namespace will use the Kafka
+       # channel ConfigMap by default (only for example, you will need
+       # to install kafka also to make use of this).
        namespaceDefaults:
-         # This allows you to specify different defaults per-namespace,
-         # in this case the "some-namespace" namespace will use the Kafka
-         # channel by default.
          some-namespace:
-           apiVersion: messaging.knative.dev/v1alpha1
-           kind: KafkaChannel
-           spec:
-             numPartitions: 2
-             replicationFactor: 1
+           apiVersion: v1
+           kind: ConfigMap
+           name: kafka-channel
+           namespace: knative-eventing
    ```
 
 {{< /tab >}}


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2314 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update broker configmap example to the new format.
-
-
