### PR TITLE
typos in kafka source

### DIFF
--- a/docs/eventing/samples/kafka/source/README.md
+++ b/docs/eventing/samples/kafka/source/README.md
@@ -170,7 +170,7 @@ Tutorial on how to build and deploy a `KafkaSource` [Eventing source](../../../s
        }
 
    ```
-   Now manually delete the kafkasource deployment and allow the `kafka-controller-manager` deployment running in `native-sources` namespace to redploy it. Debug level logs should be visible now.
+   Now manually delete the kafkasource deployment and allow the `kafka-controller-manager` deployment running in `knative-sources` namespace to redeploy it. Debug level logs should be visible now.
 
    ```
    $ kubectl logs --selector='knative-eventing-source-name=kafka-source'


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Addresses some typos in the Kafka Source tutorial.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- change `native-source` to `knative-source`
- change `redploy` to `redeploy`
