### PR TITLE
docs(cloudevents): try cloudevents-nodejs with kn

### DIFF
--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/README.md
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/README.md
@@ -56,7 +56,7 @@ In the `Dockerfile`, you will see how the dependencies are installed using npm.
    docker push <image>
    ```
 
-{{< tabs name="cloudevents_rust_deploy" default="kn" >}} {{% tab name="yaml" %}}
+{{< tabs name="cloudevents_nodejs_deploy" default="kn" >}} {{% tab name="yaml" %}}
 
 To deploy the Knative service, look in `service.yaml` and replace `<registry/repository/image:tag>` with the image just created.
 
@@ -107,7 +107,7 @@ You will get back:
 
 To remove the sample app from your cluster, delete the service.
 
-{{< tabs name="cloudevents_rust_delete" default="kn" >}} {{% tab name="yaml" %}}
+{{< tabs name="cloudevents_nodejs_delete" default="kn" >}} {{% tab name="yaml" %}}
 
 Run:
 

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/README.md
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/README.md
@@ -32,7 +32,8 @@ cd knative-docs/docs/serving/samples/cloudevents/cloudevents-nodejs
 
 ## The Sample Code
 
-In `index.js`, you will see two key functions for the different modes of operation:
+In the `index.js` file, you will see two key functions for the different modes
+of operation:
 
    ```js
    const receiveAndSend = (cloudEvent, res) => {
@@ -48,7 +49,7 @@ In `index.js`, you will see two key functions for the different modes of operati
 
 ## Build and Deploy the Application
 
-In the `Dockerfile`, you will see how the dependencies are installed using npm.
+In the `Dockerfile`, you can see how the dependencies are installed using npm.
   You can build and push this to your registry of choice via:
 
    ```shell
@@ -58,7 +59,8 @@ In the `Dockerfile`, you will see how the dependencies are installed using npm.
 
 {{< tabs name="cloudevents_nodejs_deploy" default="kn" >}} {{% tab name="yaml" %}}
 
-To deploy the Knative service, look in `service.yaml` and replace `<registry/repository/image:tag>` with the image just created.
+To deploy the Knative service, edit the `service.yaml` file and replace
+`<registry/repository/image:tag>` with the image you have just created.
 
    ```shell
    kubectl apply -f service.yaml

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/README.md
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/README.md
@@ -30,10 +30,9 @@ cd knative-docs/docs/serving/samples/cloudevents/cloudevents-nodejs
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).
 
-## The sample code.
+## The Sample Code
 
-1. If you look in `index.js`, you will see two key functions for the
-   different modes of operation:
+In `index.js`, you will see two key functions for the different modes of operation:
 
    ```js
    const receiveAndSend = (cloudEvent, res) => {
@@ -47,7 +46,9 @@ cd knative-docs/docs/serving/samples/cloudevents/cloudevents-nodejs
    }
    ```
 
-1. If you look in `Dockerfile`, you will see how the dependencies are installed using npm.
+## Build and Deploy the Application
+
+In the `Dockerfile`, you will see how the dependencies are installed using npm.
   You can build and push this to your registry of choice via:
 
    ```shell
@@ -55,12 +56,23 @@ cd knative-docs/docs/serving/samples/cloudevents/cloudevents-nodejs
    docker push <image>
    ```
 
-1. If you look in `service.yaml`, take the `<image>` name above and insert it
-   into the `image:`.
+{{< tabs name="cloudevents_rust_deploy" default="kn" >}} {{% tab name="yaml" %}}
+
+To deploy the Knative service, look in `service.yaml` and replace `<registry/repository/image:tag>` with the image just created.
 
    ```shell
    kubectl apply -f service.yaml
    ```
+
+{{< /tab >}} {{% tab name="kn" %}}
+
+To deploy using the `kn` CLI:
+
+```shell
+kn service create cloudevents-nodejs --image=<image>
+```
+
+{{ /tab }}{{ /tabs }}
 
 ## Testing the sample
 
@@ -93,8 +105,22 @@ You will get back:
 
 ## Removing the sample app deployment
 
-To remove the sample app from your cluster, delete the service record:
+To remove the sample app from your cluster, delete the service.
+
+{{< tabs name="cloudevents_rust_delete" default="kn" >}} {{% tab name="yaml" %}}
+
+Run:
 
 ```shell
 kubectl delete --filename service.yaml
 ```
+
+{{< /tab >}} {{% tab name="kn" %}}
+
+Run:
+
+```shell
+kn service delete cloudevents-nodejs
+```
+
+{{ /tab }}{{ /tabs }}


### PR DESCRIPTION
Adds tabbed instructions for deploying and deleting the Node.js cloudevents
sample using the `kn` CLI.

Signed-off-by: Lance Ball <lball@redhat.com>
