### PR TITLE
Change the field name from defaultBrokerClass to default-broker-class

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -170,7 +170,7 @@ spec:
 
 ## Configuring default broker class
 
-Knative Eventing allows you to define a default broker class when the user does not specify one. The operator ships with two broker classes: `ChannelBasedBroker` and `MTChannelBasedBroker`. The field `defaultBrokerClass` indicates which class to use; if empty, the `ChannelBasedBroker` will be used.
+Knative Eventing allows you to define a default broker class when the user does not specify one. The operator ships with two broker classes: `ChannelBasedBroker` and `MTChannelBasedBroker`. The field `default-broker-class` indicates which class to use; if empty, the `ChannelBasedBroker` will be used.
 Here is an example specifying `MTChannelBasedBroker` as the default:
 
 ```
@@ -180,5 +180,5 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  defaultBrokerClass: MTChannelBasedBroker
+  default-broker-class: MTChannelBasedBroker
 ```

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -11,8 +11,6 @@ The Knative Eventing operator can be configured with these options:
 - [Private repository and private secret](#private-repository-and-private-secrets)
 - [Configuring default broker class](#configuring-default-broker-class)
 
-__NOTE:__ Kubernetes spec level policies cannot be configured using the Knative operators.
-
 ## Private repository and private secrets
 
 The Knative Eventing operator CR is configured the same way as the Knative Serving operator CR. For more information,


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
