### PR TITLE
Remote references to obsolete knative-ingressgateway.

### DIFF
--- a/docs/serving/debugging-application-issues.md
+++ b/docs/serving/debugging-application-issues.md
@@ -56,7 +56,7 @@ helloworld-go   map[serving.knative.dev/route:helloworld-go serving.knative.dev/
 ```
 
 The labels `serving.knative.dev/route` and `serving.knative.dev/routeNamespace`
-indicate the Route in which the Ingress resource resides. Your Route and 
+indicate the Route in which the Ingress resource resides. Your Route and
 Ingress should be listed. If your Ingress does not exist, the route
 controller believes that the Revisions targeted by your Route/Service isn't
 ready. Please proceed to later sections to diagnose Revision readiness status.
@@ -97,9 +97,6 @@ To check the IP address of your Ingress, use
 ```shell
 kubectl get svc -n istio-system istio-ingressgateway
 ```
-
-Or replace that with `knative-ingressgateway` if you are using Knative release
-older than 0.3.
 
 If there is no external IP address, use
 

--- a/docs/serving/samples/knative-routing-go/routing.yaml
+++ b/docs/serving/samples/knative-routing-go/routing.yaml
@@ -33,8 +33,6 @@ spec:
       # in order to redirect requests to Search service.
       authority: search-service.default.example.com
     route:
-      # knative-ingressgateway is the k8s service created by Knative as the
-      # shared gateway of all traffic incoming to the cluster.
       # Basically here we redirect the request to the cluster entry again with
       # updated header "search-service.default.example.com" so the request will
       # eventually be directed to Search service.

--- a/docs/serving/using-external-dns-on-gcp.md
+++ b/docs/serving/using-external-dns-on-gcp.md
@@ -378,7 +378,7 @@ kubectl edit svc $INGRESSGATEWAY --namespace istio-system
 ```
 
 This command opens your default text editor and allows you to add the annotation
-to `knative-ingressgateway` service. After you've added your annotation, your
+to `istio-ingressgateway` service. After you've added your annotation, your
 file may look similar to this (assuming your custom domain is
 `external-dns-test.my-org.do`):
 
@@ -405,7 +405,7 @@ You should see output similar to:
 ```
 NAME                            TYPE  TTL  DATA
 *.external-dns-test.my-org.do.  A     300  35.231.248.30
-*.external-dns-test.my-org.do.  TXT   300  "heritage=external-dns,external-dns/owner=my-identifier,external-dns/resource=service/istio-system/knative-ingressgateway"
+*.external-dns-test.my-org.do.  TXT   300  "heritage=external-dns,external-dns/owner=my-identifier,external-dns/resource=service/istio-system/istio-ingressgateway"
 ```
 
 ### Verify domain has been published


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Remote references to obsolete knative-ingressgateway

Fixes #1872

## Proposed Changes <!-- Describe the changes the PR makes. -->

-  Remote references to obsolete knative-ingressgateway
-
-
