### PR TITLE
Promote net-contour to stable.

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -135,7 +135,7 @@ The following commands install Ambassador and enable its Knative integration.
 
 {{% tab name="Contour" %}}
 
-{{% feature-state version="v0.17" state="beta" %}}
+{{% feature-state version="v0.18" state="stable" %}}
 
 The following commands install Contour and enable its Knative integration.
 


### PR DESCRIPTION
All of the known remaining issues with our Contour integration have been resolved, and I've been carefully monitoring testgrid and digging into any 503s (or other dataplane related failures).

As of me writing this:
1. The only failure in the net-contour [testgrid](https://testgrid.knative.dev/net-contour#continuous&exclude-non-failed-tests=50&sort-by-flakiness=50&width=20) is due to its workaround for https://github.com/knative-sandbox/net-certmanager/issues/44 (tracking: https://github.com/knative-sandbox/net-contour/issues/252), which shouldn't practically manifest in the context of Serving
2. The only failures in the contour leg on Serving [testgrid](https://testgrid.knative.dev/serving#contour-latest&width=20&exclude-non-failed-tests=50&sort-by-flakiness=50) are due to infrastructure (Go, etcd, GKE, resource exhaustion)

I will continue to track testgrid carefully as we head towards 0.18, but at present it is as solid as any of our ingress options.

/assign @nak3 @ZhiminXiang @tcnghia 
cc @youngnick @michmike @jpeach @stevesloka 
/hold