### PR TITLE
Update the local cluster gateway link

### DIFF
--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -285,7 +285,7 @@ Update `spec.cluster-local-gateway` to select the labels of the new cluster-loca
 
 ### Default local gateway name:
 
-Go through the guide [here](https://knative.dev/development/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway) to use local cluster gateway,
+Go through the guide [here](https://knative.dev/development/install/installing-istio/#installing-istio-without-sidecar-injection) to use local cluster gateway,
 if you use the default gateway called `cluster-local-gateway`.
 
 ### Non-default local gateway name:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Based on #2613

## Proposed Changes <!-- Describe the changes the PR makes. -->

- This PR updated the link to the local cluster gateway configuration for istio.
