### PR TITLE
Added note about the configmap not being complete

### DIFF
--- a/docs/serving/tag-resolution.md
+++ b/docs/serving/tag-resolution.md
@@ -83,7 +83,7 @@ resolution via the `registriesSkippingTagResolving` configmap field:
 kubectl -n knative-serving edit configmap config-deployment
 ```
 
-E.g., to disable tag resolution for `registry.example.com`:
+E.g., to disable tag resolution for `registry.example.com` (note: This is not a complete configmap, it is a snippet showing registriesSkippingTagResolving):
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Fixes #2565 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds a note about the configmap saying that it is a snippet. Should keep users from copy/pasting as a complete configmap. 

