### PR TITLE
fix event_display image name

### DIFF
--- a/docs/eventing/samples/container-source/service.yaml
+++ b/docs/eventing/samples/container-source/service.yaml
@@ -20,4 +20,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/gitlab-source/README.md
+++ b/docs/eventing/samples/gitlab-source/README.md
@@ -64,7 +64,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
 ```
 
 Create the service:

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -125,7 +125,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
 ```
 
 Change `default` below to create the `Sequence` in the Namespace where you want


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->
 
## Proposed Changes <!-- Describe the changes the PR makes. -->

- fix event_display image name
-
-
