### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/docs/eventing/flows/sequence.md
+++ b/docs/eventing/flows/sequence.md
@@ -79,7 +79,7 @@ by <STEP NUMBER>", for example the first Step in the `Sequence` will take the
 incoming message and append "- Handled by 0" to the incoming message.
 
 The only difference is that we'll use the `Subscriber.Spec.Reply` field to wire
-the output of the last Step to another `Sequence` that does the smae message
+the output of the last Step to another `Sequence` that does the same message
 modifications as the first pipeline (with different steps however).
 
 ### [Using Sequence with Broker/Trigger model](../samples/sequence/sequence-with-broker-trigger/README.md)

--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -84,7 +84,7 @@ A source based on Paho (like the provided [MQTT CamelSource](source_mqtt.yaml)) 
 automatically converting IoT messages to Cloudevents.
 
 To use the MQTT source, you need a MQTT broker running and reachable from your cluster.
-For example, it's possible to run a [Mosquitto MQTT Broker](https://mosquitto.org/) for testing purposes.  
+For example, it's possible to run a [Mosquito MQTT Broker](https://mosquitto.org/) for testing purposes.  
 
 First, edit the [MQTT CamelSource](source_mqtt.yaml) and put the
 correct address of the MQTT broker in the `brokerUrl` field.


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc abrennan89 dprotaso vaikas
/assign abrennan89 dprotaso vaikas