### PR TITLE
Add deprecation message to observability section

### DIFF
--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -5,7 +5,7 @@ weight: 40
 type: "docs"
 ---
 
-**DEPRECATED:** The monitoring tools released by Knative community are deprecated. Knative community will stop releasing them in a coming release.
+{{< feature-state version="v0.14" state="deprecated" >}}
 
 If you followed one of the
 [comprehensive install guides](../install/README.md#install-guides) or you

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -5,6 +5,8 @@ weight: 40
 type: "docs"
 ---
 
+**DEPRECATED:** The monitoring tools released by Knative community are deprecated. Knative community will stop releasing them in a coming release.
+
 If you followed one of the
 [comprehensive install guides](../install/README.md#install-guides) or you
 performed a custom installation and included the `monitoring.yaml` file in your
@@ -14,6 +16,12 @@ can skip down to the
 
 If you have not yet installed any observability plugins, continue to the next
 sections to do so now.
+
+All observibility plugins require that you first install the core:
+
+```bash
+kubectl apply --filename {{< artifact repo="serving" file="monitoring-core.yaml" >}}
+```
 
 ## Metrics
 

--- a/docs/serving/installing-logging-metrics-traces.md
+++ b/docs/serving/installing-logging-metrics-traces.md
@@ -17,7 +17,7 @@ can skip down to the
 If you have not yet installed any observability plugins, continue to the next
 sections to do so now.
 
-All observibility plugins require that you first install the core:
+All observability plugins require that you first install the core:
 
 ```bash
 kubectl apply --filename {{< artifact repo="serving" file="monitoring-core.yaml" >}}


### PR DESCRIPTION
The observability tools are deprecated but some users did notice it because monitoring section does not mention about the deprecation. https://github.com/knative/serving/issues/9596.

Also, this patch adds a minor fix which creates `knative-monitoring` namespace beforehand. https://github.com/knative/serving/issues/9606

Fixes https://github.com/knative/serving/issues/9596 https://github.com/knative/serving/issues/9606

/assign @evankanderson @mattmoor @abrennan89 