### PR TITLE
examples(nodejs): bump to the latest 3.x version of cloudevents SDK

### DIFF
--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/index.js
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/index.js
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 const express = require('express')
-const { CloudEvent, Emitter, HTTP, headersFor } = require('cloudevents')
+const { CloudEvent, Emitter, HTTP } = require('cloudevents')
 const PORT = process.env.PORT || 8080
 const target = process.env.K_SINK
 const app = express()

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/package-lock.json
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/package-lock.json
@@ -115,6 +115,7 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -414,19 +415,19 @@
       }
     },
     "cloudevents": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.1.0.tgz",
-      "integrity": "sha512-98t6+Qs/r2PiYflNFztUcPSDfaaRU8KKMzaMR4dn9MPpijZj3A1W+L307t00D6xRzXdkDDiMcB2THS3dCp+kcw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.2.0.tgz",
+      "integrity": "sha512-D5QVEJtREXxM0QGmla0FKs0cctcIUQIAJpIEYx7R11PFFh9O7Bykos/gZCYJgzTieDrnEesJ+6pD03P48ZRrGw==",
       "requires": {
         "ajv": "~6.12.3",
         "axios": "~0.19.2",
-        "uuid": "~8.2.0"
+        "uuid": "~8.3.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -435,20 +436,10 @@
           }
         },
         "uuid": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
         }
-      }
-    },
-    "cloudevents-sdk": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cloudevents-sdk/-/cloudevents-sdk-2.0.1.tgz",
-      "integrity": "sha512-26gIbUtvDlVaLm+f5vFEg3R2grKgdSqCje1QoXkJH2LrSNuOqOiKkAgJ4PE4FmoiteJaaktAe8dc6e2EM4MAbg==",
-      "requires": {
-        "ajv": "~6.12.0",
-        "axios": "~0.19.2",
-        "uuid": "~8.0.0"
       }
     },
     "color-convert": {
@@ -2987,11 +2978,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/package-lock.json
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/package-lock.json
@@ -413,6 +413,34 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "cloudevents": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-3.1.0.tgz",
+      "integrity": "sha512-98t6+Qs/r2PiYflNFztUcPSDfaaRU8KKMzaMR4dn9MPpijZj3A1W+L307t00D6xRzXdkDDiMcB2THS3dCp+kcw==",
+      "requires": {
+        "ajv": "~6.12.3",
+        "axios": "~0.19.2",
+        "uuid": "~8.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "uuid": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+          "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+        }
+      }
+    },
     "cloudevents-sdk": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cloudevents-sdk/-/cloudevents-sdk-2.0.1.tgz",

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/package.json
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "cloudevents": "^3.1.0",
+    "cloudevents": "^3.2.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.4"
   },

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/package.json
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "cloudevents-sdk": "2.0.1",
+    "cloudevents": "^3.1.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.4"
   },


### PR DESCRIPTION
A few changes to the API were made in the recent release of the SDK. This commit updates the dependency and modifies the source to work with the new API.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update the Node.js example to use the `cloudevents` module version 3.1.0
- Modify the example code to work with the changed API
- Return the actual `CloudEvent` instance in the response body in `receiveAndReply()`
