### PR TITLE
Fix the doc for eventing as yaml files are renamed

### DIFF
--- a/docs/install/upgrade-installation.md
+++ b/docs/install/upgrade-installation.md
@@ -67,7 +67,7 @@ upgrade, and these are identified in the release notes. For example, upgrading
 from v0.15.0 to v0.16.0 for Eventing you have to run:
 
 ```bash
-kubectl apply --filename {{< artifact repo="eventing" file="pre-install-to-v0.16.0.yaml" >}}
+kubectl apply --filename {{< artifact repo="eventing" file="eventing-pre-install-jobs.yaml" >}}
 ```
 
 ### Upgrade existing resources to the latest stored version
@@ -106,7 +106,7 @@ upgrade, and these are identified in the release notes. For example, after
 upgrading from v0.15.0 to v0.16.0 for Eventing you should run:
 
 ```bash
-kubectl apply --filename {{< artifact repo="eventing" file="post-install-to-v0.16.0.yaml" >}}
+kubectl apply --filename {{< artifact repo="eventing" file="eventing-post-install-jobs.yaml" >}}
 ```
 
 ## Verifying the upgrade


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- This PR changed the doc of eventing, as yaml files have been renamed.
- This PR is based on https://github.com/knative/eventing/pull/3536.
