### PR TITLE
Move Kubernetes to 1.16+ (v0.16)

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -23,7 +23,7 @@ To complete this guide, you will need the following installed and running:
 
 - A
   [Kubernetes cluster](https://kubernetes.io/docs/concepts/cluster-administration/cluster-administration-overview/)
-  running v1.15 or higher.
+  running v1.16 or higher.
 
 - [`kubectl` CLI tool](https://kubernetes.io/docs/reference/kubectl/overview/)
   within a minor version of your Kubernetes cluster.

--- a/docs/eventing/samples/writing-event-source/06-yaml.md
+++ b/docs/eventing/samples/writing-event-source/06-yaml.md
@@ -10,7 +10,7 @@ type: "docs"
 Start a minikube cluster.
 
 _If you already have a Kubernetes cluster running, you can skip this step. The
-cluster must be 1.15+_
+cluster must be 1.16+_
 
 ```sh
 minikube start

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -12,7 +12,7 @@ Knative using Knative operator.
 
 Knative installation using the Operator requires the following:
 
-- A Kubernetes cluster v1.15 or newer, as well as a compatible kubectl. This guide assumes that you've already created
+- A Kubernetes cluster v1.16 or newer, as well as a compatible kubectl. This guide assumes that you've already created
 a Kubernetes cluster. If you have only one node for your cluster, set CPUs to at least 6, Memory to at least 6.0 GB,
 Disk storage to at least 30 GB. If you have multiple nodes for your cluster, set CPUs to at least 2, Memory to at least
 4.0 GB, Disk storage to at least 20 GB for each node.


### PR DESCRIPTION
All Kubernetes version is set to 1.16+ on v0.16.

https://github.com/knative/serving/releases/tag/v0.15.0

This complements #2711 and includes backport of #2784 for master.

/label proposal/0.16