### PR TITLE
Switch net-kourier to use the artifact shortcode.

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -228,7 +228,7 @@ The following commands install Kourier and enable its Knative integration.
 1. Install the Knative Kourier controller:
 
    ```bash
-   kubectl apply --filename https://raw.githubusercontent.com/knative/serving/{{< version >}}/third_party/kourier-latest/kourier.yaml
+   kubectl apply --filename {{< artifact repo="net-kourier" file="kourier.yaml" >}}
    ```
 
 1. To configure Knative Serving to use Kourier by default:


### PR DESCRIPTION
This is blocked on net-kourier actually having a successful nightly, which should be unblocked by: https://github.com/knative/net-kourier/pull/31

