### PR TITLE
[Kafka Broker] Change installation steps and artifact names

### DIFF
--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -22,13 +22,19 @@ Notable features are:
 
 ## Installation
 
-1. Install the Kafka broker by entering the following command:
+1. Install the Kafka controller by entering the following command:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-controller.yaml" >}}
+    ```
+
+1. Install the Kafka Broker data plane by entering the following command:
 
     ```bash
     kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-broker.yaml" >}}
     ```
 
-2. Verify that `kafka-broker-controller`, `kafka-broker-receiver` and `kafka-broker-dispatcher` are running,
+2. Verify that `kafka-controller`, `kafka-broker-receiver` and `kafka-broker-dispatcher` are running,
 by entering the following command:
 
     ```bash
@@ -41,7 +47,7 @@ by entering the following command:
     NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
     eventing-controller            1/1     1            1           10s
     eventing-webhook               1/1     1            1           9s
-    kafka-broker-controller        1/1     1            1           3s
+    kafka-controller        1/1     1            1           3s
     kafka-broker-dispatcher        1/1     1            1           4s
     kafka-broker-receiver          1/1     1            1           5s
     ```
@@ -158,7 +164,7 @@ installation step:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kafka-broker-config-logging
+  name: kafka-config-logging
   namespace: knative-eventing
 data:
   config.xml: |
@@ -174,14 +180,14 @@ data:
 
 To change the logging level to `DEBUG`, you need to: 
 
-1. Apply the following `kafka-broker-config-logging` `ConfigMap` or replace `level="INFO"` with `level="DEBUG"` to the
-`ConfigMap` `kafka-broker-config-logging`:
+1. Apply the following `kafka-config-logging` `ConfigMap` or replace `level="INFO"` with `level="DEBUG"` to the
+`ConfigMap` `kafka-config-logging`:
 
     ```yaml
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: kafka-broker-config-logging
+      name: kafka-config-logging
       namespace: knative-eventing
     data:
       config.xml: |

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -608,12 +608,21 @@ kubectl apply --filename {{< artifact repo="eventing" file="in-memory-channel.ya
    {{< tabs name="eventing_brokers" default="MT-Channel-based" >}}
    {{% tab name="Apache Kafka Broker" %}}
    {{< feature-state version="v0.17" state="alpha" >}}
-The following command installs the Apache Kafka broker, and runs event routing in a system namespace,
+
+The following commands install the Apache Kafka broker, and run event routing in a system namespace,
 `knative-eventing`, by default.
 
-```bash
-kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-broker.yaml" >}}
-```
+1. Install the Kafka controller by entering the following command:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-controller.yaml" >}}
+    ```
+
+1. Install the Kafka Broker data plane by entering the following command:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-broker.yaml" >}}
+    ```
 
 For more information, see the [Kafka Broker](./../eventing/broker/kafka-broker.md) documentation.
 {{< /tab >}}


### PR DESCRIPTION
The control plane is now a separate artifact, so we need to
add another step to the installation and rename the control plane
and the logging config artifacts.

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2813 
Fixes #2812

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Renamed `kafka-broker-config-logging` -> `kafka-config-logging`
- Renamed `kafka-broker-controller` -> `kafka-controller`
- Document the new installation steps.