### PR TITLE
Add doc on how to use Istio Authorization with Knative and Istio mesh mode

### DIFF
--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -4,7 +4,7 @@ weight: 25
 type: "docs"
 ---
 
-When you deployed app to Knative Serving, serving system pods such as activator and autoscaler access to your app.
+Knative Serving system pods, such as the activator and autoscaler components, require access to your deployed Knative services.
 If you have configured additional security features, such as Istio's authorization policy, you must enable access to your Knative service for these system pods.
 
 > Tip: This example assumes that your application enabled istio sidecar injection.
@@ -52,7 +52,7 @@ It generally works with Kubernetes application, but it does not work with Knativ
 
 ```
 $ kn service create hello-example --image=gcr.io/knative-samples/helloworld-go
-$ curl http://hello-example.default.52.76.125.95.nip.io
+$ curl http://hello-example.default.1.2.3.4.nip.io
 (hang up)
 ```
 

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -83,10 +83,8 @@ spec:
   - from:
     - source:
        namespaces: ["knative-serving"]
-  rules:
-  - to:
-    - operation:
-        paths:
-        - /     # The path for your application.
 EOF
 ```
+
+Some rule like from.source.namespace above needs to require mTLS enabled.
+Please refer to Istio [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) for details.

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -41,12 +41,12 @@ You can enable access by:
 Knative system pods access your application using the following paths:
 
 - `/metrics`
-- `/health`
+- `/healthz`
 
 The /metrics path allows the autoscaler pod to collect metrics.
-The /health path allows system pods to probe the service."
+The /healthz path allows system pods to probe the service."
 
-You can add the `/metrics` and `/health` paths to the AuthorizationPolicy as shown in the example:
+You can add the `/metrics` and `/healthz` paths to the AuthorizationPolicy as shown in the example:
 
 ```
 $ cat <<EOF | kubectl apply -f -

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -32,8 +32,7 @@ EOF
 
 In addition to allowing your application path, you'll need to configure Istio AuthorizationPolicy
 to allow health checking and metrics collection to your applications from system pods.
