### PR TITLE
change v1beta1 => v1 for eventing components

### DIFF
--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -20,7 +20,7 @@ which uses `InMemoryChannel`:
 Example:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: default
@@ -37,7 +37,7 @@ More complex example, showing the same `Broker` as above
 but with failed events being delivered to Knative Service called `dlq-service`
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: default
@@ -86,7 +86,7 @@ kubectl -n <namespace> delete broker default
 If you have a trigger that is coupled to the `default` broker, and there is no existing `default` broker, you can also annotate using triggers to create a broker:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   annotations:
@@ -115,7 +115,7 @@ Simple example which will receive all the events from the given (`default`) brok
 deliver them to Knative Serving service `my-service`:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: my-service-trigger
@@ -137,7 +137,7 @@ Note that we only support exact matching on string values.
 Example:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: my-service-trigger
@@ -192,7 +192,7 @@ created above (`my-service`). For this example, we use Ping Source, and it
 emits events types `dev.knative.sources.ping`.
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: my-service-trigger
@@ -216,7 +216,7 @@ unspecified.
 The Webhook will default the YAML above to:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: my-service-trigger
@@ -253,7 +253,7 @@ spec:
   sink:
     ref:
       # Deliver events to Broker.
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       kind: Broker
       name: default
 ```

--- a/docs/eventing/broker/mt-channel-based-broker.md
+++ b/docs/eventing/broker/mt-channel-based-broker.md
@@ -105,7 +105,7 @@ To create the MT broker using the default configuration, use the command:
 
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: mybroker
@@ -146,7 +146,7 @@ EOF
 
 ```shell
 kubectl apply -f - <<EOF
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: my-other-broker

--- a/docs/eventing/channels/default-channels.md
+++ b/docs/eventing/channels/default-channels.md
@@ -91,7 +91,7 @@ metadata:
 spec:
   channelTemplate:
     apiVersion: messaging.knative.dev/v1beta1
-￼    kind: InMemoryChannel
+    kind: InMemoryChannel
 ```
 
 When this mechanism is used, two objects are created, a generic `Channel` and an

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -120,7 +120,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
 1. Subscribes to GitHub _pushes_ from any source.
 
    ```yaml
-   apiVersion: eventing.knative.dev/v1beta1
+   apiVersion: eventing.knative.dev/v1
    kind: Trigger
    metadata:
      name: push-trigger
@@ -145,7 +145,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
 1. Subscribes to GitHub _pull requests_ from _knative's eventing_ repository.
 
    ```yaml
-   apiVersion: eventing.knative.dev/v1beta1
+   apiVersion: eventing.knative.dev/v1
    kind: Trigger
    metadata:
      name: gh-knative-eventing-pull-trigger
@@ -166,7 +166,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
 1. Subscribes to Kafka messages sent to the _knative-demo_ topic
 
    ```yaml
-   apiVersion: eventing.knative.dev/v1beta1
+   apiVersion: eventing.knative.dev/v1
    kind: Trigger
    metadata:
      name: kafka-knative-demo-trigger
@@ -188,7 +188,7 @@ Here are a few example Triggers that subscribe to events using exact matching on
    _testing_ topic
 
    ```yaml
-   apiVersion: eventing.knative.dev/v1beta1
+   apiVersion: eventing.knative.dev/v1
    kind: Trigger
    metadata:
      name: gcp-pubsub-knative-testing-trigger
@@ -251,7 +251,7 @@ the next topic: How do we actually populate the registry in the first place?
     bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092
     topics: knative-demo,news
     sink:
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       kind: Broker
       name: default
   ```

--- a/docs/eventing/samples/helloworld/helloworld-go/README.md
+++ b/docs/eventing/samples/helloworld/helloworld-go/README.md
@@ -181,7 +181,7 @@ cd knative-docs/docs/eventing/samples/helloworld/helloworld-go
           targetPort: 8080
     ---
     # Knative Eventing Trigger to trigger the helloworld-go service
