### PR TITLE
Split out trigger and broker docs

### DIFF
--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -1,8 +1,3 @@
-Broker and Trigger are CRDs providing an event delivery mechanism that hides the
-details of event routing from the event producer and event consumer.
-
-## Broker
-
 A Broker represents an 'event mesh'. Events are sent to the Broker's ingress and
 are then sent to any subscribers that are interested in that event. Once inside
 a Broker, all metadata other than the CloudEvent is stripped away (e.g. unless
@@ -145,62 +140,6 @@ To delete the `Broker`:
 ```shell
 kubectl delete broker default
 ```
-
-## Trigger
-
-A Trigger represents a desire to subscribe to events from a specific Broker.
-
-Simple example which will receive all the events from the given (`default`) broker and
-deliver them to Knative Serving service `my-service`:
-
-```shell
-kubectl create -f - <<EOF
-apiVersion: eventing.knative.dev/v1
-kind: Trigger
-metadata:
-  name: my-service-trigger
-spec:
-  broker: default
-  subscriber:
-    ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: my-service
-EOF
-```
-
-### Trigger Filtering
-
-Exact match filtering on any number of CloudEvents attributes as well as
-extensions are supported. If your filter sets multiple attributes, an event must
-have all of the attributes for the Trigger to filter it. Note that we only
-support exact matching on string values. 
-
-Example:
-
-```shell
-kubectl create -f - <<EOF
-apiVersion: eventing.knative.dev/v1
-kind: Trigger
-metadata:
-  name: my-service-trigger
-spec:
-  broker: default
-  filter:
-    attributes:
-      type: dev.knative.foo.bar
-      myextension: my-extension-value
-  subscriber:
-    ref:
-      apiVersion: serving.knative.dev/v1
-      kind: Service
-      name: my-service
-EOF
-```
-
-The example above filters events from the `default` Broker that are of type
-`dev.knative.foo.bar` AND have the extension `myextension` with the value
-`my-extension-value`. 
 
 ## Complete end-to-end example
 <!-- TODO: review + clean this section up-->

--- a/docs/eventing/broker/_index.md
+++ b/docs/eventing/broker/_index.md
@@ -2,7 +2,6 @@
 title: "Brokers"
 weight: 60
 type: "docs"
-showlandingtoc: "true"
 ---
 
 {{% readfile file="README.md" %}}

--- a/docs/eventing/triggers/README.md
+++ b/docs/eventing/triggers/README.md
@@ -50,4 +50,4 @@ EOF
 
 The example above filters events from the `default` Broker that are of type
 `dev.knative.foo.bar` AND have the extension `myextension` with the value
-`my-extension-value`. 
+`my-extension-value`.

--- a/docs/eventing/triggers/README.md
+++ b/docs/eventing/triggers/README.md
@@ -1,0 +1,53 @@
+A Trigger represents a desire to subscribe to events from a specific Broker.
+
+Simple example which will receive all the events from the given (`default`) broker and
+deliver them to Knative Serving service `my-service`:
+
+```shell
+kubectl create -f - <<EOF
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: my-service
+EOF
+```
+
+### Trigger Filtering
+
+Exact match filtering on any number of CloudEvents attributes as well as
+extensions are supported. If your filter sets multiple attributes, an event must
+have all of the attributes for the Trigger to filter it. Note that we only
+support exact matching on string values.
+
+Example:
+
+```shell
+kubectl create -f - <<EOF
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: dev.knative.foo.bar
+      myextension: my-extension-value
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: my-service
+EOF
+```
+
+The example above filters events from the `default` Broker that are of type
+`dev.knative.foo.bar` AND have the extension `myextension` with the value
+`my-extension-value`. 

--- a/docs/eventing/triggers/_index.md
+++ b/docs/eventing/triggers/_index.md
@@ -2,7 +2,6 @@
 title: "Triggers"
 weight: 70
 type: "docs"
-showlandingtoc: "true"
 ---
 
 {{% readfile file="README.md" %}}

--- a/docs/eventing/triggers/_index.md
+++ b/docs/eventing/triggers/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Brokers"
-weight: 60
+title: "Triggers"
+weight: 70
 type: "docs"
 showlandingtoc: "true"
 ---


### PR DESCRIPTION
Partially fixes # 2554 
## Proposed Changes

- Split broker and trigger docs into their own sections at top level.
