### PR TITLE
Fix missing hyphen in eventing getting started guide

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -63,7 +63,7 @@ demonstrate how you can configure your event producers to target a specific cons
    command:
 
      ```
-     kubectl -n event-example apply -f << EOF
+     kubectl -n event-example apply -f - << EOF
      apiVersion: apps/v1
      kind: Deployment
      metadata:


### PR DESCRIPTION
The recent clean up https://github.com/knative/docs/pull/2662/files#diff-09662e63bc9f84d2728157a440719f4cR66 removed the `-` and started failing to the command.

This patch adds it.

/cc @abrennan89 @vaikas @lionelvillard