### PR TITLE
Update SinkBinding example to v1beta1

### DIFF
--- a/docs/eventing/samples/sinkbinding/README.md
+++ b/docs/eventing/samples/sinkbinding/README.md
@@ -75,7 +75,7 @@ In order to direct events to our Event Display, we will first create a
 SinkBinding that will inject `$K_SINK` and "$K_CE_OVERRIDES" into select `Jobs`:
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1beta1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat
@@ -192,7 +192,7 @@ together.  For example, the [`cloudevents-go`
 sample](../../../serving/samples/cloudevents/cloudevents-go) may be bound with:
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1beta1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat

--- a/docs/eventing/samples/sinkbinding/sinkbinding.yaml
+++ b/docs/eventing/samples/sinkbinding/sinkbinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: sources.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1beta1
 kind: SinkBinding
 metadata:
   name: bind-heartbeat


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes https://github.com/knative/docs/issues/2663
Helps with https://github.com/knative/eventing/issues/3544

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updating example to use v1beta1

