### PR TITLE
helloworld-python: Prevent "[CRITICAL] WORKER TIMEOUT" error log

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-python/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-python/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install Flask gunicorn
 # webserver, with one worker process and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 app:app

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -74,7 +74,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    # webserver, with one worker process and 8 threads.
    # For environments with multiple CPU cores, increase the number of workers
    # to be equal to the cores available.
-   CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
+   CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 app:app
    ```
 
 1. Create a `.dockerignore` file to ensure that any files related to a local


### PR DESCRIPTION
Based on the current entrypoint configuration, the gunicorn arbiter process has a set timeout. If for any reason this timeout is reached, error logs indicating a `[CRITICAL] WORKER TIMEOUT` are produced.

In practice, this timeout is not an essential part of server resource management and creates and is only an opportunity for distractions in the logs.

Per https://github.com/benoitc/gunicorn/issues/2291, gunicorn supports setting an unlimited timeout with `--timeout 0`.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add `--timeout 0` to Python container entrypoint.