### PR TITLE
Adding sample config map configs for the two brokers

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -553,6 +553,34 @@ ConfigMap to specify which configurations are used for which namespaces:
            namespace: knative-eventing
    ```
 
+The referenced `imc-channel` and `kafka-channel` example ConfigMaps would look like:
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: imc-channel
+     namespace: knative-eventing
+   data:
+     channelTemplateSpec: |
+       apiVersion: messaging.knative.dev/v1beta1
+       kind: InMemoryChannel
+   ---
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: kafka-channel
+     namespace: knative-eventing
+   data:
+     channelTemplateSpec: |
+       apiVersion: messaging.knative.dev/v1alpha1
+       kind: KafkaChannel
+       spec:
+         numPartitions: 3
+         replicationFactor: 1
+   ```
+
+_In order to use the KafkaChannel make sure it is installed on the cluster as discussed above._
+
 {{< /tab >}}
 
 {{% tab name="MT-Channel-based" %}}
@@ -596,6 +624,34 @@ ConfigMap to specify which configurations are used for which namespaces:
            name: kafka-channel
            namespace: knative-eventing
    ```
+
+The referenced `imc-channel` and `kafka-channel` example ConfigMaps would look like:
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: imc-channel
+     namespace: knative-eventing
+   data:
+     channelTemplateSpec: |
+       apiVersion: messaging.knative.dev/v1beta1
+       kind: InMemoryChannel
+   ---
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: kafka-channel
+     namespace: knative-eventing
+   data:
+     channelTemplateSpec: |
+       apiVersion: messaging.knative.dev/v1alpha1
+       kind: KafkaChannel
+       spec:
+         numPartitions: 3
+         replicationFactor: 1
+   ```
+
+_In order to use the KafkaChannel make sure it is installed on the cluster as discussed above._
 
 {{< /tab >}}
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The config for the brokers did not provide content for the referenced sample ConfigMap objects. I've added those for completeness


/assign @mattmoor 