-You can allow access from system pods
-[by paths](#allow-access-from-system-pods-by-paths) or [by namespace](#allow-access-from-system-pods-by-namespace).
+You can allow access from system pods [by paths](#allow-access-from-system-pods-by-paths).
 
 ## Allowing access from system pods by paths
 
@@ -64,26 +63,3 @@ spec:
         - /healthz   # The path to probe by system pod.
 EOF
 ```
-
-## Allowing access from system pods by namespace
-
-You can allow access for all pods in the `knative-serving` namespace, as shown in the example:
-
-```
-$ cat <<EOF | kubectl apply -f -
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: allowlist-by-namespace
-  namespace: serving-tests
-spec:
-  action: ALLOW
-  rules:
-  - from:
-    - source:
-       namespaces: ["knative-serving"]
-EOF
-```
-
-Some rules like `from.source.namespace` above require mTLS to be enabled.
-Please refer to Istio [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) for details.

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -65,10 +65,13 @@ There are several solutions but this section is going to explain two typical sol
 
 Knative system pods access to your applcation by using the following paths.
 
-- `/metrics` is a path to collect metrics (e.g. autoscaler)
-- `/health` is a path to probe the service (e.g. activator, autoscaler, KIngres's probe)
+- `/metrics`
+- `/health`
 
-Hence you can add `/metrics` and `/healthz` to the whitelist.
+The /metrics path allows the autoscaler pod to collect metrics.
+The /health path allows system pods to probe the service."
+
+You can add the `/metrics` and `/health` paths to the AuthorizationPolicy as shown in the example:
 
 ```
 $ cat <<EOF | kubectl apply -f -
@@ -90,7 +93,7 @@ EOF
 
 ### Allow access from system pods by namespace
 
-As an alternative, You can allow all access from serving system namespace knative-serving. It also make your applications work.
+You can allow access for all pods in the `knative-serving` namespace, as shown in the example:
 
 ```
 $ cat <<EOF | kubectl apply -f -

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -5,7 +5,7 @@ type: "docs"
 ---
 
 When you deployed app to Knative Serving, serving system pods such as activator and autoscaler access to your app.
-Hence, you have to allow the requests to your app when you configure security features such as istio authorization policy.
+If you have configured additional security features, such as Istio's authorization policy, you must enable access to your Knative service for these system pods.
 
 > Tip: This example assumes that your application enabled istio sidecar injection.
 >
@@ -56,14 +56,14 @@ $ curl http://hello-example.default.52.76.125.95.nip.io
 (hang up)
 ```
 
-To access your application, you need to configure "whitelist" for the requests from system pods.
-There are several solutions but this section is going to explain two typical solutions
-[Allow access from system pods by paths](#allow-access-from-system-pods-by-paths) and
-[Allow access from system pods by namespace](#allow-access-from-system-pods-by-namespace).
+To enable access to your application for requests from system pods, you must whitelist the system pods in your Istio AuthorizationPolicy.
+You can enable access by:
+[Allowing access from system pods by paths](#allow-access-from-system-pods-by-paths).
+[Allowing access from system pods by namespace](#allow-access-from-system-pods-by-namespace).
 
-### Allow access from system pods by paths
+### Allowing access from system pods by paths
 
-Knative system pods access to your applcation by using the following paths.
+Knative system pods access your application using the following paths:
 
 - `/metrics`
 - `/health`
@@ -91,7 +91,7 @@ spec:
 EOF
 ```
 
-### Allow access from system pods by namespace
+### Allowing access from system pods by namespace
 
 You can allow access for all pods in the `knative-serving` namespace, as shown in the example:
 

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -1,0 +1,114 @@
+---
+title: "Knative application under the strict authorization policy"
+weight: 25
+type: "docs"
+---
+
+When you deployed app to Knative Serving, serving system pods such as activator and autoscaler access to your app.
+Hence, you have to allow the requests to your app when you configure security features such as istio authorization policy.
+
+> Tip: This example assumes that your application enabled istio sidecar injection.
+>
+> ```
+> $ kubectl create namespace serving-tests
+> $ kubectl label namespace serving-tests istio-injection=enabled
+> ```
+> The following policy example does not work without sidecar injection.
+
+For example, the following authorization policy denies all requests to workloads in namespace serving-tests.
+
+```
+$ cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-all
+  namespace: serving-tests
+spec:
+  {}
+EOF
+```
+
+Then, the following policy allows the request to `/` for your application.
+
+```
+$ cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-app
+  namespace: serving-tests
+spec:
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths:
+        - /     # The path for your application.
+EOF
+```
+
+It generally works with Kubernetes application, but it does not work with Knative application.
+
+```
+$ kn service create hello-example --image=gcr.io/knative-samples/helloworld-go
+$ curl http://hello-example.default.52.76.125.95.nip.io
+(hang up)
+```
+
+To access your application, you need to configure "whitelist" for the requests from system pods.
+There are several solutions but this section is going to explain two typical solutions
+[Allow access from system pods by paths](#allow-access-from-system-pods-by-paths) and
+[Allow access from system pods by namespace](#allow-access-from-system-pods-by-namespace).
+
+### Allow access from system pods by paths
+
+Knative system pods access to your applcation by using the following paths.
+
+- `/metrics` is a path to collect metrics (e.g. autoscaler)
+- `/health` is a path to probe the service (e.g. activator, autoscaler, KIngres's probe)
+
+Hence you can add `/metrics` and `/healthz` to the whitelist.
+
+```
+$ cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: whitelist-by-paths
+  namespace: serving-tests
+spec:
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths:
+        - /metrics   # The path to collect metrics by system pod.
+        - /healthz   # The path to probe by system pod.
+EOF
+```
+
+### Allow access from system pods by namespace
+
+As an alternative, You can allow all access from serving system namespace knative-serving. It also make your applications work.
+
+```
+$ cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: whitelist-by-namespace
+  namespace: serving-tests
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+       namespaces: ["knative-serving"]
+  rules:
+  - to:
+    - operation:
+        paths:
+        - /     # The path for your application.
+EOF
+```

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -11,8 +11,8 @@ If you have configured additional security features, such as Istio's authorizati
 
 You must meet the following prerequisites to use Istio AuthorizationPolicy:
 
+- [Istio must be used for your Knative Ingress](https://knative.dev/docs/install/any-kubernetes-cluster/#installing-the-serving-component).
 - [Istio sidecar injection must be enabled](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/).
-- [Using Istio for your Knative Ingress](https://knative.dev/docs/install/any-kubernetes-cluster/#installing-the-serving-component).
 
 ## Enabling Istio AuthorizationPolicy
 
@@ -30,8 +30,8 @@ spec:
 EOF
 ```
 
-In addition to allowing your application path, you must configure Istio AuthorizationPolicy
-to allow access, such as health checking and metrics collection, to your applications from system pods.
+In addition to allowing your application path, you'll need to configure Istio AuthorizationPolicy
+to allow health checking and metrics collection to your applications from system pods.
 You can allow access from system pods
 [by paths](#allow-access-from-system-pods-by-paths) or [by namespace](#allow-access-from-system-pods-by-namespace).
 
@@ -43,7 +43,7 @@ Knative system pods access your application using the following paths:
 - `/healthz`
 
 The `/metrics` path allows the autoscaler pod to collect metrics.
-The `/healthz` path allows system pods to probe the service."
+The `/healthz` path allows system pods to probe the service.
 
 You can add the `/metrics` and `/healthz` paths to the AuthorizationPolicy as shown in the example:
 

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -11,12 +11,12 @@ If you have configured additional security features, such as Istio's authorizati
 
 You must meet the following prerequisites to use Istio AuthorizationPolicy:
 
-- [Enabling istio sidecar injection](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/).
-- Using net-istio for your Knative Ingress.
+- [Istio sidecar injection must be enabled](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/).
+- [Using Istio for your Knative Ingress](https://knative.dev/docs/install/any-kubernetes-cluster/#installing-the-serving-component).
 
 ## Enabling Istio AuthorizationPolicy
 
-For example, the following authorization policy denies all requests to workloads in namespace serving-tests.
+For example, the following authorization policy denies all requests to workloads in namespace `serving-tests`.
 
 ```
 $ cat <<EOF | kubectl apply -f -
@@ -30,11 +30,10 @@ spec:
 EOF
 ```
 
-In addition to allowing your application path, you must whitelist the system pods in your Istio AuthorizationPolicy
-to enable access to your application for requests from system pods.
-You can enable access by:
-[Allowing access from system pods by paths](#allow-access-from-system-pods-by-paths).
-[Allowing access from system pods by namespace](#allow-access-from-system-pods-by-namespace).
+In addition to allowing your application path, you must configure Istio AuthorizationPolicy
+to allow access, such as health checking and metrics collection, to your applications from system pods.
+You can allow access from system pods
+[by paths](#allow-access-from-system-pods-by-paths) or [by namespace](#allow-access-from-system-pods-by-namespace).
 
 ## Allowing access from system pods by paths
 
@@ -43,8 +42,8 @@ Knative system pods access your application using the following paths:
 - `/metrics`
 - `/healthz`
 
-The /metrics path allows the autoscaler pod to collect metrics.
-The /healthz path allows system pods to probe the service."
+The `/metrics` path allows the autoscaler pod to collect metrics.
+The `/healthz` path allows system pods to probe the service."
 
 You can add the `/metrics` and `/healthz` paths to the AuthorizationPolicy as shown in the example:
 
@@ -53,7 +52,7 @@ $ cat <<EOF | kubectl apply -f -
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: whitelist-by-paths
+  name: allowlist-by-paths
   namespace: serving-tests
 spec:
   action: ALLOW
@@ -75,7 +74,7 @@ $ cat <<EOF | kubectl apply -f -
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: whitelist-by-namespace
+  name: allowlist-by-namespace
   namespace: serving-tests
 spec:
   action: ALLOW
@@ -86,5 +85,5 @@ spec:
 EOF
 ```
 
-Some rule like from.source.namespace above needs to require mTLS enabled.
+Some rules like `from.source.namespace` above require mTLS to be enabled.
 Please refer to Istio [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/) for details.


### PR DESCRIPTION
## Proposed Changes

This patch adds doc on how to use Istio Authorization with Knative.

As described in https://github.com/knative/docs/issues/2569, the sample configuration of Authorizationpolicy is helpful for our users.

Part of https://github.com/knative/docs/issues/2569