### PR TITLE
serving/samples: helloworld-go use buster-slim for final container stage

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -1,4 +1,4 @@
-# Use the offical golang image to create a binary.
+# Use the official golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.13-buster as builder

--- a/docs/serving/samples/hello-world/helloworld-go/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-go/Dockerfile
@@ -1,13 +1,14 @@
-# Use the official Golang image to create a build artifact.
+# Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.13 as builder
+FROM golang:1.13-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app
 
-# Retrieve application dependencies using go modules.
-# Allows container builds to reuse downloaded dependencies.
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+# Expecting to copy go.mod and if present go.sum.
 COPY go.* ./
 RUN go mod download
 
@@ -15,14 +16,15 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-# -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
+RUN go build -mod=readonly -v -o server
 
-# Use the official Alpine image for a lean production container.
-# https://hub.docker.com/_/alpine
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3
-RUN apk add --no-cache ca-certificates
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/server /server

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -70,7 +70,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    [Deploying Go servers with Docker](https://blog.golang.org/docker).
 
    ```docker
-   # Use the offical golang image to create a binary.
+   # Use the official golang image to create a binary.
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
    FROM golang:1.13-buster as builder

--- a/docs/serving/samples/hello-world/helloworld-go/README.md
+++ b/docs/serving/samples/hello-world/helloworld-go/README.md
@@ -70,16 +70,17 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    [Deploying Go servers with Docker](https://blog.golang.org/docker).
 
    ```docker
-   # Use the official Golang image to create a build artifact.
+   # Use the offical golang image to create a binary.
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
-   FROM golang:1.13 as builder
+   FROM golang:1.13-buster as builder
 
    # Create and change to the app directory.
    WORKDIR /app
 
-   # Retrieve application dependencies using go modules.
-   # Allows container builds to reuse downloaded dependencies.
+   # Retrieve application dependencies.
+   # This allows the container build to reuse cached dependencies.
+   # Expecting to copy go.mod and if present go.sum.
    COPY go.* ./
    RUN go mod download
 
@@ -87,14 +88,15 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-go
    COPY . ./
 
    # Build the binary.
-   # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-   RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o server
+   RUN go build -mod=readonly -v -o server
 
-   # Use the official Alpine image for a lean production container.
-   # https://hub.docker.com/_/alpine
+   # Use the official Debian slim image for a lean production container.
+   # https://hub.docker.com/_/debian
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-   FROM alpine:3
-   RUN apk add --no-cache ca-certificates
+   FROM debian:buster-slim
+   RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+     ca-certificates && \
+     rm -rf /var/lib/apt/lists/*
 
    # Copy the binary to the production image from the builder stage.
    COPY --from=builder /app/server /server


### PR DESCRIPTION
There are very occasionally compatibility issues in starting up a container where the go binary was compiled on debian/ubuntu, but the runtime stage is built on Alpine. Let's switch to buster-slim.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Remove alpine in favor of buster-slim