### PR TITLE
Migrate "easy event source" tutorial to Cloudevents javascript sdk v2

### DIFF
--- a/docs/eventing/samples/writing-event-source-easy-way/README.md
+++ b/docs/eventing/samples/writing-event-source-easy-way/README.md
@@ -19,8 +19,11 @@ Code for this tutorial is available [here](https://github.com/knative/docs/tree/
 Create the project and add the dependencies:
 ```bash
 npm init
-npm install cloudevents-sdk --save
+npm install cloudevents-sdk@2.0.1 --save
 ```
+
+Please note that because of a [bug](https://github.com/cloudevents/sdk-javascript/issues/191), you will
+need at least `2.0.1` version of the Javascript SDK.
 
 ## Making use of ContainerSource
 

--- a/docs/eventing/samples/writing-event-source-easy-way/README.md
+++ b/docs/eventing/samples/writing-event-source-easy-way/README.md
@@ -33,34 +33,30 @@ The sink URL to post the events will be made available to the application via th
 ```javascript
 // File - index.js
 
-const v1 = require("cloudevents-sdk/v1");
+const { CloudEvent, HTTPEmitter } = require("cloudevents-sdk");
 
 let sinkUrl = process.env['K_SINK'];
 
 console.log("Sink URL is " + sinkUrl);
 
-let config = {
-    method: "POST",
+let emitter = new HTTPEmitter({
     url: sinkUrl
-};
-
-// The binding instance
-let binding = new v1.BinaryHTTPEmitter(config);
+});
 
 let eventIndex = 0;
 setInterval(function () {
     console.log("Emitting event #" + ++eventIndex);
 
-    // create the event
-    let myevent = v1.event()
-        .id('your-event-id')
-        .type("your.event.source.type")
-        .source("urn:event:from:your-api/resource/123")
-        .dataContentType("application/json")
-        .data({"hello": "World " + eventIndex});
+    let myevent = new CloudEvent({
+        source: "urn:event:from:my-api/resource/123",
+        type: "your.event.source.type",
+        id: "your-event-id",
+        dataContentType: "application/json",
+        data: {"hello": "World " + eventIndex},
+    });
 
     // Emit the event
-    binding.emit(myevent)
+    emitter.send(myevent)
         .then(response => {
             // Treat the response
             console.log("Event posted successfully");

--- a/docs/eventing/samples/writing-event-source-easy-way/index.js
+++ b/docs/eventing/samples/writing-event-source-easy-way/index.js
@@ -1,31 +1,27 @@
-const v1 = require("cloudevents-sdk/v1");
+const { CloudEvent, HTTPEmitter } = require("cloudevents-sdk");
 
 let sinkUrl = process.env['K_SINK'];
 
 console.log("Sink URL is " + sinkUrl);
 
-let config = {
-    method: "POST",
+let emitter = new HTTPEmitter({
     url: sinkUrl
-};
-
-// The binding instance
-let binding = new v1.BinaryHTTPEmitter(config);
+});
 
 let eventIndex = 0;
 setInterval(function () {
     console.log("Emitting event #" + ++eventIndex);
 
-    // create the event
-    let myevent = v1.event()
-        .id('your-event-id')
-        .type("your.event.source.type")
-        .source("urn:event:from:your-api/resource/123")
-        .dataContentType("application/json")
-        .data({"hello": "World " + eventIndex});
+    let myevent = new CloudEvent({
+        source: "urn:event:from:my-api/resource/123",
+        type: "your.event.source.type",
+        id: "your-event-id",
+        dataContentType: "application/json",
+        data: {"hello": "World " + eventIndex},
+    });
 
     // Emit the event
-    binding.emit(myevent)
+    emitter.send(myevent)
         .then(response => {
             // Treat the response
             console.log("Event posted successfully");

--- a/docs/eventing/samples/writing-event-source-easy-way/package.json
+++ b/docs/eventing/samples/writing-event-source-easy-way/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cloudevents-sdk": "^1.0.0"
+    "cloudevents-sdk": "git://github.com/cloudevents/sdk-javascript.git#0710166ce9397f402b835fae745923d11357d15e"
   }
 }

--- a/docs/eventing/samples/writing-event-source-easy-way/package.json
+++ b/docs/eventing/samples/writing-event-source-easy-way/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cloudevents-sdk": "git://github.com/cloudevents/sdk-javascript.git#0710166ce9397f402b835fae745923d11357d15e"
+    "cloudevents-sdk": "^2.0.1"
   }
 }


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Migrate the tutorial to use Javascript SDK v2
- Needs Javascript SDK 2.0.1 (not released) because of https://github.com/cloudevents/sdk-javascript/issues/191, thus references a commit