### PR TITLE
Python Unbuffered

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-python/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-python/Dockerfile
@@ -2,7 +2,7 @@
 # https://hub.docker.com/_/python
 FROM python:3.7-slim
 
-# Allow statements and log messages to immediately appear in the Cloud Run logs
+# Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True
 
 # Copy local code to the container image.

--- a/docs/serving/samples/hello-world/helloworld-python/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-python/Dockerfile
@@ -2,6 +2,9 @@
 # https://hub.docker.com/_/python
 FROM python:3.7-slim
 
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -54,7 +54,6 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    # Use the official lightweight Python image.
    # https://hub.docker.com/_/python
    FROM python:3.7-slim
-   
    # Allow statements and log messages to immediately appear in the Knative logs
    ENV PYTHONUNBUFFERED True
 

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -54,6 +54,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    # Use the official lightweight Python image.
    # https://hub.docker.com/_/python
    FROM python:3.7-slim
+
    # Allow statements and log messages to immediately appear in the Knative logs
    ENV PYTHONUNBUFFERED True
 

--- a/docs/serving/samples/hello-world/helloworld-python/README.md
+++ b/docs/serving/samples/hello-world/helloworld-python/README.md
@@ -54,6 +54,9 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    # Use the official lightweight Python image.
    # https://hub.docker.com/_/python
    FROM python:3.7-slim
+   
+   # Allow statements and log messages to immediately appear in the Knative logs
+   ENV PYTHONUNBUFFERED True
 
    # Copy local code to the container image.
    ENV APP_HOME /app


### PR DESCRIPTION
Using pythonunbuffered so that  print() statements and log messages will immediately appear in the logs.

Otherwise, you have to use sys.stdout.flush() to print log messages, which is seen as buggy and confusing by our users. 

For example: https://stackoverflow.com/questions/60828641/simplest-way-to-perform-logging-from-google-cloud-run