### PR TITLE
Fix broken link for installation guide

### DIFF
--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -13,7 +13,7 @@ that are active when running Knative Serving.
 
 1. This guide assumes that you have installed Knative Serving. If you have not,
    instructions on how to do this are located
-   [here](https://knative.dev/docs/install/knative-custom-install/).
+   [here](https://knative.dev/docs/install/any-kubernetes-cluster/).
 2. Verify that you have the proper components in your cluster. To view the
    services installed in your cluster, use the command:
 


### PR DESCRIPTION
This patch fixes a broken link to installation guide.

It pointed to custom installation guide, which was obsoleted.
This patch replaces it with an installation guide.

Fixes https://github.com/knative/docs/issues/2607