### PR TITLE
build API docs for 0.17

### DIFF
--- a/docs/reference/eventing/eventing-contrib.md
+++ b/docs/reference/eventing/eventing-contrib.md
@@ -1,12 +1,6 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#bindings.knative.dev%2fv1alpha1">bindings.knative.dev/v1alpha1</a>
-</li>
-<li>
 <a href="#messaging.knative.dev%2fv1alpha1">messaging.knative.dev/v1alpha1</a>
 </li>
 <li>
@@ -18,7 +12,1414 @@
 <li>
 <a href="#sources.knative.dev%2fv1beta1">sources.knative.dev/v1beta1</a>
 </li>
+<li>
+<a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#bindings.knative.dev%2fv1alpha1">bindings.knative.dev/v1alpha1</a>
+</li>
 </ul>
+<h2 id="messaging.knative.dev/v1alpha1">messaging.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>
+</li><li>
+<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>
+</li></ul>
+<h3 id="messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel
+</h3>
+<p>
+<p>KafkaChannel is a resource representing a Kafka Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>KafkaChannel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannelSpec">
+KafkaChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>numPartitions</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationFactor</code></br>
+<em>
+int16
+</em>
+</td>
+<td>
+<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
+</em>
+</td>
+<td>
+<p>KafkaChannel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannelStatus">
+KafkaChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the KafkaChannel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel
+</h3>
+<p>
+<p>NatssChannel is a resource representing a NATSS Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>NatssChannel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.NatssChannelSpec">
+NatssChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
+</em>
+</td>
+<td>
+<p>NatssChannel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1alpha1.NatssChannelStatus">
+NatssChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the NatssChannel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.KafkaChannelSpec">KafkaChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>)
+</p>
+<p>
+<p>KafkaChannelSpec defines the specification for a KafkaChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>numPartitions</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationFactor</code></br>
+<em>
+int16
+</em>
+</td>
+<td>
+<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
+</em>
+</td>
+<td>
+<p>KafkaChannel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.KafkaChannelStatus">KafkaChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>)
+</p>
+<p>
+<p>KafkaChannelStatus represents the current state of a KafkaChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>KafkaChannel is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.NatssChannelSpec">NatssChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>)
+</p>
+<p>
+<p>NatssChannelSpec defines the specification for a NatssChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
+</em>
+</td>
+<td>
+<p>NatssChannel conforms to Duck type Subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1alpha1.NatssChannelStatus">NatssChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>)
+</p>
+<p>
+<p>NatssChannelStatus represents the current state of a NatssChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>NatssChannel is Addressable. It currently exposes the endpoint as a
+fully-qualified DNS name which will distribute traffic over the
+provided targets from inside the cluster.</p>
+<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel</a>
+</li></ul>
+<h3 id="messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel
+</h3>
+<p>
+<p>KafkaChannel is a resource representing a Kafka Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>KafkaChannel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.KafkaChannelSpec">
+KafkaChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>numPartitions</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationFactor</code></br>
+<em>
+int16
+</em>
+</td>
+<td>
+<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1.ChannelableSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.KafkaChannelStatus">
+KafkaChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the KafkaChannel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.KafkaChannelSpec">KafkaChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel</a>)
+</p>
+<p>
+<p>KafkaChannelSpec defines the specification for a KafkaChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>numPartitions</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replicationFactor</code></br>
+<em>
+int16
+</em>
+</td>
+<td>
+<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1.ChannelableSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.KafkaChannelStatus">KafkaChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel</a>)
+</p>
+<p>
+<p>KafkaChannelStatus represents the current state of a KafkaChannel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableStatus</code></br>
+<em>
+knative.dev/eventing/pkg/apis/duck/v1.ChannelableStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableStatus</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="bindings.knative.dev/v1beta1">bindings.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="bindings.knative.dev/v1beta1.KafkaAuthSpec">KafkaAuthSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaBindingSpec">KafkaBindingSpec</a>, 
+<a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>bootstrapServers</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Bootstrap servers are the Kafka servers the consumer will connect to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>net</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaNetSpec">
+KafkaNetSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.KafkaBinding">KafkaBinding
+</h3>
+<p>
+<p>KafkaBinding is the Schema for the kafkasources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaBindingSpec">
+KafkaBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaBindingStatus">
+KafkaBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.KafkaBindingSpec">KafkaBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaBinding">KafkaBinding</a>)
+</p>
+<p>
+<p>KafkaBindingSpec defines the desired state of the KafkaBinding.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.KafkaBindingStatus">KafkaBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaBinding">KafkaBinding</a>)
+</p>
+<p>
+<p>KafkaBindingStatus defines the observed state of KafkaBinding.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.KafkaNetSpec">KafkaNetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">KafkaAuthSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>sasl</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaSASLSpec">
+KafkaSASLSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>tls</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaTLSSpec">
+KafkaTLSSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.KafkaSASLSpec">KafkaSASLSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaNetSpec">KafkaNetSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>user</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>User is the Kubernetes secret containing the SASL username.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>password</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Password is the Kubernetes secret containing the SASL password.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.KafkaTLSSpec">KafkaTLSSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaNetSpec">KafkaNetSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>cert</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Cert is the Kubernetes secret containing the client certificate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Key is the Kubernetes secret containing the client key.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caCert</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CACert is the Kubernetes secret containing the server CA cert.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1beta1.SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1beta1.KafkaSASLSpec">KafkaSASLSpec</a>, 
+<a href="#bindings.knative.dev/v1beta1.KafkaTLSSpec">KafkaTLSSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.knative.dev/v1beta1">sources.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="sources.knative.dev/v1beta1.KafkaLimitsSpec">KafkaLimitsSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cpu</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>memory</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaRequestsSpec">KafkaRequestsSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cpu</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>memory</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec
+</h3>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>requests</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaRequestsSpec">
+KafkaRequestsSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>limits</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaLimitsSpec">
+KafkaLimitsSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaSource">KafkaSource
+</h3>
+<p>
+<p>KafkaSource is the Schema for the kafkasources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">
+KafkaSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topics</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Topic topics to consume messages from</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumerGroup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConsumerGroupID is the consumer group ID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaSourceStatus">
+KafkaSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
+</p>
+<p>
+<p>KafkaSourceSpec defines the desired state of the KafkaSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topics</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Topic topics to consume messages from</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumerGroup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConsumerGroupID is the consumer group ID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaSourceStatus">KafkaSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
+</p>
+<p>
+<p>KafkaSourceStatus defines the observed state of KafkaSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <h2 id="sources.knative.dev/v1alpha1">sources.knative.dev/v1alpha1</h2>
 <p>
 <p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
@@ -2269,7 +3670,7 @@ Source.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitLabSourceSpec">GitLabSourceSpec</a>)
+<a href="#sources.knative.dev/v1alpha1.GitHubSourceSpec">GitHubSourceSpec</a>)
 </p>
 <p>
 <p>SecretValueFromSource represents the source of a secret value</p>
@@ -2301,7 +3702,7 @@ Kubernetes core/v1.SecretKeySelector
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitHubSourceSpec">GitHubSourceSpec</a>)
+<a href="#sources.knative.dev/v1alpha1.GitLabSourceSpec">GitLabSourceSpec</a>)
 </p>
 <p>
 <p>SecretValueFromSource represents the source of a secret value</p>
@@ -3086,6 +4487,38 @@ SecretValueFromSource
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.GitLabBindingSpec">GitLabBindingSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
 <a href="#bindings.knative.dev/v1alpha1.GitHubBindingSpec">GitHubBindingSpec</a>)
 </p>
 <p>
@@ -3147,1441 +4580,8 @@ Kubernetes core/v1.SecretKeySelector
 </tr>
 </tbody>
 </table>
