### PR TITLE
Reorder eventing sections

### DIFF
--- a/docs/eventing/accessing-traces.md
+++ b/docs/eventing/accessing-traces.md
@@ -1,7 +1,7 @@
 ---
 title: "Accessing CloudEvent traces"
 #linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
-weight: 50
+weight: 85
 type: "docs"
 ---
 

--- a/docs/eventing/broker-trigger.md
+++ b/docs/eventing/broker-trigger.md
@@ -1,6 +1,6 @@
 ---
 title: "Broker and Trigger"
-weight: 30
+weight: 20
 type: "docs"
 ---
 

--- a/docs/eventing/channel-based-broker.md
+++ b/docs/eventing/channel-based-broker.md
@@ -4,8 +4,6 @@ weight: 30
 type: "docs"
 ---
 
-# Channel Based Broker
-
 NOTE: This doc assume the shared Knative Eventing components are installed in the `knative-eventing`
 namespace. If you installed the shared Knative Eventing components in a different namespace, replace
 `knative-eventing` with the name of that namespace.

--- a/docs/eventing/channels/_index.md
+++ b/docs/eventing/channels/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Knative Eventing channels"
 linkTitle: "Channels"
-weight: 15
+weight: 40
 type: "docs"
 showlandingtoc: "true"
 ---

--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Debugging Knative Eventing"
 linkTitle: "Debugging"
-weight: 100
+weight: 80
 type: "docs"
 ---
 

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -1,6 +1,6 @@
 ---
 title: "Event delivery"
-weight: 40
+weight: 50
 type: "docs"
 ---
 

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -1,6 +1,6 @@
 ---
 title: "Event registry"
-weight: 40
+weight: 25
 type: "docs"
 ---
 

--- a/docs/eventing/samples/_index.md
+++ b/docs/eventing/samples/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Knative Eventing code samples"
 linkTitle: "Code samples"
-weight: 90
+weight: 100
 type: "docs"
 showlandingtoc: "true"
 ---

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -1,7 +1,7 @@
 ---
 title: "Knative Eventing sources"
 linkTitle: "Eventing sources"
-weight: 20
+weight: 30
 type: "docs"
 ---
 


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Reorder eventing sections
   | Old | New |
   |---|---|
   | Getting Started | Getting Started |
   | Channels | Broker and Trigger |
   | Eventing sources | Event registry |
   | Broker and Trigger | Channel Based Broker |
   | Channel Based Broker | Eventing sources |
   | Flows | Eventing Flows |
   | Migration | Migration |
   | Event Delivery | Eventing channels |
   | Event Registry | Event delivery |
   | Accessing CloudEvent Traces | Debugging |
   | Code samples | Accessing CloudEvent traces |
   | Debugging | Code samples |
- Remove double-header on "Channel Based Broker"


/assign @vaikas @grantr 