### PR TITLE
add an explicit Broker creation not relying on defaults

### DIFF
--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -36,11 +36,18 @@ metadata:
 EOF
 ```
 
-## Explicit Broker configuration
+## Configuring broker classes
 
-You can of course create a Broker without relying on the defaults (as described
-above) by specifying the `BrokerClass` by using an annotation to specify which
-Broker implementation you'd like to use:
+You can configure Knative Eventing so that when you create a broker, it uses a
+different type of broker than the default Knative channel-based broker. To
+configure a different broker type, or *class*, you must modify the
+`eventing.knative.dev/broker.class` annotation and `spec.config` for the Broker
+object. `MTChannelBasedBroker` is the broker class default.
+
+### Procedure
+
+1. Modify the `eventing.knative.dev/broker.class` annotation. Replace
+`MTChannelBasedBroker` with the class type you want to use:
 
 ```yaml
 kind: Broker
@@ -49,7 +56,9 @@ metadata:
     eventing.knative.dev/broker.class: MTChannelBasedBroker
 ```
 
-and explicitly configuring the spec.config, for example:
+1. Configure the `spec.config` with the details of the ConfigMap that defines
+the backing channel for the broker class: 
+
 ```yaml
 kind: Broker
 spec:
@@ -60,7 +69,7 @@ spec:
     namespace: knative-eventing
 ```
 
-A full example could look something like this:
+A full example combined into a fully specified resource could look like this:
 
 ```shell
 kubectl create -f - <<EOF

--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -51,7 +51,7 @@ metadata:
 
 and explicitly configuring the spec.config, for example:
 ```yaml
-kind: Broker	kind: Broker
+kind: Broker
 spec:
   config:
     apiVersion: v1

--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -71,8 +71,7 @@ spec:
 
 A full example combined into a fully specified resource could look like this:
 
-```shell
-kubectl create -f - <<EOF
+```yaml
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
@@ -86,7 +85,6 @@ spec:
     kind: ConfigMap
     name: config-br-default-channel
     namespace: knative-eventing
-EOF
 ```
 
 ## Next steps

--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -57,7 +57,7 @@ metadata:
 ```
 
 1. Configure the `spec.config` with the details of the ConfigMap that defines
-the backing channel for the broker class: 
+the backing channel for the broker class:
 
 ```yaml
 kind: Broker

--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -36,6 +36,50 @@ metadata:
 EOF
 ```
 
+## Explicit Broker configuration
+
+You can of course create a Broker without relying on the defaults (as described
+above) by specifying the `BrokerClass` by using an annotation to specify which
+Broker implementation you'd like to use:
+
+```yaml
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: MTChannelBasedBroker
+```
+
+and explicitly configuring the spec.config, for example:
+```yaml
+kind: Broker	kind: Broker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: config-br-default-channel
+    namespace: knative-eventing
+```
+
+A full example could look something like this:
+
+```shell
+kubectl create -f - <<EOF
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: MTChannelBasedBroker
+  name: default
+  namespace: default
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: config-br-default-channel
+    namespace: knative-eventing
+EOF
+```
+
 ## Next steps
 
 After you have created a Broker, you can complete the following tasks to finish setting up event delivery.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Add an example that does not rely on defaults for creating a Broker.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add an example that does not rely on defaults for creating a Broker.

-
-
