### PR TITLE
Remove periodSeconds from examples

### DIFF
--- a/docs/serving/samples/knative-routing-go/sample.yaml
+++ b/docs/serving/samples/knative-routing-go/sample.yaml
@@ -31,7 +31,6 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 3
-          periodSeconds: 3
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -52,4 +51,3 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 3
-          periodSeconds: 3

--- a/docs/serving/samples/rest-api-go/sample.yaml
+++ b/docs/serving/samples/rest-api-go/sample.yaml
@@ -30,5 +30,4 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 0
-          periodSeconds: 3
 

--- a/docs/serving/samples/traffic-splitting/release_sample.yaml
+++ b/docs/serving/samples/traffic-splitting/release_sample.yaml
@@ -31,7 +31,6 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 0
-          periodSeconds: 3
   traffic:
   - tag: current
     revisionName: stock-service-example-first

--- a/docs/serving/samples/traffic-splitting/split_sample.yaml
+++ b/docs/serving/samples/traffic-splitting/split_sample.yaml
@@ -31,7 +31,6 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 0
-          periodSeconds: 3
   traffic:
   - tag: current
     revisionName: stock-service-example-first

--- a/docs/serving/samples/traffic-splitting/updated_sample.yaml
+++ b/docs/serving/samples/traffic-splitting/updated_sample.yaml
@@ -31,7 +31,6 @@ spec:
           httpGet:
             path: /
           initialDelaySeconds: 0
-          periodSeconds: 3
   traffic:
   - tag: current
     revisionName: stock-service-example-first


### PR DESCRIPTION
## Proposed Changes

- Fixes broken serving examples.

Since knative/serving#4731, `periodSeconds` also requires `failureThreshold` and `timeoutSeconds` to be set. The best is simply not to set it, otherwise our examples fail with

`admission webhook "resource.webhook.serving.knative.dev" denied the request: mutation failed: expected 1 <= 0 <= 2147483647: spec.template.spec.containers[0].readinessProbe.failureThreshold, spec.template.spec.containers[0].readinessProbe.timeoutSeconds`

Ref:
knative/serving#4780
knative/serving#5732