### PR TITLE
Fix default installation without sidecar injection

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -86,12 +86,14 @@ spec:
             - port: 15020
               name: status-port
             - port: 80
+              targetPort: 8080
               name: http2
             - port: 443
+              targetPort: 8443
               name: https
 EOF
 
-istioctl manifest install -f istio-minimal-operator.yaml --set values.gateways.istio-ingressgateway.runAsRoot=true
+istioctl manifest install -f istio-minimal-operator.yaml
 ```
 
 #### Installing Istio with sidecar injection

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -91,7 +91,7 @@ spec:
               name: https
 EOF
 
-istioctl manifest apply -f istio-minimal-operator.yaml
+istioctl manifest install -f istio-minimal-operator.yaml --set values.gateways.istio-ingressgateway.runAsRoot=true
 ```
 
 #### Installing Istio with sidecar injection

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -93,7 +93,7 @@ spec:
               name: https
 EOF
 
-istioctl manifest install -f istio-minimal-operator.yaml
+istioctl install -f istio-minimal-operator.yaml
 ```
 
 #### Installing Istio with sidecar injection


### PR DESCRIPTION
The default installation doesn't work as described in the documentation.

I fixed it like this

 * manifest apply no longer exists in istioctl CLI.
 * Add runAsRoot to allow targetPort creation bellow 1024.