-<h3 id="bindings.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBindingSpec">GitLabBindingSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="messaging.knative.dev/v1alpha1">messaging.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>
-</li><li>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>
-</li></ul>
-<h3 id="messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel
-</h3>
-<p>
-<p>KafkaChannel is a resource representing a Kafka Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>KafkaChannel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1alpha1.KafkaChannelSpec">
-KafkaChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>numPartitions</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicationFactor</code></br>
-<em>
-int16
-</em>
-</td>
-<td>
-<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
-</em>
-</td>
-<td>
-<p>KafkaChannel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1alpha1.KafkaChannelStatus">
-KafkaChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the KafkaChannel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel
-</h3>
-<p>
-<p>NatssChannel is a resource representing a NATSS Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>NatssChannel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannelSpec">
-NatssChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
-</em>
-</td>
-<td>
-<p>NatssChannel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannelStatus">
-NatssChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the NatssChannel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.KafkaChannelSpec">KafkaChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>)
-</p>
-<p>
-<p>KafkaChannelSpec defines the specification for a KafkaChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>numPartitions</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicationFactor</code></br>
-<em>
-int16
-</em>
-</td>
-<td>
-<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
-</em>
-</td>
-<td>
-<p>KafkaChannel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.KafkaChannelStatus">KafkaChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>)
-</p>
-<p>
-<p>KafkaChannelStatus represents the current state of a KafkaChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>KafkaChannel is Addressable. It currently exposes the endpoint as a
-fully-qualified DNS name which will distribute traffic over the
-provided targets from inside the cluster.</p>
-<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.NatssChannelSpec">NatssChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>)
-</p>
-<p>
-<p>NatssChannelSpec defines the specification for a NatssChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
-</em>
-</td>
-<td>
-<p>NatssChannel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.NatssChannelStatus">NatssChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>)
-</p>
-<p>
-<p>NatssChannelStatus represents the current state of a NatssChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>NatssChannel is Addressable. It currently exposes the endpoint as a
-fully-qualified DNS name which will distribute traffic over the
-provided targets from inside the cluster.</p>
-<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel</a>
-</li></ul>
-<h3 id="messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel
-</h3>
-<p>
-<p>KafkaChannel is a resource representing a Kafka Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>KafkaChannel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.KafkaChannelSpec">
-KafkaChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>numPartitions</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicationFactor</code></br>
-<em>
-int16
-</em>
-</td>
-<td>
-<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1.ChannelableSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.KafkaChannelStatus">
-KafkaChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the KafkaChannel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.KafkaChannelSpec">KafkaChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel</a>)
-</p>
-<p>
-<p>KafkaChannelSpec defines the specification for a KafkaChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>numPartitions</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>NumPartitions is the number of partitions of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replicationFactor</code></br>
-<em>
-int16
-</em>
-</td>
-<td>
-<p>ReplicationFactor is the replication factor of a Kafka topic. By default, it is set to 1.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1.ChannelableSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.KafkaChannelStatus">KafkaChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.KafkaChannel">KafkaChannel</a>)
-</p>
-<p>
-<p>KafkaChannelStatus represents the current state of a KafkaChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableStatus</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1.ChannelableStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableStatus</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="bindings.knative.dev/v1beta1">bindings.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="bindings.knative.dev/v1beta1.KafkaAuthSpec">KafkaAuthSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaBindingSpec">KafkaBindingSpec</a>, 
-<a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>bootstrapServers</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Bootstrap servers are the Kafka servers the consumer will connect to.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>net</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaNetSpec">
-KafkaNetSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.KafkaBinding">KafkaBinding
-</h3>
-<p>
-<p>KafkaBinding is the Schema for the kafkasources API.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaBindingSpec">
-KafkaBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaBindingStatus">
-KafkaBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.KafkaBindingSpec">KafkaBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaBinding">KafkaBinding</a>)
-</p>
-<p>
-<p>KafkaBindingSpec defines the desired state of the KafkaBinding.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.KafkaBindingStatus">KafkaBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaBinding">KafkaBinding</a>)
-</p>
-<p>
-<p>KafkaBindingStatus defines the observed state of KafkaBinding.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.KafkaNetSpec">KafkaNetSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">KafkaAuthSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>sasl</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaSASLSpec">
-KafkaSASLSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>tls</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaTLSSpec">
-KafkaTLSSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.KafkaSASLSpec">KafkaSASLSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaNetSpec">KafkaNetSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>enable</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>user</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>User is the Kubernetes secret containing the SASL username.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>password</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Password is the Kubernetes secret containing the SASL password.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.KafkaTLSSpec">KafkaTLSSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaNetSpec">KafkaNetSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>enable</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>cert</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Cert is the Kubernetes secret containing the client certificate.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>key</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Key is the Kubernetes secret containing the client key.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caCert</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CACert is the Kubernetes secret containing the server CA cert.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1beta1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaSASLSpec">KafkaSASLSpec</a>, 
-<a href="#bindings.knative.dev/v1beta1.KafkaTLSSpec">KafkaTLSSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="sources.knative.dev/v1beta1">sources.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="sources.knative.dev/v1beta1.KafkaLimitsSpec">KafkaLimitsSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>cpu</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>memory</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaRequestsSpec">KafkaRequestsSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>cpu</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>memory</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec
-</h3>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>requests</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaRequestsSpec">
-KafkaRequestsSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>limits</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaLimitsSpec">
-KafkaLimitsSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaSource">KafkaSource
-</h3>
-<p>
-<p>KafkaSource is the Schema for the kafkasources API.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">
-KafkaSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>topics</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Topic topics to consume messages from</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>consumerGroup</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConsumerGroupID is the consumer group ID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaSourceStatus">
-KafkaSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
-</p>
-<p>
-<p>KafkaSourceSpec defines the desired state of the KafkaSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>topics</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Topic topics to consume messages from</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>consumerGroup</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConsumerGroupID is the consumer group ID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaSourceStatus">KafkaSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
-</p>
-<p>
-<p>KafkaSourceStatus defines the observed state of KafkaSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>9cefcda1</code>.
+on git commit <code>9683a047</code>.
 </em></p>

--- a/docs/reference/eventing/eventing.md
+++ b/docs/reference/eventing/eventing.md
@@ -1,10 +1,10 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#flows.knative.dev%2fv1beta1">flows.knative.dev/v1beta1</a>
+<a href="#messaging.knative.dev%2fv1beta1">messaging.knative.dev/v1beta1</a>
 </li>
 <li>
-<a href="#messaging.knative.dev%2fv1beta1">messaging.knative.dev/v1beta1</a>
+<a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
 </li>
 <li>
 <a href="#sources.knative.dev%2fv1alpha2">sources.knative.dev/v1alpha2</a>
@@ -16,7 +16,16 @@
 <a href="#duck.knative.dev%2fv1">duck.knative.dev/v1</a>
 </li>
 <li>
+<a href="#duck.knative.dev%2fv1beta1">duck.knative.dev/v1beta1</a>
+</li>
+<li>
 <a href="#eventing.knative.dev%2fv1">eventing.knative.dev/v1</a>
+</li>
+<li>
+<a href="#flows.knative.dev%2fv1beta1">flows.knative.dev/v1beta1</a>
+</li>
+<li>
+<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
 </li>
 <li>
 <a href="#eventing.knative.dev%2fv1beta1">eventing.knative.dev/v1beta1</a>
@@ -25,852 +34,12 @@
 <a href="#flows.knative.dev%2fv1">flows.knative.dev/v1</a>
 </li>
 <li>
-<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#duck.knative.dev%2fv1beta1">duck.knative.dev/v1beta1</a>
-</li>
-<li>
 <a href="#messaging.knative.dev%2fv1">messaging.knative.dev/v1</a>
 </li>
 <li>
-<a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
+<a href="#sources.knative.dev%2fv1beta1">sources.knative.dev/v1beta1</a>
 </li>
 </ul>
-<h2 id="flows.knative.dev/v1beta1">flows.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="flows.knative.dev/v1beta1.Parallel">Parallel
-</h3>
-<p>
-<p>Parallel defines conditional branches that will be wired in
-series through Channels and Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">
-ParallelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Parallel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>branches</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">
-[]ParallelBranch
-</a>
-</em>
-</td>
-<td>
-<p>Branches is the list of Filter/Subscribers pairs.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of a case Subscriber gets sent to
-when the case does not have a Reply</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelStatus">
-ParallelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Parallel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the expression guarding the branch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Subscriber receiving the event when the filter passes</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
-If not specified, sent the result to the Parallel Reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for events to the subscriber
-This includes things like retries, DLQ, etc.
-Needed for Roundtripping v1alpha1 &lt;-&gt; v1beta1.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
-</p>
-<p>
-<p>ParallelBranchStatus represents the current state of a Parallel branch</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>filterSubscriptionStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
-ParallelSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filterChannelStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
-ParallelChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>FilterChannelStatus corresponds to the filter channel status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberSubscriptionStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
-ParallelSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelChannelStatus">ParallelChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Channel is the reference to the underlying channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Channel is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>branches</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">
-[]ParallelBranch
-</a>
-</em>
-</td>
-<td>
-<p>Branches is the list of Filter/Subscribers pairs.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of a case Subscriber gets sent to
-when the case does not have a Reply</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
-</p>
-<p>
-<p>ParallelStatus represents the current state of a Parallel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ingressChannelStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
-ParallelChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>IngressChannelStatus corresponds to the ingress channel status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>branchStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">
-[]ParallelBranchStatus
-</a>
-</em>
-</td>
-<td>
-<p>BranchStatuses is an array of corresponding to branch statuses.
-Matches the Spec.Branches array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the starting point to this Parallel. Sending to this
-will target the first subscriber.
-It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelSubscriptionStatus">ParallelSubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscription</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Subscription is the reference to the underlying Subscription.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.Sequence">Sequence
-</h3>
-<p>
-<p>Sequence defines a sequence of Subscribers that will be wired in
-series through Channels and Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">
-SequenceSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Sequence.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>steps</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceStep">
-[]SequenceStep
-</a>
-</em>
-</td>
-<td>
-<p>Steps is the list of Destinations (processors / functions) that will be called in the order
-provided. Each step has its own delivery options</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceStatus">
-SequenceStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Sequence. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceChannelStatus">SequenceChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Channel is the reference to the underlying channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Channel is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>steps</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceStep">
-[]SequenceStep
-</a>
-</em>
-</td>
-<td>
-<p>Steps is the list of Destinations (processors / functions) that will be called in the order
-provided. Each step has its own delivery options</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
-</p>
-<p>
-<p>SequenceStatus represents the current state of a Sequence.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriptionStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceSubscriptionStatus">
-[]SequenceSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscriptionStatuses is an array of corresponding Subscription statuses.
-Matches the Spec.Steps array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceChannelStatus">
-[]SequenceChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>ChannelStatuses is an array of corresponding Channel statuses.
-Matches the Spec.Steps array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the starting point to this Sequence. Sending to this
-will target the first subscriber.
-It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceStep">SequenceStep
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Destination</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Destination</code> are embedded into this type.)
-</p>
-<p>Subscriber receiving the step event</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for events to the subscriber
-This includes things like retries, DLQ, etc.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscription</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Subscription is the reference to the underlying Subscription.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
 <p>
 <p>Package v1beta1 is the v1beta1 version of the API.</p>
