### PR TITLE
Add documentation for max-scale global setting

### DIFF
--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -48,7 +48,7 @@ spec:
 This value controls the maximum number of replicas that each revision should have.
 Knative will attempt to never have more than this number of replicas running, or in the process of being created, at any one point in time.
 
-* **Global key:** n/a
+* **Global key:** max-scale
 * **Per-revision annotation key:** `autoscaling.knative.dev/maxScale`
 * **Possible values:** integer
 * **Default:** `0` which means unlimited
@@ -71,6 +71,31 @@ spec:
       containers:
         - image: gcr.io/knative-samples/helloworld-go
 ```
+{{< /tab >}}
+
+{{% tab name="Global (ConfigMap)" %}}
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+data:
+  max-scale: "3"
+```
+{{< /tab >}}
+{{% tab name="Global (Operator)" %}}
+```yaml
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    autoscaler:
+      max-scale: "3"
+```
+
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -48,7 +48,7 @@ spec:
 This value controls the maximum number of replicas that each revision should have.
 Knative will attempt to never have more than this number of replicas running, or in the process of being created, at any one point in time.
 
-* **Global key:** max-scale
+* **Global key:** `max-scale`
 * **Per-revision annotation key:** `autoscaling.knative.dev/maxScale`
 * **Possible values:** integer
 * **Default:** `0` which means unlimited


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add documentation for new max-scale global config addressed by issue knative/serving#8627 and introduced in knative/serving#8951.
