### PR TITLE
Remove "Configuring DNS" from Installing Istio for Knative

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -139,44 +139,6 @@ spec:
 EOF
 ```
 
-### Configuring DNS
-
-Knative dispatches to different services based on their hostname, so it greatly
-simplifies things to have DNS properly configured. For this, we must look up the
-external IP address that Istio received. This can be done with the following
-command:
-
-```
-$ kubectl get svc -nistio-system
-NAME                    TYPE           CLUSTER-IP   EXTERNAL-IP    PORT(S)                                      AGE
-cluster-local-gateway   ClusterIP      10.0.2.216   <none>         15020/TCP,80/TCP,443/TCP                     2m14s
-istio-ingressgateway    LoadBalancer   10.0.2.24    34.83.80.117   15020:32206/TCP,80:30742/TCP,443:30996/TCP   2m14s
-istio-pilot             ClusterIP      10.0.3.27    <none>         15010/TCP,15011/TCP,8080/TCP,15014/TCP       2m14s
-```
-
-This external IP can be used with your DNS provider with a wildcard `A` record;
-however, for a basic functioning DNS setup (not suitable for production!) this
-external IP address can be used with `xip.io` in the `config-domain` ConfigMap
-in `knative-serving`. You can edit this with the following command:
-
-```
-kubectl edit cm config-domain --namespace knative-serving
-```
-
-Given the external IP above, change the content to:
-
-```
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-domain
-  namespace: knative-serving
-data:
-  # xip.io is a "magic" DNS provider, which resolves all DNS lookups for:
-  # *.{ip}.xip.io to {ip}.
-  34.83.80.117.xip.io: ""
-```
-
 ## Istio resources
 
 - For the official Istio installation guide, see the


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

This patch removes "Configuring DNS" section from Installing Istio for Knative.

It needs to install Knative Serving, so it is not correct to explain
it in Istio which is pre-req.
Also, the configuration is instructed in knative installation.

https://knative.dev/docs/install/any-kubernetes-cluster/
> 4. Configure DNS
`Magic DNS (xip.io)`

Fixes https://github.com/knative/docs/issues/2343
