### PR TITLE
event_display image seems wrong.  produces "unknown encoding" error.

### DIFF
--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -98,7 +98,7 @@ You must ensure that you meet the [prerequisites listed in the Apache Kafka over
          containers:
            - # This corresponds to
              # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
-             image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+             image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
    ```
 
 1. Deploy the Event Display Service


### PR DESCRIPTION
Using "gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display: produces "unknown encoding error" in this Example.  

Switching to image @ gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display resolves these issues for me.

See: https://github.com/knative/docs/issues/2145

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
- (instead of) image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
-
