### PR TITLE
Template for verifying AutoTLS was moved

### DIFF
--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -308,7 +308,7 @@ be able to handle HTTPS traffic.
 
 1.  Run the following comand to create a Knative Service:
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/knative/docs/master/docs/serving/samples/autoscale-go/service.yaml
+    kubectl apply -f https://raw.githubusercontent.com/knative/docs/master/docs/serving/autoscaling/autoscale-go/service.yaml
     ```
 
 1.  When the certificate is provisioned (which could take up to several minutes depending on 


### PR DESCRIPTION
Auto TLS verification used the `autoscale-go` sample, but it was moved in https://github.com/knative/docs/pull/2439, and not updated here.

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves
 - Didn't find any. I came from the documentation's "*View / Edit this page*" link

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update the link to the deployment template for verifying auto-tls is correctly configured
