### PR TITLE
Label to k8s service instead of route

### DIFF
--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -47,7 +47,7 @@ kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local
 To label a Kubernetes service:
 
 ```shell
-kubectl label route ${SERVICE_NAME} serving.knative.dev/visibility=cluster-local
+kubectl label service ${SERVICE_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
 By labeling the Kubernetes service it allows you to restrict visibility in a more


### PR DESCRIPTION
Fixes https://github.com/knative/docs/issues/2702

## Proposed Changes <!-- Describe the changes the PR makes. -->

- This patch fixes wrong resource name to label. It should be `service` instead of `route` under the `To label a Kubernetes service:`.

/cc @abrennan89 @ajtomato
