### PR TITLE
Update the stale content of configuring TLS of Istio Gateway

### DIFF
--- a/docs/serving/using-a-tls-cert.md
+++ b/docs/serving/using-a-tls-cert.md
@@ -260,7 +260,7 @@ Kubernetes secret and then configure the `knative-ingress-gateway`:
               mode: SIMPLE
               credentialName: tls-cert
       ```
-      In above example, `TLS_HOSTS` represents the hosts of your TLS certificate. It could be single host, multiple hosts, or wildcard host.
+      In above example, `TLS_HOSTS` represents the hosts of your TLS certificate. It can be single host, multiple hosts, or wildcard host.
       For detailed instructions, please refer [Istio documentation](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/)
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/serving/using-a-tls-cert.md
+++ b/docs/serving/using-a-tls-cert.md
@@ -205,12 +205,11 @@ Kubernetes secret and then configure the `knative-ingress-gateway`:
    private key, `key.pem`, by entering the following command:
 
    ```shell
-   kubectl create --namespace istio-system secret tls istio-ingressgateway-certs \
+   kubectl create --namespace istio-system secret tls tls-cert \
      --key key.pem \
      --cert cert.pem
    ```
 
-   Note that the `istio-ingressgateway-certs` secret name is required.
 
 1. Configure Knative to use the new secret that you created for HTTPS
    connections:
@@ -228,8 +227,7 @@ Kubernetes secret and then configure the `knative-ingress-gateway`:
       ```yaml
       tls:
         mode: SIMPLE
-        privateKey: /etc/istio/ingressgateway-certs/tls.key
-        serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+        credentialName: tls-cert
       ```
 
       Example:
@@ -253,16 +251,17 @@ Kubernetes secret and then configure the `knative-ingress-gateway`:
               number: 80
               protocol: HTTP
           - hosts:
-              - "*"
+              - TLS_HOSTS
             port:
               name: https
               number: 443
               protocol: HTTPS
             tls:
               mode: SIMPLE
-              privateKey: /etc/istio/ingressgateway-certs/tls.key
-              serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+              credentialName: tls-cert
       ```
+      In above example, `TLS_HOSTS` represents the hosts of your TLS certificate. It could be single host, multiple hosts, or wildcard host.
+      For detailed instructions, please refer [Istio documentation](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/)
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/docs/serving/using-a-tls-cert.md
+++ b/docs/serving/using-a-tls-cert.md
@@ -260,7 +260,7 @@ Kubernetes secret and then configure the `knative-ingress-gateway`:
               mode: SIMPLE
               credentialName: tls-cert
       ```
-      In above example, `TLS_HOSTS` represents the hosts of your TLS certificate. It can be single host, multiple hosts, or wildcard host.
+      In the example above, `TLS_HOSTS` represents the hosts of your TLS certificate. It can be a single host, multiple hosts, or a wildcard host.
       For detailed instructions, please refer [Istio documentation](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/)
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves
https://github.com/knative/docs/issues/1210

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Use the latest way in Istio for manually configuring TLS of Istio Gateway 

