### PR TITLE
Updates a broken docker link to docker.io

### DIFF
--- a/docs/serving/deploying/private-registry.md
+++ b/docs/serving/deploying/private-registry.md
@@ -43,7 +43,7 @@ You need:
 
        Examples:
        - Google Container Registry: [https://gcr.io/](https://gcr.io/)
-       - DockerHub [https://index.docker.io/v1/](https://index.docker.io/v1/)
+       - DockerHub [https://docker.io/](https://docker.io/)
 
     * `[PRIVATE_REGISTRY_EMAIL]` is your email address that is associated with
       the private registry.


### PR DESCRIPTION
Fixes #2570 

## Proposed Changes

- Updates the dockerhub url. The previous URL was broken.
