### PR TITLE
Remove warning about activator load balancing behaviour

### DIFF
--- a/docs/serving/autoscaling/concurrency.md
+++ b/docs/serving/autoscaling/concurrency.md
@@ -113,8 +113,6 @@ Requests numbered 7 to 10 will still be sent to the existing replicas, but this 
 * **Possible values:** float
 * **Default:** `70`
 
-**Note:** If the activator is in the routing path, it will fully load all replicas up to `containerConcurrency`. It currently does not take target utilization into account.
-
 **Example:**
 {{< tabs name="target-utilization" default="Per Revision" >}}
 {{% tab name="Per Revision" %}}


### PR DESCRIPTION
As of https://github.com/knative/serving/pull/8263 the activator no longer has this behaviour when in the path, and instead does nice round-robin load balancing, so this warning is no longer needed \o/.

/assign @markusthoemmes  
