### PR TITLE
Fix dry-run flag name

### DIFF
--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -18,11 +18,11 @@ Flags can have the following values:
 * Disabled: the feature cannot be enabled.
 
 These three states don't make sense for all features.
-Let's consider two types of features: `multi-container` and `kubernetes/podspec-dryrun`.
+Let's consider two types of features: `multi-container` and `kubernetes.podspec-dryrun`.
 
 `multi-container` allows the user to specify more than one container in the Knative Service spec. In this case, `Enabled` and `Allowed` are equivalent because using this feature requires to actually use it in the Knative Service spec. If a single container is specified, whether the feature is enabled or not doesn't change anything.
 
-`kubernetes/podspec-dryrun` changes the behavior of the Kubernetes implementation of the Knative API, but it has nothing to do with the Knative API itself. In this case, `Enabled` means the feature will be enabled unconditionally, `Allowed` means that the feature will be enabled only when specified with an annotation, and `Disabled` means that the feature cannot be used at all.
+`kubernetes.podspec-dryrun` changes the behavior of the Kubernetes implementation of the Knative API, but it has nothing to do with the Knative API itself. In this case, `Enabled` means the feature will be enabled unconditionally, `Allowed` means that the feature will be enabled only when specified with an annotation, and `Disabled` means that the feature cannot be used at all.
 
 ## Lifecyle
 Features and extensions go through 3 similar phases (Alpha, Beta, GA) but with important differences.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Issue https://github.com/knative/docs/issues/2684

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix the name of the dry-run feature flag. `/` isn't a legal character for flags.