### PR TITLE
fix: revert hello-deno std lib to pre 1.0, see denoland/deno#5267

### DIFF
--- a/community/samples/serving/helloworld-deno/README.md
+++ b/community/samples/serving/helloworld-deno/README.md
@@ -29,7 +29,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-deno
 1. Create a new file named `deps.ts` and paste the following script:
 
    ```ts
-   export { serve } from "https://deno.land/std@v1.0.0-rc2/http/server.ts";
+   export { serve } from "https://deno.land/std@std@0.50.0/http/server.ts";
    ```
 
 1. Create a new file named `main.ts` and paste the following script:

--- a/community/samples/serving/helloworld-deno/deps.ts
+++ b/community/samples/serving/helloworld-deno/deps.ts
@@ -1,1 +1,1 @@
-export { serve } from "https://deno.land/std@v1.0.0-rc2/http/server.ts";
+export { serve } from "https://deno.land/std@0.50.0/http/server.ts";


### PR DESCRIPTION
Fixes #2466.
Deno std lib version broke last night. See issue for details.
Tested locally.
R: @averikitsch 