### PR TITLE
Added clone of docs to steps and updated paths

### DIFF
--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -84,7 +84,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
    cd knative-docs/docs/eventing/samples/kafka/source
    ```
 
-2. Build the Event Display Service (`even-display.yaml`)
+2. Build the Event Display Service (`event-display.yaml`)
 
    ```yaml
    apiVersion: serving.knative.dev/v1

--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -63,7 +63,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
 2. Deploy the `KafkaTopic`
 
    ```shell
-   $ kubectl apply -f kafka/source/samples/strimzi-topic.yaml
+   $ kubectl apply -f strimzi-topic.yaml
    kafkatopic.kafka.strimzi.io/knative-demo-topic created
    ```
 
@@ -77,7 +77,14 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
 
 ### Create the Event Display service
 
-1. Build the Event Display Service (`even-display.yaml`)
+1. Download a copy of the code:
+
+   ```shell
+   git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
+   cd knative-docs/docs/eventing/samples/kafka/source
+   ```
+
+2. Build the Event Display Service (`even-display.yaml`)
 
    ```yaml
    apiVersion: serving.knative.dev/v1
@@ -97,7 +104,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
 1. Deploy the Event Display Service
 
    ```
-   $ kubectl apply --filename source/samples/event-display.yaml
+   $ kubectl apply --filename event-display.yaml
    ...
    service.serving.knative.dev/event-display created
    ```
@@ -133,7 +140,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
 
 1. Deploy the event source.
    ```
-   $ kubectl apply -f kafka/source/samples/event-source.yaml
+   $ kubectl apply -f event-source.yaml
    ...
    kafkasource.sources.eventing.knative.dev/kafka-source created
    ```
@@ -218,7 +225,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
 4. (Optional) Remove the Apache Kafka Topic
 
    ```shell
-   $ kubectl delete -f kafka/source/samples/kafka-topic.yaml
+   $ kubectl delete -f kafka-topic.yaml
    kafkatopic.kafka.strimzi.io "knative-demo-topic" deleted
    ```
 


### PR DESCRIPTION
Fixes readability and matches serving docs where you will clone the docs first so that you are aware of where the files are. 

## Proposed Changes 
- add doc clone
- update paths

There is some additional cleanup that might be needed since this file doesn't actually exist now - strimzi-topic.yaml. If needed I can take the yaml from the docs and add it as a file in the sample/source folder. 

Also, not sure if we want to move the clone further up. I added it where you start applying files. 