### PR TITLE
add Kong Ingress Controller as a supported network layer

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -219,6 +219,37 @@ The following commands install Istio and enable its Knative integration.
 
 {{< /tab >}}
 
+{{% tab name="Kong" %}}
+
+{{% feature-state version="v0.13" state="" %}}
+
+The following commands install Kong and enable its Knative integration.
+
+1. Install Kong Ingress Controller:
+
+   ```bash
+   kubectl apply --filename https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/0.9.x/deploy/single/all-in-one-dbless.yaml
+   ```
+
+1. To configure Knative Serving to use Kong by default:
+
+    ```bash
+    kubectl patch configmap/config-network \
+      --namespace knative-serving \
+      --type merge \
+      --patch '{"data":{"ingress.class":"kong"}}'
+    ```
+
+1. Fetch the External IP or CNAME:
+
+   ```bash
+   kubectl --namespace kong get service kong-proxy
+   ```
+
+   Save this for configuring DNS below.
+
+{{< /tab >}}
+
 {{% tab name="Kourier" %}}
 
 {{% feature-state version="v0.12" state="alpha" %}}


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

Adds Kong as another option for networking layer.
