### PR TITLE
Update triggermesh docs links after repo move

### DIFF
--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -45,7 +45,7 @@ Name | Status | Support | Description
 [CloudStorageSource](https://github.com/google/knative-gcp/blob/master/docs/examples/cloudstoragesource/README.md) | Active Development | None | Registers for events of the specified types on the specified [Google Cloud Storage](https://cloud.google.com/storage/) bucket and optional object prefix. Brings those events into Knative.
 [Cron Job](https://knative.dev/docs/eventing/migration/ping) | Replaced by PingSource | None | Deprecated, replace with [PingSource](https://knative.dev/docs/eventing/migration/ping) or a [CronJob using SinkBinding](https://knative.dev/docs/eventing/samples/sinkbinding/)
 [GitHub](https://github.com/knative/eventing-contrib/blob/master/github/pkg/apis/sources/v1alpha1/githubsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitHub organization/repository. Brings those events into Knative.
-[GitLab](https://gitlab.com/triggermesh/gitlabsource) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
+[GitLab](https://github.com/knative/eventing-contrib/blob/master/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go) | Proof of Concept | None | Registers for events of the specified types on the specified GitLab repository. Brings those events into Knative.
 [Kubernetes](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha1/apiserver_types.go) | Active Development | Knative | Brings Kubernetes API server events into Knative.
 [Ping](https://github.com/knative/eventing/blob/master/pkg/apis/sources/v1alpha2/ping_types.go) | In development | None | Uses an in-memory timer to produce events with a fixed payload on a specified cron schedule.
 [VMware](https://github.com/vmware-tanzu/sources-for-knative/tree/{{< branch >}}/pkg/apis/source/v1alpha1/vspheresource_types.go) | Active Development | None | Brings [vSphere](https://www.vmware.com/products/vsphere.html) events into Knative.
@@ -71,12 +71,12 @@ These are containers intended to be used with `ContainerSource`.
 
 Name | Status | Support | Description
 --- | --- | --- | ---
-[AWS CodeCommit](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit) | Supported | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
-[AWS Cognito](https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito) | Supported | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.
-[AWS DynamoDB](https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb) | Supported | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
-[AWS Kinesis](https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis) | Supported | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
-[AWS SNS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns) | Supported | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.
-[AWS SQS](https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs) | Supported | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.
+[AWS CodeCommit](https://github.com/triggermesh/aws-event-sources/blob/master/cmd/awscodecommitsource/README.md) | Supported | TriggerMesh | Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
+[AWS Cognito](https://github.com/triggermesh/aws-event-sources/blob/master/cmd/awscognitosource/README.md) | Supported | TriggerMesh | Registers for AWS Cognito events. Brings those events into Knative.
+[AWS DynamoDB](https://github.com/triggermesh/aws-event-sources/blob/master/cmd/awsdynamodbsource/README.md) | Supported | TriggerMesh | Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
+[AWS Kinesis](https://github.com/triggermesh/aws-event-sources/tree/master/cmd/awskinesissource/README.md) | Supported | TriggerMesh | Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
+[AWS SNS](https://github.com/triggermesh/aws-event-sources/tree/master/cmd/awssnssource) | Supported | TriggerMesh | Registers for events of the specified AWS SNS endpoint. Brings those events into Knative.
+[AWS SQS](https://github.com/triggermesh/aws-event-sources/tree/master/cmd/awssqssource/README.md) | Supported | TriggerMesh | Registers for events of the specified AWS SQS queue. Brings those events into Knative.
 [FTP / SFTP](https://github.com/vaikas-google/ftp) | Proof of concept | None | Watches for files being uploaded into a FTP/SFTP and generates events for those.
 [Heartbeat](https://github.com/Harwayne/auto-container-source/tree/master/heartbeat-source) | Proof of Concept | None | Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource for underlying infrastructure.
 [Heartbeats](https://github.com/knative/eventing-contrib/tree/{{< branch >}}/cmd/heartbeats) | Proof of Concept | None | Uses an in-memory timer to produce events at the specified interval.

--- a/docs/eventing/sources/sources.yaml
+++ b/docs/eventing/sources/sources.yaml
@@ -161,37 +161,37 @@ containers:
       Uses an in-memory timer to produce events as the specified interval. Uses AutoContainerSource
       for underlying infrastructure.
   - name: AWS CodeCommit
-    url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awscodecommit
+    url: https://github.com/triggermesh/aws-event-sources/blob/master/cmd/awscodecommitsource/README.md
     status: Supported
     support: TriggerMesh
     description: >
       Registers for events of the specified types on the specified AWS CodeCommit repository. Brings those events into Knative.
   - name: AWS Cognito
-    url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awscognito
+    url: https://github.com/triggermesh/aws-event-sources/blob/master/cmd/awscognitosource/README.md
     status: Supported
     support: TriggerMesh
     description: >
       Registers for AWS Cognito events. Brings those events into Knative.
   - name: AWS DynamoDB
-    url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awsdynamodb
+    url: https://github.com/triggermesh/aws-event-sources/blob/master/cmd/awsdynamodbsource/README.md
     status: Supported
     support: TriggerMesh
     description: >
       Registers for events of on the specified AWS DynamoDB table. Brings those events into Knative.
   - name: AWS Kinesis
-    url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awskinesis
+    url: https://github.com/triggermesh/aws-event-sources/tree/master/cmd/awskinesissource/README.md
     status: Supported
     support: TriggerMesh
     description: >
       Registers for events on the specified AWS Kinesis stream. Brings those events into Knative.
   - name: AWS SQS
-    url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awssqs
+    url: https://github.com/triggermesh/aws-event-sources/tree/master/cmd/awssqssource/README.md
     status: Supported
     support: TriggerMesh
     description: >
       Registers for events of the specified AWS SQS queue. Brings those events into Knative.
   - name: AWS SNS
-    url: https://github.com/triggermesh/knative-lambda-sources/tree/master/awssns
+    url: https://github.com/triggermesh/aws-event-sources/tree/master/cmd/awssnssource
     status: Supported
     support: TriggerMesh
     description: >


### PR DESCRIPTION
Fixes docs links in Sources page; see https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_docs/2377/pull-knative-docs-markdown-link-check/1255562718677569538 for an example of the failing link check.

/assign @sebgoa @mpetason 