@@ -1684,6 +853,576 @@ knative.dev/pkg/apis.URL
 </td>
 <td>
 <p>ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.knative.dev/v1alpha1">sources.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>
+</li></ul>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource
+</h3>
+<p>
+<p>ApiServerSource is the Schema for the apiserversources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ApiServerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">
+ApiServerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
+[]ApiServerResource
+</a>
+</em>
+</td>
+<td>
+<p>Resources is the list of resources to watch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ceOverrides</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CloudEventOverrides defines overrides to control the output format and
+modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
+<code>Ref</code> sends only the reference to the resource.
+<code>Resource</code> send the full resource.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceStatus">
+ApiServerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.SinkBinding">SinkBinding
+</h3>
+<p>
+<p>SinkBinding describes a Binding that is also a Source.
+The <code>sink</code> (from the Source duck) is resolved to a URL and
+then projected into the <code>subject</code> by augmenting the runtime
+contract of the referenced containers to have a <code>K_SINK</code>
+environment variable holding the endpoint to which to send
+cloud events.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>SinkBinding</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.SinkBindingSpec">
+SinkBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.SinkBindingStatus">
+SinkBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerResource">ApiServerResource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>ApiServerResource defines the resource to watch</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labelSelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>LabelSelector restricts this source to objects with the selected labels
+More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controllerSelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ownerreference-v1-meta">
+Kubernetes meta/v1.OwnerReference
+</a>
+</em>
+</td>
+<td>
+<p>ControllerSelector restricts this source to objects with a controlling owner reference of the specified kind.
+Only apiVersion and kind are used. Both are optional.
+Deprecated: Per-resource owner refs will no longer be supported in
+v1alpha2, please use Spec.Owner as a GKV.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controller</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>If true, send an event referencing the object controlling the resource
+Deprecated: Per-resource controller flag will no longer be supported in
+v1alpha2, please use Spec.Owner as a GKV.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
+[]ApiServerResource
+</a>
+</em>
+</td>
+<td>
+<p>Resources is the list of resources to watch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ceOverrides</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CloudEventOverrides defines overrides to control the output format and
+modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
+<code>Ref</code> sends only the reference to the resource.
+<code>Resource</code> send the full resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceStatus">ApiServerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.SinkBindingSpec">SinkBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.SinkBindingStatus">SinkBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
 </td>
 </tr>
 </tbody>
@@ -3239,9 +2978,11 @@ Failed messages are delivered here.</p>
 <p>
 (<em>Appears on:</em>
 <a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
 <a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
 <a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
 <a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
 <a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
 <a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
@@ -3307,7 +3048,9 @@ string
 <td>
 <em>(Optional)</em>
 <p>BackoffDelay is the delay before retrying.
-More information on Duration format: <a href="https://www.ietf.org/rfc/rfc3339.txt">https://www.ietf.org/rfc/rfc3339.txt</a></p>
+More information on Duration format:
+- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
 <p>For linear policy, backoff delay is the time interval between retries.
 For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 </td>
@@ -3422,6 +3165,7 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
 <a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
 <a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
@@ -3455,6 +3199,7 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
 <a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
 <a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
@@ -3571,7 +3316,652 @@ DeliverySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">SubscribableStatus</a>)
+<a href="#duck.knative.dev/v1.SubscribableStatus">SubscribableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>)
+</p>
+<p>
+<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A human readable message indicating details of Ready status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="duck.knative.dev/v1beta1">duck.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="duck.knative.dev/v1beta1.BackoffPolicyType">BackoffPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec</a>)
+</p>
+<p>
+<p>BackoffPolicyType is the type for backoff policies</p>
+</p>
+<h3 id="duck.knative.dev/v1beta1.Channelable">Channelable
+</h3>
+<p>
+<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterChannel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
+Failed messages are delivered here.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
+<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>DeliverySpec contains the delivery options for event senders,
+such as channelable and source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterSink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterSink is the sink receiving event that could not be sent to
+a destination.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retry</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retry is the minimum number of retries the sender should attempt when
+sending an event before moving it to the dead letter sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffPolicy</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.BackoffPolicyType">
+BackoffPolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffDelay</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffDelay is the delay before retrying.
+More information on Duration format:
+- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
+<p>For linear policy, backoff delay is the time interval between retries.
+For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.DeliveryStatus">DeliveryStatus
+</h3>
+<p>
+<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterChannel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
+where failed events are sent to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.Subscribable">Subscribable
+</h3>
+<p>
+<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
+<p>At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberURI is the endpoint for the subscriber</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyURI is the endpoint for the reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscriberStatus">SubscriberStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>)
 </p>
 <p>
 <p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
@@ -3651,7 +4041,7 @@ Resource Types:
 <p>
 <p>Broker collects a pool of events that are consumable using Triggers. Brokers
 provide a well-known endpoint for event delivery that senders can use with
-minimal knowledge of the event routing strategy. Receivers use Triggers to
+minimal knowledge of the event routing strategy. Subscribers use Triggers to
 request delivery of events from a Broker&rsquo;s pool to a specific URL or
 Addressable endpoint.</p>
 </p>
@@ -3761,7 +4151,7 @@ date.</p>
 <h3 id="eventing.knative.dev/v1.Trigger">Trigger
 </h3>
 <p>
-<p>Trigger represents a request to have events delivered to a consumer from a
+<p>Trigger represents a request to have events delivered to a subscriber from a
 Broker&rsquo;s event pool.</p>
 </p>
 <table>
@@ -3826,8 +4216,7 @@ string
 </em>
 </td>
 <td>
-<p>Broker is the broker that this trigger receives events from. If not specified, will default
-to &lsquo;default&rsquo;.</p>
+<p>Broker is the broker that this trigger receives events from.</p>
 </td>
 </tr>
 <tr>
@@ -4042,8 +4431,7 @@ string
 </em>
 </td>
 <td>
-<p>Broker is the broker that this trigger receives events from. If not specified, will default
-to &lsquo;default&rsquo;.</p>
+<p>Broker is the broker that this trigger receives events from.</p>
 </td>
 </tr>
 <tr>
@@ -4117,6 +4505,1767 @@ knative.dev/pkg/apis.URL
 </td>
 <td>
 <p>SubscriberURI is the resolved URI of the receiver for this Trigger.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="flows.knative.dev/v1beta1">flows.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="flows.knative.dev/v1beta1.Parallel">Parallel