-    apiVersion: eventing.knative.dev/v1beta1
+    apiVersion: eventing.knative.dev/v1
     kind: Trigger
     metadata:
       name: helloworld-go
@@ -379,7 +379,7 @@ mesh via the Broker and can be delivered to other services using a Trigger
 
    ```shell
    kubectl --namespace knative-samples apply --filename - << END
-   apiVersion: eventing.knative.dev/v1beta1
+   apiVersion: eventing.knative.dev/v1
    kind: Trigger
    metadata:
      name: event-display

--- a/docs/eventing/samples/helloworld/helloworld-go/sample-app.yaml
+++ b/docs/eventing/samples/helloworld/helloworld-go/sample-app.yaml
@@ -41,7 +41,7 @@ spec:
       targetPort: 8080
 ---
 # Knative Eventing Trigger to trigger the helloworld-go service
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: helloworld-go

--- a/docs/eventing/samples/iot-core/gcp-pubsub-source.yaml
+++ b/docs/eventing/samples/iot-core/gcp-pubsub-source.yaml
@@ -13,6 +13,6 @@ spec:
   googleCloudProject: PROJECT_ID
   topic: TOPIC_NAME
   sink:
-    apiVersion: eventing.knative.dev/v1beta1
+    apiVersion: eventing.knative.dev/v1
     kind: Broker
     name: default

--- a/docs/eventing/samples/iot-core/trigger.yaml
+++ b/docs/eventing/samples/iot-core/trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: iot-demo

--- a/docs/eventing/samples/kafka/channel/020-k8s-events.yaml
+++ b/docs/eventing/samples/kafka/channel/020-k8s-events.yaml
@@ -11,6 +11,6 @@ spec:
     kind: Event
   sink:
     ref:
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       kind: Broker
       name: default

--- a/docs/eventing/samples/kafka/channel/030-trigger.yaml
+++ b/docs/eventing/samples/kafka/channel/030-trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: testevents-trigger

--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -100,7 +100,7 @@ all the YAML files deployed in this sample to point at that namespace.
          kind: Event
      sink:
        ref:
-         apiVersion: eventing.knative.dev/v1beta1
+         apiVersion: eventing.knative.dev/v1
          kind: Broker
          name: default
    ```
@@ -123,7 +123,7 @@ simple Knative Service that dumps incoming messages to its log and creates a
 1. Create a file named `trigger.yaml` and copy the code block below into it.
 
    ```yaml
-   apiVersion: eventing.knative.dev/v1beta1
+   apiVersion: eventing.knative.dev/v1
    kind: Trigger
    metadata:
      name: testevents-trigger

--- a/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/k8s-events.yaml
@@ -11,6 +11,6 @@ spec:
     kind: Event
   sink:
     ref:
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       kind: Broker
       name: default

--- a/docs/eventing/samples/kubernetes-event-source/trigger.yaml
+++ b/docs/eventing/samples/kubernetes-event-source/trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: testevents-trigger

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -115,7 +115,7 @@ spec:
   reply:
     ref:
       kind: Broker
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       name: default
 ```
 
@@ -141,7 +141,7 @@ spec:
   jsonData: '{"message": "Hello world!"}'
   sink:
     ref:
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       kind: Broker
       name: default
 ```
@@ -160,7 +160,7 @@ kubectl -n default create -f ./ping-source.yaml
 ### Create the Trigger targeting the Sequence
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: sequence-trigger
@@ -196,7 +196,7 @@ spec:
       containers:
         - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/appender
 ---
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: display-trigger

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/display-trigger.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
 ---
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: display-trigger

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/ping-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/ping-source.yaml
@@ -7,6 +7,6 @@ spec:
   jsonData: '{"message": "Hello world!"}'
   sink:
     ref:
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       kind: Broker
       name: default

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/trigger.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/trigger.yaml
@@ -1,4 +1,4 @@
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: sequence-trigger


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Addresses: #2609 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Change examples and docs from v1beta1 to v1 for eventing components (Broker/Trigger)
-
-
