### PR TITLE
Document Scale Down Delay

### DIFF
--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -158,4 +158,63 @@ spec:
 {{< /tab >}}
 {{< /tabs >}}
 
+## Scale Down Delay
+
+Scale Down Delay specifies a time window which must pass at reduced concurrency
+before a scale-down decision is applied. This can be useful, for example, to
+keep containers around for a configurable duration to avoid a cold start
+penalty if new requests come in. Unlike setting a Lower Bound, the revision
+will eventually be scaled down if reduced concurrency is maintained for the
+delay period.
+
+* **Global key:** `scale-down-delay`
+* **Per-revision annotation key:** `autoscaling.knative.dev/scaleDownDelay`
+* **Possible values:** Duration, `0s` <= value <= `1h`
+* **Default:** `0s` (no delay)
+
+**Example:**
+{{< tabs name="scale-down-delay" default="Per Revision" >}}
+{{% tab name="Per Revision" %}}
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/scaleDownDelay: "15m"
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+```
+{{< /tab >}}
+{{% tab name="Global (ConfigMap)" %}}
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+data:
+  scale-down-delay: "15m"
+```
+{{< /tab >}}
+{{% tab name="Global (Operator)" %}}
+```yaml
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    autoscaler:
+      scale-down-delay: "15m"
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
 ---

--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -163,7 +163,7 @@ spec:
 Scale Down Delay specifies a time window which must pass at reduced concurrency
 before a scale-down decision is applied. This can be useful, for example, to
 keep containers around for a configurable duration to avoid a cold start
-penalty if new requests come in. Unlike setting a Lower Bound, the revision
+penalty if new requests come in. Unlike setting a lower bound, the revision
 will eventually be scaled down if reduced concurrency is maintained for the
 delay period.
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Part of knative/serving#9092.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Documents the new Scale Down Delay feature

/hold till we finish landing the feature

/assign @markusthoemmes @vagababov @abrennan89 