### PR TITLE
Deliver events to a particular path of a Trigger subscriber

### DIFF
--- a/docs/eventing/triggers/README.md
+++ b/docs/eventing/triggers/README.md
@@ -1,5 +1,7 @@
 A Trigger represents a desire to subscribe to events from a specific Broker.
 
+The `subscriber` value must be a [Destination](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination).
+
 Simple example which will receive all the events from the given (`default`) broker and
 deliver them to Knative Serving service `my-service`:
 
@@ -16,6 +18,26 @@ spec:
       apiVersion: serving.knative.dev/v1
       kind: Service
       name: my-service
+EOF
+```
+
+Simple example which will receive all the events from the given (`default`) broker and
+deliver them to Kubernetes service `my-service` to a custom path `/my-custom-path`:
+
+```shell
+kubectl create -f - <<EOF
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+spec:
+  broker: default
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: my-service
+    uri: /my-custom-path
 EOF
 ```
 

--- a/docs/eventing/triggers/README.md
+++ b/docs/eventing/triggers/README.md
@@ -22,7 +22,7 @@ EOF
 ```
 
 Simple example which will receive all the events from the given (`default`) broker and
-deliver them to Kubernetes service `my-service` to a custom path `/my-custom-path`:
+deliver them to the custom path `/my-custom-path` for the Kubernetes service `my-service`:
 
 ```shell
 kubectl create -f - <<EOF


### PR DESCRIPTION
Fixes #2759

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Document trigger.spec.subscriber type and usage with a particular path


