### PR TITLE
Updated eventing github sample to v0.15.0

### DIFF
--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -25,7 +25,7 @@ Github Event source lives in the [knative/eventing-contrib](https://github.com/k
 You can install it by running the following (this is currently the latest released version (0.11.2))
 
 ```shell
-kubectl apply -f https://github.com/knative/eventing-contrib/releases/download/v0.11.2/github.yaml
+kubectl apply -f https://github.com/knative/eventing-contrib/releases/download/v0.15.0/github.yaml
 ```
 
 ### Create a Knative Service


### PR DESCRIPTION
Fixes #2578

- The github event source version was still v0.12.* so I updated it to
v0.15.0


