### PR TITLE
Remove "Verifying your Istio install" from section Installing Istio for Knative

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -139,19 +139,6 @@ spec:
 EOF
 ```
 
-### Verifying your Istio install
-
-View the status of your Istio installation to make sure the install was
-successful. It might take a few seconds, so rerun the following command until
-all of the pods show a `STATUS` of `Running` or `Completed`:
-
-```bash
-kubectl get pods --namespace istio-system
-```
-
-> Tip: You can append the `--watch` flag to the `kubectl get` commands to view
-> the pod status in realtime. You use `CTRL + C` to exit watch mode.
-
 ### Configuring DNS
 
 Knative dispatches to different services based on their hostname, so it greatly


### PR DESCRIPTION
## Proposed Changes

This patch removes "Verifying your Istio install" section from
Installing Istio for Knative.

When we install istio by `istioctl manifest apply` command, the
command verifies the installation and we can determine the
installation success or failure by the command result.

Hence we don't need this section anymore.

/cc @ZhiminXiang @tcnghia 
