### PR TITLE
Updated link to contributor doc because broken

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -89,7 +89,7 @@ To generate a version of the API:
 
 You can now perform the necessary steps to open a PR, complete a review, and
 merge the new API files into the appropriate branch of the `knative/docs` repo.
-See the [contributor flow](https://github.com/knative/community/tree/master/DOCS-CONTRIBUTING.md) for details
+See the [contributor flow](https://github.com/knative/community/blob/master/docs/DOCS-CONTRIBUTING.md) for details
 about requesting changes in the `knative/docs` repo.
 
 ### Example


### PR DESCRIPTION
Should be https://github.com/knative/community/blob/master/docs/DOCS-CONTRIBUTING.md

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Fixes borked link to contributor doc
-
-
-