+</h3>
+<p>
+<p>Parallel defines conditional branches that will be wired in
+series through Channels and Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">
+ParallelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Parallel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>branches</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">
+[]ParallelBranch
+</a>
+</em>
+</td>
+<td>
+<p>Branches is the list of Filter/Subscribers pairs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelStatus">
+ParallelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Parallel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the expression guarding the branch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>Subscriber receiving the event when the filter passes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
+If not specified, sent the result to the Parallel Reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for events to the subscriber
+This includes things like retries, DLQ, etc.
+Needed for Roundtripping v1alpha1 &lt;-&gt; v1beta1.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
+</p>
+<p>
+<p>ParallelBranchStatus represents the current state of a Parallel branch</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filterSubscriptionStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
+ParallelSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filterChannelStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
+ParallelChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterChannelStatus corresponds to the filter channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberSubscriptionStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
+ParallelSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelChannelStatus">ParallelChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>branches</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">
+[]ParallelBranch
+</a>
+</em>
+</td>
+<td>
+<p>Branches is the list of Filter/Subscribers pairs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
+</p>
+<p>
+<p>ParallelStatus represents the current state of a Parallel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressChannelStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
+ParallelChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>IngressChannelStatus corresponds to the ingress channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>branchStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">
+[]ParallelBranchStatus
+</a>
+</em>
+</td>
+<td>
+<p>BranchStatuses is an array of corresponding to branch statuses.
+Matches the Spec.Branches array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Parallel. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelSubscriptionStatus">ParallelSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.Sequence">Sequence
+</h3>
+<p>
+<p>Sequence defines a sequence of Subscribers that will be wired in
+series through Channels and Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">
+SequenceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Sequence.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceStep">
+[]SequenceStep
+</a>
+</em>
+</td>
+<td>
+<p>Steps is the list of Destinations (processors / functions) that will be called in the order
+provided. Each step has its own delivery options</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceStatus">
+SequenceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Sequence. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceChannelStatus">SequenceChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceStep">
+[]SequenceStep
+</a>
+</em>
+</td>
+<td>
+<p>Steps is the list of Destinations (processors / functions) that will be called in the order
+provided. Each step has its own delivery options</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
+</p>
+<p>
+<p>SequenceStatus represents the current state of a Sequence.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriptionStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceSubscriptionStatus">
+[]SequenceSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatuses is an array of corresponding Subscription statuses.
+Matches the Spec.Steps array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceChannelStatus">
+[]SequenceChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>ChannelStatuses is an array of corresponding Channel statuses.
+Matches the Spec.Steps array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Sequence. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceStep">SequenceStep
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Destination</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Destination</code> are embedded into this type.)
+</p>
+<p>Subscriber receiving the step event</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for events to the subscriber
+This includes things like retries, DLQ, etc.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="duck.knative.dev/v1alpha1.Channelable">Channelable
+</h3>
+<p>
+<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined
+</h3>
+<p>
+<p>ChannelableCombined is a skeleton type wrapping Subscribable and Addressable of
+v1alpha1, v1beta1 and v1 duck types. This is not to be used by resource writers and is
+only used by Subscription Controller to synthesize patches and read the Status
+of the Channelable Resources.
+This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">
+ChannelableCombinedSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery
+for the v1beta1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableSpecv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpecv1</code> are embedded into this type.)
+</p>
+<p>SubscribableSpecv1 is for the v1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deliveryv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpecv1 contains options controlling the event delivery
+for the v1 spec compatibility.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">
+ChannelableCombinedStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery
+for the v1beta1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableSpecv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpecv1</code> are embedded into this type.)
+</p>
+<p>SubscribableSpecv1 is for the v1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deliveryv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpecv1 contains options controlling the event delivery
+for the v1 spec compatibility.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>SubscribableTypeStatus is the v1alpha1 part of the Subscribers status</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableStatus</code> are embedded into this type.)
+</p>
+<p>SubscribableStatus is the v1beta1 part of the Subscribers status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableStatusv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableStatusv1</code> are embedded into this type.)
+</p>
+<p>SubscribableStatusv1 is the v1 part of the Subscribers status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>errorChannel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>errorChannel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.Resource">Resource
+</h3>
+<p>
+<p>Resource is a skeleton type wrapping all Kubernetes resources. It is typically used to watch
+arbitrary other resources (such as any Source or Addressable). This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.Subscribable">Subscribable
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
+</p>
+<p>
+<p>Subscribable is the schema for the subscribable portion of the spec
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscribersv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableType">SubscribableType
+</h3>
+<p>
+<p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableTypeSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableTypeStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
+</p>
+<p>
+<p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
+</p>
+<p>
+<p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.
+Ref is a reference to the Subscription this SubscriberSpec was created for
+SubscriberURI is the endpoint for the subscriber
+ReplyURI is the endpoint for the reply
+At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberURI</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyURI</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterSink</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>deliveryv1</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
 </td>
 </tr>
 </tbody>
@@ -4249,6 +6398,7 @@ date.</p>
 <h3 id="eventing.knative.dev/v1beta1.EventType">EventType
 </h3>
 <p>
+<p>EventType represents a type of event that can be consumed from a Broker.</p>
 </p>
 <table>
 <thead>
@@ -5725,1469 +7875,6 @@ knative.dev/pkg/apis.Condition
 </tbody>
 </table>
 <hr/>
-<h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="duck.knative.dev/v1alpha1.Channelable">Channelable
-</h3>
-<p>
-<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined
-</h3>
-<p>
-<p>ChannelableCombined is a skeleton type wrapping Subscribable and Addressable of both
-v1alpha1 and v1beta1 duck types. This is not to be used by resource writers and is
-only used by Subscription Controller to synthesize patches and read the Status
-of the Channelable Resources.
-This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">
-ChannelableCombinedSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">
-ChannelableCombinedStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>SubscribableTypeStatus is the v1alpha1 part of the Subscribers status</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableStatus</code> are embedded into this type.)
-</p>
-<p>SubscribableStatus is the v1beta1 part of the Subscribers status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>errorChannel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>errorChannel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.Resource">Resource
-</h3>
-<p>
-<p>Resource is a skeleton type wrapping all Kubernetes resources. It is typically used to watch
-arbitrary other resources (such as any Source or Addressable). This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.Subscribable">Subscribable
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
-</p>
-<p>
-<p>Subscribable is the schema for the subscribable portion of the spec
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableType">SubscribableType
-</h3>
-<p>
-<p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableTypeSpec is the part where Subscribable object is
-configured as to be compatible with Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableTypeStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
-</p>
-<p>
-<p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
-</p>
-<p>
-<p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.
-Ref is a reference to the Subscription this SubscriberSpec was created for
-SubscriberURI is the endpoint for the subscriber
-ReplyURI is the endpoint for the reply
-At least one of SubscriberURI and ReplyURI must be present</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberURI</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyURI</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterSink</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="duck.knative.dev/v1beta1">duck.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="duck.knative.dev/v1beta1.BackoffPolicyType">BackoffPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec</a>)
-</p>
-<p>
-<p>BackoffPolicyType is the type for backoff policies</p>
-</p>
-<h3 id="duck.knative.dev/v1beta1.Channelable">Channelable
-</h3>
-<p>
-<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
-Failed messages are delivered here.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
-<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
-</p>
-<p>
-<p>DeliverySpec contains the delivery options for event senders,
-such as channelable and source.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterSink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterSink is the sink receiving event that could not be sent to
-a destination.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retry</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retry is the minimum number of retries the sender should attempt when
-sending an event before moving it to the dead letter sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffPolicy</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.BackoffPolicyType">
-BackoffPolicyType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffDelay</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffDelay is the delay before retrying.
-More information on Duration format: <a href="https://www.ietf.org/rfc/rfc3339.txt">https://www.ietf.org/rfc/rfc3339.txt</a></p>
-<p>For linear policy, backoff delay is the time interval between retries.
-For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.DeliveryStatus">DeliveryStatus
-</h3>
-<p>
-<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
-where failed events are sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.Subscribable">Subscribable
-</h3>
-<p>
-<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableSpec is the part where Subscribable object is
-configured as to be compatible with Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec</a>)
-</p>
-<p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
-<p>At least one of SubscriberURI and ReplyURI must be present</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubscriberURI is the endpoint for the subscriber</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReplyURI is the endpoint for the reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscriberStatus">SubscriberStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus</a>)
-</p>
-<p>
-<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
-Kubernetes core/v1.ConditionStatus
-</a>
-</em>
-</td>
-<td>
-<p>Status of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>message</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>A human readable message indicating details of Ready status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="messaging.knative.dev/v1">messaging.knative.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
@@ -8006,19 +8693,21 @@ knative.dev/pkg/apis.URL
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.knative.dev/v1alpha1">sources.knative.dev/v1alpha1</h2>
+<h2 id="sources.knative.dev/v1beta1">sources.knative.dev/v1beta1</h2>
 <p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group.</p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>
+<a href="#sources.knative.dev/v1beta1.ApiServerSource">ApiServerSource</a>
 </li><li>
-<a href="#sources.knative.dev/v1alpha1.PingSource">PingSource</a>
+<a href="#sources.knative.dev/v1beta1.ContainerSource">ContainerSource</a>
 </li><li>
-<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>
+<a href="#sources.knative.dev/v1beta1.PingSource">PingSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1beta1.SinkBinding">SinkBinding</a>
 </li></ul>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource
+<h3 id="sources.knative.dev/v1beta1.ApiServerSource">ApiServerSource
 </h3>
 <p>
 <p>ApiServerSource is the Schema for the apiserversources API</p>
@@ -8037,7 +8726,7 @@ Resource Types:
 string</td>
 <td>
 <code>
-sources.knative.dev/v1alpha1
+sources.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -8066,7 +8755,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">
+<a href="#sources.knative.dev/v1beta1.ApiServerSourceSpec">
 ApiServerSourceSpec
 </a>
 </em>
@@ -8077,60 +8766,42 @@ ApiServerSourceSpec
 <table>
 <tr>
 <td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>resources</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
