### PR TITLE
Remove redundant paragraph in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,6 @@ The following are guidelines for contributing to the Knative documentation.
 These are just guidelines, not rules. Use your best judgment, and feel free to
 propose changes to this document in a pull request.
 
-**First off, thanks for taking the time to contribute!**
-
-The following are guidelines for contributing to the Knative documentation.
-These are just guidelines, not rules. Use your best judgment, and feel free to
-propose changes to this document in a pull request.
-
 ## Before you begin
 
 ### Code of conduct


### PR DESCRIPTION
The first paragraph appears twice. This is my first pull request to the knative/docs project.

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.