### PR TITLE
Adding missing broker class

### DIFF
--- a/docs/eventing/broker/channel-based-broker.md
+++ b/docs/eventing/broker/channel-based-broker.md
@@ -62,18 +62,19 @@ metadata:
 data:
   default-br-config: |
     clusterDefault:
+      brokerClass: ChannelBasedBroker
       apiVersion: v1
       kind: ConfigMap
       name: imc-channel
       namespace: knative-eventing
     namespaceDefaults:
+      brokerClass: ChannelBasedBroker
       test-broker-6:
         apiVersion: v1
         kind: ConfigMap
         name: kafka-channel
         namespace: knative-eventing
 ```
-
 
 ## Installing Broker by Annotation
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

- adding `brokerClass` to match the doc for the MTChannelBasedBroker
-
-
