### PR TITLE
CloudEvents 1.0

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -360,7 +360,7 @@ To show the various types of events you can send, you will make three requests:
     curl -v "http://default-broker.event-example.svc.cluster.local" \
       -X POST \
       -H "Ce-Id: say-hello" \
-      -H "Ce-Specversion: 0.3" \
+      -H "Ce-Specversion: 1.0" \
       -H "Ce-Type: greeting" \
       -H "Ce-Source: not-sendoff" \
       -H "Content-Type: application/json" \
@@ -384,7 +384,7 @@ To show the various types of events you can send, you will make three requests:
     curl -v "http://default-broker.event-example.svc.cluster.local" \
       -X POST \
       -H "Ce-Id: say-goodbye" \
-      -H "Ce-Specversion: 0.3" \
+      -H "Ce-Specversion: 1.0" \
       -H "Ce-Type: not-greeting" \
       -H "Ce-Source: sendoff" \
       -H "Content-Type: application/json" \
@@ -407,7 +407,7 @@ To show the various types of events you can send, you will make three requests:
     curl -v "http://default-broker.event-example.svc.cluster.local" \
       -X POST \
       -H "Ce-Id: say-hello-goodbye" \
-      -H "Ce-Specversion: 0.3" \
+      -H "Ce-Specversion: 1.0" \
       -H "Ce-Type: greeting" \
       -H "Ce-Source: sendoff" \
       -H "Content-Type: application/json" \
@@ -444,7 +444,7 @@ After sending events, verify that your events were received by the appropriate `
     ☁️  cloudevents.Event
     Validation: valid
     Context Attributes,
-      specversion: 0.3
+      specversion: 1.0
       type: greeting
       source: not-sendoff
       id: say-hello
@@ -459,7 +459,7 @@ After sending events, verify that your events were received by the appropriate `
     ☁️  cloudevents.Event
     Validation: valid
     Context Attributes,
-      specversion: 0.3
+      specversion: 1.0
       type: greeting
       source: sendoff
       id: say-hello-goodbye
@@ -485,7 +485,7 @@ After sending events, verify that your events were received by the appropriate `
     ☁️  cloudevents.Event
     Validation: valid
     Context Attributes,
-       specversion: 0.3
+       specversion: 1.0
        type: not-greeting
        source: sendoff
        id: say-goodbye
@@ -500,7 +500,7 @@ After sending events, verify that your events were received by the appropriate `
      ☁️  cloudevents.Event
      Validation: valid
      Context Attributes,
-       specversion: 0.3
+       specversion: 1.0
        type: greeting
        source: sendoff
        id: say-hello-goodbye

--- a/docs/eventing/samples/helloworld/helloworld-go/README.md
+++ b/docs/eventing/samples/helloworld/helloworld-go/README.md
@@ -409,7 +409,7 @@ mesh via the Broker and can be delivered to other services using a Trigger
      cloudevents.Event
      Validation: valid
      Context Attributes,
-       specversion: 0.3
+       specversion: 1.0
        type: dev.knative.samples.hifromknative
        source: knative/eventing/samples/hello-world
        id: 8a7384b9-8bbe-4634-bf0f-ead07e450b2a

--- a/docs/eventing/samples/helloworld/helloworld-go/helloworld.go
+++ b/docs/eventing/samples/helloworld/helloworld-go/helloworld.go
@@ -23,6 +23,8 @@ func receive(ctx context.Context, event cloudevents.Event) (*cloudevents.Event, 
 	// This is optional and is intended to show how to respond back with another event after processing.
 	// The response will go back into the knative eventing system just like any other event
 	newEvent := cloudevents.NewEvent()
+	// Setting the ID here is not necessary. When using NewDefaultClient the ID is set
+	// automatically. We set the ID anyway so it appears in the log below.
 	newEvent.SetID(uuid.New().String())
 	newEvent.SetSource("knative/eventing/samples/hello-world")
 	newEvent.SetType("dev.knative.samples.hifromknative")


### PR DESCRIPTION
I saw some references to CloudEvents 0.3 and wanted to clean those up.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Use CloudEvents 1.0 in Eventing Getting Started guide.
- Use CloudEvents 1.0 in Eventing hello world sample.
- Add comment about ID generation in Eventing hello world sample (thanks @n3wscott)

The only remaining reference to 0.3 that I can find is in the GitLabSource sample. That source still uses 0.3 (tracked in https://github.com/knative/eventing-contrib/issues/1325).