-[]ApiServerResource
+<a href="#sources.knative.dev/v1beta1.APIVersionKindSelector">
+[]APIVersionKindSelector
 </a>
 </em>
 </td>
 <td>
-<p>Resources is the list of resources to watch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1beta1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
+<p>Resource are the resources this source will track and send related
+lifecycle events from the Kubernetes ApiServer, with an optional label
+selector to help filter.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>owner</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+<a href="#sources.knative.dev/v1beta1.APIVersionKind">
 APIVersionKind
 </a>
 </em>
@@ -8150,9 +8821,24 @@ string
 </em>
 </td>
 <td>
-<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
-<code>Ref</code> sends only the reference to the resource.
-<code>Resource</code> send the full resource.</p>
+<em>(Optional)</em>
+<p>EventMode controls the format of the event.
+<code>Reference</code> sends a dataref event type for the resource under watch.
+<code>Resource</code> send the full resource lifecycle event.
+Defaults to <code>Reference</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source. Defaults to default if not set.</p>
 </td>
 </tr>
 </table>
@@ -8162,7 +8848,7 @@ string
 <td>
 <code>status</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceStatus">
+<a href="#sources.knative.dev/v1beta1.ApiServerSourceStatus">
 ApiServerSourceStatus
 </a>
 </em>
@@ -8172,7 +8858,112 @@ ApiServerSourceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.PingSource">PingSource
+<h3 id="sources.knative.dev/v1beta1.ContainerSource">ContainerSource
+</h3>
+<p>
+<p>ContainerSource is the Schema for the containersources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ContainerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.ContainerSourceSpec">
+ContainerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the pods that will be created</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.ContainerSourceStatus">
+ContainerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.PingSource">PingSource
 </h3>
 <p>
 <p>PingSource is the Schema for the PingSources API.</p>
@@ -8191,7 +8982,7 @@ ApiServerSourceStatus
 string</td>
 <td>
 <code>
-sources.knative.dev/v1alpha1
+sources.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -8220,7 +9011,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.PingSourceSpec">
+<a href="#sources.knative.dev/v1beta1.PingSourceSpec">
 PingSourceSpec
 </a>
 </em>
@@ -8231,75 +9022,60 @@ PingSourceSpec
 <table>
 <tr>
 <td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>schedule</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Schedule is the cronjob schedule.</p>
+<em>(Optional)</em>
+<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>data</code></br>
+<code>timezone</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Data is the data posted to the target function.</p>
+<p>Timezone modifies the actual time relative to the specified timezone.
+Defaults to the system time zone.
+More general information about time zones: <a href="https://www.iana.org/time-zones">https://www.iana.org/time-zones</a>
+List of valid timezone values: <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">https://en.wikipedia.org/wiki/List_of_tz_database_time_zones</a></p>
 </td>
 </tr>
 <tr>
 <td>
-<code>sink</code></br>
+<code>jsonData</code></br>
 <em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Sink is a reference to an object that will resolve to a uri to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
-Adapter Deployment.
-Deprecated: v1beta1 drops this field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.PingResourceSpec">
-PingResourceSpec
-</a>
-</em>
-</td>
-<td>
-<p>Resource limits and Request specifications of the Receive Adapter Deployment
-Deprecated: v1beta1 drops this field.</p>
+<p>JsonData is json encoded data used as the body of the event posted to
+the sink. Default is empty. If set, datacontenttype will also be set
+to &ldquo;application/json&rdquo;.</p>
 </td>
 </tr>
 </table>
@@ -8309,7 +9085,7 @@ Deprecated: v1beta1 drops this field.</p>
 <td>
 <code>status</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.PingSourceStatus">
+<a href="#sources.knative.dev/v1beta1.PingSourceStatus">
 PingSourceStatus
 </a>
 </em>
@@ -8319,7 +9095,7 @@ PingSourceStatus
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.SinkBinding">SinkBinding
+<h3 id="sources.knative.dev/v1beta1.SinkBinding">SinkBinding
 </h3>
 <p>
 <p>SinkBinding describes a Binding that is also a Source.
@@ -8343,7 +9119,7 @@ cloud events.</p>
 string</td>
 <td>
 <code>
-sources.knative.dev/v1alpha1
+sources.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -8372,7 +9148,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.SinkBindingSpec">
+<a href="#sources.knative.dev/v1beta1.SinkBindingSpec">
 SinkBindingSpec
 </a>
 </em>
@@ -8392,19 +9168,27 @@ knative.dev/pkg/apis/duck/v1.SourceSpec
 <p>
 (Members of <code>SourceSpec</code> are embedded into this type.)
 </p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>BindingSpec</code></br>
 <em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+knative.dev/pkg/apis/duck/v1beta1.BindingSpec
 </em>
 </td>
 <td>
 <p>
 (Members of <code>BindingSpec</code> are embedded into this type.)
 </p>
+<p>inherits duck/v1beta1 BindingSpec, which currently provides:
+* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
+should be augmented by Binding implementations.</p>
 </td>
 </tr>
 </table>
@@ -8414,7 +9198,7 @@ knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.SinkBindingStatus">
+<a href="#sources.knative.dev/v1beta1.SinkBindingStatus">
 SinkBindingStatus
 </a>
 </em>
@@ -8424,14 +9208,14 @@ SinkBindingStatus
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerResource">ApiServerResource
+<h3 id="sources.knative.dev/v1beta1.APIVersionKind">APIVersionKind
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+<a href="#sources.knative.dev/v1beta1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
 </p>
 <p>
-<p>ApiServerResource defines the resource to watch</p>
+<p>APIVersionKind is an APIVersion and Kind tuple.</p>
 </p>
 <table>
 <thead>
@@ -8449,7 +9233,49 @@ string
 </em>
 </td>
 <td>
-<p>API version of the resource to watch.</p>
+<p>APIVersion - the API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.APIVersionKindSelector">APIVersionKindSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIVersion - the API version of the resource to watch.</p>
 </td>
 </tr>
 <tr>
@@ -8466,7 +9292,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 </tr>
 <tr>
 <td>
-<code>labelSelector</code></br>
+<code>selector</code></br>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -8474,46 +9300,19 @@ Kubernetes meta/v1.LabelSelector
 </em>
 </td>
 <td>
-<p>LabelSelector restricts this source to objects with the selected labels
+<em>(Optional)</em>
+<p>LabelSelector filters this source to objects to those resources pass the
+label selector.
 More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>controllerSelector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ownerreference-v1-meta">
-Kubernetes meta/v1.OwnerReference
-</a>
-</em>
-</td>
-<td>
-<p>ControllerSelector restricts this source to objects with a controlling owner reference of the specified kind.
-Only apiVersion and kind are used. Both are optional.
-Deprecated: Per-resource owner refs will no longer be supported in
-v1alpha2, please use Spec.Owner as a GKV.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>controller</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>If true, send an event referencing the object controlling the resource
-Deprecated: Per-resource controller flag will no longer be supported in
-v1alpha2, please use Spec.Owner as a GKV.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec
+<h3 id="sources.knative.dev/v1beta1.ApiServerSourceSpec">ApiServerSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
+<a href="#sources.knative.dev/v1beta1.ApiServerSource">ApiServerSource</a>)
 </p>
 <p>
 <p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
@@ -8528,60 +9327,42 @@ v1alpha2, please use Spec.Owner as a GKV.</p>
 <tbody>
 <tr>
 <td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>resources</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
-[]ApiServerResource
+<a href="#sources.knative.dev/v1beta1.APIVersionKindSelector">
+[]APIVersionKindSelector
 </a>
 </em>
 </td>
 <td>
-<p>Resources is the list of resources to watch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1beta1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
+<p>Resource are the resources this source will track and send related
+lifecycle events from the Kubernetes ApiServer, with an optional label
+selector to help filter.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>owner</code></br>
 <em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+<a href="#sources.knative.dev/v1beta1.APIVersionKind">
 APIVersionKind
 </a>
 </em>
@@ -8601,18 +9382,33 @@ string
 </em>
 </td>
 <td>
-<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
-<code>Ref</code> sends only the reference to the resource.
-<code>Resource</code> send the full resource.</p>
+<em>(Optional)</em>
+<p>EventMode controls the format of the event.
+<code>Reference</code> sends a dataref event type for the resource under watch.
+<code>Resource</code> send the full resource lifecycle event.
+Defaults to <code>Reference</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source. Defaults to default if not set.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceStatus">ApiServerSourceStatus
+<h3 id="sources.knative.dev/v1beta1.ApiServerSourceStatus">ApiServerSourceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
+<a href="#sources.knative.dev/v1beta1.ApiServerSource">ApiServerSource</a>)
 </p>
 <p>
 <p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
@@ -8647,13 +9443,14 @@ Source.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.PingLimitsSpec">PingLimitsSpec
+<h3 id="sources.knative.dev/v1beta1.ContainerSourceSpec">ContainerSourceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PingResourceSpec">PingResourceSpec</a>)
+<a href="#sources.knative.dev/v1beta1.ContainerSource">ContainerSource</a>)
 </p>
 <p>
