### PR TITLE
Change from sources.eventing.knative.dev/v1alpha1 to

### DIFF
--- a/docs/eventing/migration/ping.md
+++ b/docs/eventing/migration/ping.md
@@ -11,7 +11,7 @@ In 0.13, the deprecated `CronJobSource` should be converted to the `PingSource`.
 The YAML file for a `CronJobSource` that emits events to a Knative Serving service will look similar to this:
 
 ```yaml
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: CronJobSource
 metadata:
   name: cronjob-source

--- a/docs/eventing/samples/apache-camel-source/source_http_poller.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_http_poller.yaml
@@ -5,7 +5,7 @@
 #
 # List of available Apache Camel components: https://camel.apache.org/components/latest/
 #
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: CamelSource
 metadata:
   name: camel-http-poller-source

--- a/docs/eventing/samples/apache-camel-source/source_mqtt.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_mqtt.yaml
@@ -4,7 +4,7 @@
 #
 # List of available Apache Camel components: https://camel.apache.org/components/latest/
 #
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: CamelSource
 metadata:
   name: camel-mqtt-source

--- a/docs/eventing/samples/apache-camel-source/source_telegram.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_telegram.yaml
@@ -5,7 +5,7 @@
 #
 # List of available Apache Camel components: https://camel.apache.org/components/latest/
 #
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: CamelSource
 metadata:
   name: camel-telegram-source

--- a/docs/eventing/samples/apache-camel-source/source_timer.yaml
+++ b/docs/eventing/samples/apache-camel-source/source_timer.yaml
@@ -4,7 +4,7 @@
 #
 # List of available Apache Camel components: https://camel.apache.org/components/latest/
 #
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: CamelSource
 metadata:
   name: camel-timer-source

--- a/docs/eventing/samples/iot-core/gcp-pubsub-source.yaml
+++ b/docs/eventing/samples/iot-core/gcp-pubsub-source.yaml
@@ -2,7 +2,7 @@
 #   TOPIC_NAME: Replace with the GCP PubSub Topic name.
 #   MY_GCP_PROJECT: Replace with the GCP Project's ID.
 
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: GcpPubSubSource
 metadata:
   name: TOPIC_NAME-source


### PR DESCRIPTION
sources.knative.dev/v1alpha1 #2765

the apiVersion naming has been modified

Signed-off-by: Aurélien Pupier <apupier@redhat.com>

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
