### PR TITLE
Added title/aliases to rendor the document

### DIFF
--- a/docs/eventing/samples/ping-source/README.md
+++ b/docs/eventing/samples/ping-source/README.md
@@ -1,3 +1,12 @@
+---
+title: "PingSource example"
+linkTitle: "PingSource"
+weight: 10
+type: "docs"
+aliases:
+  - ../cronjob-source
+---
+
 This example shows how to configure PingSource as an event source for
 functions.
 


### PR DESCRIPTION
https://github.com/knative/docs/issues/2586

- It looks like the block at the top of the README was lost between 0.14
and 0.15. Added the block back.

I think this is what fixes the issues with the tabs being rendered since it is on other files and got dropped for this version. 