+<p>ContainerSourceSpec defines the desired state of ContainerSource</p>
 </p>
 <table>
 <thead>
@@ -8665,111 +9462,81 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>cpu</code></br>
+<code>SourceSpec</code></br>
 <em>
-string
+knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
 </td>
 <td>
-</td>
-</tr>
-<tr>
-<td>
-<code>memory</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.PingRequestsSpec">PingRequestsSpec
-</h3>
 <p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PingResourceSpec">PingResourceSpec</a>)
+(Members of <code>SourceSpec</code> are embedded into this type.)
 </p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
 </tr>
-</thead>
-<tbody>
 <tr>
 <td>
-<code>cpu</code></br>
+<code>template</code></br>
 <em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>memory</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.PingResourceSpec">PingResourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PingSourceSpec">PingSourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>requests</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.PingRequestsSpec">
-PingRequestsSpec
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
 </a>
 </em>
 </td>
 <td>
-</td>
-</tr>
-<tr>
-<td>
-<code>limits</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.PingLimitsSpec">
-PingLimitsSpec
-</a>
-</em>
-</td>
-<td>
+<p>Template describes the pods that will be created</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.PingSourceSpec">PingSourceSpec
+<h3 id="sources.knative.dev/v1beta1.ContainerSourceStatus">ContainerSourceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PingSource">PingSource</a>)
+<a href="#sources.knative.dev/v1beta1.ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceStatus defines the observed state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.PingSourceSpec">PingSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.PingSource">PingSource</a>)
 </p>
 <p>
 <p>PingSourceSpec defines the desired state of the PingSource.</p>
@@ -8784,84 +9551,69 @@ PingLimitsSpec
 <tbody>
 <tr>
 <td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>schedule</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Schedule is the cronjob schedule.</p>
+<em>(Optional)</em>
+<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>data</code></br>
+<code>timezone</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Data is the data posted to the target function.</p>
+<p>Timezone modifies the actual time relative to the specified timezone.
+Defaults to the system time zone.
+More general information about time zones: <a href="https://www.iana.org/time-zones">https://www.iana.org/time-zones</a>
+List of valid timezone values: <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">https://en.wikipedia.org/wiki/List_of_tz_database_time_zones</a></p>
 </td>
 </tr>
 <tr>
 <td>
-<code>sink</code></br>
+<code>jsonData</code></br>
 <em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Sink is a reference to an object that will resolve to a uri to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServiceAccoutName is the name of the ServiceAccount that will be used to run the Receive
-Adapter Deployment.
-Deprecated: v1beta1 drops this field.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.PingResourceSpec">
-PingResourceSpec
-</a>
-</em>
-</td>
-<td>
-<p>Resource limits and Request specifications of the Receive Adapter Deployment
-Deprecated: v1beta1 drops this field.</p>
+<p>JsonData is json encoded data used as the body of the event posted to
+the sink. Default is empty. If set, datacontenttype will also be set
+to &ldquo;application/json&rdquo;.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.PingSourceStatus">PingSourceStatus
+<h3 id="sources.knative.dev/v1beta1.PingSourceStatus">PingSourceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PingSource">PingSource</a>)
+<a href="#sources.knative.dev/v1beta1.PingSource">PingSource</a>)
 </p>
 <p>
 <p>PingSourceStatus defines the observed state of PingSource.</p>
@@ -8896,11 +9648,11 @@ Source.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.SinkBindingSpec">SinkBindingSpec
+<h3 id="sources.knative.dev/v1beta1.SinkBindingSpec">SinkBindingSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
+<a href="#sources.knative.dev/v1beta1.SinkBinding">SinkBinding</a>)
 </p>
 <p>
 <p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
@@ -8924,28 +9676,36 @@ knative.dev/pkg/apis/duck/v1.SourceSpec
 <p>
 (Members of <code>SourceSpec</code> are embedded into this type.)
 </p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>BindingSpec</code></br>
 <em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+knative.dev/pkg/apis/duck/v1beta1.BindingSpec
 </em>
 </td>
 <td>
 <p>
 (Members of <code>BindingSpec</code> are embedded into this type.)
 </p>
+<p>inherits duck/v1beta1 BindingSpec, which currently provides:
+* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
+should be augmented by Binding implementations.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.SinkBindingStatus">SinkBindingStatus
+<h3 id="sources.knative.dev/v1beta1.SinkBindingStatus">SinkBindingStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
+<a href="#sources.knative.dev/v1beta1.SinkBinding">SinkBinding</a>)
 </p>
 <p>
 <p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
@@ -8969,6 +9729,13 @@ knative.dev/pkg/apis/duck/v1.SourceStatus
 <p>
 (Members of <code>SourceStatus</code> are embedded into this type.)
 </p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
 </td>
 </tr>
 </tbody>
@@ -8976,5 +9743,5 @@ knative.dev/pkg/apis/duck/v1.SourceStatus
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>e018fe79</code>.
+on git commit <code>9f3fb3ff</code>.
 </em></p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1155,7 +1155,7 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>,
 <a href="#serving.knative.dev/v1.Revision">Revision</a>)
 </p>
 <p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -954,7 +954,7 @@ RevisionTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>, 
+<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>,
 <a href="#serving.knative.dev/v1.Configuration">Configuration</a>)
 </p>
 <p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -920,7 +920,7 @@ ServiceStatus
 <p>
 (<em>Appears on:</em>
 <a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>, 
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>,
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1,7 +1,7 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#autoscaling.internal.knative.dev%2fv1alpha1">autoscaling.internal.knative.dev/v1alpha1</a>
+<a href="#serving.knative.dev%2fv1beta1">serving.knative.dev/v1beta1</a>
 </li>
 <li>
 <a href="#serving.knative.dev%2fv1">serving.knative.dev/v1</a>
@@ -9,24 +9,28 @@
 <li>
 <a href="#serving.knative.dev%2fv1alpha1">serving.knative.dev/v1alpha1</a>
 </li>
-<li>
-<a href="#serving.knative.dev%2fv1beta1">serving.knative.dev/v1beta1</a>
-</li>
 </ul>
-<h2 id="autoscaling.internal.knative.dev/v1alpha1">autoscaling.internal.knative.dev/v1alpha1</h2>
+<h2 id="serving.knative.dev/v1beta1">serving.knative.dev/v1beta1</h2>
 <p>
 </p>
 Resource Types:
 <ul><li>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscaler">PodAutoscaler</a>
+<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>
+</li><li>
+<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>
+</li><li>
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>
+</li><li>
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>
 </li></ul>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.PodAutoscaler">PodAutoscaler
+<h3 id="serving.knative.dev/v1beta1.Configuration">Configuration
 </h3>
 <p>
-<p>PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
-components instantiate autoscalers.  This definition is an abstraction that may be backed
-by multiple definitions.  For more information, see the Knative Pluggability presentation:
-<a href="https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit">https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit</a></p>
+<p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions.
+Users create new Revisions by updating the Configuration&rsquo;s spec.
+The &ldquo;latest created&rdquo; revision&rsquo;s name is available under status, as is the
+&ldquo;latest ready&rdquo; revision&rsquo;s name.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration">https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration</a></p>
 </p>
 <table>
 <thead>
@@ -42,7 +46,7 @@ by multiple definitions.  For more information, see the Knative Pluggability pre
 string</td>
 <td>
 <code>
-autoscaling.internal.knative.dev/v1alpha1
+serving.knative.dev/v1beta1
 </code>
 </td>
 </tr>
@@ -51,7 +55,7 @@ autoscaling.internal.knative.dev/v1alpha1
 <code>kind</code></br>
 string
 </td>
-<td><code>PodAutoscaler</code></td>
+<td><code>Configuration</code></td>
 </tr>
 <tr>
 <td>
@@ -72,31 +76,123 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerSpec">
-PodAutoscalerSpec
+<a href="#serving.knative.dev/v1.ConfigurationSpec">
+ConfigurationSpec
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Spec holds the desired state of the PodAutoscaler (from the client).</p>
 <br/>
 <br/>
 <table>
 <tr>
 <td>
-<code>generation</code></br>
+<code>template</code></br>
 <em>
-int64
+<a href="#serving.knative.dev/v1.RevisionTemplateSpec">
+RevisionTemplateSpec
+</a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
-when metadata.generation was not being incremented by the api server</p>
-<p>This property will be dropped in future Knative releases and should
-not be used - use metadata.generation</p>
-<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
+<p>Template holds the latest specification for the Revision to be stamped out.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#serving.knative.dev/v1.ConfigurationStatus">
+ConfigurationStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.knative.dev/v1beta1.Revision">Revision
+</h3>
+<p>
+<p>Revision is an immutable snapshot of code and configuration.  A revision
+references a container image. Revisions are created by updates to a
+Configuration.</p>
+<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision">https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Revision</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RevisionSpec">
+RevisionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>PodSpec</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
+Kubernetes core/v1.PodSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PodSpec</code> are embedded into this type.)
+</p>
 </td>
 </tr>
 <tr>
