### PR TITLE
[release-0.16] Add the section to describe the field spec.version (#2697)

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -8,11 +8,38 @@ aliases:
 
 The Knative Eventing operator can be configured with these options:
 
+- [Version Configuration](#version-configuration)
 - [Eventing Configuration by ConfigMap](#eventing-configuration-by-configMap)
 - [Private repository and private secret](#private-repository-and-private-secrets)
 - [Configuring default broker class](#configuring-default-broker-class)
 
 __NOTE:__ Kubernetes spec level policies cannot be configured using the Knative operators.
+
+## Version Configuration
+
+Cluster administrators can install a specific version of Knative Eventing by using the `spec.version` field. For example,
+if you want to install Knative Eventing 0.16.0, you can apply the following `KnativeEventing` custom resource:
+
+```
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  version: 0.16.0
+```
+
+If `spec.version` is not specified, the Knative Operator will install the latest available version of Knative Eventing.
+If users specify an invalid or unavailable version, the Knative Operator will do nothing. The Knative Operator always
+includes the latest 3 minor release versions. For example, if the current version of the Knative Operator is 0.16.x, the
+earliest version of Knative Eventing available through the Operator is 0.14.0.
+
+If Knative Eventing is already managed by the Operator, updating the `spec.version` field in the `KnativeEventing` resource
+enables upgrading or downgrading the Knative Eventing version, without needing to change the Operator.
+
+Note that the Knative Operator only permits upgrades or downgrades by one minor release version at a time. For example,
+if the current Knative Eventing deployment is version 0.14.x, you must upgrade to 0.15.x before upgrading to 0.16.x.
 
 ## Eventing Configuration by ConfigMap
 

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -8,6 +8,7 @@ aliases:
 
 The Knative Serving operator can be configured with these options:
 
+- [Version Configuration](#version-configuration)
 - [Serving Configuration by ConfigMap](#serving-configuration-by-configMap)
 - [Private repository and private secret](#private-repository-and-private-secrets)
 - [SSL certificate for controller](#ssl-certificate-for-controller)
@@ -15,6 +16,32 @@ The Knative Serving operator can be configured with these options:
 - [Cluster local gateway](#configuration-of-cluster-local-gateway)
 - [High availability](#high-availability)
 - [System Resource Settings](#system-resource-settings)
+
+## Version Configuration
+
+Cluster administrators can install a specific version of Knative Serving by using the `spec.version` field. For example,
+if you want to install Knative Serving 0.16.0, you can apply the following `KnativeServing` custom resource:
+
+```
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  version: 0.16.0
+```
+
+If `spec.version` is not specified, the Knative Operator will install the latest available version of Knative Serving.
+If users specify an invalid or unavailable version, the Knative Operator will do nothing. The Knative Operator always
+includes the latest 3 minor release versions. For example, if the current version of the Knative Operator is 0.16.x, the
+earliest version of Knative Serving available through the Operator is 0.14.0.
+
+If Knative Serving is already managed by the Operator, updating the `spec.version` field in the `KnativeServing` resource
+enables upgrading or downgrading the Knative Serving version, without needing to change the Operator.
+
+Note that the Knative Operator only permits upgrades or downgrades by one minor release version at a time. For example,
+if the current Knative Serving deployment is version 0.14.x, you must upgrade to 0.15.x before upgrading to 0.16.x.
 
 ## Serving Configuration by ConfigMap
 


### PR DESCRIPTION

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Cherry-pick of e8f35156bb1c31330cb77292b60bcf70ae25bac6 

## Proposed Changes <!-- Describe the changes the PR makes. -->

* Add the section to describe the field spec.version

* Change the description on the included releases

* Add the limitation about upgrade and downgrade

* Resolved the comments

* Update the `spec.version` docs
