### PR TITLE
Fix URL to net-istio for istio manifest

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,14 +17,14 @@
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 function install_istio() {
-  ISTIO_VERSION=$(curl https://raw.githubusercontent.com/knative/serving/master/third_party/istio-1.5-latest)
+  ISTIO_VERSION=$(curl https://raw.githubusercontent.com/knative-sandbox/net-istio/master/third_party/istio-stable)
   echo ">> Bringing up Istio"
   echo ">> Running Istio CRD installer"
-  kubectl apply -f "https://raw.githubusercontent.com/knative/serving/master/third_party/${ISTIO_VERSION}/istio-crds.yaml" || return 1
+  kubectl apply -f "https://raw.githubusercontent.com/knative-sandbox/net-istio/master/third_party/${ISTIO_VERSION}/istio-crds.yaml" || return 1
   wait_until_batch_job_complete istio-system || return 1
 
   echo ">> Running Istio"
-  kubectl apply -f "https://raw.githubusercontent.com/knative/serving/master/third_party/${ISTIO_VERSION}/istio-ci-no-mesh.yaml" || return 1
+  kubectl apply -f "https://raw.githubusercontent.com/knative-sandbox/net-istio/master/third_party/${ISTIO_VERSION}/istio-ci-no-mesh.yaml" || return 1
   wait_until_pods_running istio-system || return 1
 }
 


### PR DESCRIPTION
Currently integration test is failing like https://github.com/knative/docs/pull/2735 / [log](https://prow.knative.dev/view/gs/knative-prow/pr-logs/pull/knative_docs/2735/pull-knative-docs-integration-tests/1293718156736466944).
It is because https://github.com/knative/serving/commit/0a29c97556466ebf1a99566b66732796d0c3f7a4 deleted istio manifests in serving repo.

This patch fixes the URL for Istio manifest.
