### PR TITLE
Fixes #2675 The channel-broker.yaml doesn't exist anymore but it stil…

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -551,7 +551,7 @@ The following command installs an implementation of Channel that runs in-memory.
 The following command installs an implementation of Broker that utilizes Channels:
 
    ```bash
-   kubectl apply --filename {{< artifact repo="eventing" file="channel-broker.yaml" >}}
+   kubectl apply --filename {{< artifact repo="eventing" file="deprecated-channel-broker.yaml" >}}
    ```
 
 To customize which broker channel implementation is used, update the following

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -551,7 +551,7 @@ The following command installs an implementation of Channel that runs in-memory.
 The following command installs an implementation of Broker that utilizes Channels:
 
    ```bash
-   kubectl apply --filename {{< artifact repo="eventing" file="deprecated-channel-broker.yaml" >}}
+   kubectl apply --filename {{< artifact repo="eventing" file="mt-channel-broker.yaml" >}}
    ```
 
 To customize which broker channel implementation is used, update the following
@@ -567,7 +567,7 @@ ConfigMap to specify which configurations are used for which namespaces:
      default-br-config: |
        # This is the cluster-wide default broker channel.
        clusterDefault:
-         brokerClass: ChannelBasedBroker
+         brokerClass: MTChannelBasedBroker
          apiVersion: v1
          kind: ConfigMap
          name: imc-channel


### PR DESCRIPTION
…l reported in the documentation of 0.15.x

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2675 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Pointing to the deprecated channel broker yaml
-
-
