### PR TITLE
Update docs to fix broken link

### DIFF
--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -13,7 +13,7 @@ that are active when running Knative Serving.
 
 1. This guide assumes that you have installed Knative Serving. If you have not,
    instructions on how to do this are located
-   [here](https://knative.dev/docs/install/knative-custom-install/).
+   [here](https://knative.dev/docs/install/).
 2. Verify that you have the proper components in your cluster. To view the
    services installed in your cluster, use the command:
 


### PR DESCRIPTION
The page "Knative Kubernetes Services" linked to a page that doesn't exist anymore. This PR updates the link. 
