### PR TITLE
Updated link and default target from 100 to 70

### DIFF
--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -118,7 +118,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
 Knative Serving autoscaling is based on the average number of in-flight requests
 per pod (concurrency). The system has a default
-[target concurrency of 70](https://github.com/knative/serving/blob/8c7134ebfe368ee178229e99166e5bff8167b8ed/config/core/configmaps/autoscaler.yaml#L40-L55)
+[target concurrency of 100](https://github.com/knative/serving/blob/8c7134ebfe368ee178229e99166e5bff8167b8ed/config/core/configmaps/autoscaler.yaml#L74)
 but [we used 10](service.yaml#L25-L26) for our service. We loaded the service
 with 50 concurrent requests so the autoscaler created 5 pods
 (`50 concurrent requests / target of 10 = 5 pods`)

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -118,7 +118,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
 Knative Serving autoscaling is based on the average number of in-flight requests
 per pod (concurrency). The system has a default
-[target concurrency of 100](https://github.com/knative/serving/blob/8c7134ebfe368ee178229e99166e5bff8167b8ed/config/core/configmaps/autoscaler.yaml#L74)
+[target concurrency of 100](https://github.com/knative/serving/blob/master/config/core/configmaps/autoscaler.yaml)(Search for container-concurrency-target-default)
 but [we used 10](service.yaml#L25-L26) for our service. We loaded the service
 with 50 concurrent requests so the autoscaler created 5 pods
 (`50 concurrent requests / target of 10 = 5 pods`)

--- a/docs/serving/samples/autoscale-go/README.md
+++ b/docs/serving/samples/autoscale-go/README.md
@@ -118,7 +118,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
 Knative Serving autoscaling is based on the average number of in-flight requests
 per pod (concurrency). The system has a default
-[target concurrency of 100](https://github.com/knative/serving/blob/master/config/core/configmaps/autoscaler.yaml#L54-L60)
+[target concurrency of 70](https://github.com/knative/serving/blob/8c7134ebfe368ee178229e99166e5bff8167b8ed/config/core/configmaps/autoscaler.yaml#L40-L55)
 but [we used 10](service.yaml#L25-L26) for our service. We loaded the service
 with 50 concurrent requests so the autoscaler created 5 pods
 (`50 concurrent requests / target of 10 = 5 pods`)


### PR DESCRIPTION
Fixes an issue with a previously merged PR - https://github.com/knative/docs/pull/2334

## Proposed Changes 
- Updated default from 100 to 70 based on the default in the configs
- Updated link to a static file instead of based on Master
