### PR TITLE
Removed broken link in autoscale go sample

### DIFF
--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -270,3 +270,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 ```
 kubectl delete --filename docs/serving/samples/autoscale-go/service.yaml
 ```
+
+## Further reading
+
+[Autoscaling Developer Documentation](https://github.com/knative/serving/blob/master/docs/scaling/SYSTEM.md)

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -270,7 +270,3 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 ```
 kubectl delete --filename docs/serving/samples/autoscale-go/service.yaml
 ```
-
-## Further reading
-
-[Autoscaling Developer Documentation](https://github.com/knative/serving/blob/master/docs/scaling/DEVELOPMENT.md)


### PR DESCRIPTION
Fixes an invalid link and removes a Further Reading section.

## Proposed Changes

- Removed further reading from autoscale-go sample as the link doesn't work - https://github.com/knative/serving/blob/master/docs/scaling/DEVELOPMENT.md <-- There doesn't look to be a scaling development.md file for serving in the repository. 

I'm wondering if this should instead point to:

https://github.com/knative/serving/blob/master/docs/scaling/SYSTEM.md

If we want to point to SYSTEM.md I can make the update in the PR, otherwise we probably want to remove the further reading section. 
