### PR TITLE
add blurp to eventing storage version migration

### DIFF
--- a/docs/install/upgrade-installation.md
+++ b/docs/install/upgrade-installation.md
@@ -75,6 +75,12 @@ ie.
 kubectl apply --filename {{< artifact repo="serving" file="serving-storage-version-migration.yaml" >}}
 ```
 
+for eventing:
+```bash
+kubectl apply --filename {{< artifact repo="eventing" file="storage-version-migration-v0.15.0.yaml" >}}
+```
+
+
 
 ## Performing the upgrade
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Addresses #https://github.com/knative/eventing/issues/3095

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
