### PR TITLE
messaging v1beta1->v1

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -113,11 +113,11 @@ the event destination.
 
 Knative Eventing also defines an event forwarding and persistence layer, called
 a
-[**Channel**](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1beta1/channel_types.go#L57).
+[**Channel**](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1/channel_types.go#L57).
 Each channel is a separate Kubernetes [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 Events are delivered to Services or forwarded to other channels
 (possibly of a different type) using
-[Subscriptions](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1beta1/subscription_types.go).
+[Subscriptions](https://github.com/knative/eventing/blob/master/pkg/apis/messaging/v1/subscription_types.go).
 This allows message delivery in a cluster to vary based on requirements, so that
 some events might be handled by an in-memory implementation while others would
 be persisted using Apache Kafka or NATS Streaming.

--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -161,7 +161,7 @@ In addition to the sources explained below, there are
 [other sources](./sources/README.md) that you can install.
 If you need a Source not covered by the ones mentioned below nor by the other
 [available implementations](./sources/README.md), there is a
-[tutorial on writing a Source with a Receive Adapter](./samples/writing-receive-adapter-source).
+[tutorial on writing a Source with a Receive Adapter](./samples/writing-receive-adapter-source/).
 
 If your code needs to send events as part of its business logic and doesn't fit
 the model of a Source, consider

--- a/docs/eventing/broker/mt-channel-based-broker.md
+++ b/docs/eventing/broker/mt-channel-based-broker.md
@@ -37,7 +37,7 @@ metadata:
   name: imc-channel
 data:
   channelTemplateSpec: |
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
 ```
 

--- a/docs/eventing/channels/default-channels.md
+++ b/docs/eventing/channels/default-channels.md
@@ -42,7 +42,7 @@ metadata:
 data:
   default-ch-config: |
     clusterDefault:
-      apiVersion: messaging.knative.dev/v1beta1
+      apiVersion: messaging.knative.dev/v1
       kind: InMemoryChannel
     namespaceDefaults:
       some-namespace:
@@ -65,7 +65,7 @@ the operator has selected for you.
 For example, this is a valid `Channel` object:
 
 ```yaml
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Channel
 metadata:
   name: my-channel
@@ -83,14 +83,14 @@ For example, this is the output when the default channel is set using the above
 `ConfigMap` configuration:
 
 ```yaml
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Channel
 metadata:
   name: my-channel
   namespace: default
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
 ```
 

--- a/docs/eventing/debugging/README.md
+++ b/docs/eventing/debugging/README.md
@@ -186,7 +186,7 @@ kubectl --namespace knative-debug get apiserversource src -o jsonpath='{.spec.si
 ```
 
 Which should return
-`map[apiVersion:messaging.knative.dev/v1beta1 kind:Channel name:chan]`. If it
+`map[apiVersion:messaging.knative.dev/v1 kind:Channel name:chan]`. If it
 doesn't, then `src` was setup incorrectly and its `spec` needs to be fixed.
 Fixing should be as simple as updating its `spec` to have the correct `sink`
 (see [example.yaml](example.yaml)).

--- a/docs/eventing/debugging/example.yaml
+++ b/docs/eventing/debugging/example.yaml
@@ -24,7 +24,7 @@ spec:
       kind: Event
   sink:
     ref:
-      apiVersion: messaging.knative.dev/v1beta1
+      apiVersion: messaging.knative.dev/v1
       kind: InMemoryChannel
       name: chan
 
@@ -32,7 +32,7 @@ spec:
 
 # The Channel events are sent to.
 
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: InMemoryChannel
 metadata:
   name: chan
@@ -41,14 +41,14 @@ metadata:
 
 # The Subscription to the InMemoryChannel.
 
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Subscription
 metadata:
   name: sub
   namespace: knative-debug
 spec:
   channel:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
     name: chan
   subscriber:

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -16,13 +16,13 @@ events to a dead letter sink.
 Knative Eventing offers fine-grained control on how events are delivered for each subscription by adding a `delivery` section. Consider this example:
 
 ```yaml
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Subscription
 metadata:
   name: with-dead-letter-sink
 spec:
   channel:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
     name: default
   delivery:

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -55,7 +55,7 @@ looks like:
 Omitting irrelevant fields:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1beta1
+apiVersion: eventing.knative.dev/v1
 kind: EventType
 metadata:
   name: dev.knative.source.github.push-34cnb

--- a/docs/eventing/flows/sequence.md
+++ b/docs/eventing/flows/sequence.md
@@ -18,7 +18,7 @@ Sequence has three parts for the Spec:
 
 1. `Steps` which defines the in-order list of `Subscriber`s, aka, which
    functions are executed in the listed order. These are specified using the
-   `messaging.v1beta1.SubscriberSpec` just like you would when creating
+   `messaging.v1.SubscriberSpec` just like you would when creating
    `Subscription`. Each step should be `Addressable`.
 1. `ChannelTemplate` defines the Template which will be used to create
    `Channel`s between the steps.

--- a/docs/eventing/samples/apache-camel-source/display_resources.yaml
+++ b/docs/eventing/samples/apache-camel-source/display_resources.yaml
@@ -1,6 +1,6 @@
 # Channel for testing events.
 
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: InMemoryChannel
 metadata:
   name: camel-test
@@ -9,13 +9,13 @@ metadata:
 
 # Subscription from the CamelSource's output Channel to the Knative Service below.
 
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Subscription
 metadata:
   name: camel-source-display
 spec:
   channel:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
     name: camel-test
   subscriber:

--- a/docs/eventing/samples/apache-camel-source/source_http_poller.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_http_poller.yaml
@@ -21,6 +21,6 @@ spec:
               constant: application/json
   sink:
     ref:
-      apiVersion: messaging.knative.dev/v1beta1
+      apiVersion: messaging.knative.dev/v1
       kind: InMemoryChannel
       name: camel-test

--- a/docs/eventing/samples/apache-camel-source/source_mqtt.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_mqtt.yaml
@@ -27,6 +27,6 @@ spec:
               message: "Forwarding: ${body}"
   sink:
     ref:
-      apiVersion: messaging.knative.dev/v1beta1
+      apiVersion: messaging.knative.dev/v1
       kind: InMemoryChannel
       name: camel-test

--- a/docs/eventing/samples/apache-camel-source/source_telegram.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_telegram.yaml
@@ -30,6 +30,6 @@ spec:
               simple: "${body.text}"
   sink:
     ref:
-      apiVersion: messaging.knative.dev/v1beta1
+      apiVersion: messaging.knative.dev/v1
       kind: InMemoryChannel
       name: camel-test

--- a/docs/eventing/samples/apache-camel-source/source_timer.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_timer.yaml
@@ -23,6 +23,6 @@ spec:
               constant: Hello world!
   sink:
     ref:
-      apiVersion: messaging.knative.dev/v1beta1
+      apiVersion: messaging.knative.dev/v1
       kind: InMemoryChannel
       name: camel-test

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -55,7 +55,7 @@ Now that `KafkaChannel` is set as the default channel configuration, you can use
 ```
 cat <<-EOF | kubectl apply -f -
 ---
-apiVersion: messaging.knative.dev/v1beta1
+apiVersion: messaging.knative.dev/v1
 kind: Channel
 metadata:
   name: testchannel-one

--- a/docs/eventing/samples/parallel/multiple-branches/README.md
+++ b/docs/eventing/samples/parallel/multiple-branches/README.md
@@ -110,7 +110,7 @@ metadata:
   name: odd-even-parallel
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   branches:
     - filter:

--- a/docs/eventing/samples/parallel/multiple-branches/parallel.yaml
+++ b/docs/eventing/samples/parallel/multiple-branches/parallel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: odd-even-parallel
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   branches:
   - filter:

--- a/docs/eventing/samples/parallel/mutual-exclusivity/README.md
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/README.md
@@ -98,7 +98,7 @@ metadata:
   name: me-odd-even-parallel
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   branches:
     - filter:

--- a/docs/eventing/samples/parallel/mutual-exclusivity/parallel.yaml
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/parallel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: me-odd-even-parallel
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   branches:
   - filter:

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -85,7 +85,7 @@ metadata:
   name: sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
     - ref:

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/sequence.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
   - ref:

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -126,7 +126,7 @@ metadata:
   name: first-sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
     - ref:
@@ -168,7 +168,7 @@ metadata:
   name: second-sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
     - ref:

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence1.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: first-sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
   - ref:

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence2.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/sequence2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: second-sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
   - ref:

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -84,7 +84,7 @@ metadata:
   name: sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
     - ref:

--- a/docs/eventing/samples/sequence/sequence-terminal/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/sequence.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
   - ref:

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -97,7 +97,7 @@ metadata:
   name: sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
     - ref:

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/sequence.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/sequence.yaml
@@ -4,7 +4,7 @@ metadata:
   name: sequence
 spec:
   channelTemplate:
-    apiVersion: messaging.knative.dev/v1beta1
+    apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
   steps:
   - ref:
@@ -22,5 +22,5 @@ spec:
   reply:
     ref:
       kind: Broker
-      apiVersion: eventing.knative.dev/v1beta1
+      apiVersion: eventing.knative.dev/v1
       name: default

--- a/docs/eventing/samples/sinkbinding/README.md
+++ b/docs/eventing/samples/sinkbinding/README.md
@@ -111,7 +111,7 @@ Now we will use the heartbeats container to send events to `$K_SINK` every time
 the CronJob runs:
 
 ```yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: heartbeat-cron


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Change messaging resources to v1 from v1beta1.
-
-
