### PR TITLE
Document alternative process to setup a custom hostname for a Service

### DIFF
--- a/docs/serving/using-a-custom-domain-per-service.md
+++ b/docs/serving/using-a-custom-domain-per-service.md
@@ -1,0 +1,67 @@
+
+---
+title: "Setting up a custom domain per Service"
+#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
+weight: 55
+type: "docs"
+---
+
+By default, Knative uses the `{route}.{namespace}.{default-domain}` fully qualified domain name for the Service, where `default-domain` is `example.com`. You are able to change the `default-domain` following the [Setting up a custom domain](./using-a-custom-domain.md) guide.
+
+This guide documents the process to use a custom FQDN for a Service, like `my-service.example.com`, created by [@bsideup](https://bsideup.github.io/posts/knative_custom_domains/).
+
+> There is currently no formal process to set up a custom domain per Service. The topic is being discussed [here](https://github.com/knative/serving/issues/2985).
+
+## Edit using kubectl
+
+1. Edit the `domainTemplate` entry on the `config-network` configuration:
+
+   ```shell
+   kubectl edit cm config-network --namespace knative-serving
+   ```
+
+   Replace the `domainTemplate` with the following (the spaces must be respected):
+
+   ```yaml
+   [...]
+   data:
+     [...]
+     domainTemplate: |-
+       {{if index .Annotations "custom-hostname" -}}
+         {{- index .Annotations "custom-hostname" -}}
+       {{else -}}
+         {{- .Name}}.{{.Namespace -}}
+       {{end -}}
+       .{{.Domain}}
+   ```
+
+   Save and close your editor.
+
+## Edit the Service
+
+1. In a Service definition, add the `custom-hostname` annotation:
+   
+   ```yaml
+   apiVersion: serving.knative.dev/v1
+   kind: Service
+   metadata:
+     name: hello-world
+     annotations:
+       # the Service FQDN will become hello-world.{default-domain}
+       custom-hostname: hello-world
+   spec:
+   [...]
+   ```
+
+   Apply your changes.
+
+## Verify the changes
+
+1. Verify that the Service was created with the specified hostname:
+
+  ```shell
+  kubectl get ksvc hello-world
+
+  NAME          URL                              LATESTCREATED       LATESTREADY         READY   REASON
+  hello-world   http://hello-world.example.com   hello-world-nfqh2   hello-world-nfqh2   True    
+  ```

--- a/docs/serving/using-a-custom-domain-per-service.md
+++ b/docs/serving/using-a-custom-domain-per-service.md
@@ -39,7 +39,7 @@ This guide documents the process to use a custom FQDN for a Service, like `my-se
 ## Edit the Service
 
 1. In a Service definition, add the `custom-hostname` annotation:
-   
+
    ```yaml
    apiVersion: serving.knative.dev/v1
    kind: Service
@@ -62,5 +62,5 @@ This guide documents the process to use a custom FQDN for a Service, like `my-se
   kubectl get ksvc hello-world
 
   NAME          URL                              LATESTCREATED       LATESTREADY         READY   REASON
-  hello-world   http://hello-world.example.com   hello-world-nfqh2   hello-world-nfqh2   True    
+  hello-world   http://hello-world.example.com   hello-world-nfqh2   hello-world-nfqh2   True
   ```

--- a/docs/serving/using-a-custom-domain-per-service.md
+++ b/docs/serving/using-a-custom-domain-per-service.md
@@ -1,7 +1,6 @@
 
 ---
 title: "Setting up a custom domain per Service"
-#linkTitle: "OPTIONAL_ALTERNATE_NAV_TITLE"
 weight: 55
 type: "docs"
 ---

--- a/docs/serving/using-a-custom-domain-per-service.md
+++ b/docs/serving/using-a-custom-domain-per-service.md
@@ -9,11 +9,11 @@ By default, Knative uses the `{route}.{namespace}.{default-domain}` fully qualif
 
 This guide documents the process to use a custom FQDN for a Service, like `my-service.example.com`, created by [@bsideup](https://bsideup.github.io/posts/knative_custom_domains/).
 
-> There is currently no formal process to set up a custom domain per Service. The topic is being discussed [here](https://github.com/knative/serving/issues/2985).
+> There is currently no official process to set up a custom domain per Service. The topic is being discussed [here](https://github.com/knative/serving/issues/2985).
 
 ## Edit using kubectl
 
-1. Edit the `domainTemplate` entry on the `config-network` configuration:
+1. Edit the `domainTemplate` entry on the `config-network` configuration. You can find more information about it [here](https://github.com/knative/serving/blob/master/config/core/configmaps/network.yaml#L89):
 
    ```shell
    kubectl edit cm config-network --namespace knative-serving


### PR DESCRIPTION
Adds an alternative method to fix [Serving #1185](https://github.com/knative/serving/issues/1185) and #1964.

## Proposed Changes 
- Adds an alternative documentation to create custom Service FQDN.