### PR TITLE
Change the CR name from KnativeServing into KnativeEventing

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -98,10 +98,10 @@ The operator CR should be modified to include the full list:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
+kind: KnativeEventing
 metadata:
-  name: knative-serving
-  namespace: knative-serving
+  name: knative-eventing
+  namespace: knative-eventing
 spec:
   registry:
     override:
@@ -118,10 +118,10 @@ target image is `docker.io/knative-images-repo5/DISPATCHER_IMAGE:v0.13.0`:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
+kind: KnativeEventing
 metadata:
-  name: knative-serving
-  namespace: knative-serving
+  name: knative-eventing
+  namespace: knative-eventing
 spec:
   registry:
     override:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- The section of configuring KnativeEventing CR has several typos regarding the CR name and namespace.
