### PR TITLE
Add Meetup page

### DIFF
--- a/community/meetup/README.md
+++ b/community/meetup/README.md
@@ -2,9 +2,11 @@ Welcome to the Knative Community Meetup page!
 
 The virtual event is designed for end users, a space for our community to meet, get to know each other, and learn about uses and applications of Knative.
 
+Catch up with past community meetups on our [YouTube channel](https://www.youtube.com/playlist?list=PLQjzPfIiEQLLyCyLBKLlwDLfE_A-P7nyg).
+
 Here we will list all the information related to past and future events.
 
-Stay tuned for new events by subscribing to our [calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) ([iCal export file](https://calendar.google.com/calendar/ical/google.com_18un4fuh6rokqf8hmfftm5oqq4@group.calendar.google.com/public/basic.ics)), [YouTube channel](https://www.youtube.com/channel/UCq7cipu-A1UHOkZ9fls1N8A) and following us on [Twitter](https://twitter.com/KnativeProject).
+Stay tuned for new events by subscribing to our [calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) ([iCal export file](https://calendar.google.com/calendar/ical/google.com_18un4fuh6rokqf8hmfftm5oqq4@group.calendar.google.com/public/basic.ics)) and following us on [Twitter](https://twitter.com/KnativeProject).
 
 ---
 

--- a/community/meetup/README.md
+++ b/community/meetup/README.md
@@ -1,0 +1,31 @@
+Welcome to the Knative Community Meetup page! 
+
+The virtual event is designed for end users, a space for our community to meet, get to know each other, and learn about uses and applications of Knative.
+
+Here we will list all the information related to past and future events.
+
+Stay tuned for new events by subscribing to our calendar and following the [@KnativeProject](https://twitter.com/KnativeProject) on Twitter.
+
+## 2020-04-16
+Video:
+
+Agenda:
+- Welcome! (5’)
+  - Announce recording of meeting. 
+- Update from the Steering Committee (5’)
+  - TOC election announcement (Brenda Chan)
+- Working groups updates (15’-20’)
+  - Eventing (Aleksander Slominski and Davy Odom)
+  - Networking (Nghia Tran)
+  - Operation (Vincent Hou)
+  - Client (Roland Huss)
+- Demo - "Tracking the Bitcoin ledger" - by Johana Saladas (IBM) (30’)
+- Demo discussion / conversation (15’-20’)
+- Close (5’)
+  - Take the [survey](https://docs.google.com/forms/d/e/1FAIpQLSebw2IOjmnStiUhPpnndpjyuBUoziZOw9PK9fnJeFBQX0QxWw/viewform)! (it’s good karma)
+
+The demo for this first community meetup is "Tracking the Bitcoin ledger", designed and carried out by @josiemundi, software engineer at IBM. Thank you for volunteering, Johana!
+
+Here are the resources from the demo:
+- https://github.com/josiemundi/knative-eventing-blockchain-demo
+- https://github.com/josiemundi/knative-bitcoin-websocket-eventsource

--- a/community/meetup/README.md
+++ b/community/meetup/README.md
@@ -21,7 +21,7 @@ Agenda:
   - Networking (Nghia Tran)
   - Operation (Vincent Hou)
   - Client (Roland Huss)
-- Demo - "Tracking the Bitcoin ledger" - by Johana Saladas (IBM) (30’)
+- [Demo - "Tracking the Bitcoin ledger" - by Johana Saladas (IBM) (30’)](https://www.youtube.com/watch?v=sGi_LuAaaT0)
 - Demo discussion / conversation (15’-20’)
 - Close (5’)
   - Take the [survey](https://docs.google.com/forms/d/e/1FAIpQLSebw2IOjmnStiUhPpnndpjyuBUoziZOw9PK9fnJeFBQX0QxWw/viewform)! (it’s good karma)

--- a/community/meetup/README.md
+++ b/community/meetup/README.md
@@ -1,4 +1,4 @@
-Welcome to the Knative Community Meetup page! 
+Welcome to the Knative Community Meetup page!
 
 The virtual event is designed for end users, a space for our community to meet, get to know each other, and learn about uses and applications of Knative.
 
@@ -11,7 +11,7 @@ Video:
 
 Agenda:
 - Welcome! (5’)
-  - Announce recording of meeting. 
+  - Announce recording of meeting.
 - Update from the Steering Committee (5’)
   - TOC election announcement (Brenda Chan)
 - Working groups updates (15’-20’)

--- a/community/meetup/README.md
+++ b/community/meetup/README.md
@@ -4,10 +4,12 @@ The virtual event is designed for end users, a space for our community to meet, 
 
 Here we will list all the information related to past and future events.
 
-Stay tuned for new events by subscribing to our calendar and following the [@KnativeProject](https://twitter.com/KnativeProject) on Twitter.
+Stay tuned for new events by subscribing to our [calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) ([iCal export file](https://calendar.google.com/calendar/ical/google.com_18un4fuh6rokqf8hmfftm5oqq4@group.calendar.google.com/public/basic.ics)), [YouTube channel](https://www.youtube.com/channel/UCq7cipu-A1UHOkZ9fls1N8A) and following us on [Twitter](https://twitter.com/KnativeProject).
 
-## 2020-04-16
-Video:
+---
+
+### 2020-04-16 – Knative Community Meetup #1
+Video: https://www.youtube.com/watch?v=k0QJEyV4U-4
 
 Agenda:
 - Welcome! (5’)

--- a/community/meetup/_index.md
+++ b/community/meetup/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Knative Community Meetup"
-linkTitle: "Meetup"
+linkTitle: "Community Meetup"
 weight: 40
 type: "docs"
 ---

--- a/community/meetup/_index.md
+++ b/community/meetup/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Knative Community Meetup"
+linkTitle: "Meetup"
+weight: 40
+type: "docs"
+---
+
+{{% readfile file="README.md" %}}

--- a/community/meetup/_index.md
+++ b/community/meetup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Knative Community Meetup"
 linkTitle: "Community Meetup"
-weight: 40
+weight: 30
 type: "docs"
 ---
 


### PR DESCRIPTION
## Proposed Changes

Hi there 👋

This PR adds the Meetup page, as discussed with @evankanderson and María Cruz.

Two things I'd like to discuss:
1. Could we have a separated Google Calendar for the Knative Community Meetings? I believe that people would like to stay tuned for the events with a calendar, but the Knative one has a loooot of events, cluttering anyone's calendar 😅 

2. I wasn't able to build the page locally for testing and I didn't find the instructions anywhere :( could someone help me out?

Cheers ✨