@@ -108,49 +204,24 @@ int64
 </td>
 <td>
 <em>(Optional)</em>
-<p>ContainerConcurrency specifies the maximum allowed
-in-flight (concurrent) requests per container of the Revision.
-Defaults to <code>0</code> which means unlimited concurrency.</p>
+<p>ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+requests per container of the Revision.  Defaults to <code>0</code> which means
+concurrency to the application is not limited, and the system decides the
+target concurrency for the autoscaler.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>scaleTargetRef</code></br>
+<code>timeoutSeconds</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
-is responsible for quickly right-sizing.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reachability</code></br>
-<em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.ReachabilityType">
-ReachabilityType
-</a>
+int64
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Reachable specifies whether or not the <code>ScaleTargetRef</code> can be reached (ie. has a route).
-Defaults to <code>ReachabilityUnknown</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>protocolType</code></br>
-<em>
-knative.dev/networking/pkg/apis/networking.ProtocolType
-</em>
-</td>
-<td>
-<p>The application-layer protocol. Matches <code>ProtocolType</code> inferred from the revision spec.</p>
+<p>TimeoutSeconds holds the max duration the instance is allowed for
+responding to a request.  If unspecified, a system default will
+be provided.</p>
 </td>
 </tr>
 </table>
@@ -160,22 +231,26 @@ knative.dev/networking/pkg/apis/networking.ProtocolType
 <td>
 <code>status</code></br>
 <em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerStatus">
-PodAutoscalerStatus
+<a href="#serving.knative.dev/v1.RevisionStatus">
+RevisionStatus
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Status communicates the observed state of the PodAutoscaler (from the controller).</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.Metric">Metric
+<h3 id="serving.knative.dev/v1beta1.Route">Route
 </h3>
 <p>
-<p>Metric represents a resource to configure the metric collector with.</p>
+<p>Route is responsible for configuring ingress over a collection of Revisions.
+Some of the Revisions a Route distributes traffic over may be specified by
+referencing the Configuration responsible for creating them; in these cases
+the Route is additionally responsible for monitoring the Configuration for
+&ldquo;latest ready revision&rdquo; changes, and smoothly rolling out latest revisions.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#route">https://github.com/knative/serving/blob/master/docs/spec/overview.md#route</a></p>
 </p>
 <table>
 <thead>
@@ -185,6 +260,23 @@ PodAutoscalerStatus
 </tr>
 </thead>
 <tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Route</code></td>
+</tr>
 <tr>
 <td>
 <code>metadata</code></br>
@@ -204,48 +296,30 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.MetricSpec">
-MetricSpec
+<a href="#serving.knative.dev/v1.RouteSpec">
+RouteSpec
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Spec holds the desired state of the Metric (from the client).</p>
+<p>Spec holds the desired state of the Route (from the client).</p>
 <br/>
 <br/>
 <table>
 <tr>
 <td>
-<code>stableWindow</code></br>
+<code>traffic</code></br>
 <em>
-time.Duration
+<a href="#serving.knative.dev/v1.TrafficTarget">
+[]TrafficTarget
+</a>
 </em>
 </td>
 <td>
-<p>StableWindow is the aggregation window for metrics in a stable state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>panicWindow</code></br>
-<em>
-time.Duration
-</em>
-</td>
-<td>
-<p>PanicWindow is the aggregation window for metrics where quick reactions are needed.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scrapeTarget</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ScrapeTarget is the K8s service that publishes the metric endpoint.</p>
+<em>(Optional)</em>
+<p>Traffic specifies how to distribute traffic over a collection of
+revisions and configurations.</p>
 </td>
 </tr>
 </table>
@@ -255,26 +329,31 @@ string
 <td>
 <code>status</code></br>
 <em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.MetricStatus">
-MetricStatus
+<a href="#serving.knative.dev/v1.RouteStatus">
+RouteStatus
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Status communicates the observed state of the Metric (from the controller).</p>
+<p>Status communicates the observed state of the Route (from the controller).</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.MetricSpec">MetricSpec
+<h3 id="serving.knative.dev/v1beta1.Service">Service
 </h3>
 <p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.Metric">Metric</a>)
-</p>
-<p>
-<p>MetricSpec contains all values a metric collector needs to operate.</p>
+<p>Service acts as a top-level container that manages a Route and Configuration
+which implement a network service. Service exists to provide a singular
+abstraction which can be access controlled, reasoned about, and which
+encapsulates software lifecycle decisions such as rollout policy and
+team resource ownership. Service acts only as an orchestrator of the
+underlying Routes and Configurations (much as a kubernetes Deployment
+orchestrates ReplicaSets), and its usage is optional but recommended.</p>
+<p>The Service&rsquo;s controller will track the statuses of its owned Configuration
+and Route, reflecting their statuses and conditions as its own.</p>
+<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#service">https://github.com/knative/serving/blob/master/docs/spec/overview.md#service</a></p>
 </p>
 <table>
 <thead>
@@ -286,255 +365,21 @@ MetricStatus
 <tbody>
 <tr>
 <td>
-<code>stableWindow</code></br>
-<em>
-time.Duration
-</em>
-</td>
+<code>apiVersion</code></br>
+string</td>
 <td>
-<p>StableWindow is the aggregation window for metrics in a stable state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>panicWindow</code></br>
-<em>
-time.Duration
-</em>
-</td>
-<td>
-<p>PanicWindow is the aggregation window for metrics where quick reactions are needed.</p>
+<code>
+serving.knative.dev/v1beta1
+</code>
 </td>
 </tr>
 <tr>
 <td>
-<code>scrapeTarget</code></br>
-<em>
+<code>kind</code></br>
 string
-</em>
 </td>
-<td>
-<p>ScrapeTarget is the K8s service that publishes the metric endpoint.</p>
-</td>
+<td><code>Service</code></td>
 </tr>
-</tbody>
-</table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.MetricStatus">MetricStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.Metric">Metric</a>)
-</p>
-<p>
-<p>MetricStatus reflects the status of metric collection for this specific entity.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerSpec">PodAutoscalerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscaler">PodAutoscaler</a>)
-</p>
-<p>
-<p>PodAutoscalerSpec holds the desired state of the PodAutoscaler (from the client).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeprecatedGeneration was used prior in Kubernetes versions <1.11
-when metadata.generation was not being incremented by the api server</p>
-<p>This property will be dropped in future Knative releases and should
-not be used - use metadata.generation</p>
-<p>Tracking issue: <a href="https://github.com/knative/serving/issues/643">https://github.com/knative/serving/issues/643</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>containerConcurrency</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ContainerConcurrency specifies the maximum allowed
-in-flight (concurrent) requests per container of the Revision.
-Defaults to <code>0</code> which means unlimited concurrency.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>scaleTargetRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
-is responsible for quickly right-sizing.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reachability</code></br>
-<em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.ReachabilityType">
-ReachabilityType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reachable specifies whether or not the <code>ScaleTargetRef</code> can be reached (ie. has a route).
-Defaults to <code>ReachabilityUnknown</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>protocolType</code></br>
-<em>
-knative.dev/networking/pkg/apis/networking.ProtocolType
-</em>
-</td>
-<td>
-<p>The application-layer protocol. Matches <code>ProtocolType</code> inferred from the revision spec.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerStatus">PodAutoscalerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscaler">PodAutoscaler</a>)
-</p>
-<p>
-<p>PodAutoscalerStatus communicates the observed state of the PodAutoscaler (from the controller).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServiceName is the K8s Service name that serves the revision, scaled by this PA.
-The service is created and owned by the ServerlessService object owned by this PA.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>metricsServiceName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>MetricsServiceName is the K8s Service name that provides revision metrics.
-The service is managed by the PA object.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>desiredScale</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>DesiredScale shows the current desired number of replicas for the revision.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>actualScale</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<p>ActualScale shows the actual number of replicas for the revision.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.PodScalable">PodScalable
-</h3>
-<p>
-<p>PodScalable is a duck type that the resources referenced by the
-PodAutoscaler&rsquo;s ScaleTargetRef must implement.  They must also
-implement the <code>/scale</code> sub-resource for use with <code>/scale</code> based
-implementations (e.g. HPA), but this further constrains the shape
-the referenced resources may take.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
 <tr>
 <td>
 <code>metadata</code></br>
@@ -545,6 +390,7 @@ Kubernetes meta/v1.ObjectMeta
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
 </td>
@@ -553,47 +399,49 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodScalableSpec">
-PodScalableSpec
+<a href="#serving.knative.dev/v1.ServiceSpec">
+ServiceSpec
 </a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <br/>
 <br/>
 <table>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>ConfigurationSpec</code></br>
 <em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
+<a href="#serving.knative.dev/v1.ConfigurationSpec">
+ConfigurationSpec
 </a>
 </em>
 </td>
 <td>
