### PR TITLE
Update link to point to website contributing guidelines for now.

### DIFF
--- a/community/samples/README.md
+++ b/community/samples/README.md
@@ -5,7 +5,7 @@ Note: It is possible that one or more samples might become outdated or the
 original author is unable to maintain their contribution. If you find that
 something isn't working, lend a helping hand and fix it in a PR.
 
-[Learn more about the lifespan of samples](https://github.com/knative/community/tree/master/DOCS-CONTRIBUTING.md).
+[Learn more about the lifespan of samples](https://knative.dev/community/contributing/docs/docs-contributing/#determining-where-to-add-user-focused-code-samples)
 
 [**See all Knative code samples**](../../docs/samples.md)
 


### PR DESCRIPTION
I'll need to update this again when https://github.com/knative/docs/pull/2387 lands.

Fixes Markdown_Link error in community/samples https://prow.knative.dev/view/gcs/knative-prow/pr-logs/pull/knative_docs/2396/pull-knative-docs-markdown-link-check/1253615911399591937

## Proposed Changes

- Points to the rendered page on knative.dev; this will be moving back into the docs repo soon-ish, and I'll need to figure out how to hande it then, probably by changing the website build to not canonicalize https://github.com/... links.