### PR TITLE
Update installing-istio.md

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -250,8 +250,8 @@ Alternatively, if you want to install the cluster local gateway for **developmen
 without `helm` for an easy installation:
 
 ```shell
-# Istio minor version should be 1.2 or 1.3
-export ISTIO_MINOR_VERSION=1.2
+# Istio minor version should be 1.3, 1.4 or 1.5
+export ISTIO_MINOR_VERSION=1.3
 
 export VERSION=$(curl https://raw.githubusercontent.com/knative/serving/master/third_party/istio-${ISTIO_MINOR_VERSION}-latest)
 


### PR DESCRIPTION
Cluster local ISTIO_MINOR_VERSION

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

The doc currently mentions you need 1.2 or 1.3 and specifies ISTIO_MINOR_VERSION=1.2, however this no longer exists. Have changed to what I believe is now correct. 
