### PR TITLE
update pingsource doc to use v1beta1 API

### DIFF
--- a/docs/eventing/samples/parallel/multiple-branches/README.md
+++ b/docs/eventing/samples/parallel/multiple-branches/README.md
@@ -150,13 +150,13 @@ This will create a PingSource which will send a CloudEvent with
 `{"message": "Even or odd?"}` as the data payload every minute.
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source
 spec:
   schedule: "*/1 * * * *"
-  data: '{"message": "Even or odd?"}'
+  jsonData: '{"message": "Even or odd?"}'
   sink:
     ref:
       apiVersion: flows.knative.dev/v1

--- a/docs/eventing/samples/parallel/multiple-branches/ping-source.yaml
+++ b/docs/eventing/samples/parallel/multiple-branches/ping-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/parallel/mutual-exclusivity/README.md
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/README.md
@@ -133,7 +133,7 @@ This will create a PingSource which will send a CloudEvent with
 `{"message": "Even or odd?"}` as the data payload every minute.
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: me-ping-source

--- a/docs/eventing/samples/parallel/mutual-exclusivity/ping-source.yaml
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/ping-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: me-ping-source

--- a/docs/eventing/samples/ping-source/README.md
+++ b/docs/eventing/samples/ping-source/README.md
@@ -1,5 +1,5 @@
-This example shows how to configure PingSource as an event source for
-functions.
+This example shows how to configure PingSource as an event source targeting
+a Knative Service.
 
 ## Before you begin
 
@@ -50,7 +50,7 @@ Use following command to create the event source from STDIN:
 
 ```shell
 cat <<EOF | kubectl create -f -
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: test-ping-source

--- a/docs/eventing/samples/ping-source/ping-source.yaml
+++ b/docs/eventing/samples/ping-source/ping-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: test-ping-source

--- a/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-event-display/README.md
@@ -141,7 +141,7 @@ This will create a PingSource which will send a CloudEvent with {"message":
 "Hello world!"} as the data payload every 2 minutes.
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/README.md
@@ -221,7 +221,7 @@ This will create a PingSource which will send a CloudEvent with
 `{"message": "Hello world!"}` as the data payload every 2 minutes.
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/sequence/sequence-reply-to-sequence/ping-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-reply-to-sequence/ping-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -115,7 +115,7 @@ This will create a PingSource which will send a CloudEvent with
 `{"message": "Hello world!"}` as the data payload every 2 minutes.
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/sequence/sequence-terminal/ping-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-terminal/ping-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -138,7 +138,7 @@ This will create a PingSource which will send a CloudEvent with {"message":
 "Hello world!"} as the data payload every 2 minutes.
 
 ```yaml
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/ping-source.yaml
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/ping-source.yaml
@@ -1,4 +1,4 @@
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: ping-source

--- a/docs/eventing/sources/pingsource.md
+++ b/docs/eventing/sources/pingsource.md
@@ -79,7 +79,7 @@ You can now create the `PingSource` sending an event containing
 
 ```shell
 kubectl create -n pingsource-example -f - <<EOF
-apiVersion: sources.knative.dev/v1alpha2
+apiVersion: sources.knative.dev/v1beta1
 kind: PingSource
 metadata:
   name: test-ping-source


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update PingSource code/sample to use v1beta1
-
-
