### PR TITLE
remove spec / annotations so broker uses defaults

### DIFF
--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -19,7 +19,9 @@ Triggers register a subscriber's interest in a particular class of events, so th
 
 ## Default Broker configuration
 
-Knative Eventing provides a `config-br-defaults` ConfigMap, which lives in the `knative-eventing` namespace, and provides default configuration settings to enable the creation of Brokers and Channels.
+Knative Eventing provides a `config-br-defaults` ConfigMap, which lives in the
+`knative-eventing` namespace, and provides default configuration settings to
+enable the creation of Brokers and Channels by using defaults.
 For more information, see the [`config-br-defaults`](./config-br-defaults.md) ConfigMap documentation.
 
 Create a Broker using the default settings:
@@ -29,16 +31,8 @@ kubectl create -f - <<EOF
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
-  annotations:
-    eventing.knative.dev/broker.class: MTChannelBasedBroker
   name: default
   namespace: default
-spec:
-  config:
-    apiVersion: v1
-    kind: ConfigMap
-    name: config-br-default-channel
-    namespace: knative-eventing
 EOF
 ```
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2753

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Remove spec / annotations broker.class so `config-br-defaults` values will actually be used.
-
-
