### PR TITLE
doc: fix path to autoscale-go sample

### DIFF
--- a/docs/serving/autoscaling/autoscale-go/README.md
+++ b/docs/serving/autoscaling/autoscale-go/README.md
@@ -19,7 +19,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 1. Deploy the [sample](./service.yaml) Knative Service:
 
    ```
-   kubectl apply --filename docs/serving/samples/autoscale-go/service.yaml
+   kubectl apply --filename docs/serving/autoscaling/autoscale-go/service.yaml
    ```
 
 1. Obtain the URL of the service (once `Ready`):

--- a/docs/serving/autoscaling/autoscale-go/README.md
+++ b/docs/serving/autoscaling/autoscale-go/README.md
@@ -112,7 +112,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 Knative Serving autoscaling is based on the average number of in-flight requests
 per pod (concurrency). The system has a default
 [target concurrency of 100](https://github.com/knative/serving/blob/master/config/core/configmaps/autoscaler.yaml)(Search for container-concurrency-target-default)
-but [we used 10](service.yaml#L25-L26) for our service. We loaded the service
+but [we used 10](https://github.com/knative/docs/blob/master/docs/serving/autoscaling/autoscale-go/service.yaml#L23-L24) for our service. We loaded the service
 with 50 concurrent requests so the autoscaler created 5 pods
 (`50 concurrent requests / target of 10 = 5 pods`)
 


### PR DESCRIPTION
corrected the path to `docs/serving/autoscaling/autoscale-go/service.yaml` in the sample command invocation

