### PR TITLE
chore: Add `kn` usage to Getting Started guide

### DIFF
--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -46,7 +46,7 @@ The easiest way to deploy a Knative Service is by using the Knative CLI [kn](htt
 `kn` allows you to create a service interactively on the command line.
 Eventually, it will create a corresponding resource description internally as when using a YAML file directly.
 
-To create our service directly at the cluster, use:
+To create a Service directly at the cluster, use:
 
 ```shell
 # Create a Knative service with the Knatice CLI kn

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -40,7 +40,8 @@ The Hello World sample app reads in an `env` variable, `TARGET`, then prints "He
 ## Creating your Deployment with the Knative CLI
 
 The easiest way to deploy a Knative Service is by using the Knative CLI [kn](https://github.com/knative/client).
-You can install the `kn` binary as described in [Installing the Knative CLI](../install/install-kn.md)
+
+**Prerequisite:** install the `kn` binary as described in [Installing the Knative CLI](../install/install-kn.md)
 
 `kn` allows you to create a service interactively on the command line.
 Eventually, it will create a corresponding resource description internally as when using a YAML file directly.

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -15,16 +15,15 @@ using cURL requests.
 You need:
 
 - A Kubernetes cluster with [Knative installed](../install/README.md).
-- An image of the app that you'd like to deploy available on a container
-  registry. The image of the sample app used in this guide is available on
+- An image of the app that you'd like to deploy available on a container registry. The image of the sample app used in this guide is available on
   Google Container Registry.
 
 ## Sample application
 
 This guide demonstrates the basic workflow for deploying the
-[Hello World sample app (Go)](../serving/samples/hello-world/helloworld-go) from the 
+[Hello World sample app (Go)](../serving/samples/hello-world/helloworld-go) from the
 [Google Container Registry](https://cloud.google.com/container-registry/docs/pushing-and-pulling).
-You can use these steps as a guide for deploying your own container images from other
+You can use these steps as a guide for deploying your container images from other
 registries like [Docker Hub](https://docs.docker.com/docker-hub/repos/).
 
 To deploy a local container image, you need to disable image tag resolution by running the following command:
@@ -36,24 +35,41 @@ docker tag local-image dev.local/local-image
 
 [Learn more about image tag resolution.](./tag-resolution.md)
 
-The Hello World sample app reads in an `env` variable, `TARGET`, from the
-configuration `.yaml` file, then prints "Hello World: \${TARGET}!". If `TARGET`
-isn't defined, it will print "NOT SPECIFIED".
+The Hello World sample app reads in an `env` variable, `TARGET`, then prints "Hello World: \${TARGET}!". If `TARGET` isn't defined, it will print "NOT SPECIFIED".
 
-## Configuring your deployment
+## Creating your Deployment with the Knative CLI
 
-To deploy an app using Knative, you need a configuration `.yaml` file that
-defines a Service. For more information about the Service object, see the
+The easiest way to create Knative service deployment is by using the Knative CLI [kn](https://github.com/knative/client).
+You can install the `kn` binary as described in [Installing the Knative CLI](../install/install-kn.md)
+
+`kn` allows you to create a service interactively on the command line.
+Eventually, it will create a corresponding resource description internally as when using a YAML file directly.
+
+To create our service directly at the cluster, use:
+
+```shell
+# Create a Knative service with the Knatice CLI kn
+kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go --env TARGET="Go Sample v1"
+```
+
+Now that you have deployed the service, Knative will perform the following steps:
+
+- Create a new immutable revision for this version of the app.
+- Perform network programming to create a route, ingress, service, and load
+  balancer for your app.
+- Automatically scale your pods up and down based on traffic, including to zero
+  active pods.
+
+## Creating your Deployment with YAML
+
+Alternatively, to deploy an app using Knative, you can also create the configuration in a YAML file that defines a service. For more information about the Service object, see the
 [Resource Types documentation](https://github.com/knative/serving/blob/master/docs/spec/overview.md#service).
 
-This configuration file specifies metadata about the application, points to the
-hosted image of the app for deployment, and allows the deployment to be
+If a configuration file is used, it specifies metadata about the application, points to the hosted image of the app for deployment, and allows the deployment to be
 configured. For more information about what configuration options are available,
-see the
-[Serving spec documentation](https://github.com/knative/serving/blob/master/docs/spec/spec.md).
+see the [Serving spec documentation](https://github.com/knative/serving/blob/master/docs/spec/spec.md).
 
-Create a new file named `service.yaml`, then copy and paste the following
-content into it:
+To create the same application as in the previous `kn` example, create a new file named `service.yaml`, then copy and paste the following content into it:
 
 ```yaml
 apiVersion: serving.knative.dev/v1 # Current version of Knative
@@ -72,10 +88,8 @@ spec:
 ```
 
 If you want to deploy the sample app, leave the config file as-is. If you're
-deploying an image of your own app, update the name of the app and the URL of
+deploying an image of your app, update the name of the app and the URL of
 the image accordingly.
-
-## Deploying your app
 
 From the directory where the new `service.yaml` file was created, apply the
 configuration:
@@ -84,19 +98,35 @@ configuration:
 kubectl apply --filename service.yaml
 ```
 
-Now that your service is created, Knative will perform the following steps:
-
-- Create a new immutable revision for this version of the app.
-- Perform network programming to create a route, ingress, service, and load
-  balancer for your app.
-- Automatically scale your pods up and down based on traffic, including to zero
-  active pods.
-
-### Interacting with your app
+## Interacting with your app
 
 To see if your app has been deployed successfully, you need the URL created by Knative.
 
 1. To find the URL for your service, enter:
+   ```shell
+   kn service describe helloworld-go
+   ```
+
+   This will return something like
+
+   ```
+   Name:       helloworld-go
+   Namespace:  default
+   Age:        12m
+   URL:        http://helloworld-go.default.34.83.80.117.xip.io
+
+   Revisions:
+     100%  @latest (helloworld-go-dyqsj-1) [1] (39s)
+           Image:  gcr.io/knative-samples/helloworld-go (pinned to 946b7c)
+
+   Conditions:
+     OK TYPE                   AGE REASON
+     ++ Ready                  25s
+     ++ ConfigurationsReady    26s
+     ++ RoutesReady            25s
+   ```
+
+   Alternatively, if you don't have `kn` installed you can also use `kubectl`:
 
    ```shell
    kubectl get ksvc helloworld-go
@@ -113,8 +143,7 @@ To see if your app has been deployed successfully, you need the URL created by K
    > configuring DNS (e.g. with `xip.io`), or [using a Custom Domain](../serving/using-a-custom-domain.md).
 
    If you changed the name from `helloworld-go` to something else when creating
-   the `.yaml` file, replace `helloworld-go` in the above commands with the name
-   you entered.
+   the `.yaml` file, replace `helloworld-go` in the above commands with the name you entered.
 
 1. Now you can make a request to your app and see the results. Replace
    the URL with the one returned by the command in the previous step.
@@ -124,7 +153,7 @@ To see if your app has been deployed successfully, you need the URL created by K
    Hello World: Go Sample v1!
    ```
 
-   If you deployed your own app, you might want to customize this cURL request
+   If you deployed your app, you might want to customize this cURL request
    to interact with your application.
 
    It can take a few seconds for Knative to scale up your application and return
@@ -139,11 +168,15 @@ You've successfully deployed your first application using Knative!
 To remove the sample app from your cluster, delete the service record:
 
 ```shell
-kubectl delete --filename service.yaml
+kn service delete helloworld-go
 ```
 
-Alternatively, delete the service by name:
+Alternatively, you can also delete the service with `kubectl` via the definition file or by name.
 
 ```shell
+# Delete with the KService given in the yaml file:
+kubectl delete --filename service.yaml
+
+# Or just delete it by name:
 kubectl delete kservice helloworld-go
 ```

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -109,11 +109,11 @@ To see if your app has been deployed successfully, you need the URL created by K
 
    This will return something like
 
-   ```fence {MD031}
-   Name:       helloworld-go
-   Namespace:  default
-   Age:        12m
-   URL:        http://helloworld-go.default.34.83.80.117.xip.io
+   ```
+   Name        helloworld-go
+   Namespace   default
+   Age         12m
+   URL         http://helloworld-go.default.34.83.80.117.xip.io
 
    Revisions:
      100%  @latest (helloworld-go-dyqsj-1) [1] (39s)
@@ -124,7 +124,7 @@ To see if your app has been deployed successfully, you need the URL created by K
      ++ Ready                  25s
      ++ ConfigurationsReady    26s
      ++ RoutesReady            25s
-   ``` {MD031}
+   ```
 
    Alternatively, if you don't have `kn` installed you can also use `kubectl`:
 

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -41,10 +41,12 @@ The Hello World sample app reads in an `env` variable, `TARGET`, then prints "He
 
 The easiest way to deploy a Knative Service is by using the Knative CLI [kn](https://github.com/knative/client).
 
-**Prerequisite:** install the `kn` binary as described in [Installing the Knative CLI](../install/install-kn.md)
+**Prerequisite:** Install the `kn` binary as described in [Installing the Knative CLI](../install/install-kn.md)
 
-`kn` allows you to create a service interactively on the command line.
-Eventually, it will create a corresponding resource description internally as when using a YAML file directly.
+It will create a corresponding resource description internally as when using a YAML file directly.
+`kn` provides a command-line mechanism for managing Services.
+It allows you to configure every aspect of a Service.
+The only mandatory flag for creating a Service is `--image` with the container image reference as value.
 
 To create a Service directly at the cluster, use:
 
@@ -52,6 +54,9 @@ To create a Service directly at the cluster, use:
 # Create a Knative service with the Knatice CLI kn
 kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go --env TARGET="Go Sample v1"
 ```
+
+If you want to deploy the sample app, leave the `--image` config as-is. If you're
+deploying an image of your app, update the name of the Service and the value of the `--image` flag accordingly.
 
 Now that you have deployed the service, Knative will perform the following steps:
 
@@ -66,7 +71,8 @@ Now that you have deployed the service, Knative will perform the following steps
 Alternatively, to deploy an app using Knative, you can also create the configuration in a YAML file that defines a service. For more information about the Service object, see the
 [Resource Types documentation](https://github.com/knative/serving/blob/master/docs/spec/overview.md#service).
 
-If a configuration file is used, it specifies metadata about the application, points to the hosted image of the app for deployment, and allows the deployment to be
+This configuration file specifies metadata about the application, points to the
+hosted image of the app for deployment, and allows the deployment to be
 configured. For more information about what configuration options are available,
 see the [Serving spec documentation](https://github.com/knative/serving/blob/master/docs/spec/spec.md).
 
@@ -82,15 +88,14 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-samples/helloworld-go # The URL to the image of the app
+        - image: gcr.io/knative-samples/helloworld-go # Reference to the image of the app
           env:
             - name: TARGET # The environment variable printed out by the sample app
               value: "Go Sample v1"
 ```
 
 If you want to deploy the sample app, leave the config file as-is. If you're
-deploying an image of your app, update the name of the app and the URL of
-the image accordingly.
+deploying an image of your app, update the name of the Service (`.metadata.name`) and the reference to the container image (`.spec.containers[].image`) accordingly.
 
 From the directory where the new `service.yaml` file was created, apply the
 configuration:
@@ -99,11 +104,23 @@ configuration:
 kubectl apply --filename service.yaml
 ```
 
+Now that you have deployed the service, Knative will perform the following steps:
+
+- Create a new immutable revision for this version of the app.
+- Perform network programming to create a route, ingress, service, and load
+  balancer for your app.
+- Automatically scale your pods up and down based on traffic, including to zero
+  active pods.
+
 ## Interacting with your app
 
 To see if your app has been deployed successfully, you need the URL created by Knative.
 
-1. To find the URL for your service, enter:
+1. To find the URL for your service, use either `kn` or `kubectl`
+
+  {{< tabs name="create" default="kn">}}
+  {{% tab name="kn" %}}
+
    ```shell
    kn service describe helloworld-go
    ```
@@ -127,7 +144,8 @@ To see if your app has been deployed successfully, you need the URL created by K
      ++ RoutesReady            25s
    ```
 
-   Alternatively, if you don't have `kn` installed you can also use `kubectl`:
+  {{< /tab >}}
+  {{% tab name="kubectl" %}}
 
    ```shell
    kubectl get ksvc helloworld-go
@@ -139,6 +157,9 @@ To see if your app has been deployed successfully, you need the URL created by K
    NAME            URL                                                LATESTCREATED         LATESTREADY           READY   REASON
    helloworld-go   http://helloworld-go.default.34.83.80.117.xip.io   helloworld-go-96dtk   helloworld-go-96dtk   True
    ```
+
+  {{< /tab >}}
+  {{< /tabs >}}
 
    > Note: If your URL includes `example.com` then consult the setup instructions for
    > configuring DNS (e.g. with `xip.io`), or [using a Custom Domain](../serving/using-a-custom-domain.md).

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -39,7 +39,7 @@ The Hello World sample app reads in an `env` variable, `TARGET`, then prints "He
 
 ## Creating your Deployment with the Knative CLI
 
-The easiest way to create Knative service deployment is by using the Knative CLI [kn](https://github.com/knative/client).
+The easiest way to deploy a Knative Service is by using the Knative CLI [kn](https://github.com/knative/client).
 You can install the `kn` binary as described in [Installing the Knative CLI](../install/install-kn.md)
 
 `kn` allows you to create a service interactively on the command line.

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -109,7 +109,7 @@ To see if your app has been deployed successfully, you need the URL created by K
 
    This will return something like
 
-   ```
+   ```fence {MD031}
    Name:       helloworld-go
    Namespace:  default
    Age:        12m
@@ -124,7 +124,7 @@ To see if your app has been deployed successfully, you need the URL created by K
      ++ Ready                  25s
      ++ ConfigurationsReady    26s
      ++ RoutesReady            25s
-   ```
+   ``` {MD031}
 
    Alternatively, if you don't have `kn` installed you can also use `kubectl`:
 


### PR DESCRIPTION
This PR add the usage splits up the walkthrough for the first service into two sections: How to create with YAML and kubectl and how to create a service with kn.

The PR is best reviewed by looking at the file as a whole.

PR replacing #2514 that I have messed up.