### PR TITLE
Allow Maria Cruz to manage Knative blog

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,6 +17,9 @@ aliases:
   - abrennan89
   - mpetason
   - jonatasbaldin
+
+  blog-approvers:
+  - macruzbar
  
   productivity-approvers:
   - chaodaiG

--- a/blog/OWNERS
+++ b/blog/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+- blog-approvers


### PR DESCRIPTION
Allow Maria Cruz to approve and manage blog posts.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds Maria Cruz (community manager from Google) to OWNERS
