### PR TITLE
Add multi-tenant GitHub source installation doc

### DIFF
--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -22,11 +22,32 @@ You will need:
 ### Install Github Event Source
 
 Github Event source lives in the [knative/eventing-contrib](https://github.com/knative/eventing-contrib).
-You can install it by running the following (this is currently the latest released version (0.11.2))
+
+{{< tabs name="install-github-source" default="single-tenant" >}}
+{{% tab name="single-tenant" %}}
+
+The following command install the single-tenant GitHub source:
 
 ```shell
-kubectl apply -f https://github.com/knative/eventing-contrib/releases/download/v0.15.0/github.yaml
+kubectl apply -f {{< artifact repo="eventing-contrib" file="github.yaml" >}}
 ```
+
+The single-tenant GitHub source creates one Knative service per GitHub source.
+
+{{< /tab >}}
+
+{{% tab name="multi-tenant" %}}
+
+The following command install the multi-tenant GitHub source:
+
+```shell
+kubectl apply -f {{< artifact repo="eventing-contrib" file="mt-github.yaml" >}}
+```
+
+{{< /tab >}}
+
+The multi-tenant GitHub source creates only one Knative service handling all
+GitHub sources in the cluster.
 
 ### Create a Knative Service
 

--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -1,7 +1,7 @@
 GitHub Source example shows how to wire GitHub events for consumption
 by a Knative Service.
 
-## Before you beging
+## Before you begin
 
 1. Set up [Knative Serving](../../../serving).
 1. Ensure Knative Serving is [configured with a domain

--- a/docs/eventing/samples/github-source/README.md
+++ b/docs/eventing/samples/github-source/README.md
@@ -1,59 +1,20 @@
 GitHub Source example shows how to wire GitHub events for consumption
 by a Knative Service.
 
-## Deployment Steps
+## Before you beging
 
-### Prerequisites
-
-You will need:
-
-1. An internet-accessible Kubernetes cluster with Knative Serving
-   installed. Follow the [installation instructions](../../../install/README.md)
-   if you need to create one.
+1. Set up [Knative Serving](../../../serving).
 1. Ensure Knative Serving is [configured with a domain
    name](../../../serving/using-a-custom-domain.md)
    that allows GitHub to call into the cluster.
 1. If you're using GKE, you'll also want to [assign a static IP address](../../../serving/gke-assigning-static-ip-address.md).
-1. Install [Knative
-   Eventing](../../../eventing). Those
-   instructions also install the default eventing sources, including
-   the `GitHubSource` we'll use.
-
-### Install Github Event Source
-
-Github Event source lives in the [knative/eventing-contrib](https://github.com/knative/eventing-contrib).
-
-{{< tabs name="install-github-source" default="single-tenant" >}}
-{{% tab name="single-tenant" %}}
-
-The following command install the single-tenant GitHub source:
-
-```shell
-kubectl apply -f {{< artifact repo="eventing-contrib" file="github.yaml" >}}
-```
-
-The single-tenant GitHub source creates one Knative service per GitHub source.
-
-{{< /tab >}}
-
-{{% tab name="multi-tenant" %}}
-
-The following command install the multi-tenant GitHub source:
-
-```shell
-kubectl apply -f {{< artifact repo="eventing-contrib" file="mt-github.yaml" >}}
-```
-
-{{< /tab >}}
-
-The multi-tenant GitHub source creates only one Knative service handling all
-GitHub sources in the cluster.
+1. Set up [Knative Eventing](../../../eventing) with the GitHub source.
 
 ### Create a Knative Service
 
-To verify the `GitHubSource` is working, we will create a simple Knative
-`Service` that dumps incoming messages to its log. The `service.yaml` file
-defines this basic service.
+To verify the GitHub source is working, create a simple Knative
+Service that dumps incoming messages to its log. The `service.yaml` file
+defines this basic Service.
 
 ```yaml
 apiVersion: serving.knative.dev/v1

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -746,7 +746,7 @@ kubectl apply --filename {{< artifact repo="eventing-contrib" file="mt-github.ya
 ```
 
 The multi-tenant GitHub source creates only one Knative service handling all
-GitHub sources in the cluster. This source does not support logging and tracing
+GitHub sources in the cluster. This source does not support logging or tracing
 configuration yet.
 
 To learn more about the Github source, try

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -731,11 +731,23 @@ kubectl label namespace default eventing.knative.dev/injection=enabled
 
 {{< feature-state version="v0.2" state="alpha" >}}
 
-The following command installs the Github Source:
+The following command installs the single-tenant Github source:
 
 ```bash
 kubectl apply --filename {{< artifact repo="eventing-contrib" file="github.yaml" >}}
 ```
+
+The single-tenant GitHub source creates one Knative service per GitHub source.
+
+The following command installs the multi-tenant GitHub source:
+
+```bash
+kubectl apply --filename {{< artifact repo="eventing-contrib" file="mt-github.yaml" >}}
+```
+
+The multi-tenant GitHub source creates only one Knative service handling all
+GitHub sources in the cluster. This source does not support logging and tracing
+configuration yet.
 
 To learn more about the Github source, try
 [our sample](../eventing/samples/github-source/README.md)


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2544

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add multi-tenant GitHub source installation documentation
- Update sample
-
