### PR TITLE
Fix docker images to point to released event_display binary

### DIFF
--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -131,7 +131,7 @@ spec:
       containers:
       -  # This corresponds to
          # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display
-         image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a214514d6ba674d7393ec8448dd272472b2956207acb3f83152d3071f0ab1911
+         image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
 ```
 
 ### Trigger

--- a/docs/eventing/debugging/example.yaml
+++ b/docs/eventing/debugging/example.yaml
@@ -97,7 +97,7 @@ spec:
         - name: user-container
           # This corresponds to
           # https://github.com/knative/eventing-contrib/blob/v0.2.1/cmd/message_dumper/dumper.go.
-          image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/message_dumper@sha256:ab5391755f11a5821e7263686564b3c3cd5348522f5b31509963afb269ddcd63
+          image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/message_dumper
           ports:
             - containerPort: 8080
 

--- a/docs/eventing/samples/apache-camel-source/display_resources.yaml
+++ b/docs/eventing/samples/apache-camel-source/display_resources.yaml
@@ -36,4 +36,4 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:f4628e97a836c77ed38bd3b6fd3d0b06de4d5e7db6704772fe674d48b20bd477
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/container-source/heartbeats-source.yaml
+++ b/docs/eventing/samples/container-source/heartbeats-source.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
         # This corresponds to a heartbeats image uri you build and publish,
-        # e.g. gcr.io/[gcloud-project]/github.com/knative/eventing-contrib/cmd/heartbeats
+        # e.g. gcr.io/[gcloud-project]/knative.dev/eventing-contrib/cmd/heartbeats
         - image: knative.dev/eventing-contrib/cmd/heartbeats
           name: heartbeats
           args:

--- a/docs/eventing/samples/github-source/service.yaml
+++ b/docs/eventing/samples/github-source/service.yaml
@@ -7,4 +7,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/iot-core/trigger.yaml
+++ b/docs/eventing/samples/iot-core/trigger.yaml
@@ -24,4 +24,4 @@ spec:
       containers:
       - # This corresponds to
         # https://github.com/knative/eventing-contrib/blob/release-0.5/cmd/event_display/main.go
-        image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display@sha256:bf45b3eb1e7fc4cb63d6a5a6416cf696295484a7662e0cf9ccdf5c080542c21d
+        image: gcr.io/knative-releases/knative.dev/eventing-sources/cmd/event_display

--- a/docs/eventing/samples/kafka/binding/README.md
+++ b/docs/eventing/samples/kafka/binding/README.md
@@ -48,7 +48,7 @@ via Kafka Source
      template:
        spec:
          containers:
-           - image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+           - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
    ```
 
    ```
@@ -63,7 +63,7 @@ via Kafka Source
    below
 
    ```
-   kn service create event-display --image=gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+   kn service create event-display --image=gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
    ```
 
 1. Ensure that the Service pod is running. The pod name will be prefixed with

--- a/docs/eventing/samples/kafka/binding/event-display.yaml
+++ b/docs/eventing/samples/kafka/binding/event-display.yaml
@@ -20,4 +20,4 @@
      template:
        spec:
          containers:
-         - image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+         - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/kafka/channel/000-ksvc.yaml
+++ b/docs/eventing/samples/kafka/channel/000-ksvc.yaml
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a214514d6ba674d7393ec8448dd272472b2956207acb3f83152d3071f0ab1911
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -69,7 +69,7 @@ Tutorial on how to build and deploy a `KafkaSource` [Eventing source](../../../s
          containers:
            - # This corresponds to
              # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
-             image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+             image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
    ```
 
 1. Deploy the Event Display Service

--- a/docs/eventing/samples/kafka/source/event-display.yaml
+++ b/docs/eventing/samples/kafka/source/event-display.yaml
@@ -20,4 +20,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:a214514d6ba674d7393ec8448dd272472b2956207acb3f83152d3071f0ab1911
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -149,7 +149,7 @@ simple Knative Service that dumps incoming messages to its log and creates a
          containers:
            - # This corresponds to
              # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
-             image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+             image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
    ```
 
 1. If the deployed `ApiServerSource` is pointing at a `Broker` other than

--- a/docs/eventing/samples/kubernetes-event-source/trigger.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/trigger.yaml
@@ -25,4 +25,4 @@ spec:
       containers:
       - # This corresponds to
         # https://github.com/knative/eventing-contrib/tree/master/cmd/event_display/main.go
-        image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+        image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/sinkbinding/README.md
+++ b/docs/eventing/samples/sinkbinding/README.md
@@ -51,7 +51,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
 ```
 
 Use following command to create the service from `service.yaml`:

--- a/docs/eventing/samples/sinkbinding/heartbeats-source.yaml
+++ b/docs/eventing/samples/sinkbinding/heartbeats-source.yaml
@@ -29,7 +29,7 @@ spec:
           restartPolicy: Never
           containers:
             # This corresponds to a heartbeats image uri you build and publish,
-            # e.g. gcr.io/[gcloud-project]/github.com/knative/eventing-contrib/cmd/heartbeats
+            # e.g. gcr.io/[gcloud-project]/knative.dev/eventing-contrib/cmd/heartbeats
             - name: single-heartbeat
               image: knative.dev/eventing-contrib/cmd/heartbeats
               args:

--- a/docs/eventing/samples/sinkbinding/service.yaml
+++ b/docs/eventing/samples/sinkbinding/service.yaml
@@ -20,4 +20,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-contrib/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/eventing/samples/writing-receive-adapter-source/06-yaml.md
+++ b/docs/eventing/samples/writing-receive-adapter-source/06-yaml.md
@@ -40,7 +40,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display@sha256:526fdb25f5c26d25506e88e86f22b122b5d56be7de31091bcb1a46e5e8e50615
+        - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
 ---
 apiVersion: samples.knative.dev/v1alpha1
 kind: SampleSource


### PR DESCRIPTION
Fixes #2487 

## Proposed Changes

- Updates a bunch of docker image links to remove specific version pins and point to the current location that images are published to.