### PR TITLE
feat: bump deno to 1.0

### DIFF
--- a/community/samples/serving/helloworld-deno/Dockerfile
+++ b/community/samples/serving/helloworld-deno/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:0.38.0
+FROM hayd/alpine-deno:1.0.0-rc2
 WORKDIR /app
 
 # Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).


### PR DESCRIPTION
Bump to 1.0 major release of Deno

Related PR: https://github.com/knative/docs/pull/2444

https://hub.docker.com/layers/hayd/alpine-deno/1.0.0-rc2/images/sha256-afabec0749e708106934b1929283653cebc529ec44c74d7b836139e601697e92?context=explore