+<p>
+(Members of <code>ConfigurationSpec</code> are embedded into this type.)
+</p>
+<p>ServiceSpec inlines an unrestricted ConfigurationSpec.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>RouteSpec</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
+<a href="#serving.knative.dev/v1.RouteSpec">
+RouteSpec
 </a>
 </em>
 </td>
 <td>
+<p>
+(Members of <code>RouteSpec</code> are embedded into this type.)
+</p>
+<p>ServiceSpec inlines RouteSpec and restricts/defaults its fields
+via webhook.  In particular, this spec can only reference this
+Service&rsquo;s configuration and revisions (which also influences
+defaults).</p>
 </td>
 </tr>
 </table>
@@ -603,110 +451,17 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodScalableStatus">
-PodScalableStatus
+<a href="#serving.knative.dev/v1.ServiceStatus">
+ServiceStatus
 </a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.PodScalableSpec">PodScalableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodScalable">PodScalable</a>)
-</p>
-<p>
-<p>PodScalableSpec is the specification for the desired state of a
-PodScalable (or at least our shared portion).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.PodScalableStatus">PodScalableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodScalable">PodScalable</a>)
-</p>
-<p>
-<p>PodScalableStatus is the observed state of a PodScalable (or at
-least our shared portion).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>replicas</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="autoscaling.internal.knative.dev/v1alpha1.ReachabilityType">ReachabilityType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerSpec">PodAutoscalerSpec</a>)
-</p>
-<p>
-<p>ReachabilityType is the enumeration type for the different states of reachability
-to the <code>ScaleTarget</code> of a <code>PodAutoscaler</code></p>
-</p>
 <hr/>
 <h2 id="serving.knative.dev/v1">serving.knative.dev/v1</h2>
 <p>
@@ -1165,7 +920,7 @@ ServiceStatus
 <p>
 (<em>Appears on:</em>
 <a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>, 
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>,
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -1199,8 +954,8 @@ RevisionTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
-<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>)
+<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>, 
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>)
 </p>
 <p>
 <p>ConfigurationStatus communicates the observed state of the Configuration (from the controller).</p>
@@ -1334,8 +1089,8 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
 <a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
 <a href="#serving.knative.dev/v1alpha1.RevisionSpec">RevisionSpec</a>, 
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
@@ -1400,8 +1155,8 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
-<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>)
+<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1.Revision">Revision</a>)
 </p>
 <p>
 <p>RevisionStatus communicates the observed state of the Revision (from the controller).</p>
@@ -1595,8 +1350,8 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Route">Route</a>, 
 <a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1.Route">Route</a>, 
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -1631,8 +1386,8 @@ revisions and configurations.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Route">Route</a>, 
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>)
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1.Route">Route</a>)
 </p>
 <p>
 <p>RouteStatus communicates the observed state of the Route (from the controller).</p>
@@ -1739,12 +1494,17 @@ LatestReadyRevisionName that we last observed.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="serving.knative.dev/v1.RoutingState">RoutingState
+(<code>string</code> alias)</p></h3>
+<p>
+<p>RoutingState represents states of a revision with regards to serving a route.</p>
+</p>
 <h3 id="serving.knative.dev/v1.ServiceSpec">ServiceSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Service">Service</a>, 
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>)
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceSpec represents the configuration for the Service object.
@@ -1804,8 +1564,8 @@ defaults).</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Service">Service</a>, 
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>)
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceStatus represents the Status stanza of the Service resource.</p>
@@ -3758,460 +3518,7 @@ Ultimately all non-v1 fields will be deprecated.</p>
 </tbody>
 </table>
 <hr/>
-<h2 id="serving.knative.dev/v1beta1">serving.knative.dev/v1beta1</h2>
-<p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>
-</li><li>
-<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>
-</li><li>
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>
-</li><li>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>
-</li></ul>
-<h3 id="serving.knative.dev/v1beta1.Configuration">Configuration
-</h3>
-<p>
-<p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions.
-Users create new Revisions by updating the Configuration&rsquo;s spec.
-The &ldquo;latest created&rdquo; revision&rsquo;s name is available under status, as is the
-&ldquo;latest ready&rdquo; revision&rsquo;s name.
-See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration">https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Configuration</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ConfigurationSpec">
-ConfigurationSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RevisionTemplateSpec">
-RevisionTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Template holds the latest specification for the Revision to be stamped out.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ConfigurationStatus">
-ConfigurationStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="serving.knative.dev/v1beta1.Revision">Revision
-</h3>
-<p>
-<p>Revision is an immutable snapshot of code and configuration.  A revision
-references a container image. Revisions are created by updates to a
-Configuration.</p>
-<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision">https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Revision</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RevisionSpec">
-RevisionSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>PodSpec</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
-Kubernetes core/v1.PodSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>PodSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>containerConcurrency</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
-requests per container of the Revision.  Defaults to <code>0</code> which means
-concurrency to the application is not limited, and the system decides the
-target concurrency for the autoscaler.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeoutSeconds</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TimeoutSeconds holds the max duration the instance is allowed for
-responding to a request.  If unspecified, a system default will
-be provided.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RevisionStatus">
-RevisionStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="serving.knative.dev/v1beta1.Route">Route
-</h3>
-<p>
-<p>Route is responsible for configuring ingress over a collection of Revisions.
-Some of the Revisions a Route distributes traffic over may be specified by
-referencing the Configuration responsible for creating them; in these cases
-the Route is additionally responsible for monitoring the Configuration for
-&ldquo;latest ready revision&rdquo; changes, and smoothly rolling out latest revisions.
-See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#route">https://github.com/knative/serving/blob/master/docs/spec/overview.md#route</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Route</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RouteSpec">
-RouteSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Route (from the client).</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>traffic</code></br>
-<em>
-<a href="#serving.knative.dev/v1.TrafficTarget">
-[]TrafficTarget
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Traffic specifies how to distribute traffic over a collection of
-revisions and configurations.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RouteStatus">
-RouteStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status communicates the observed state of the Route (from the controller).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="serving.knative.dev/v1beta1.Service">Service
-</h3>
-<p>
-<p>Service acts as a top-level container that manages a Route and Configuration
-which implement a network service. Service exists to provide a singular
-abstraction which can be access controlled, reasoned about, and which
-encapsulates software lifecycle decisions such as rollout policy and
-team resource ownership. Service acts only as an orchestrator of the
-underlying Routes and Configurations (much as a kubernetes Deployment
-orchestrates ReplicaSets), and its usage is optional but recommended.</p>
-<p>The Service&rsquo;s controller will track the statuses of its owned Configuration
-and Route, reflecting their statuses and conditions as its own.</p>
-<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#service">https://github.com/knative/serving/blob/master/docs/spec/overview.md#service</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Service</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ServiceSpec">
-ServiceSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>ConfigurationSpec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ConfigurationSpec">
-ConfigurationSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ConfigurationSpec</code> are embedded into this type.)
-</p>
-<p>ServiceSpec inlines an unrestricted ConfigurationSpec.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>RouteSpec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RouteSpec">
-RouteSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>RouteSpec</code> are embedded into this type.)
-</p>
-<p>ServiceSpec inlines RouteSpec and restricts/defaults its fields
-via webhook.  In particular, this spec can only reference this
-Service&rsquo;s configuration and revisions (which also influences
-defaults).</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ServiceStatus">
-ServiceStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>d74ecbeb1</code>.
+on git commit <code>427b2bf86</code>.
 </em></p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1503,7 +1503,7 @@ LatestReadyRevisionName that we last observed.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>,
 <a href="#serving.knative.dev/v1.Service">Service</a>)
 </p>
 <p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1386,7 +1386,7 @@ revisions and configurations.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>,
 <a href="#serving.knative.dev/v1.Route">Route</a>)
 </p>
 <p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1351,7 +1351,7 @@ be provided.</p>
 <p>
 (<em>Appears on:</em>
 <a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
-<a href="#serving.knative.dev/v1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1.Route">Route</a>,
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1090,7 +1090,7 @@ string
 <p>
 (<em>Appears on:</em>
 <a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
-<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1.Revision">Revision</a>,
 <a href="#serving.knative.dev/v1alpha1.RevisionSpec">RevisionSpec</a>, 
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>

--- a/docs/reference/serving.md
+++ b/docs/reference/serving.md
@@ -1564,7 +1564,7 @@ defaults).</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>,
 <a href="#serving.knative.dev/v1.Service">Service</a>)
 </p>
 <p>


### PR DESCRIPTION
Update API ref docs using new 0.17 knative components

https://github.com/knative/docs/tree/master/docs/reference#updating-api-reference-docs-for-knative-maintainers

```
cd hack

KNATIVE_SERVING_COMMIT=v0.17.0 KNATIVE_EVENTING_COMMIT=v0.17.0 KNATIVE_EVENTING_CONTRIB_COMMIT=v0.17.0 ./gen-api-reference-docs.sh
```