### PR TITLE
Fix incorrect yaml format in "Kubernetes event using the API Server Source"

### DIFF
--- a/docs/eventing/samples/kubernetes-event-source/README.md
+++ b/docs/eventing/samples/kubernetes-event-source/README.md
@@ -41,7 +41,6 @@ all the YAML files deployed in this sample to point at that namespace.
      name: events-sa
      namespace: default
    
-   ---
    apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRole
    metadata:
@@ -56,7 +55,6 @@ all the YAML files deployed in this sample to point at that namespace.
          - list
          - watch
    
-   ---
    apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
    metadata:
@@ -136,7 +134,6 @@ simple Knative Service that dumps incoming messages to its log and creates a
          kind: Service
          name: event-display
 
-   ---
    # This is a very simple Knative Service that writes the input request to its log.
    
    apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
This patch deletes `---` which creates incorrect yaml rendering.

Please refer to https://knative.dev/docs/eventing/samples/kubernetes-event-source/#deployment-steps
The yaml format in `ServiceAccount` is broken.

![image](https://user-images.githubusercontent.com/2138339/86523747-e7734e00-beab-11ea-81eb-5e54e6c1e936.png)
