### PR TITLE
Move Kubernetes to 1.16+ (v0.17)

### DIFF
--- a/docs/eventing/samples/writing-event-source/06-yaml.md
+++ b/docs/eventing/samples/writing-event-source/06-yaml.md
@@ -10,7 +10,7 @@ type: "docs"
 Start a minikube cluster.
 
 _If you already have a Kubernetes cluster running, you can skip this step. The
-cluster must be 1.15+_
+cluster must be 1.16+_
 
 ```sh
 minikube start

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -47,7 +47,7 @@ This guide assumes that you want to install an upstream Knative release on a
 Kubernetes cluster. A growing number of vendors have managed Knative offerings;
 see the [Knative Offerings](../knative-offerings.md) page for a full list.
 
-Knative {{< version >}} requires a Kubernetes cluster v1.15 or newer, as well as
+Knative {{< version >}} requires a Kubernetes cluster v1.16 or newer, as well as
 a compatible `kubectl`. This guide assumes that you've already created a
 Kubernetes cluster, and that you are using bash in a Mac or Linux environment;
 some commands will need to be adjusted for use in a Windows environment.

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -12,7 +12,7 @@ Knative using Knative operator.
 
 Knative installation using the Operator requires the following:
 
-- A Kubernetes cluster v1.15 or newer, as well as a compatible kubectl. This guide assumes that you've already created
+- A Kubernetes cluster v1.16 or newer, as well as a compatible kubectl. This guide assumes that you've already created
 a Kubernetes cluster. If you have only one node for your cluster, set CPUs to at least 6, Memory to at least 6.0 GB,
 Disk storage to at least 30 GB. If you have multiple nodes for your cluster, set CPUs to at least 2, Memory to at least
 4.0 GB, Disk storage to at least 20 GB for each node.


### PR DESCRIPTION
All Kubernetes version is set to 1.16+ on 0.17.

https://github.com/knative/serving/releases/tag/v0.15.0

This includes backport of #2784 for master (or #2711 for v0.16).