### PR TITLE
fix the min k8s version

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -47,7 +47,7 @@ This guide assumes that you want to install an upstream Knative release on a
 Kubernetes cluster. A growing number of vendors have managed Knative offerings;
 see the [Knative Offerings](../knative-offerings.md) page for a full list.
 
-Knative {{< version >}} requires a Kubernetes cluster v1.15 or newer, as well as
+Knative {{< version >}} requires a Kubernetes cluster v1.16 or newer, as well as
 a compatible `kubectl`. This guide assumes that you've already created a
 Kubernetes cluster, and that you are using bash in a Mac or Linux environment;
 some commands will need to be adjusted for use in a Windows environment.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix the min k8s version. It should be 1.16

