### PR TITLE
Update Docs to include new field ContainerStatus to the revision status

### DIFF
--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -2859,6 +2859,23 @@ based on the revision url template specified in the controller&rsquo;s config.</
 </tr>
 <tr>
 <td>
+<code>containerStatuses</code></br>
+<a href="#serving.knative.dev/v1.ContainerStatuses">
+ContainerStatuses
+</a>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerStatuses is a slice of images present in .Spec.Container[*].Image
+to their respective digests and their container name.
+The digests are resolved during the creation of Revision.
+ContainerStatuses holds the container name and image digests
+for both serving and non serving containers.
+ref: http://bit.ly/image-digests.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>imageDigest</code></br>
 <em>
 string
@@ -3355,6 +3372,49 @@ knative.dev/pkg/apis.URL
 <p>URL displays the URL for accessing named traffic targets. URL is displayed in
 status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
 a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.knative.dev/v1.ContainerStatuses">ContainerStatuses
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#serving.knative.dev/v1.RevisionStatus">RevisionStatus</a>)
+</p>
+<p>
+<p>ContainerStatuses holds the container name and image digests for both serving and non serving containers.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Name represents the container name and name must be a DNS_LABEL.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageDigest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImageDigest is the digest value for the container's image.</p>
 </td>
 </tr>
 </tbody>
@@ -4574,6 +4634,23 @@ based on the revision url template specified in the controller&rsquo;s config.</
 </tr>
 <tr>
 <td>
+<code>containerStatuses</code></br>
+<a href="#serving.knative.dev/v1alpha1.ContainerStatuses">
+ContainerStatuses
+</a>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerStatuses is a slice of images present in .Spec.Container[*].Image
+to their respective digests and their container name.
+The digests are resolved during the creation of Revision.
+ContainerStatuses holds the container name and image digests
+for both serving and non serving containers.
+ref: http://bit.ly/image-digests.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>imageDigest</code></br>
 <em>
 string
@@ -5220,6 +5297,49 @@ TrafficTarget
 </p>
 <p>We inherit most of our fields by inlining the v1 type.
 Ultimately all non-v1 fields will be deprecated.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.knative.dev/v1alpha1.ContainerStatuses">ContainerStatuses
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#serving.knative.dev/v1alpha1.RevisionStatus">RevisionStatus</a>)
+</p>
+<p>
+<p>ContainerStatuses holds the container name and image digests for both serving and non serving containers.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Name represents the container name and name must be a DNS_LABEL.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>imageDigest</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ImageDigest is the digest value for the container's image.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/serving/spec/knative-api-specification-1.0.md
+++ b/docs/serving/spec/knative-api-specification-1.0.md
@@ -1239,6 +1239,16 @@ constitutes a request.
    </td>
   </tr>
   <tr>
+   <td><code>containerStatuses</code>
+   </td>
+   <td>[]<a href="#containerStatuses">ContainerStatuses</a>
+   </td>
+   <td>The ContainerStatuses holds the resolved image digest for both serving and non serving containers.
+   </td>
+   <td>RECOMMENDED
+   </td>
+  </tr>
+  <tr>
    <td><code>imageDigest</code>
    </td>
    <td>string
@@ -1257,6 +1267,45 @@ core Kubernetes objects, there are additional limitations applied to ensure that
 created containers can statelessly autoscale. The set of fields that have been
 determined to be compatible with statelessly scaling are detailed below.
 Restrictions to the values of the field are noted in the Description column.
+
+## ContainerStatuses
+
+<table>
+  <tr>
+   <td><strong>FieldName</strong>
+   </td>
+   <td><strong>Field Type</strong>
+   </td>
+   <td><strong>Description</strong>
+   </td>
+   <td><strong>Schema Requirement</strong>
+   </td>
+  </tr>
+  <tr>
+   <td><code>name</code>
+   </td>
+   <td>string
+<p>
+(Optional)
+   </td>
+   <td>Name represents the container name and name must be a DNS_LABEL.
+   </td>
+   <td>REQUIRED
+   </td>
+  </tr>
+  <tr>
+   <td><code>imageDigest</code>
+   </td>
+   <td>string
+<p>
+(Optional)
+   </td>
+   <td>ImageDigest is the digest value for the container's image.
+   </td>
+   <td>REQUIRED
+   </td>
+  </tr>
+</table>
 
 ## TrafficTarget
 


### PR DESCRIPTION

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

**Background:**
A new field has been added as part of the [PR](https://github.com/knative/serving/pull/7373) which is ContainerStatus to the revision status

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updated new field `ContainerStatus` to  [reference/serving.md](https://github.com/knative/docs/blob/master/docs/reference/serving.md) and [spec/knative-api-specification-1.0.md](https://github.com/knative/docs/blob/master/docs/serving/spec/knative-api-specification-1.0.md)

