### PR TITLE
Update KafkaChannel examples to use v1beta1

### DIFF
--- a/docs/eventing/broker/mt-channel-based-broker.md
+++ b/docs/eventing/broker/mt-channel-based-broker.md
@@ -85,7 +85,7 @@ metadata:
   namespace: knative-eventing
 data:
   channelTemplateSpec: |
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1beta1
     kind: KafkaChannel
     spec:
       numPartitions: 3

--- a/docs/eventing/channels/default-channels.md
+++ b/docs/eventing/channels/default-channels.md
@@ -46,7 +46,7 @@ data:
       kind: InMemoryChannel
     namespaceDefaults:
       some-namespace:
-        apiVersion: messaging.knative.dev/v1alpha1
+        apiVersion: messaging.knative.dev/v1beta1
         kind: KafkaChannel
         spec:
           numPartitions: 2

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -12,7 +12,7 @@ Create a new object by configuring the YAML file as follows:
 ```
 cat <<-EOF | kubectl apply -f -
 ---
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: KafkaChannel
 metadata:
   name: my-kafka-channel
@@ -40,7 +40,7 @@ data:
   # Configuration for defaulting channels that do not specify CRD implementations.
   default-ch-config: |
     clusterDefault:
-      apiVersion: messaging.knative.dev/v1alpha1
+      apiVersion: messaging.knative.dev/v1beta1
       kind: KafkaChannel
       spec:
         numPartitions: 3

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -35,7 +35,7 @@ spec:
   config:
     br-default-channel:
       channelTemplateSpec: |
-        apiVersion: messaging.knative.dev/v1alpha1
+        apiVersion: messaging.knative.dev/v1beta1
         kind: KafkaChannel
         spec:
           numPartitions: 10


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes https://github.com/knative/eventing-contrib/issues/1355

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Use v1beta1 of KafkaChannel in docs
-
-
