### PR TITLE
Fix #2415

### DIFF
--- a/docs/serving/deploying/private-registry.md
+++ b/docs/serving/deploying/private-registry.md
@@ -78,20 +78,12 @@ You need:
     of your Knative cluster are use by your revisions unless 
     [`serviceAccountName`](../spec/knative-api-specification-1.0.md) is specified.
 
-   1. Run the following command to modify your `default` service account:
-   
-      For example, if you named your secrets `container-registry`, then you
-	  patch it with this.
+   Run the following command to modify your `default` service account, assuming
+   you named your secrets `container-registry`:
 
-       ```shell
-       kubectl patch serviceaccount default -p "{\"imagePullSecrets\": [{\"name\": \"container-registry\"}]}"
-       ```
-
-1. Deploy the updated service account to your Knative cluster:
-
-    ```bash
-   kubectl apply --filename service-account.yaml
-   ```
+    ```shell
+    kubectl patch serviceaccount default -p "{\"imagePullSecrets\": [{\"name\": \"container-registry\"}]}"
+    ```
 
 Now, all the new pods that are created in the `default` namespace will include
 your credentials and have access to your container images in the private registry.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2415

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Remove extraneous steps (they were always extraneous, even from version 1 of the doc).