### PR TITLE
Update Deno Syntax to New 1.0 Syntax, 

### DIFF
--- a/community/samples/serving/helloworld-deno/Dockerfile
+++ b/community/samples/serving/helloworld-deno/Dockerfile
@@ -1,4 +1,4 @@
-FROM hayd/alpine-deno:0.38.0
+FROM hayd/alpine-deno:1.0.0-rc2
 WORKDIR /app
 
 # Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).

--- a/community/samples/serving/helloworld-deno/Dockerfile
+++ b/community/samples/serving/helloworld-deno/Dockerfile
@@ -1,14 +1,8 @@
 FROM hayd/alpine-deno:1.0.0-rc2
 WORKDIR /app
 
-# Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).
-COPY deps.ts ./
-RUN deno fetch deps.ts
-
 # These steps will be re-run upon each file change in your working directory:
 COPY . ./
-# Compile the main app so that it doesn't need to be compiled each startup/entry.
-RUN deno fetch main.ts
 
 # Added to ENTRYPOINT of base image.
-CMD ["--allow-net", "main.ts"]
+CMD ["run", "--allow-env", "--allow-net", "main.ts"]

--- a/community/samples/serving/helloworld-deno/README.md
+++ b/community/samples/serving/helloworld-deno/README.md
@@ -29,47 +29,37 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-deno
 1. Create a new file named `deps.ts` and paste the following script:
 
    ```ts
-   export { serve } from "https://deno.land/std@v0.38.0/http/server.ts";
+   export { serve } from "https://deno.land/std@v1.0.0-rc2/http/server.ts";
    ```
 
 1. Create a new file named `main.ts` and paste the following script:
 
    ```ts
    import { serve } from "./deps.ts";
-
-   const PORT = 8080;
+   import "https://deno.land/x/dotenv/mod.ts";
+   
+   const PORT = Deno.env.get('PORT') || 8080;
    const s = serve(`0.0.0.0:${PORT}`);
    const body = new TextEncoder().encode("Hello Deno\n");
-
+   
    console.log(`Server started on port ${PORT}`);
    for await (const req of s) {
      req.respond({ body });
    }
    ```
 
-  1. Create a new file named `Dockerfile` and copy the code block below into it.
+1. Create a new file named `Dockerfile` and copy the code block below into it.
 
-    ```docker
-    FROM hayd/alpine-deno:0.38.0
-    EXPOSE 8080
-    WORKDIR /app
-
-    # Prefer not to run as root.
-    USER deno
-
-    # Cache the dependencies as a layer (the following two steps are re-run only when deps.ts is modified).
-    # Ideally fetch deps.ts will download and compile _all_ external files used in main.ts.
-    COPY deps.ts .
-    RUN deno fetch deps.ts
-
-    # These steps will be re-run upon each file change in your working directory:
-    ADD . .
-    # Compile the main app so that it doesn't need to be compiled each startup/entry.
-    RUN deno fetch main.ts
-
-    # Added to ENTRYPOINT of base image.
-    CMD ["--allow-net", "main.ts"]
-    ```
+   ```docker
+   FROM hayd/alpine-deno:1.0.0-rc2
+   WORKDIR /app
+ 
+   # These steps will be re-run upon each file change in your working directory:
+   COPY . ./
+ 
+   # Added to ENTRYPOINT of base image.
+   CMD ["run", "--allow-env", "--allow-net", "main.ts"]
+   ```
 
 1. Create a new file, `service.yaml` and copy the following service definition
    into the file. Make sure to replace `{username}` with your Docker Hub

--- a/community/samples/serving/helloworld-deno/README.md
+++ b/community/samples/serving/helloworld-deno/README.md
@@ -37,11 +37,11 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-deno
    ```ts
    import { serve } from "./deps.ts";
    import "https://deno.land/x/dotenv/mod.ts";
-   
+
    const PORT = Deno.env.get('PORT') || 8080;
    const s = serve(`0.0.0.0:${PORT}`);
    const body = new TextEncoder().encode("Hello Deno\n");
-   
+
    console.log(`Server started on port ${PORT}`);
    for await (const req of s) {
      req.respond({ body });
@@ -53,10 +53,10 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-deno
    ```docker
    FROM hayd/alpine-deno:1.0.0-rc2
    WORKDIR /app
- 
+
    # These steps will be re-run upon each file change in your working directory:
    COPY . ./
- 
+
    # Added to ENTRYPOINT of base image.
    CMD ["run", "--allow-env", "--allow-net", "main.ts"]
    ```

--- a/community/samples/serving/helloworld-deno/deps.ts
+++ b/community/samples/serving/helloworld-deno/deps.ts
@@ -1,1 +1,1 @@
-export { serve } from "https://deno.land/std@v0.38.0/http/server.ts";
+export { serve } from "https://deno.land/std@v1.0.0-rc2/http/server.ts";

--- a/community/samples/serving/helloworld-deno/main.ts
+++ b/community/samples/serving/helloworld-deno/main.ts
@@ -1,7 +1,7 @@
 import { serve } from "./deps.ts";
-import "https://deno.land/x/dotenv/load.ts";
+import "https://deno.land/x/dotenv/mod.ts";
 
-const PORT = Deno.env('PORT') || 8080;
+const PORT = Deno.env.get('PORT') || 8080;
 const s = serve(`0.0.0.0:${PORT}`);
 const body = new TextEncoder().encode("Hello Deno\n");
 


### PR DESCRIPTION
This PR fixes some issues with upgrading the `helloworld-deno` sample to `deno@1.0.0-rc2`.
Related #2444 #2456

@averikitsch https://github.com/knative/docs/pull/2456#issuecomment-627676819

Tested locally and on Cloud Run:
https://hellodeno-q7vieseilq-uc.a.run.app

Sorry for the multiple PRs!