### PR TITLE
API docs for 0.18 docs release

### DIFF
--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -85,8 +85,8 @@ To generate a version of the API:
 1. Copy the generated API files into the `docs/reference` directory of your
    knative/docs clone.
 
-1. The linter now fails for content with trailing whitespaces. Use a tool of your choice to 
-remove all trailing whitespace. For example, search for and remove: `\s+$`
+1. The linter now fails for content with trailing whitespaces. Use a tool of your choice to
+   remove all trailing whitespace. For example, search for and remove: `\s+$`
 
 You can now perform the necessary steps to open a PR, complete a review, and
 merge the new API files into the appropriate branch of the `knative/docs` repo.

--- a/docs/reference/api/README.md
+++ b/docs/reference/api/README.md
@@ -85,6 +85,9 @@ To generate a version of the API:
 1. Copy the generated API files into the `docs/reference` directory of your
    knative/docs clone.
 
+1. The linter now fails for content with trailing whitespaces. Use a tool of your choice to 
+remove all trailing whitespace. For example, search for and remove: `\s+$`
+
 You can now perform the necessary steps to open a PR, complete a review, and
 merge the new API files into the appropriate branch of the `knative/docs` repo.
 See the [contributor flow](https://github.com/knative/community/blob/master/docs/DOCS-CONTRIBUTING.md) for details
@@ -92,19 +95,18 @@ about requesting changes in the `knative/docs` repo.
 
 ### Example
 
-<!--TODO: UPDATE THIS EXAMPLE VERSION-->
-To build a set of Knative API docs for v0.3, you can use the `v0.3.0` the tags
+To build a set of Knative API docs for v0.18, you can use the `v0.18.0` the tags
 from each of the Knative component repositories, like
-[Serving v0.3.0](https://github.com/knative/serving/tree/v0.3.0). If you want to
-use a commit for Serving v0.3.0, you would use
-[4d198d](https://github.com/knative/serving/commit/4d198db8756db2f8a3c228302a97fb3a216a9475).
+[Serving v0.18.0](https://github.com/knative/serving/tree/v0.18.0). If you want to
+use a commit for Serving v0.18.0, you would use
+[850b7c](https://github.com/knative/serving/commit/850b7cca7d7701b052420a030f2308d19938d45e).
 
 Using tags from each repo, you would run the following command to generate the
-v0.3.0 API source files:
+v0.18.0 API source files:
 
 ```
-KNATIVE_SERVING_COMMIT=v0.3.0 \
-KNATIVE_EVENTING_COMMIT=v0.3.0 \
-KNATIVE_EVENTING_CONTRIB_COMMIT=v0.3.0 \
+KNATIVE_SERVING_COMMIT=v0.18.0 \
+KNATIVE_EVENTING_COMMIT=v0.18.0 \
+KNATIVE_EVENTING_CONTRIB_COMMIT=v0.18.0 \
 ./gen-api-reference-docs.sh
 ```

--- a/docs/reference/api/_index.md
+++ b/docs/reference/api/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Knative API Reference Documentation"
 linkTitle: "API"
-weight: 100
+weight: 50
 type: "docs"
 ---

--- a/docs/reference/api/_index.md
+++ b/docs/reference/api/_index.md
@@ -3,9 +3,4 @@ title: "Knative API Reference Documentation"
 linkTitle: "API"
 weight: 100
 type: "docs"
-aliases:
-aliases:
-   - /docs/reference/
 ---
-
-{{% readfile file="README.md" %}}

--- a/docs/reference/api/eventing/eventing-contrib.md
+++ b/docs/reference/api/eventing/eventing-contrib.md
@@ -1,24 +1,372 @@
 <p>Packages:</p>
 <ul>
 <li>
+<a href="#sources.knative.dev%2fv1beta1">sources.knative.dev/v1beta1</a>
+</li>
+<li>
 <a href="#messaging.knative.dev%2fv1alpha1">messaging.knative.dev/v1alpha1</a>
 </li>
 <li>
 <a href="#messaging.knative.dev%2fv1beta1">messaging.knative.dev/v1beta1</a>
 </li>
 <li>
-<a href="#bindings.knative.dev%2fv1beta1">bindings.knative.dev/v1beta1</a>
+<a href="#bindings.knative.dev%2fv1alpha1">bindings.knative.dev/v1alpha1</a>
 </li>
 <li>
-<a href="#sources.knative.dev%2fv1beta1">sources.knative.dev/v1beta1</a>
+<a href="#bindings.knative.dev%2fv1beta1">bindings.knative.dev/v1beta1</a>
 </li>
 <li>
 <a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
 </li>
-<li>
-<a href="#bindings.knative.dev%2fv1alpha1">bindings.knative.dev/v1alpha1</a>
-</li>
 </ul>
+<h2 id="sources.knative.dev/v1beta1">sources.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="sources.knative.dev/v1beta1.KafkaLimitsSpec">KafkaLimitsSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cpu</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>memory</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaRequestsSpec">KafkaRequestsSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>cpu</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>memory</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec
+</h3>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>requests</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaRequestsSpec">
+KafkaRequestsSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>limits</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaLimitsSpec">
+KafkaLimitsSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaSource">KafkaSource
+</h3>
+<p>
+<p>KafkaSource is the Schema for the kafkasources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">
+KafkaSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topics</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Topic topics to consume messages from</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumerGroup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConsumerGroupID is the consumer group ID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1beta1.KafkaSourceStatus">
+KafkaSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
+</p>
+<p>
+<p>KafkaSourceSpec defines the desired state of the KafkaSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>topics</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Topic topics to consume messages from</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>consumerGroup</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ConsumerGroupID is the consumer group ID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1beta1.KafkaSourceStatus">KafkaSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
+</p>
+<p>
+<p>KafkaSourceStatus defines the observed state of KafkaSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <h2 id="messaging.knative.dev/v1alpha1">messaging.knative.dev/v1alpha1</h2>
 <p>
 <p>Package v1alpha1 is the v1alpha1 version of the API.</p>
@@ -26,8 +374,6 @@
 Resource Types:
 <ul><li>
 <a href="#messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel</a>
-</li><li>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>
 </li></ul>
 <h3 id="messaging.knative.dev/v1alpha1.KafkaChannel">KafkaChannel
 </h3>
@@ -141,96 +487,6 @@ date.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel
-</h3>
-<p>
-<p>NatssChannel is a resource representing a NATSS Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>NatssChannel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannelSpec">
-NatssChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
-</em>
-</td>
-<td>
-<p>NatssChannel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannelStatus">
-NatssChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the NatssChannel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
 <h3 id="messaging.knative.dev/v1alpha1.KafkaChannelSpec">KafkaChannelSpec
 </h3>
 <p>
@@ -328,102 +584,6 @@ knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 (Members of <code>AddressStatus</code> are embedded into this type.)
 </p>
 <p>KafkaChannel is Addressable. It currently exposes the endpoint as a
-fully-qualified DNS name which will distribute traffic over the
-provided targets from inside the cluster.</p>
-<p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.SubscribableTypeStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.NatssChannelSpec">NatssChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>)
-</p>
-<p>
-<p>NatssChannelSpec defines the specification for a NatssChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-knative.dev/eventing/pkg/apis/duck/v1alpha1.Subscribable
-</em>
-</td>
-<td>
-<p>NatssChannel conforms to Duck type Subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1alpha1.NatssChannelStatus">NatssChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1alpha1.NatssChannel">NatssChannel</a>)
-</p>
-<p>
-<p>NatssChannelStatus represents the current state of a NatssChannel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>NatssChannel is Addressable. It currently exposes the endpoint as a
 fully-qualified DNS name which will distribute traffic over the
 provided targets from inside the cluster.</p>
 <p>It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
@@ -653,6 +813,420 @@ knative.dev/eventing/pkg/apis/duck/v1.ChannelableStatus
 (Members of <code>ChannelableStatus</code> are embedded into this type.)
 </p>
 <p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="bindings.knative.dev/v1alpha1">bindings.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaAuthSpec">KafkaAuthSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaBindingSpec">KafkaBindingSpec</a>, 
+<a href="#sources.knative.dev/v1alpha1.KafkaSourceSpec">KafkaSourceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>bootstrapServers</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<p>Bootstrap servers are the Kafka servers the consumer will connect to.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>net</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaNetSpec">
+KafkaNetSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaBinding">KafkaBinding
+</h3>
+<p>
+<p>KafkaBinding is the Schema for the kafkasources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaBindingSpec">
+KafkaBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaBindingStatus">
+KafkaBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaBindingSpec">KafkaBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaBinding">KafkaBinding</a>)
+</p>
+<p>
+<p>KafkaBindingSpec defines the desired state of the KafkaBinding.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>KafkaAuthSpec</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaAuthSpec">
+KafkaAuthSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaBindingStatus">KafkaBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaBinding">KafkaBinding</a>)
+</p>
+<p>
+<p>KafkaBindingStatus defines the observed state of KafkaBinding.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaNetSpec">KafkaNetSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaAuthSpec">KafkaAuthSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>sasl</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaSASLSpec">
+KafkaSASLSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>tls</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaTLSSpec">
+KafkaTLSSpec
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaSASLSpec">KafkaSASLSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaNetSpec">KafkaNetSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>user</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>User is the Kubernetes secret containing the SASL username.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>password</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Password is the Kubernetes secret containing the SASL password.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.KafkaTLSSpec">KafkaTLSSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaNetSpec">KafkaNetSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>enable</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>cert</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Cert is the Kubernetes secret containing the client certificate.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>key</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Key is the Kubernetes secret containing the client key.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>caCert</code></br>
+<em>
+<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
+SecretValueFromSource
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CACert is the Kubernetes secret containing the server CA cert.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="bindings.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#bindings.knative.dev/v1alpha1.KafkaSASLSpec">KafkaSASLSpec</a>, 
+<a href="#bindings.knative.dev/v1alpha1.KafkaTLSSpec">KafkaTLSSpec</a>)
+</p>
+<p>
+<p>SecretValueFromSource represents the source of a secret value</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>secretKeyRef</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>The Secret key to select from.</p>
 </td>
 </tr>
 </tbody>
@@ -1072,2056 +1646,12 @@ Kubernetes core/v1.SecretKeySelector
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.knative.dev/v1beta1">sources.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="sources.knative.dev/v1beta1.KafkaLimitsSpec">KafkaLimitsSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>cpu</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>memory</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaRequestsSpec">KafkaRequestsSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>cpu</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>memory</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaResourceSpec">KafkaResourceSpec
-</h3>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>requests</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaRequestsSpec">
-KafkaRequestsSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>limits</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaLimitsSpec">
-KafkaLimitsSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaSource">KafkaSource
-</h3>
-<p>
-<p>KafkaSource is the Schema for the kafkasources API.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">
-KafkaSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>topics</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Topic topics to consume messages from</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>consumerGroup</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConsumerGroupID is the consumer group ID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1beta1.KafkaSourceStatus">
-KafkaSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
-</p>
-<p>
-<p>KafkaSourceSpec defines the desired state of the KafkaSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1beta1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>topics</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Topic topics to consume messages from</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>consumerGroup</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ConsumerGroupID is the consumer group ID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1beta1.KafkaSourceStatus">KafkaSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1beta1.KafkaSource">KafkaSource</a>)
-</p>
-<p>
-<p>KafkaSourceStatus defines the observed state of KafkaSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="sources.knative.dev/v1alpha1">sources.knative.dev/v1alpha1</h2>
 <p>
 <p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
 </p>
 Resource Types:
-<ul><li>
-<a href="#sources.knative.dev/v1alpha1.AwsSqsSource">AwsSqsSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha1.CamelSource">CamelSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha1.CouchDbSource">CouchDbSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha1.GitHubSource">GitHubSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha1.GitLabSource">GitLabSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha1.PrometheusSource">PrometheusSource</a>
-</li></ul>
-<h3 id="sources.knative.dev/v1alpha1.AwsSqsSource">AwsSqsSource
-</h3>
-<p>
-<p>AwsSqsSource is the Schema for the AWS SQS API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>AwsSqsSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.AwsSqsSourceSpec">
-AwsSqsSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>queueUrl</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>QueueURL of the SQS queue that we will poll from.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>awsCredsSecret</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>AwsCredsSecret is the credential to use to poll the AWS SQS</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code></br>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Annotations to add to the pod, mostly used for Kube2IAM role</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to
-use as the sink.  This is where events will be received.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServiceAccoutName is the name of the ServiceAccount that will be used to
-run the Receive Adapter Deployment.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.AwsSqsSourceStatus">
-AwsSqsSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CamelSource">CamelSource
-</h3>
-<p>
-<p>CamelSource is the Schema for the camelsources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>CamelSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.CamelSourceSpec">
-CamelSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.CamelSourceOriginSpec">
-CamelSourceOriginSpec
-</a>
-</em>
-</td>
-<td>
-<p>Source is the reference to the integration flow to run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1beta1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.CamelSourceStatus">
-CamelSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CouchDbSource">CouchDbSource
-</h3>
-<p>
-<p>CouchDbSource is the Schema for the githubsources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>CouchDbSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.CouchDbSourceSpec">
-CouchDbSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the CouchDbSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>credentials</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>CouchDbCredentials is the credential to use to access CouchDb.
-Must be a secret. Only Name and Namespace are used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>feed</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.FeedType">
-FeedType
-</a>
-</em>
-</td>
-<td>
-<p>Feed changes how CouchDB sends the response.
-More information: <a href="https://docs.couchdb.org/en/stable/api/database/changes.html#changes-feeds">https://docs.couchdb.org/en/stable/api/database/changes.html#changes-feeds</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>database</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Database is the database to watch for changes</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.CouchDbSourceStatus">
-CouchDbSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.GitHubSource">GitHubSource
-</h3>
-<p>
-<p>GitHubSource is the Schema for the githubsources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GitHubSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.GitHubSourceSpec">
-GitHubSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the GitHubSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ownerAndRepository</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>OwnerAndRepository is the GitHub owner/org and repository to
-receive events from. The repository may be left off to receive
-events from an entire organization.
-Examples:
-myuser/project
-myorganization</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eventTypes</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>EventType is the type of event to receive from GitHub. These
-correspond to the &ldquo;Webhook event name&rdquo; values listed at
-<a href="https://developer.github.com/v3/activity/events/types/">https://developer.github.com/v3/activity/events/types/</a> - ie
-&ldquo;pull_request&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitHub
-access token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>SecretToken is the Kubernetes secret containing the GitHub
-secret token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>githubAPIURL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API URL if using github enterprise (default <a href="https://api.github.com">https://api.github.com</a>)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secure</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Secure can be set to true to configure the webhook to use https,
-or false to use http.  Omitting it relies on the scheme of the
-Knative Service created (e.g. if auto-TLS is enabled it should
-do the right thing).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.GitHubSourceStatus">
-GitHubSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.GitLabSource">GitLabSource
-</h3>
-<p>
-<p>GitLabSource is the Schema for the gitlabsources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GitLabSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.GitLabSourceSpec">
-GitLabSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the GitLabSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>projectUrl</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ProjectUrl is the url of the GitLab project for which we are interested
-to receive events from.
-Examples:
-<a href="https://gitlab.com/gitlab-org/gitlab-foss">https://gitlab.com/gitlab-org/gitlab-foss</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eventTypes</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>EventType is the type of event to receive from Gitlab. These
-correspond to supported events to the add project hook
-<a href="https://docs.gitlab.com/ee/api/projects.html#add-project-hook">https://docs.gitlab.com/ee/api/projects.html#add-project-hook</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitLab
-access token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>SecretToken is the Kubernetes secret containing the GitLab
-secret token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sslverify</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>SslVerify if true configure webhook so the ssl verification is done when triggering the hook</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain
-name to use as the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.GitLabSourceStatus">
-GitLabSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.PrometheusSource">PrometheusSource
-</h3>
-<p>
-<p>PrometheusSource is the Schema for the prometheussources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>PrometheusSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.PrometheusSourceSpec">
-PrometheusSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the PrometheusSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serverURL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServerURL is the URL of the Prometheus server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>promQL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PromQL is the Prometheus query for this source</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>authTokenFile</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The name of the file containing the authenication token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caCertConfigMap</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The name of the config map containing the CA certificate of the
-Prometheus service&rsquo;s signer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>A crontab-formatted schedule for running the PromQL query</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>step</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Query resolution step width in duration format or float number of seconds.
-Prometheus duration strings are of the form [0-9]+[smhdwy].</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a host
-name to use as the sink.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.PrometheusSourceStatus">
-PrometheusSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.AwsSqsSourceSpec">AwsSqsSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.AwsSqsSource">AwsSqsSource</a>)
-</p>
-<p>
-<p>AwsSqsSourceSpec defines the desired state of the source.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>queueUrl</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>QueueURL of the SQS queue that we will poll from.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>awsCredsSecret</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>AwsCredsSecret is the credential to use to poll the AWS SQS</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>annotations</code></br>
-<em>
-map[string]string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Annotations to add to the pod, mostly used for Kube2IAM role</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to
-use as the sink.  This is where events will be received.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServiceAccoutName is the name of the ServiceAccount that will be used to
-run the Receive Adapter Deployment.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.AwsSqsSourceStatus">AwsSqsSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.AwsSqsSource">AwsSqsSource</a>)
-</p>
-<p>
-<p>AwsSqsSourceStatus defines the observed state of the source.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CamelSourceOriginSpec">CamelSourceOriginSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CamelSourceSpec">CamelSourceSpec</a>)
-</p>
-<p>
-<p>CamelSourceOriginSpec is the integration flow to run</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>integration</code></br>
-<em>
-github.com/apache/camel-k/pkg/apis/camel/v1.IntegrationSpec
-</em>
-</td>
-<td>
-<p>Integration is a kind of source that contains a Camel K integration</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>flow</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.Flow">
-Flow
-</a>
-</em>
-</td>
-<td>
-<p>Flow is a kind of source that contains a single Camel YAML flow route</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CamelSourceSpec">CamelSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CamelSource">CamelSource</a>)
-</p>
-<p>
-<p>CamelSourceSpec defines the desired state of CamelSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.CamelSourceOriginSpec">
-CamelSourceOriginSpec
-</a>
-</em>
-</td>
-<td>
-<p>Source is the reference to the integration flow to run.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1beta1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CamelSourceStatus">CamelSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CamelSource">CamelSource</a>)
-</p>
-<p>
-<p>CamelSourceStatus defines the observed state of CamelSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1alpha1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sinkUri</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SinkURI is the current active sink URI that has been configured for the CamelSource.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CouchDbSourceSpec">CouchDbSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CouchDbSource">CouchDbSource</a>)
-</p>
-<p>
-<p>CouchDbSourceSpec defines the desired state of CouchDbSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the CouchDbSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>credentials</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>CouchDbCredentials is the credential to use to access CouchDb.
-Must be a secret. Only Name and Namespace are used.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>feed</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.FeedType">
-FeedType
-</a>
-</em>
-</td>
-<td>
-<p>Feed changes how CouchDB sends the response.
-More information: <a href="https://docs.couchdb.org/en/stable/api/database/changes.html#changes-feeds">https://docs.couchdb.org/en/stable/api/database/changes.html#changes-feeds</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>database</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Database is the database to watch for changes</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.CouchDbSourceStatus">CouchDbSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CouchDbSource">CouchDbSource</a>)
-</p>
-<p>
-<p>CouchDbSourceStatus defines the observed state of CouchDbSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.FeedType">FeedType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CouchDbSourceSpec">CouchDbSourceSpec</a>)
-</p>
-<p>
-<p>FeedType is the type of Feed</p>
-</p>
-<h3 id="sources.knative.dev/v1alpha1.Flow">Flow
-(<code>map[string]interface{}</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.CamelSourceOriginSpec">CamelSourceOriginSpec</a>)
-</p>
-<p>
-<p>Flow is an unstructured object representing a Camel Flow in YAML/JSON DSL</p>
-</p>
-<h3 id="sources.knative.dev/v1alpha1.GitHubSourceSpec">GitHubSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitHubSource">GitHubSource</a>)
-</p>
-<p>
-<p>GitHubSourceSpec defines the desired state of GitHubSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the GitHubSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ownerAndRepository</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>OwnerAndRepository is the GitHub owner/org and repository to
-receive events from. The repository may be left off to receive
-events from an entire organization.
-Examples:
-myuser/project
-myorganization</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eventTypes</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>EventType is the type of event to receive from GitHub. These
-correspond to the &ldquo;Webhook event name&rdquo; values listed at
-<a href="https://developer.github.com/v3/activity/events/types/">https://developer.github.com/v3/activity/events/types/</a> - ie
-&ldquo;pull_request&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitHub
-access token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>SecretToken is the Kubernetes secret containing the GitHub
-secret token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>githubAPIURL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>API URL if using github enterprise (default <a href="https://api.github.com">https://api.github.com</a>)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secure</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Secure can be set to true to configure the webhook to use https,
-or false to use http.  Omitting it relies on the scheme of the
-Knative Service created (e.g. if auto-TLS is enabled it should
-do the right thing).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.GitHubSourceStatus">GitHubSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitHubSource">GitHubSource</a>)
-</p>
-<p>
-<p>GitHubSourceStatus defines the observed state of GitHubSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>webhookIDKey</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>WebhookIDKey is the ID of the webhook registered with GitHub</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.GitLabSourceSpec">GitLabSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitLabSource">GitLabSource</a>)
-</p>
-<p>
-<p>GitLabSourceSpec defines the desired state of GitLabSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the GitLabSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>projectUrl</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ProjectUrl is the url of the GitLab project for which we are interested
-to receive events from.
-Examples:
-<a href="https://gitlab.com/gitlab-org/gitlab-foss">https://gitlab.com/gitlab-org/gitlab-foss</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>eventTypes</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>EventType is the type of event to receive from Gitlab. These
-correspond to supported events to the add project hook
-<a href="https://docs.gitlab.com/ee/api/projects.html#add-project-hook">https://docs.gitlab.com/ee/api/projects.html#add-project-hook</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitLab
-access token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>secretToken</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>SecretToken is the Kubernetes secret containing the GitLab
-secret token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sslverify</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>SslVerify if true configure webhook so the ssl verification is done when triggering the hook</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain
-name to use as the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.GitLabSourceStatus">GitLabSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitLabSource">GitLabSource</a>)
-</p>
-<p>
-<p>GitLabSourceStatus defines the observed state of GitLabSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>Id</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ID of the project hook registered with GitLab</p>
-</td>
-</tr>
-</tbody>
-</table>
+<ul></ul>
 <h3 id="sources.knative.dev/v1alpha1.KafkaLimitsSpec">KafkaLimitsSpec
 </h3>
 <p>
@@ -3509,1079 +2039,8 @@ Source.</p>
 </tr>
 </tbody>
 </table>
-<h3 id="sources.knative.dev/v1alpha1.PrometheusSourceSpec">PrometheusSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PrometheusSource">PrometheusSource</a>)
-</p>
-<p>
-<p>PrometheusSourceSpec defines the desired state of PrometheusSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName holds the name of the Kubernetes service account
-as which the underlying K8s resources should be run. If unspecified
-this will default to the &ldquo;default&rdquo; service account for the namespace
-in which the PrometheusSource exists.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serverURL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ServerURL is the URL of the Prometheus server</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>promQL</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>PromQL is the Prometheus query for this source</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>authTokenFile</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The name of the file containing the authenication token</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caCertConfigMap</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The name of the config map containing the CA certificate of the
-Prometheus service&rsquo;s signer.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>A crontab-formatted schedule for running the PromQL query</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>step</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Query resolution step width in duration format or float number of seconds.
-Prometheus duration strings are of the form [0-9]+[smhdwy].</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a host
-name to use as the sink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.PrometheusSourceStatus">PrometheusSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.PrometheusSource">PrometheusSource</a>)
-</p>
-<p>
-<p>PrometheusSourceStatus defines the observed state of PrometheusSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitHubSourceSpec">GitHubSourceSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.GitLabSourceSpec">GitLabSourceSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="bindings.knative.dev/v1alpha1">bindings.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#bindings.knative.dev/v1alpha1.GitHubBinding">GitHubBinding</a>
-</li><li>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBinding">GitLabBinding</a>
-</li></ul>
-<h3 id="bindings.knative.dev/v1alpha1.GitHubBinding">GitHubBinding
-</h3>
-<p>
-<p>GitHubBinding describes a Binding that is also a Source.
-The <code>sink</code> (from the Source duck) is resolved to a URL and
-then projected into the <code>subject</code> by augmenting the runtime
-contract of the referenced containers to have a <code>K_SINK</code>
-environment variable holding the endpoint to which to send
-cloud events.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-bindings.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GitHubBinding</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.GitHubBindingSpec">
-GitHubBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitHub
-access token</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.GitHubBindingStatus">
-GitHubBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.GitLabBinding">GitLabBinding
-</h3>
-<p>
-<p>GitLabBinding describes a Binding that is also a Source.
-The <code>sink</code> (from the Source duck) is resolved to a URL and
-then projected into the <code>subject</code> by augmenting the runtime
-contract of the referenced containers to have a <code>K_SINK</code>
-environment variable holding the endpoint to which to send
-cloud events.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-bindings.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>GitLabBinding</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBindingSpec">
-GitLabBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitLab
-access token</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBindingStatus">
-GitLabBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.GitHubBindingSpec">GitHubBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitHubBinding">GitHubBinding</a>)
-</p>
-<p>
-<p>GitHubBindingSpec holds the desired state of the GitHubBinding (from the client).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitHub
-access token</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.GitHubBindingStatus">GitHubBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitHubBinding">GitHubBinding</a>)
-</p>
-<p>
-<p>GitHubBindingStatus communicates the observed state of the GitHubBinding (from the controller).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.GitLabBindingSpec">GitLabBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBinding">GitLabBinding</a>)
-</p>
-<p>
-<p>GitLabBindingSpec holds the desired state of the GitLabBinding (from the client).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>accessToken</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<p>AccessToken is the Kubernetes secret containing the GitLab
-access token</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.GitLabBindingStatus">GitLabBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBinding">GitLabBinding</a>)
-</p>
-<p>
-<p>GitLabBindingStatus communicates the observed state of the GitLabBinding (from the controller).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaAuthSpec">KafkaAuthSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaBindingSpec">KafkaBindingSpec</a>, 
-<a href="#sources.knative.dev/v1alpha1.KafkaSourceSpec">KafkaSourceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>bootstrapServers</code></br>
-<em>
-[]string
-</em>
-</td>
-<td>
-<p>Bootstrap servers are the Kafka servers the consumer will connect to.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>net</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaNetSpec">
-KafkaNetSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaBinding">KafkaBinding
-</h3>
-<p>
-<p>KafkaBinding is the Schema for the kafkasources API.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaBindingSpec">
-KafkaBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaBindingStatus">
-KafkaBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaBindingSpec">KafkaBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaBinding">KafkaBinding</a>)
-</p>
-<p>
-<p>KafkaBindingSpec defines the desired state of the KafkaBinding.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>KafkaAuthSpec</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaAuthSpec">
-KafkaAuthSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>KafkaAuthSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaBindingStatus">KafkaBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaBinding">KafkaBinding</a>)
-</p>
-<p>
-<p>KafkaBindingStatus defines the observed state of KafkaBinding.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaNetSpec">KafkaNetSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaAuthSpec">KafkaAuthSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>sasl</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaSASLSpec">
-KafkaSASLSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>tls</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaTLSSpec">
-KafkaTLSSpec
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaSASLSpec">KafkaSASLSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaNetSpec">KafkaNetSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>enable</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>user</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>User is the Kubernetes secret containing the SASL username.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>password</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Password is the Kubernetes secret containing the SASL password.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.KafkaTLSSpec">KafkaTLSSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaNetSpec">KafkaNetSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>enable</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
-<code>cert</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Cert is the Kubernetes secret containing the client certificate.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>key</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Key is the Kubernetes secret containing the client key.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>caCert</code></br>
-<em>
-<a href="#bindings.knative.dev/v1alpha1.SecretValueFromSource">
-SecretValueFromSource
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CACert is the Kubernetes secret containing the server CA cert.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitLabBindingSpec">GitLabBindingSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.GitHubBindingSpec">GitHubBindingSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="bindings.knative.dev/v1alpha1.SecretValueFromSource">SecretValueFromSource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaSASLSpec">KafkaSASLSpec</a>, 
-<a href="#bindings.knative.dev/v1alpha1.KafkaTLSSpec">KafkaTLSSpec</a>)
-</p>
-<p>
-<p>SecretValueFromSource represents the source of a secret value</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>secretKeyRef</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#secretkeyselector-v1-core">
-Kubernetes core/v1.SecretKeySelector
-</a>
-</em>
-</td>
-<td>
-<p>The Secret key to select from.</p>
-</td>
-</tr>
-</tbody>
-</table>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>9683a047</code>.
+on git commit <code>ef8b78ed</code>.
 </em></p>

--- a/docs/reference/api/eventing/eventing-contrib.md
+++ b/docs/reference/api/eventing/eventing-contrib.md
@@ -828,7 +828,7 @@ Resource Types:
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaBindingSpec">KafkaBindingSpec</a>, 
+<a href="#bindings.knative.dev/v1alpha1.KafkaBindingSpec">KafkaBindingSpec</a>,
 <a href="#sources.knative.dev/v1alpha1.KafkaSourceSpec">KafkaSourceSpec</a>)
 </p>
 <p>
@@ -1202,7 +1202,7 @@ SecretValueFromSource
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1alpha1.KafkaSASLSpec">KafkaSASLSpec</a>, 
+<a href="#bindings.knative.dev/v1alpha1.KafkaSASLSpec">KafkaSASLSpec</a>,
 <a href="#bindings.knative.dev/v1alpha1.KafkaTLSSpec">KafkaTLSSpec</a>)
 </p>
 <p>
@@ -1242,7 +1242,7 @@ Resource Types:
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaBindingSpec">KafkaBindingSpec</a>, 
+<a href="#bindings.knative.dev/v1beta1.KafkaBindingSpec">KafkaBindingSpec</a>,
 <a href="#sources.knative.dev/v1beta1.KafkaSourceSpec">KafkaSourceSpec</a>)
 </p>
 <p>
@@ -1616,7 +1616,7 @@ SecretValueFromSource
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#bindings.knative.dev/v1beta1.KafkaSASLSpec">KafkaSASLSpec</a>, 
+<a href="#bindings.knative.dev/v1beta1.KafkaSASLSpec">KafkaSASLSpec</a>,
 <a href="#bindings.knative.dev/v1beta1.KafkaTLSSpec">KafkaTLSSpec</a>)
 </p>
 <p>

--- a/docs/reference/api/eventing/eventing.md
+++ b/docs/reference/api/eventing/eventing.md
@@ -148,8 +148,8 @@ ChannelableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>,
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>,
 <a href="#messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
 </p>
 <p>
@@ -198,8 +198,8 @@ DeliverySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>,
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>,
 <a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
 </p>
 <p>
@@ -278,11 +278,11 @@ Failed messages are delivered here.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
-<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>,
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>,
+<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>,
+<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>,
+<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>,
 <a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
 <p>
@@ -464,7 +464,7 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>,
 <a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -497,7 +497,7 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>,
 <a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -786,8 +786,8 @@ ChannelableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>,
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>,
 <a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
 </p>
 <p>
@@ -836,8 +836,8 @@ DeliverySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>,
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>,
 <a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
 </p>
 <p>
@@ -916,14 +916,14 @@ Failed messages are delivered here.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
-<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>,
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>,
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>,
+<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>,
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>,
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>,
 <a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
 <p>
@@ -1105,8 +1105,8 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>,
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>,
 <a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -1139,8 +1139,8 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>,
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>,
 <a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -1256,7 +1256,7 @@ DeliverySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>,
 <a href="#duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus</a>)
 </p>
 <p>
@@ -3042,8 +3042,8 @@ knative.dev/pkg/apis/duck/v1.KReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
-<a href="#flows.knative.dev/v1.ParallelSpec">ParallelSpec</a>, 
+<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>,
+<a href="#flows.knative.dev/v1.ParallelSpec">ParallelSpec</a>,
 <a href="#flows.knative.dev/v1.SequenceSpec">SequenceSpec</a>)
 </p>
 <p>
@@ -5968,8 +5968,8 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>,
 <a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
 </p>
 <p>
@@ -6001,8 +6001,8 @@ Subscribable
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>,
 <a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
 </p>
 <p>
@@ -6365,7 +6365,7 @@ ParallelSubscriptionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>, 
+<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>,
 <a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>)
 </p>
 <p>
@@ -7199,7 +7199,7 @@ ParallelSubscriptionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>,
 <a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
 </p>
 <p>
@@ -8256,8 +8256,8 @@ knative.dev/pkg/apis/duck/v1.KReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>, 
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>,
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>,
 <a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
 </p>
 <p>
@@ -9114,7 +9114,7 @@ SinkBindingStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>, 
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>,
 <a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
 </p>
 <p>

--- a/docs/reference/api/eventing/eventing.md
+++ b/docs/reference/api/eventing/eventing.md
@@ -1,16 +1,7 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#flows.knative.dev%2fv1beta1">flows.knative.dev/v1beta1</a>
-</li>
-<li>
-<a href="#messaging.knative.dev%2fv1beta1">messaging.knative.dev/v1beta1</a>
-</li>
-<li>
-<a href="#configs.internal.knative.dev%2fv1alpha1">configs.internal.knative.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
+<a href="#duck.knative.dev%2fv1">duck.knative.dev/v1</a>
 </li>
 <li>
 <a href="#duck.knative.dev%2fv1beta1">duck.knative.dev/v1beta1</a>
@@ -22,1973 +13,49 @@
 <a href="#eventing.knative.dev%2fv1beta1">eventing.knative.dev/v1beta1</a>
 </li>
 <li>
-<a href="#flows.knative.dev%2fv1">flows.knative.dev/v1</a>
-</li>
-<li>
-<a href="#duck.knative.dev%2fv1">duck.knative.dev/v1</a>
-</li>
-<li>
 <a href="#messaging.knative.dev%2fv1">messaging.knative.dev/v1</a>
 </li>
 <li>
 <a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
 </li>
 <li>
-<a href="#sources.knative.dev%2fv1alpha2">sources.knative.dev/v1alpha2</a>
-</li>
-<li>
 <a href="#sources.knative.dev%2fv1beta1">sources.knative.dev/v1beta1</a>
 </li>
+<li>
+<a href="#configs.internal.knative.dev%2fv1alpha1">configs.internal.knative.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#flows.knative.dev%2fv1">flows.knative.dev/v1</a>
+</li>
+<li>
+<a href="#flows.knative.dev%2fv1beta1">flows.knative.dev/v1beta1</a>
+</li>
+<li>
+<a href="#messaging.knative.dev%2fv1beta1">messaging.knative.dev/v1beta1</a>
+</li>
+<li>
+<a href="#sources.knative.dev%2fv1alpha2">sources.knative.dev/v1alpha2</a>
+</li>
 </ul>
-<h2 id="flows.knative.dev/v1beta1">flows.knative.dev/v1beta1</h2>
+<h2 id="duck.knative.dev/v1">duck.knative.dev/v1</h2>
 <p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
+<p>Package v1 is the v1 version of the API.</p>
 </p>
 Resource Types:
 <ul></ul>
-<h3 id="flows.knative.dev/v1beta1.Parallel">Parallel
-</h3>
-<p>
-<p>Parallel defines conditional branches that will be wired in
-series through Channels and Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">
-ParallelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Parallel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>branches</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">
-[]ParallelBranch
-</a>
-</em>
-</td>
-<td>
-<p>Branches is the list of Filter/Subscribers pairs.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of a case Subscriber gets sent to
-when the case does not have a Reply</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelStatus">
-ParallelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Parallel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch
-</h3>
+<h3 id="duck.knative.dev/v1.BackoffPolicyType">BackoffPolicyType
+(<code>string</code> alias)</p></h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>)
+<a href="#duck.knative.dev/v1.DeliverySpec">DeliverySpec</a>)
 </p>
 <p>
+<p>BackoffPolicyType is the type for backoff policies</p>
 </p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the expression guarding the branch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Subscriber receiving the event when the filter passes</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
-If not specified, sent the result to the Parallel Reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for events to the subscriber
-This includes things like retries, DLQ, etc.
-Needed for Roundtripping v1alpha1 &lt;-&gt; v1beta1.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
-</p>
-<p>
-<p>ParallelBranchStatus represents the current state of a Parallel branch</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>filterSubscriptionStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
-ParallelSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filterChannelStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
-ParallelChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>FilterChannelStatus corresponds to the filter channel status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberSubscriptionStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
-ParallelSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelChannelStatus">ParallelChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Channel is the reference to the underlying channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Channel is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>branches</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">
-[]ParallelBranch
-</a>
-</em>
-</td>
-<td>
-<p>Branches is the list of Filter/Subscribers pairs.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of a case Subscriber gets sent to
-when the case does not have a Reply</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
-</p>
-<p>
-<p>ParallelStatus represents the current state of a Parallel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ingressChannelStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
-ParallelChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>IngressChannelStatus corresponds to the ingress channel status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>branchStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">
-[]ParallelBranchStatus
-</a>
-</em>
-</td>
-<td>
-<p>BranchStatuses is an array of corresponding to branch statuses.
-Matches the Spec.Branches array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the starting point to this Parallel. Sending to this
-will target the first subscriber.
-It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.ParallelSubscriptionStatus">ParallelSubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscription</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Subscription is the reference to the underlying Subscription.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.Sequence">Sequence
-</h3>
-<p>
-<p>Sequence defines a sequence of Subscribers that will be wired in
-series through Channels and Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">
-SequenceSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Sequence.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>steps</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceStep">
-[]SequenceStep
-</a>
-</em>
-</td>
-<td>
-<p>Steps is the list of Destinations (processors / functions) that will be called in the order
-provided. Each step has its own delivery options</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceStatus">
-SequenceStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Sequence. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceChannelStatus">SequenceChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Channel is the reference to the underlying channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Channel is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>steps</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceStep">
-[]SequenceStep
-</a>
-</em>
-</td>
-<td>
-<p>Steps is the list of Destinations (processors / functions) that will be called in the order
-provided. Each step has its own delivery options</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
-</p>
-<p>
-<p>SequenceStatus represents the current state of a Sequence.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriptionStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceSubscriptionStatus">
-[]SequenceSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscriptionStatuses is an array of corresponding Subscription statuses.
-Matches the Spec.Steps array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1beta1.SequenceChannelStatus">
-[]SequenceChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>ChannelStatuses is an array of corresponding Channel statuses.
-Matches the Spec.Steps array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the starting point to this Sequence. Sending to this
-will target the first subscriber.
-It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceStep">SequenceStep
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Destination</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Destination</code> are embedded into this type.)
-</p>
-<p>Subscriber receiving the step event</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for events to the subscriber
-This includes things like retries, DLQ, etc.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1beta1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscription</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Subscription is the reference to the underlying Subscription.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>
-</li><li>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>
-</li><li>
-<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>
-</li></ul>
-<h3 id="messaging.knative.dev/v1beta1.Channel">Channel
-</h3>
-<p>
-<p>Channel represents a generic Channel. It is normally used when we want a Channel, but don&rsquo;t need a specific Channel implementation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Channel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">
-ChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
-This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to ChannelableSpec</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelStatus">
-ChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Channel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel
-</h3>
-<p>
-<p>InMemoryChannel is a resource representing an in memory channel</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>InMemoryChannel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">
-InMemoryChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">
-InMemoryChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Channel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.Subscription">Subscription
-</h3>
-<p>
-<p>Subscription routes events received on a Channel to a DNS name and
-corresponds to the subscriptions.channels.knative.dev CRD.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Subscription</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">
-SubscriptionSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Reference to a channel that will be used to create the subscription
-You can specify only the following fields of the ObjectReference:
-- Kind
-- APIVersion
-- Name
-The resource pointed by this ObjectReference must meet the
-contract to the ChannelableSpec duck type. If the resource does not
-meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
-<p>This field is immutable. We have no good answer on what happens to
-the events that are currently in the channel being consumed from
-and what the semantics there should be. For now, you can always
-delete the Subscription and recreate it to point to a different
-channel, giving the user more control over what semantics should
-be used (drain the channel first, possibly have events dropped,
-etc.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
-Events from the Channel will be delivered here and replies are
-sent to a Destination as specified by the Reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply specifies (optionally) how to handle events returned from
-the Subscriber target.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery configuration</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">
-SubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelDefaulter">ChannelDefaulter
-</h3>
-<p>
-<p>ChannelDefaulter sets the default Channel CRD and Arguments on Channels that do not
-specify any implementation.</p>
-</p>
-<h3 id="messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
-</p>
-<p>
-<p>ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
-It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
-This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to ChannelableSpec</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
-</p>
-<p>
-<p>ChannelStatus represents the current state of a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableStatus</code> are embedded into this type.)
-</p>
-<p>Channel conforms to ChannelableStatus</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<p>Channel is an KReference to the Channel CRD backing this Channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpec">ChannelTemplateSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
-</h3>
-<p>
-<p>ChannelTemplateSpecInternal is an internal only version that includes ObjectMeta so that
-we can easily create new Channels off of it.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
-</p>
-<p>
-<p>InMemoryChannelSpec defines which subscribers have expressed interest in
-receiving events from this InMemoryChannel.
-arguments for a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
-</p>
-<p>
-<p>ChannelStatus represents the current state of a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableStatus</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
-</p>
-<p>
-<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
-for processing those events and where to put the result of the processing. Only
-From (where the events are coming from) is always required. You can optionally
-only Process the events (results in no output events) by leaving out the Result.
-You can also perform an identity transformation on the incoming events by leaving
-out the Subscriber and only specifying Result.</p>
-<p>The following are all valid specifications:
-channel &ndash;[subscriber]&ndash;&gt; reply
-Sink, no outgoing events:
-channel &ndash; subscriber
-no-op function (identity transformation):
-channel &ndash;&gt; reply</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Reference to a channel that will be used to create the subscription
-You can specify only the following fields of the ObjectReference:
-- Kind
-- APIVersion
-- Name
-The resource pointed by this ObjectReference must meet the
-contract to the ChannelableSpec duck type. If the resource does not
-meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
-<p>This field is immutable. We have no good answer on what happens to
-the events that are currently in the channel being consumed from
-and what the semantics there should be. For now, you can always
-delete the Subscription and recreate it to point to a different
-channel, giving the user more control over what semantics should
-be used (drain the channel first, possibly have events dropped,
-etc.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
-Events from the Channel will be delivered here and replies are
-sent to a Destination as specified by the Reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply specifies (optionally) how to handle events returned from
-the Subscriber target.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery configuration</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
-</p>
-<p>
-<p>SubscriptionStatus (computed) for a subscription</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>physicalSubscription</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">
-SubscriptionStatusPhysicalSubscription
-</a>
-</em>
-</td>
-<td>
-<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus</a>)
-</p>
-<p>
-<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
-Subscription.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterSinkUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="configs.internal.knative.dev/v1alpha1">configs.internal.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>
-</li></ul>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation
-</h3>
-<p>
-<p>ConfigMapPropagation is used to propagate configMaps from original namespace to current namespace</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-configs.internal.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ConfigMapPropagation</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">
-ConfigMapPropagationSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the ConfigMapPropagation</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>originalNamespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>OriginalNamespace is the namespace where the original configMaps are in</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Selector only selects original configMaps with corresponding labels</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">
-ConfigMapPropagationStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the EventType.
-This data may be out of date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">ConfigMapPropagationSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>originalNamespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>OriginalNamespace is the namespace where the original configMaps are in</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Selector only selects original configMaps with corresponding labels</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
-</p>
-<p>
-<p>ConfigMapPropagationStatus represents the current state of a ConfigMapPropagation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>copyConfigmaps</code></br>
-<em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">
-[]ConfigMapPropagationStatusCopyConfigMap
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CopyConfigMaps is the status for each copied configmap.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">ConfigMapPropagationStatusCopyConfigMap
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus</a>)
-</p>
-<p>
-<p>ConfigMapPropagationStatusCopyConfigMap represents the status of a copied configmap</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is copy configmap&rsquo;s name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Source is &ldquo;originalNamespace/originalConfigMapName&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>operation</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Operation represents the operation CMP takes for this configmap. The operations are copy|delete|stop</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Ready represents the operation is ready or not</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reason</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Reason indicates reasons if the operation is not ready</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourceVersionFromSource</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ResourceVersion is the resourceVersion of original configmap</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="duck.knative.dev/v1alpha1.Channelable">Channelable
+<h3 id="duck.knative.dev/v1.Channelable">Channelable
 </h3>
 <p>
 <p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
@@ -2021,7 +88,7 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
+<a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
 </a>
 </em>
@@ -2033,16 +100,16 @@ ChannelableSpec
 <table>
 <tr>
 <td>
-<code>SubscribableTypeSpec</code></br>
+<code>SubscribableSpec</code></br>
 <em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
 </a>
 </em>
 </td>
 <td>
 <p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
 </p>
 </td>
 </tr>
@@ -2050,7 +117,7 @@ SubscribableTypeSpec
 <td>
 <code>delivery</code></br>
 <em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+<a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
 </a>
 </em>
@@ -2067,7 +134,7 @@ DeliverySpec
 <td>
 <code>status</code></br>
 <em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
+<a href="#duck.knative.dev/v1.ChannelableStatus">
 ChannelableStatus
 </a>
 </em>
@@ -2077,119 +144,13 @@ ChannelableStatus
 </tr>
 </tbody>
 </table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined
-</h3>
-<p>
-<p>ChannelableCombined is a skeleton type wrapping Subscribable and Addressable of
-v1alpha1 and v1beta1 duck types. This is not to be used by resource writers and is
-only used by Subscription Controller to synthesize patches and read the Status
-of the Channelable Resources.
-This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">
-ChannelableCombinedSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">
-ChannelableCombinedStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec
+<h3 id="duck.knative.dev/v1.ChannelableSpec">ChannelableSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
+<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
 </p>
 <p>
 <p>ChannelableSpec contains Spec of the Channelable object</p>
@@ -2204,25 +165,9 @@ ChannelableCombinedStatus
 <tbody>
 <tr>
 <td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>SubscribableSpec</code></br>
 <em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+<a href="#duck.knative.dev/v1.SubscribableSpec">
 SubscribableSpec
 </a>
 </em>
@@ -2231,14 +176,13 @@ SubscribableSpec
 <p>
 (Members of <code>SubscribableSpec</code> are embedded into this type.)
 </p>
-<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>delivery</code></br>
 <em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+<a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
 </a>
 </em>
@@ -2250,11 +194,13 @@ DeliverySpec
 </tr>
 </tbody>
 </table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus
+<h3 id="duck.knative.dev/v1.ChannelableStatus">ChannelableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
+<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>, 
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
 </p>
 <p>
 <p>ChannelableStatus contains the Status of a Channelable object.</p>
@@ -2287,7 +233,7 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>AddressStatus</code></br>
 <em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
 </td>
 <td>
@@ -2299,25 +245,9 @@ knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </tr>
 <tr>
 <td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
-<p>SubscribableTypeStatus is the v1alpha1 part of the Subscribers status</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>SubscribableStatus</code></br>
 <em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+<a href="#duck.knative.dev/v1.SubscribableStatus">
 SubscribableStatus
 </a>
 </em>
@@ -2326,157 +256,110 @@ SubscribableStatus
 <p>
 (Members of <code>SubscribableStatus</code> are embedded into this type.)
 </p>
-<p>SubscribableStatus is the v1beta1 part of the Subscribers status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>errorChannel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableTypeSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableTypeStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
-</p>
 <p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>errorChannel</code></br>
+<code>deadLetterChannel</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
+Failed messages are delivered here.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.DeliverySpec">DeliverySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
+<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
+<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>DeliverySpec contains the delivery options for event senders,
+such as channelable and source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterSink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterSink is the sink receiving event that could not be sent to
+a destination.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retry</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retry is the minimum number of retries the sender should attempt when
+sending an event before moving it to the dead letter sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffPolicy</code></br>
+<em>
+<a href="#duck.knative.dev/v1.BackoffPolicyType">
+BackoffPolicyType
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
+<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffDelay</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffDelay is the delay before retrying.
+More information on Duration format:
+- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
+<p>For linear policy, backoff delay is the time interval between retries.
+For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="duck.knative.dev/v1alpha1.Resource">Resource
+<h3 id="duck.knative.dev/v1.DeliveryStatus">DeliveryStatus
 </h3>
 <p>
-<p>Resource is a skeleton type wrapping all Kubernetes resources. It is typically used to watch
-arbitrary other resources (such as any Source or Addressable). This is not a real resource.</p>
+<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
 </p>
 <table>
 <thead>
@@ -2488,90 +371,23 @@ arbitrary other resources (such as any Source or Addressable). This is not a rea
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>deadLetterChannel</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
+knative.dev/pkg/apis/duck/v1.KReference
 </em>
 </td>
 <td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
+where failed events are sent to.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="duck.knative.dev/v1alpha1.Subscribable">Subscribable
+<h3 id="duck.knative.dev/v1.Subscribable">Subscribable
 </h3>
 <p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
-</p>
-<p>
-<p>Subscribable is the schema for the subscribable portion of the spec
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableType">SubscribableType
-</h3>
-<p>
-<p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
+<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
 defining compatible resources to embed it. We will typically use this type to deserialize
 SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
 </p>
@@ -2601,27 +417,28 @@ Refer to the Kubernetes API documentation for the fields of the
 <td>
 <code>spec</code></br>
 <em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
-SubscribableTypeSpec
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
 </a>
 </em>
 </td>
 <td>
-<p>SubscribableTypeSpec is the part where Subscribable object is
+<p>SubscribableSpec is the part where Subscribable object is
 configured as to be compatible with Subscribable contract.</p>
 <br/>
 <br/>
 <table>
 <tr>
 <td>
-<code>subscribable</code></br>
+<code>subscribers</code></br>
 <em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
+<a href="#duck.knative.dev/v1.SubscriberSpec">
+[]SubscriberSpec
 </a>
 </em>
 </td>
 <td>
+<p>This is the list of subscriptions for this subscribable.</p>
 </td>
 </tr>
 </table>
@@ -2631,96 +448,94 @@ Subscribable
 <td>
 <code>status</code></br>
 <em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
-SubscribableTypeStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableTypeStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
-</p>
-<p>
-<p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribable</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">
-Subscribable
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
-</p>
-<p>
-<p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
+<a href="#duck.knative.dev/v1.SubscribableStatus">
 SubscribableStatus
 </a>
 </em>
 </td>
 <td>
+<p>SubscribableStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
 </td>
 </tr>
 </tbody>
 </table>
-<h3 id="duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
+<h3 id="duck.knative.dev/v1.SubscribableSpec">SubscribableSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.Subscribable">Subscribable</a>)
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
 <p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.
-Ref is a reference to the Subscription this SubscriberSpec was created for
-SubscriberURI is the endpoint for the subscriber
-ReplyURI is the endpoint for the reply
-At least one of SubscriberURI and ReplyURI must be present</p>
+<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">SubscribableSpec</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
+<p>At least one of SubscriberURI and ReplyURI must be present</p>
 </p>
 <table>
 <thead>
@@ -2756,48 +571,108 @@ int64
 </tr>
 <tr>
 <td>
-<code>subscriberURI</code></br>
+<code>subscriberUri</code></br>
 <em>
 knative.dev/pkg/apis.URL
 </em>
 </td>
 <td>
 <em>(Optional)</em>
+<p>SubscriberURI is the endpoint for the subscriber</p>
 </td>
 </tr>
 <tr>
 <td>
-<code>replyURI</code></br>
+<code>replyUri</code></br>
 <em>
 knative.dev/pkg/apis.URL
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterSink</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
+<p>ReplyURI is the endpoint for the reply</p>
 </td>
 </tr>
 <tr>
 <td>
 <code>delivery</code></br>
 <em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+<a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
 </a>
 </em>
 </td>
 <td>
 <em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscriberStatus">SubscriberStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.SubscribableStatus">SubscribableStatus</a>)
+</p>
+<p>
+<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A human readable message indicating details of Ready status.</p>
 </td>
 </tr>
 </tbody>
@@ -3047,8 +922,8 @@ Failed messages are delivered here.</p>
 <a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
 <a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
 <a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
 <a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
 <a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
 <p>
@@ -4702,1477 +2577,6 @@ knative.dev/pkg/apis.URL
 </tbody>
 </table>
 <hr/>
-<h2 id="flows.knative.dev/v1">flows.knative.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="flows.knative.dev/v1.Parallel">Parallel
-</h3>
-<p>
-<p>Parallel defines conditional branches that will be wired in
-series through Channels and Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelSpec">
-ParallelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Parallel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>branches</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelBranch">
-[]ParallelBranch
-</a>
-</em>
-</td>
-<td>
-<p>Branches is the list of Filter/Subscribers pairs.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of a case Subscriber gets sent to
-when the case does not have a Reply</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelStatus">
-ParallelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Parallel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.ParallelBranch">ParallelBranch
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelSpec">ParallelSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the expression guarding the branch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Subscriber receiving the event when the filter passes</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
-If not specified, sent the result to the Parallel Reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for events to the subscriber
-This includes things like retries, DLQ, etc.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>)
-</p>
-<p>
-<p>ParallelBranchStatus represents the current state of a Parallel branch</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>filterSubscriptionStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelSubscriptionStatus">
-ParallelSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filterChannelStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelChannelStatus">
-ParallelChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>FilterChannelStatus corresponds to the filter channel status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberSubscriptionStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelSubscriptionStatus">
-ParallelSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.ParallelChannelStatus">ParallelChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>, 
-<a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Channel is the reference to the underlying channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Channel is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.ParallelSpec">ParallelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.Parallel">Parallel</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>branches</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelBranch">
-[]ParallelBranch
-</a>
-</em>
-</td>
-<td>
-<p>Branches is the list of Filter/Subscribers pairs.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of a case Subscriber gets sent to
-when the case does not have a Reply</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.ParallelStatus">ParallelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.Parallel">Parallel</a>)
-</p>
-<p>
-<p>ParallelStatus represents the current state of a Parallel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ingressChannelStatus</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelChannelStatus">
-ParallelChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>IngressChannelStatus corresponds to the ingress channel status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>branchStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1.ParallelBranchStatus">
-[]ParallelBranchStatus
-</a>
-</em>
-</td>
-<td>
-<p>BranchStatuses is an array of corresponding to branch statuses.
-Matches the Spec.Branches array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the starting point to this Parallel. Sending to this
-will target the first subscriber.
-It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.ParallelSubscriptionStatus">ParallelSubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscription</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Subscription is the reference to the underlying Subscription.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.Sequence">Sequence
-</h3>
-<p>
-<p>Sequence defines a sequence of Subscribers that will be wired in
-series through Channels and Subscriptions.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#flows.knative.dev/v1.SequenceSpec">
-SequenceSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Sequence.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>steps</code></br>
-<em>
-<a href="#flows.knative.dev/v1.SequenceStep">
-[]SequenceStep
-</a>
-</em>
-</td>
-<td>
-<p>Steps is the list of Destinations (processors / functions) that will be called in the order
-provided. Each step has its own delivery options</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#flows.knative.dev/v1.SequenceStatus">
-SequenceStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Sequence. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.SequenceChannelStatus">SequenceChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.SequenceStatus">SequenceStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Channel is the reference to the underlying channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Channel is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.SequenceSpec">SequenceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.Sequence">Sequence</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>steps</code></br>
-<em>
-<a href="#flows.knative.dev/v1.SequenceStep">
-[]SequenceStep
-</a>
-</em>
-</td>
-<td>
-<p>Steps is the list of Destinations (processors / functions) that will be called in the order
-provided. Each step has its own delivery options</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
-for the namespace (or cluster, in case there are no defaults for the namespace).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.SequenceStatus">SequenceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.Sequence">Sequence</a>)
-</p>
-<p>
-<p>SequenceStatus represents the current state of a Sequence.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriptionStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1.SequenceSubscriptionStatus">
-[]SequenceSubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscriptionStatuses is an array of corresponding Subscription statuses.
-Matches the Spec.Steps array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channelStatuses</code></br>
-<em>
-<a href="#flows.knative.dev/v1.SequenceChannelStatus">
-[]SequenceChannelStatus
-</a>
-</em>
-</td>
-<td>
-<p>ChannelStatuses is an array of corresponding Channel statuses.
-Matches the Spec.Steps array in the order.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the starting point to this Sequence. Sending to this
-will target the first subscriber.
-It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.SequenceStep">SequenceStep
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.SequenceSpec">SequenceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Destination</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Destination</code> are embedded into this type.)
-</p>
-<p>Subscriber receiving the step event</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for events to the subscriber
-This includes things like retries, DLQ, etc.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="flows.knative.dev/v1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.SequenceStatus">SequenceStatus</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscription</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Subscription is the reference to the underlying Subscription.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-knative.dev/pkg/apis.Condition
-</em>
-</td>
-<td>
-<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="duck.knative.dev/v1">duck.knative.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="duck.knative.dev/v1.BackoffPolicyType">BackoffPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.DeliverySpec">DeliverySpec</a>)
-</p>
-<p>
-<p>BackoffPolicyType is the type for backoff policies</p>
-</p>
-<h3 id="duck.knative.dev/v1.Channelable">Channelable
-</h3>
-<p>
-<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
-Failed messages are delivered here.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.DeliverySpec">DeliverySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
-<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
-</p>
-<p>
-<p>DeliverySpec contains the delivery options for event senders,
-such as channelable and source.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterSink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterSink is the sink receiving event that could not be sent to
-a destination.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retry</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retry is the minimum number of retries the sender should attempt when
-sending an event before moving it to the dead letter sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffPolicy</code></br>
-<em>
-<a href="#duck.knative.dev/v1.BackoffPolicyType">
-BackoffPolicyType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffDelay</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffDelay is the delay before retrying.
-More information on Duration format:
-- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
-- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
-<p>For linear policy, backoff delay is the time interval between retries.
-For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.DeliveryStatus">DeliveryStatus
-</h3>
-<p>
-<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
-where failed events are sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.Subscribable">Subscribable
-</h3>
-<p>
-<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableSpec is the part where Subscribable object is
-configured as to be compatible with Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscribableSpec">SubscribableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">SubscribableSpec</a>)
-</p>
-<p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
-<p>At least one of SubscriberURI and ReplyURI must be present</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubscriberURI is the endpoint for the subscriber</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReplyURI is the endpoint for the reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscriberStatus">SubscriberStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">SubscribableStatus</a>)
-</p>
-<p>
-<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
-Kubernetes core/v1.ConditionStatus
-</a>
-</em>
-</td>
-<td>
-<p>Status of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>message</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>A human readable message indicating details of Ready status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="messaging.knative.dev/v1">messaging.knative.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
@@ -7561,1027 +3965,6 @@ knative.dev/pkg/apis/duck/v1.SourceStatus
 </tbody>
 </table>
 <hr/>
-<h2 id="sources.knative.dev/v1alpha2">sources.knative.dev/v1alpha2</h2>
-<p>
-<p>Package v1alpha2 contains API Schema definitions for the sources v1beta1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>
-</li></ul>
-<h3 id="sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource
-</h3>
-<p>
-<p>ApiServerSource is the Schema for the apiserversources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ApiServerSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">
-ApiServerSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
-[]APIVersionKindSelector
-</a>
-</em>
-</td>
-<td>
-<p>Resource are the resources this source will track and send related
-lifecycle events from the Kubernetes ApiServer, with an optional label
-selector to help filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>owner</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
-APIVersionKind
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceOwner is an additional filter to only track resources that are
-owned by a specific resource type. If ResourceOwner matches Resources[n]
-then Resources[n] is allowed to pass the ResourceOwner filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EventMode controls the format of the event.
-<code>Reference</code> sends a dataref event type for the resource under watch.
-<code>Resource</code> send the full resource lifecycle event.
-Defaults to <code>Reference</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source. Defaults to default if not set.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceStatus">
-ApiServerSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ContainerSource">ContainerSource
-</h3>
-<p>
-<p>ContainerSource is the Schema for the containersources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ContainerSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSourceSpec">
-ContainerSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the pods that will be created</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSourceStatus">
-ContainerSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.PingSource">PingSource
-</h3>
-<p>
-<p>PingSource is the Schema for the PingSources API.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>PingSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.PingSourceSpec">
-PingSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>jsonData</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>JsonData is json encoded data used as the body of the event posted to
-the sink. Default is empty. If set, datacontenttype will also be set
-to &ldquo;application/json&rdquo;.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.PingSourceStatus">
-PingSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.SinkBinding">SinkBinding
-</h3>
-<p>
-<p>SinkBinding describes a Binding that is also a Source.
-The <code>sink</code> (from the Source duck) is resolved to a URL and
-then projected into the <code>subject</code> by augmenting the runtime
-contract of the referenced containers to have a <code>K_SINK</code>
-environment variable holding the endpoint to which to send
-cloud events.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>SinkBinding</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.SinkBindingSpec">
-SinkBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
-* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
-should be augmented by Binding implementations.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.SinkBindingStatus">
-SinkBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.APIVersionKind">APIVersionKind
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>, 
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
-</p>
-<p>
-<p>APIVersionKind is an APIVersion and Kind tuple.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>APIVersion - the API version of the resource to watch.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Kind of the resource to watch.
-More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.APIVersionKindSelector">APIVersionKindSelector
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
-</p>
-<p>
-<p>APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>APIVersion - the API version of the resource to watch.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Kind of the resource to watch.
-More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>LabelSelector filters this source to objects to those resources pass the
-label selector.
-More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
-</p>
-<p>
-<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
-[]APIVersionKindSelector
-</a>
-</em>
-</td>
-<td>
-<p>Resource are the resources this source will track and send related
-lifecycle events from the Kubernetes ApiServer, with an optional label
-selector to help filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>owner</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
-APIVersionKind
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceOwner is an additional filter to only track resources that are
-owned by a specific resource type. If ResourceOwner matches Resources[n]
-then Resources[n] is allowed to pass the ResourceOwner filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EventMode controls the format of the event.
-<code>Reference</code> sends a dataref event type for the resource under watch.
-<code>Resource</code> send the full resource lifecycle event.
-Defaults to <code>Reference</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source. Defaults to default if not set.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceStatus">ApiServerSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
-</p>
-<p>
-<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ContainerSourceSpec">ContainerSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
-</p>
-<p>
-<p>ContainerSourceSpec defines the desired state of ContainerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the pods that will be created</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ContainerSourceStatus">ContainerSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
-</p>
-<p>
-<p>ContainerSourceStatus defines the observed state of ContainerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.PingSourceSpec">PingSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
-</p>
-<p>
-<p>PingSourceSpec defines the desired state of the PingSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>jsonData</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>JsonData is json encoded data used as the body of the event posted to
-the sink. Default is empty. If set, datacontenttype will also be set
-to &ldquo;application/json&rdquo;.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.PingSourceStatus">PingSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
-</p>
-<p>
-<p>PingSourceStatus defines the observed state of PingSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.SinkBindingSpec">SinkBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
-</p>
-<p>
-<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
-* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
-should be augmented by Binding implementations.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.SinkBindingStatus">SinkBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
-</p>
-<p>
-<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="sources.knative.dev/v1beta1">sources.knative.dev/v1beta1</h2>
 <p>
 <p>Package v1beta1 contains API Schema definitions for the sources v1beta1 API group.</p>
@@ -9595,6 +4978,4623 @@ should be augmented by Binding implementations.</p>
 <p>
 (<em>Appears on:</em>
 <a href="#sources.knative.dev/v1beta1.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="configs.internal.knative.dev/v1alpha1">configs.internal.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>
+</li></ul>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation
+</h3>
+<p>
+<p>ConfigMapPropagation is used to propagate configMaps from original namespace to current namespace</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+configs.internal.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ConfigMapPropagation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">
+ConfigMapPropagationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the ConfigMapPropagation</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>originalNamespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OriginalNamespace is the namespace where the original configMaps are in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Selector only selects original configMaps with corresponding labels</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">
+ConfigMapPropagationStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the EventType.
+This data may be out of date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">ConfigMapPropagationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>originalNamespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OriginalNamespace is the namespace where the original configMaps are in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Selector only selects original configMaps with corresponding labels</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
+</p>
+<p>
+<p>ConfigMapPropagationStatus represents the current state of a ConfigMapPropagation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>copyConfigmaps</code></br>
+<em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">
+[]ConfigMapPropagationStatusCopyConfigMap
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CopyConfigMaps is the status for each copied configmap.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">ConfigMapPropagationStatusCopyConfigMap
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus</a>)
+</p>
+<p>
+<p>ConfigMapPropagationStatusCopyConfigMap represents the status of a copied configmap</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is copy configmap&rsquo;s name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Source is &ldquo;originalNamespace/originalConfigMapName&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>operation</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Operation represents the operation CMP takes for this configmap. The operations are copy|delete|stop</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Ready represents the operation is ready or not</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Reason indicates reasons if the operation is not ready</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceVersionFromSource</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ResourceVersion is the resourceVersion of original configmap</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="duck.knative.dev/v1alpha1.Channelable">Channelable
+</h3>
+<p>
+<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined
+</h3>
+<p>
+<p>ChannelableCombined is a skeleton type wrapping Subscribable and Addressable of
+v1alpha1 and v1beta1 duck types. This is not to be used by resource writers and is
+only used by Subscription Controller to synthesize patches and read the Status
+of the Channelable Resources.
+This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">
+ChannelableCombinedSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">
+ChannelableCombinedStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableTypeSpec is for the v1alpha1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+<p>SubscribableSpec is for the v1beta1 spec compatibility.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombined">ChannelableCombined</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>SubscribableTypeStatus is the v1alpha1 part of the Subscribers status</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableStatus</code> are embedded into this type.)
+</p>
+<p>SubscribableStatus is the v1beta1 part of the Subscribers status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>errorChannel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableTypeSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Channelable">Channelable</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableTypeStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableTypeStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>errorChannel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ErrorChannel is set by the channel when it supports native error handling via a channel</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.Resource">Resource
+</h3>
+<p>
+<p>Resource is a skeleton type wrapping all Kubernetes resources. It is typically used to watch
+arbitrary other resources (such as any Source or Addressable). This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.Subscribable">Subscribable
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec</a>)
+</p>
+<p>
+<p>Subscribable is the schema for the subscribable portion of the spec
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableType">SubscribableType
+</h3>
+<p>
+<p>SubscribableType is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
+SubscribableTypeSpec
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableTypeSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
+SubscribableTypeStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableTypeStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeSpec">SubscribableTypeSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
+</p>
+<p>
+<p>SubscribableTypeSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribable</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">
+Subscribable
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscribableTypeStatus">SubscribableTypeStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
+</p>
+<p>
+<p>SubscribableTypeStatus shows how we expect folks to embed Subscribable in their Status field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.
+Ref is a reference to the Subscription this SubscriberSpec was created for
+SubscriberURI is the endpoint for the subscriber
+ReplyURI is the endpoint for the reply
+At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberURI</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyURI</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterSink</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="flows.knative.dev/v1">flows.knative.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="flows.knative.dev/v1.Parallel">Parallel
+</h3>
+<p>
+<p>Parallel defines conditional branches that will be wired in
+series through Channels and Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelSpec">
+ParallelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Parallel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>branches</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelBranch">
+[]ParallelBranch
+</a>
+</em>
+</td>
+<td>
+<p>Branches is the list of Filter/Subscribers pairs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelStatus">
+ParallelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Parallel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.ParallelBranch">ParallelBranch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.ParallelSpec">ParallelSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the expression guarding the branch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>Subscriber receiving the event when the filter passes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
+If not specified, sent the result to the Parallel Reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for events to the subscriber
+This includes things like retries, DLQ, etc.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>)
+</p>
+<p>
+<p>ParallelBranchStatus represents the current state of a Parallel branch</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filterSubscriptionStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelSubscriptionStatus">
+ParallelSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filterChannelStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelChannelStatus">
+ParallelChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterChannelStatus corresponds to the filter channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberSubscriptionStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelSubscriptionStatus">
+ParallelSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.ParallelChannelStatus">ParallelChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>, 
+<a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.ParallelSpec">ParallelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.Parallel">Parallel</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>branches</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelBranch">
+[]ParallelBranch
+</a>
+</em>
+</td>
+<td>
+<p>Branches is the list of Filter/Subscribers pairs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.ParallelStatus">ParallelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.Parallel">Parallel</a>)
+</p>
+<p>
+<p>ParallelStatus represents the current state of a Parallel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressChannelStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelChannelStatus">
+ParallelChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>IngressChannelStatus corresponds to the ingress channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>branchStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1.ParallelBranchStatus">
+[]ParallelBranchStatus
+</a>
+</em>
+</td>
+<td>
+<p>BranchStatuses is an array of corresponding to branch statuses.
+Matches the Spec.Branches array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Parallel. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.ParallelSubscriptionStatus">ParallelSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.Sequence">Sequence
+</h3>
+<p>
+<p>Sequence defines a sequence of Subscribers that will be wired in
+series through Channels and Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#flows.knative.dev/v1.SequenceSpec">
+SequenceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Sequence.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#flows.knative.dev/v1.SequenceStep">
+[]SequenceStep
+</a>
+</em>
+</td>
+<td>
+<p>Steps is the list of Destinations (processors / functions) that will be called in the order
+provided. Each step has its own delivery options</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#flows.knative.dev/v1.SequenceStatus">
+SequenceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Sequence. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.SequenceChannelStatus">SequenceChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.SequenceStatus">SequenceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.SequenceSpec">SequenceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.Sequence">Sequence</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#flows.knative.dev/v1.SequenceStep">
+[]SequenceStep
+</a>
+</em>
+</td>
+<td>
+<p>Steps is the list of Destinations (processors / functions) that will be called in the order
+provided. Each step has its own delivery options</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.SequenceStatus">SequenceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.Sequence">Sequence</a>)
+</p>
+<p>
+<p>SequenceStatus represents the current state of a Sequence.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriptionStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1.SequenceSubscriptionStatus">
+[]SequenceSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatuses is an array of corresponding Subscription statuses.
+Matches the Spec.Steps array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1.SequenceChannelStatus">
+[]SequenceChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>ChannelStatuses is an array of corresponding Channel statuses.
+Matches the Spec.Steps array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Sequence. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.SequenceStep">SequenceStep
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.SequenceSpec">SequenceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Destination</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Destination</code> are embedded into this type.)
+</p>
+<p>Subscriber receiving the step event</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for events to the subscriber
+This includes things like retries, DLQ, etc.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1.SequenceStatus">SequenceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="flows.knative.dev/v1beta1">flows.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="flows.knative.dev/v1beta1.Parallel">Parallel
+</h3>
+<p>
+<p>Parallel defines conditional branches that will be wired in
+series through Channels and Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">
+ParallelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Parallel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>branches</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">
+[]ParallelBranch
+</a>
+</em>
+</td>
+<td>
+<p>Branches is the list of Filter/Subscribers pairs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelStatus">
+ParallelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Parallel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the expression guarding the branch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>Subscriber receiving the event when the filter passes</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of Subscriber of this case gets sent to.
+If not specified, sent the result to the Parallel Reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for events to the subscriber
+This includes things like retries, DLQ, etc.
+Needed for Roundtripping v1alpha1 &lt;-&gt; v1beta1.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
+</p>
+<p>
+<p>ParallelBranchStatus represents the current state of a Parallel branch</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>filterSubscriptionStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
+ParallelSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterSubscriptionStatus corresponds to the filter subscription status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filterChannelStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
+ParallelChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>FilterChannelStatus corresponds to the filter channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberSubscriptionStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
+ParallelSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatus corresponds to the subscriber subscription status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelChannelStatus">ParallelChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>branches</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">
+[]ParallelBranch
+</a>
+</em>
+</td>
+<td>
+<p>Branches is the list of Filter/Subscribers pairs.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of a case Subscriber gets sent to
+when the case does not have a Reply</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Parallel">Parallel</a>)
+</p>
+<p>
+<p>ParallelStatus represents the current state of a Parallel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ingressChannelStatus</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
+ParallelChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>IngressChannelStatus corresponds to the ingress channel status.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>branchStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">
+[]ParallelBranchStatus
+</a>
+</em>
+</td>
+<td>
+<p>BranchStatuses is an array of corresponding to branch statuses.
+Matches the Spec.Branches array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Parallel. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.ParallelSubscriptionStatus">ParallelSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.Sequence">Sequence
+</h3>
+<p>
+<p>Sequence defines a sequence of Subscribers that will be wired in
+series through Channels and Subscriptions.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">
+SequenceSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Sequence.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceStep">
+[]SequenceStep
+</a>
+</em>
+</td>
+<td>
+<p>Steps is the list of Destinations (processors / functions) that will be called in the order
+provided. Each step has its own delivery options</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceStatus">
+SequenceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Sequence. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceChannelStatus">SequenceChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Channel is the reference to the underlying channel.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Channel is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>steps</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceStep">
+[]SequenceStep
+</a>
+</em>
+</td>
+<td>
+<p>Steps is the list of Destinations (processors / functions) that will be called in the order
+provided. Each step has its own delivery options</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ChannelTemplate specifies which Channel CRD to use. If left unspecified, it is set to the default Channel CRD
+for the namespace (or cluster, in case there are no defaults for the namespace).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply is a Reference to where the result of the last Subscriber gets sent to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.Sequence">Sequence</a>)
+</p>
+<p>
+<p>SequenceStatus represents the current state of a Sequence.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriptionStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceSubscriptionStatus">
+[]SequenceSubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscriptionStatuses is an array of corresponding Subscription statuses.
+Matches the Spec.Steps array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channelStatuses</code></br>
+<em>
+<a href="#flows.knative.dev/v1beta1.SequenceChannelStatus">
+[]SequenceChannelStatus
+</a>
+</em>
+</td>
+<td>
+<p>ChannelStatuses is an array of corresponding Channel statuses.
+Matches the Spec.Steps array in the order.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the starting point to this Sequence. Sending to this
+will target the first subscriber.
+It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceStep">SequenceStep
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Destination</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Destination</code> are embedded into this type.)
+</p>
+<p>Subscriber receiving the step event</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for events to the subscriber
+This includes things like retries, DLQ, etc.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="flows.knative.dev/v1beta1.SequenceSubscriptionStatus">SequenceSubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#flows.knative.dev/v1beta1.SequenceStatus">SequenceStatus</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscription</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Subscription is the reference to the underlying Subscription.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+knative.dev/pkg/apis.Condition
+</em>
+</td>
+<td>
+<p>ReadyCondition indicates whether the Subscription is ready or not.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>
+</li><li>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>
+</li><li>
+<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>
+</li></ul>
+<h3 id="messaging.knative.dev/v1beta1.Channel">Channel
+</h3>
+<p>
+<p>Channel represents a generic Channel. It is normally used when we want a Channel, but don&rsquo;t need a specific Channel implementation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Channel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
+This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to ChannelableSpec</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelStatus">
+ChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Channel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel
+</h3>
+<p>
+<p>InMemoryChannel is a resource representing an in memory channel</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>InMemoryChannel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">
+InMemoryChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">
+InMemoryChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Channel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.Subscription">Subscription
+</h3>
+<p>
+<p>Subscription routes events received on a Channel to a DNS name and
+corresponds to the subscriptions.channels.knative.dev CRD.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Subscription</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">
+SubscriptionSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Reference to a channel that will be used to create the subscription
+You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+The resource pointed by this ObjectReference must meet the
+contract to the ChannelableSpec duck type. If the resource does not
+meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a Destination as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery configuration</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">
+SubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelDefaulter">ChannelDefaulter
+</h3>
+<p>
+<p>ChannelDefaulter sets the default Channel CRD and Arguments on Channels that do not
+specify any implementation.</p>
+</p>
+<h3 id="messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
+It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
+This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to ChannelableSpec</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableStatus</code> are embedded into this type.)
+</p>
+<p>Channel conforms to ChannelableStatus</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<p>Channel is an KReference to the Channel CRD backing this Channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpec">ChannelTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the Spec to use for each channel created. Passed
+in verbatim to the Channel CRD as Spec section.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
+</h3>
+<p>
+<p>ChannelTemplateSpecInternal is an internal only version that includes ObjectMeta so that
+we can easily create new Channels off of it.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the Spec to use for each channel created. Passed
+in verbatim to the Channel CRD as Spec section.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
+</p>
+<p>
+<p>InMemoryChannelSpec defines which subscribers have expressed interest in
+receiving events from this InMemoryChannel.
+arguments for a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableStatus</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
+for processing those events and where to put the result of the processing. Only
+From (where the events are coming from) is always required. You can optionally
+only Process the events (results in no output events) by leaving out the Result.
+You can also perform an identity transformation on the incoming events by leaving
+out the Subscriber and only specifying Result.</p>
+<p>The following are all valid specifications:
+channel &ndash;[subscriber]&ndash;&gt; reply
+Sink, no outgoing events:
+channel &ndash; subscriber
+no-op function (identity transformation):
+channel &ndash;&gt; reply</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Reference to a channel that will be used to create the subscription
+You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+The resource pointed by this ObjectReference must meet the
+contract to the ChannelableSpec duck type. If the resource does not
+meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a Destination as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery configuration</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionStatus (computed) for a subscription</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>physicalSubscription</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">
+SubscriptionStatusPhysicalSubscription
+</a>
+</em>
+</td>
+<td>
+<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus</a>)
+</p>
+<p>
+<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
+Subscription.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscriberUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterSinkUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.knative.dev/v1alpha2">sources.knative.dev/v1alpha2</h2>
+<p>
+<p>Package v1alpha2 contains API Schema definitions for the sources v1beta1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>
+</li></ul>
+<h3 id="sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource
+</h3>
+<p>
+<p>ApiServerSource is the Schema for the apiserversources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ApiServerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">
+ApiServerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
+[]APIVersionKindSelector
+</a>
+</em>
+</td>
+<td>
+<p>Resource are the resources this source will track and send related
+lifecycle events from the Kubernetes ApiServer, with an optional label
+selector to help filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EventMode controls the format of the event.
+<code>Reference</code> sends a dataref event type for the resource under watch.
+<code>Resource</code> send the full resource lifecycle event.
+Defaults to <code>Reference</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source. Defaults to default if not set.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceStatus">
+ApiServerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ContainerSource">ContainerSource
+</h3>
+<p>
+<p>ContainerSource is the Schema for the containersources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ContainerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSourceSpec">
+ContainerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the pods that will be created</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSourceStatus">
+ContainerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.PingSource">PingSource
+</h3>
+<p>
+<p>PingSource is the Schema for the PingSources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>PingSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.PingSourceSpec">
+PingSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedule</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>jsonData</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>JsonData is json encoded data used as the body of the event posted to
+the sink. Default is empty. If set, datacontenttype will also be set
+to &ldquo;application/json&rdquo;.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.PingSourceStatus">
+PingSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.SinkBinding">SinkBinding
+</h3>
+<p>
+<p>SinkBinding describes a Binding that is also a Source.
+The <code>sink</code> (from the Source duck) is resolved to a URL and
+then projected into the <code>subject</code> by augmenting the runtime
+contract of the referenced containers to have a <code>K_SINK</code>
+environment variable holding the endpoint to which to send
+cloud events.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>SinkBinding</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.SinkBindingSpec">
+SinkBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
+* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
+should be augmented by Binding implementations.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.SinkBindingStatus">
+SinkBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.APIVersionKind">APIVersionKind
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>, 
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>APIVersionKind is an APIVersion and Kind tuple.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIVersion - the API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.APIVersionKindSelector">APIVersionKindSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIVersion - the API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LabelSelector filters this source to objects to those resources pass the
+label selector.
+More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
+[]APIVersionKindSelector
+</a>
+</em>
+</td>
+<td>
+<p>Resource are the resources this source will track and send related
+lifecycle events from the Kubernetes ApiServer, with an optional label
+selector to help filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EventMode controls the format of the event.
+<code>Reference</code> sends a dataref event type for the resource under watch.
+<code>Resource</code> send the full resource lifecycle event.
+Defaults to <code>Reference</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source. Defaults to default if not set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceStatus">ApiServerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ContainerSourceSpec">ContainerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceSpec defines the desired state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the pods that will be created</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ContainerSourceStatus">ContainerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceStatus defines the observed state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.PingSourceSpec">PingSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
+</p>
+<p>
+<p>PingSourceSpec defines the desired state of the PingSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedule</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>jsonData</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>JsonData is json encoded data used as the body of the event posted to
+the sink. Default is empty. If set, datacontenttype will also be set
+to &ldquo;application/json&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.PingSourceStatus">PingSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
+</p>
+<p>
+<p>PingSourceStatus defines the observed state of PingSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.SinkBindingSpec">SinkBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
+* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
+should be augmented by Binding implementations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.SinkBindingStatus">SinkBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
 </p>
 <p>
 <p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>

--- a/docs/reference/api/eventing/eventing.md
+++ b/docs/reference/api/eventing/eventing.md
@@ -1,19 +1,16 @@
 <p>Packages:</p>
 <ul>
 <li>
+<a href="#flows.knative.dev%2fv1beta1">flows.knative.dev/v1beta1</a>
+</li>
+<li>
 <a href="#messaging.knative.dev%2fv1beta1">messaging.knative.dev/v1beta1</a>
-</li>
-<li>
-<a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
-</li>
-<li>
-<a href="#sources.knative.dev%2fv1alpha2">sources.knative.dev/v1alpha2</a>
 </li>
 <li>
 <a href="#configs.internal.knative.dev%2fv1alpha1">configs.internal.knative.dev/v1alpha1</a>
 </li>
 <li>
-<a href="#duck.knative.dev%2fv1">duck.knative.dev/v1</a>
+<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
 </li>
 <li>
 <a href="#duck.knative.dev%2fv1beta1">duck.knative.dev/v1beta1</a>
@@ -22,4494 +19,27 @@
 <a href="#eventing.knative.dev%2fv1">eventing.knative.dev/v1</a>
 </li>
 <li>
-<a href="#flows.knative.dev%2fv1beta1">flows.knative.dev/v1beta1</a>
-</li>
-<li>
-<a href="#duck.knative.dev%2fv1alpha1">duck.knative.dev/v1alpha1</a>
-</li>
-<li>
 <a href="#eventing.knative.dev%2fv1beta1">eventing.knative.dev/v1beta1</a>
 </li>
 <li>
 <a href="#flows.knative.dev%2fv1">flows.knative.dev/v1</a>
 </li>
 <li>
+<a href="#duck.knative.dev%2fv1">duck.knative.dev/v1</a>
+</li>
+<li>
 <a href="#messaging.knative.dev%2fv1">messaging.knative.dev/v1</a>
+</li>
+<li>
+<a href="#sources.knative.dev%2fv1alpha1">sources.knative.dev/v1alpha1</a>
+</li>
+<li>
+<a href="#sources.knative.dev%2fv1alpha2">sources.knative.dev/v1alpha2</a>
 </li>
 <li>
 <a href="#sources.knative.dev%2fv1beta1">sources.knative.dev/v1beta1</a>
 </li>
 </ul>
-<h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>
-</li><li>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>
-</li><li>
-<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>
-</li></ul>
-<h3 id="messaging.knative.dev/v1beta1.Channel">Channel
-</h3>
-<p>
-<p>Channel represents a generic Channel. It is normally used when we want a Channel, but don&rsquo;t need a specific Channel implementation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Channel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">
-ChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
-This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to ChannelableSpec</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelStatus">
-ChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Channel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel
-</h3>
-<p>
-<p>InMemoryChannel is a resource representing an in memory channel</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>InMemoryChannel</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">
-InMemoryChannelSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Channel.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">
-InMemoryChannelStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Channel. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.Subscription">Subscription
-</h3>
-<p>
-<p>Subscription routes events received on a Channel to a DNS name and
-corresponds to the subscriptions.channels.knative.dev CRD.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-messaging.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Subscription</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">
-SubscriptionSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Reference to a channel that will be used to create the subscription
-You can specify only the following fields of the ObjectReference:
-- Kind
-- APIVersion
-- Name
-The resource pointed by this ObjectReference must meet the
-contract to the ChannelableSpec duck type. If the resource does not
-meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
-<p>This field is immutable. We have no good answer on what happens to
-the events that are currently in the channel being consumed from
-and what the semantics there should be. For now, you can always
-delete the Subscription and recreate it to point to a different
-channel, giving the user more control over what semantics should
-be used (drain the channel first, possibly have events dropped,
-etc.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
-Events from the Channel will be delivered here and replies are
-sent to a Destination as specified by the Reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply specifies (optionally) how to handle events returned from
-the Subscriber target.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery configuration</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">
-SubscriptionStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelDefaulter">ChannelDefaulter
-</h3>
-<p>
-<p>ChannelDefaulter sets the default Channel CRD and Arguments on Channels that do not
-specify any implementation.</p>
-</p>
-<h3 id="messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
-</p>
-<p>
-<p>ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
-It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channelTemplate</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
-ChannelTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
-This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to ChannelableSpec</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
-</p>
-<p>
-<p>ChannelStatus represents the current state of a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableStatus</code> are embedded into this type.)
-</p>
-<p>Channel conforms to ChannelableStatus</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<p>Channel is an KReference to the Channel CRD backing this Channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpec">ChannelTemplateSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
-</h3>
-<p>
-<p>ChannelTemplateSpecInternal is an internal only version that includes ObjectMeta so that
-we can easily create new Channels off of it.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec defines the Spec to use for each channel created. Passed
-in verbatim to the Channel CRD as Spec section.</p>
-<br/>
-<br/>
-<table>
-</table>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
-</p>
-<p>
-<p>InMemoryChannelSpec defines which subscribers have expressed interest in
-receiving events from this InMemoryChannel.
-arguments for a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableSpec</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
-</p>
-<p>
-<p>ChannelStatus represents the current state of a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>ChannelableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ChannelableStatus</code> are embedded into this type.)
-</p>
-<p>Channel conforms to Duck type Channelable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
-</p>
-<p>
-<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
-for processing those events and where to put the result of the processing. Only
-From (where the events are coming from) is always required. You can optionally
-only Process the events (results in no output events) by leaving out the Result.
-You can also perform an identity transformation on the incoming events by leaving
-out the Subscriber and only specifying Result.</p>
-<p>The following are all valid specifications:
-channel &ndash;[subscriber]&ndash;&gt; reply
-Sink, no outgoing events:
-channel &ndash; subscriber
-no-op function (identity transformation):
-channel &ndash;&gt; reply</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>channel</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
-Kubernetes core/v1.ObjectReference
-</a>
-</em>
-</td>
-<td>
-<p>Reference to a channel that will be used to create the subscription
-You can specify only the following fields of the ObjectReference:
-- Kind
-- APIVersion
-- Name
-The resource pointed by this ObjectReference must meet the
-contract to the ChannelableSpec duck type. If the resource does not
-meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
-<p>This field is immutable. We have no good answer on what happens to
-the events that are currently in the channel being consumed from
-and what the semantics there should be. For now, you can always
-delete the Subscription and recreate it to point to a different
-channel, giving the user more control over what semantics should
-be used (drain the channel first, possibly have events dropped,
-etc.)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Subscriber is reference to (optional) function for processing events.
-Events from the Channel will be delivered here and replies are
-sent to a Destination as specified by the Reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reply</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Reply specifies (optionally) how to handle events returned from
-the Subscriber target.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery configuration</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
-</p>
-<p>
-<p>SubscriptionStatus (computed) for a subscription</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>physicalSubscription</code></br>
-<em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">
-SubscriptionStatusPhysicalSubscription
-</a>
-</em>
-</td>
-<td>
-<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus</a>)
-</p>
-<p>
-<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
-Subscription.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterSinkUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="sources.knative.dev/v1alpha1">sources.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>
-</li></ul>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource
-</h3>
-<p>
-<p>ApiServerSource is the Schema for the apiserversources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ApiServerSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">
-ApiServerSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
-[]ApiServerResource
-</a>
-</em>
-</td>
-<td>
-<p>Resources is the list of resources to watch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1beta1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>owner</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
-APIVersionKind
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceOwner is an additional filter to only track resources that are
-owned by a specific resource type. If ResourceOwner matches Resources[n]
-then Resources[n] is allowed to pass the ResourceOwner filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
-<code>Ref</code> sends only the reference to the resource.
-<code>Resource</code> send the full resource.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceStatus">
-ApiServerSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.SinkBinding">SinkBinding
-</h3>
-<p>
-<p>SinkBinding describes a Binding that is also a Source.
-The <code>sink</code> (from the Source duck) is resolved to a URL and
-then projected into the <code>subject</code> by augmenting the runtime
-contract of the referenced containers to have a <code>K_SINK</code>
-environment variable holding the endpoint to which to send
-cloud events.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>SinkBinding</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SinkBindingSpec">
-SinkBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.SinkBindingStatus">
-SinkBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerResource">ApiServerResource
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
-</p>
-<p>
-<p>ApiServerResource defines the resource to watch</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>API version of the resource to watch.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Kind of the resource to watch.
-More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>labelSelector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<p>LabelSelector restricts this source to objects with the selected labels
-More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>controllerSelector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ownerreference-v1-meta">
-Kubernetes meta/v1.OwnerReference
-</a>
-</em>
-</td>
-<td>
-<p>ControllerSelector restricts this source to objects with a controlling owner reference of the specified kind.
-Only apiVersion and kind are used. Both are optional.
-Deprecated: Per-resource owner refs will no longer be supported in
-v1alpha2, please use Spec.Owner as a GKV.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>controller</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>If true, send an event referencing the object controlling the resource
-Deprecated: Per-resource controller flag will no longer be supported in
-v1alpha2, please use Spec.Owner as a GKV.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
-</p>
-<p>
-<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
-[]ApiServerResource
-</a>
-</em>
-</td>
-<td>
-<p>Resources is the list of resources to watch</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>sink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1beta1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ceOverrides</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.CloudEventOverrides
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CloudEventOverrides defines overrides to control the output format and
-modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>owner</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
-APIVersionKind
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceOwner is an additional filter to only track resources that are
-owned by a specific resource type. If ResourceOwner matches Resources[n]
-then Resources[n] is allowed to pass the ResourceOwner filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
-<code>Ref</code> sends only the reference to the resource.
-<code>Resource</code> send the full resource.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceStatus">ApiServerSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
-</p>
-<p>
-<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.SinkBindingSpec">SinkBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
-</p>
-<p>
-<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha1.SinkBindingStatus">SinkBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
-</p>
-<p>
-<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="sources.knative.dev/v1alpha2">sources.knative.dev/v1alpha2</h2>
-<p>
-<p>Package v1alpha2 contains API Schema definitions for the sources v1beta1 API group</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>
-</li><li>
-<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>
-</li></ul>
-<h3 id="sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource
-</h3>
-<p>
-<p>ApiServerSource is the Schema for the apiserversources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ApiServerSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">
-ApiServerSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
-[]APIVersionKindSelector
-</a>
-</em>
-</td>
-<td>
-<p>Resource are the resources this source will track and send related
-lifecycle events from the Kubernetes ApiServer, with an optional label
-selector to help filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>owner</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
-APIVersionKind
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceOwner is an additional filter to only track resources that are
-owned by a specific resource type. If ResourceOwner matches Resources[n]
-then Resources[n] is allowed to pass the ResourceOwner filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EventMode controls the format of the event.
-<code>Reference</code> sends a dataref event type for the resource under watch.
-<code>Resource</code> send the full resource lifecycle event.
-Defaults to <code>Reference</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source. Defaults to default if not set.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceStatus">
-ApiServerSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ContainerSource">ContainerSource
-</h3>
-<p>
-<p>ContainerSource is the Schema for the containersources API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ContainerSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSourceSpec">
-ContainerSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the pods that will be created</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSourceStatus">
-ContainerSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.PingSource">PingSource
-</h3>
-<p>
-<p>PingSource is the Schema for the PingSources API.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>PingSource</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.PingSourceSpec">
-PingSourceSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>jsonData</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>JsonData is json encoded data used as the body of the event posted to
-the sink. Default is empty. If set, datacontenttype will also be set
-to &ldquo;application/json&rdquo;.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.PingSourceStatus">
-PingSourceStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.SinkBinding">SinkBinding
-</h3>
-<p>
-<p>SinkBinding describes a Binding that is also a Source.
-The <code>sink</code> (from the Source duck) is resolved to a URL and
-then projected into the <code>subject</code> by augmenting the runtime
-contract of the referenced containers to have a <code>K_SINK</code>
-environment variable holding the endpoint to which to send
-cloud events.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-sources.knative.dev/v1alpha2
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>SinkBinding</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.SinkBindingSpec">
-SinkBindingSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
-* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
-should be augmented by Binding implementations.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.SinkBindingStatus">
-SinkBindingStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.APIVersionKind">APIVersionKind
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>, 
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
-</p>
-<p>
-<p>APIVersionKind is an APIVersion and Kind tuple.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>APIVersion - the API version of the resource to watch.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Kind of the resource to watch.
-More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.APIVersionKindSelector">APIVersionKindSelector
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
-</p>
-<p>
-<p>APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>APIVersion - the API version of the resource to watch.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Kind of the resource to watch.
-More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>LabelSelector filters this source to objects to those resources pass the
-label selector.
-More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
-</p>
-<p>
-<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resources</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
-[]APIVersionKindSelector
-</a>
-</em>
-</td>
-<td>
-<p>Resource are the resources this source will track and send related
-lifecycle events from the Kubernetes ApiServer, with an optional label
-selector to help filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>owner</code></br>
-<em>
-<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
-APIVersionKind
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ResourceOwner is an additional filter to only track resources that are
-owned by a specific resource type. If ResourceOwner matches Resources[n]
-then Resources[n] is allowed to pass the ResourceOwner filter.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>mode</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>EventMode controls the format of the event.
-<code>Reference</code> sends a dataref event type for the resource under watch.
-<code>Resource</code> send the full resource lifecycle event.
-Defaults to <code>Reference</code></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>serviceAccountName</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ServiceAccountName is the name of the ServiceAccount to use to run this
-source. Defaults to default if not set.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceStatus">ApiServerSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
-</p>
-<p>
-<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ContainerSourceSpec">ContainerSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
-</p>
-<p>
-<p>ContainerSourceSpec defines the desired state of ContainerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
-Kubernetes core/v1.PodTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the pods that will be created</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.ContainerSourceStatus">ContainerSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
-</p>
-<p>
-<p>ContainerSourceStatus defines the observed state of ContainerSource</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.PingSourceSpec">PingSourceSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
-</p>
-<p>
-<p>PingSourceSpec defines the desired state of the PingSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>schedule</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>jsonData</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>JsonData is json encoded data used as the body of the event posted to
-the sink. Default is empty. If set, datacontenttype will also be set
-to &ldquo;application/json&rdquo;.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.PingSourceStatus">PingSourceStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
-</p>
-<p>
-<p>PingSourceStatus defines the observed state of PingSource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.SinkBindingSpec">SinkBindingSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
-</p>
-<p>
-<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceSpec, which currently provides:
-* Sink - a reference to an object that will resolve to a domain name or
-a URI directly to use as the sink.
-* CloudEventOverrides - defines overrides to control the output format
-and modifications of the event sent to the sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>BindingSpec</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
-</em>
-</td>
-<td>
-<p>
-(Members of <code>BindingSpec</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
-* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
-should be augmented by Binding implementations.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="sources.knative.dev/v1alpha2.SinkBindingStatus">SinkBindingStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
-</p>
-<p>
-<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SourceStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.SourceStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SourceStatus</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 SourceStatus, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
-processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current
-state.
-* SinkURI - the current active sink URI that has been configured for the
-Source.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="configs.internal.knative.dev/v1alpha1">configs.internal.knative.dev/v1alpha1</h2>
-<p>
-<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>
-</li></ul>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation
-</h3>
-<p>
-<p>ConfigMapPropagation is used to propagate configMaps from original namespace to current namespace</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-configs.internal.knative.dev/v1alpha1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>ConfigMapPropagation</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">
-ConfigMapPropagationSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the ConfigMapPropagation</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>originalNamespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>OriginalNamespace is the namespace where the original configMaps are in</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Selector only selects original configMaps with corresponding labels</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">
-ConfigMapPropagationStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the EventType.
-This data may be out of date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">ConfigMapPropagationSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>originalNamespace</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>OriginalNamespace is the namespace where the original configMaps are in</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Selector only selects original configMaps with corresponding labels</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
-</p>
-<p>
-<p>ConfigMapPropagationStatus represents the current state of a ConfigMapPropagation.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>copyConfigmaps</code></br>
-<em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">
-[]ConfigMapPropagationStatusCopyConfigMap
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>CopyConfigMaps is the status for each copied configmap.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">ConfigMapPropagationStatusCopyConfigMap
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus</a>)
-</p>
-<p>
-<p>ConfigMapPropagationStatusCopyConfigMap represents the status of a copied configmap</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>name</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Name is copy configmap&rsquo;s name</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>source</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Source is &ldquo;originalNamespace/originalConfigMapName&rdquo;</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>operation</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Operation represents the operation CMP takes for this configmap. The operations are copy|delete|stop</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Ready represents the operation is ready or not</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>reason</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Reason indicates reasons if the operation is not ready</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>resourceVersionFromSource</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>ResourceVersion is the resourceVersion of original configmap</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="duck.knative.dev/v1">duck.knative.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="duck.knative.dev/v1.BackoffPolicyType">BackoffPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.DeliverySpec">DeliverySpec</a>)
-</p>
-<p>
-<p>BackoffPolicyType is the type for backoff policies</p>
-</p>
-<h3 id="duck.knative.dev/v1.Channelable">Channelable
-</h3>
-<p>
-<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
-Failed messages are delivered here.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.DeliverySpec">DeliverySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
-<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
-</p>
-<p>
-<p>DeliverySpec contains the delivery options for event senders,
-such as channelable and source.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterSink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterSink is the sink receiving event that could not be sent to
-a destination.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retry</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retry is the minimum number of retries the sender should attempt when
-sending an event before moving it to the dead letter sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffPolicy</code></br>
-<em>
-<a href="#duck.knative.dev/v1.BackoffPolicyType">
-BackoffPolicyType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffDelay</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffDelay is the delay before retrying.
-More information on Duration format:
-- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
-- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
-<p>For linear policy, backoff delay is the time interval between retries.
-For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.DeliveryStatus">DeliveryStatus
-</h3>
-<p>
-<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
-where failed events are sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.Subscribable">Subscribable
-</h3>
-<p>
-<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableSpec is the part where Subscribable object is
-configured as to be compatible with Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscribableSpec">SubscribableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">SubscribableSpec</a>)
-</p>
-<p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
-<p>At least one of SubscriberURI and ReplyURI must be present</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubscriberURI is the endpoint for the subscriber</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReplyURI is the endpoint for the reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1.SubscriberStatus">SubscriberStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">SubscribableStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>)
-</p>
-<p>
-<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
-Kubernetes core/v1.ConditionStatus
-</a>
-</em>
-</td>
-<td>
-<p>Status of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>message</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>A human readable message indicating details of Ready status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="duck.knative.dev/v1beta1">duck.knative.dev/v1beta1</h2>
-<p>
-<p>Package v1beta1 is the v1beta1 version of the API.</p>
-</p>
-Resource Types:
-<ul></ul>
-<h3 id="duck.knative.dev/v1beta1.BackoffPolicyType">BackoffPolicyType
-(<code>string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec</a>)
-</p>
-<p>
-<p>BackoffPolicyType is the type for backoff policies</p>
-</p>
-<h3 id="duck.knative.dev/v1beta1.Channelable">Channelable
-</h3>
-<p>
-<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
-ChannelableSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
-ChannelableStatus
-</a>
-</em>
-</td>
-<td>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
-</p>
-<p>
-<p>ChannelableSpec contains Spec of the Channelable object</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>SubscribableSpec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
-<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
-</p>
-<p>
-<p>ChannelableStatus contains the Status of a Channelable object.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>AddressStatus</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.AddressStatus
-</em>
-</td>
-<td>
-<p>
-(Members of <code>AddressStatus</code> are embedded into this type.)
-</p>
-<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableStatus</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableStatus</code> are embedded into this type.)
-</p>
-<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
-Failed messages are delivered here.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
-<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
-<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
-</p>
-<p>
-<p>DeliverySpec contains the delivery options for event senders,
-such as channelable and source.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterSink</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterSink is the sink receiving event that could not be sent to
-a destination.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>retry</code></br>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Retry is the minimum number of retries the sender should attempt when
-sending an event before moving it to the dead letter sink.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffPolicy</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.BackoffPolicyType">
-BackoffPolicyType
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>backoffDelay</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>BackoffDelay is the delay before retrying.
-More information on Duration format:
-- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
-- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
-<p>For linear policy, backoff delay is the time interval between retries.
-For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.DeliveryStatus">DeliveryStatus
-</h3>
-<p>
-<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>deadLetterChannel</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
-where failed events are sent to.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.Subscribable">Subscribable
-</h3>
-<p>
-<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
-defining compatible resources to embed it. We will typically use this type to deserialize
-SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableSpec is the part where Subscribable object is
-configured as to be compatible with Subscribable contract.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>SubscribableStatus is the part where SubscribableStatus object is
-configured as to be compatible with Subscribable contract.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
-<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
-[]SubscriberSpec
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscriptions for this subscribable.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>, 
-<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
-</p>
-<p>
-<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
-section of the resource.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>subscribers</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec</a>)
-</p>
-<p>
-<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
-<p>At least one of SubscriberURI and ReplyURI must be present</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>generation</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>SubscriberURI is the endpoint for the subscriber</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>replyUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ReplyURI is the endpoint for the reply</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1beta1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="duck.knative.dev/v1beta1.SubscriberStatus">SubscriberStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus</a>, 
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>)
-</p>
-<p>
-<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>uid</code></br>
-<em>
-k8s.io/apimachinery/pkg/types.UID
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>UID is used to understand the origin of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>observedGeneration</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Generation of the origin of the subscriber with uid:UID.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>ready</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
-Kubernetes core/v1.ConditionStatus
-</a>
-</em>
-</td>
-<td>
-<p>Status of the subscriber.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>message</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>A human readable message indicating details of Ready status.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
-<h2 id="eventing.knative.dev/v1">eventing.knative.dev/v1</h2>
-<p>
-<p>Package v1 is the v1 version of the API.</p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#eventing.knative.dev/v1.Broker">Broker</a>
-</li><li>
-<a href="#eventing.knative.dev/v1.Trigger">Trigger</a>
-</li></ul>
-<h3 id="eventing.knative.dev/v1.Broker">Broker
-</h3>
-<p>
-<p>Broker collects a pool of events that are consumable using Triggers. Brokers
-provide a well-known endpoint for event delivery that senders can use with
-minimal knowledge of the event routing strategy. Subscribers use Triggers to
-request delivery of events from a Broker&rsquo;s pool to a specific URL or
-Addressable endpoint.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Broker</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.BrokerSpec">
-BrokerSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Broker.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>config</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Config is a KReference to the configuration that specifies
-configuration options for this Broker. For example, this could be
-a pointer to a ConfigMap.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for Events within the Broker mesh.
-This includes things like retries, DLQ, etc.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.BrokerStatus">
-BrokerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Broker. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1.Trigger">Trigger
-</h3>
-<p>
-<p>Trigger represents a request to have events delivered to a subscriber from a
-Broker&rsquo;s event pool.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-eventing.knative.dev/v1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Trigger</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.TriggerSpec">
-TriggerSpec
-</a>
-</em>
-</td>
-<td>
-<p>Spec defines the desired state of the Trigger.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>broker</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Broker is the broker that this trigger receives events from.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.TriggerFilter">
-TriggerFilter
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
-filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
-is required.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.TriggerStatus">
-TriggerStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status represents the current state of the Trigger. This data may be out of
-date.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1.BrokerSpec">BrokerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.Broker">Broker</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>config</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.KReference
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Config is a KReference to the configuration that specifies
-configuration options for this Broker. For example, this could be
-a pointer to a ConfigMap.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>delivery</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Delivery is the delivery specification for Events within the Broker mesh.
-This includes things like retries, DLQ, etc.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1.BrokerStatus">BrokerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.Broker">Broker</a>)
-</p>
-<p>
-<p>BrokerStatus represents the current state of a Broker.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Broker that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>address</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Addressable
-</em>
-</td>
-<td>
-<p>Broker is Addressable. It exposes the endpoint as an URI to get events
-delivered into the Broker mesh.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1.TriggerFilter">TriggerFilter
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.TriggerSpec">TriggerSpec</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>attributes</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.TriggerFilterAttributes">
-TriggerFilterAttributes
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Attributes filters events by exact match on event context attributes.
-Each key in the map is compared with the equivalent key in the event
-context. An event passes the filter if all values are equal to the
-specified values.</p>
-<p>Nested context attributes are not supported as keys. Only string values are supported.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1.TriggerFilterAttributes">TriggerFilterAttributes
-(<code>map[string]string</code> alias)</p></h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.TriggerFilter">TriggerFilter</a>)
-</p>
-<p>
-<p>TriggerFilterAttributes is a map of context attribute names to values for
-filtering by equality. Only exact matches will pass the filter. You can use the value &ldquo;
-to indicate all strings match.</p>
-</p>
-<h3 id="eventing.knative.dev/v1.TriggerSpec">TriggerSpec
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.Trigger">Trigger</a>)
-</p>
-<p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>broker</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>Broker is the broker that this trigger receives events from.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>filter</code></br>
-<em>
-<a href="#eventing.knative.dev/v1.TriggerFilter">
-TriggerFilter
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
-filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriber</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Destination
-</em>
-</td>
-<td>
-<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
-is required.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="eventing.knative.dev/v1.TriggerStatus">TriggerStatus
-</h3>
-<p>
-(<em>Appears on:</em>
-<a href="#eventing.knative.dev/v1.Trigger">Trigger</a>)
-</p>
-<p>
-<p>TriggerStatus represents the current state of a Trigger.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>Status</code></br>
-<em>
-knative.dev/pkg/apis/duck/v1.Status
-</em>
-</td>
-<td>
-<p>
-(Members of <code>Status</code> are embedded into this type.)
-</p>
-<p>inherits duck/v1 Status, which currently provides:
-* ObservedGeneration - the &lsquo;Generation&rsquo; of the Trigger that was last processed by the controller.
-* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscriberUri</code></br>
-<em>
-knative.dev/pkg/apis.URL
-</em>
-</td>
-<td>
-<p>SubscriberURI is the resolved URI of the receiver for this Trigger.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="flows.knative.dev/v1beta1">flows.knative.dev/v1beta1</h2>
 <p>
 <p>Package v1beta1 is the v1beta1 version of the API.</p>
@@ -5344,6 +874,1114 @@ knative.dev/pkg/apis.Condition
 </tbody>
 </table>
 <hr/>
+<h2 id="messaging.knative.dev/v1beta1">messaging.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>
+</li><li>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>
+</li><li>
+<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>
+</li></ul>
+<h3 id="messaging.knative.dev/v1beta1.Channel">Channel
+</h3>
+<p>
+<p>Channel represents a generic Channel. It is normally used when we want a Channel, but don&rsquo;t need a specific Channel implementation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Channel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">
+ChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
+This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to ChannelableSpec</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelStatus">
+ChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Channel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel
+</h3>
+<p>
+<p>InMemoryChannel is a resource representing an in memory channel</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>InMemoryChannel</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">
+InMemoryChannelSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Channel.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">
+InMemoryChannelStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Channel. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.Subscription">Subscription
+</h3>
+<p>
+<p>Subscription routes events received on a Channel to a DNS name and
+corresponds to the subscriptions.channels.knative.dev CRD.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+messaging.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Subscription</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">
+SubscriptionSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Reference to a channel that will be used to create the subscription
+You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+The resource pointed by this ObjectReference must meet the
+contract to the ChannelableSpec duck type. If the resource does not
+meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a Destination as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery configuration</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">
+SubscriptionStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelDefaulter">ChannelDefaulter
+</h3>
+<p>
+<p>ChannelDefaulter sets the default Channel CRD and Arguments on Channels that do not
+specify any implementation.</p>
+</p>
+<h3 id="messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelSpec defines which subscribers have expressed interest in receiving events from this Channel.
+It also defines the ChannelTemplate to use in order to create the CRD Channel backing this Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channelTemplate</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
+ChannelTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>ChannelTemplate specifies which Channel CRD to use to create the CRD Channel backing this Channel.
+This is immutable after creation. Normally this is set by the Channel defaulter, not directly by the user.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to ChannelableSpec</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Channel">Channel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableStatus</code> are embedded into this type.)
+</p>
+<p>Channel conforms to ChannelableStatus</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<p>Channel is an KReference to the Channel CRD backing this Channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpec">ChannelTemplateSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the Spec to use for each channel created. Passed
+in verbatim to the Channel CRD as Spec section.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.ChannelTemplateSpecInternal">ChannelTemplateSpecInternal
+</h3>
+<p>
+<p>ChannelTemplateSpecInternal is an internal only version that includes ObjectMeta so that
+we can easily create new Channels off of it.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+k8s.io/apimachinery/pkg/runtime.RawExtension
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec defines the Spec to use for each channel created. Passed
+in verbatim to the Channel CRD as Spec section.</p>
+<br/>
+<br/>
+<table>
+</table>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
+</p>
+<p>
+<p>InMemoryChannelSpec defines which subscribers have expressed interest in
+receiving events from this InMemoryChannel.
+arguments for a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableSpec</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannel">InMemoryChannel</a>)
+</p>
+<p>
+<p>ChannelStatus represents the current state of a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>ChannelableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ChannelableStatus</code> are embedded into this type.)
+</p>
+<p>Channel conforms to Duck type Channelable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionSpec specifies the Channel for incoming events, a Subscriber target
+for processing those events and where to put the result of the processing. Only
+From (where the events are coming from) is always required. You can optionally
+only Process the events (results in no output events) by leaving out the Result.
+You can also perform an identity transformation on the incoming events by leaving
+out the Subscriber and only specifying Result.</p>
+<p>The following are all valid specifications:
+channel &ndash;[subscriber]&ndash;&gt; reply
+Sink, no outgoing events:
+channel &ndash; subscriber
+no-op function (identity transformation):
+channel &ndash;&gt; reply</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>channel</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
+Kubernetes core/v1.ObjectReference
+</a>
+</em>
+</td>
+<td>
+<p>Reference to a channel that will be used to create the subscription
+You can specify only the following fields of the ObjectReference:
+- Kind
+- APIVersion
+- Name
+The resource pointed by this ObjectReference must meet the
+contract to the ChannelableSpec duck type. If the resource does not
+meet this contract it will be reflected in the Subscription&rsquo;s status.</p>
+<p>This field is immutable. We have no good answer on what happens to
+the events that are currently in the channel being consumed from
+and what the semantics there should be. For now, you can always
+delete the Subscription and recreate it to point to a different
+channel, giving the user more control over what semantics should
+be used (drain the channel first, possibly have events dropped,
+etc.)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Subscriber is reference to (optional) function for processing events.
+Events from the Channel will be delivered here and replies are
+sent to a Destination as specified by the Reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reply</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Reply specifies (optionally) how to handle events returned from
+the Subscriber target.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery configuration</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.Subscription">Subscription</a>)
+</p>
+<p>
+<p>SubscriptionStatus (computed) for a subscription</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>physicalSubscription</code></br>
+<em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">
+SubscriptionStatusPhysicalSubscription
+</a>
+</em>
+</td>
+<td>
+<p>PhysicalSubscription is the fully resolved values that this Subscription represents.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">SubscriptionStatusPhysicalSubscription
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">SubscriptionStatus</a>)
+</p>
+<p>
+<p>SubscriptionStatusPhysicalSubscription represents the fully resolved values for this
+Subscription.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscriberUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>SubscriberURI is the fully resolved URI for spec.subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>ReplyURI is the fully resolved URI for the spec.reply.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterSinkUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="configs.internal.knative.dev/v1alpha1">configs.internal.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 is the v1alpha1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>
+</li></ul>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation
+</h3>
+<p>
+<p>ConfigMapPropagation is used to propagate configMaps from original namespace to current namespace</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+configs.internal.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ConfigMapPropagation</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">
+ConfigMapPropagationSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the ConfigMapPropagation</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>originalNamespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OriginalNamespace is the namespace where the original configMaps are in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Selector only selects original configMaps with corresponding labels</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">
+ConfigMapPropagationStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the EventType.
+This data may be out of date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">ConfigMapPropagationSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>originalNamespace</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>OriginalNamespace is the namespace where the original configMaps are in</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Selector only selects original configMaps with corresponding labels</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagation">ConfigMapPropagation</a>)
+</p>
+<p>
+<p>ConfigMapPropagationStatus represents the current state of a ConfigMapPropagation.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>copyConfigmaps</code></br>
+<em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">
+[]ConfigMapPropagationStatusCopyConfigMap
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CopyConfigMaps is the status for each copied configmap.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">ConfigMapPropagationStatusCopyConfigMap
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">ConfigMapPropagationStatus</a>)
+</p>
+<p>
+<p>ConfigMapPropagationStatusCopyConfigMap represents the status of a copied configmap</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is copy configmap&rsquo;s name</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>source</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Source is &ldquo;originalNamespace/originalConfigMapName&rdquo;</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>operation</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Operation represents the operation CMP takes for this configmap. The operations are copy|delete|stop</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Ready represents the operation is ready or not</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>reason</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Reason indicates reasons if the operation is not ready</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resourceVersionFromSource</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>ResourceVersion is the resourceVersion of original configmap</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <h2 id="duck.knative.dev/v1alpha1">duck.knative.dev/v1alpha1</h2>
 <p>
 <p>Package v1alpha1 is the v1alpha1 version of the API.</p>
@@ -5443,7 +2081,7 @@ ChannelableStatus
 </h3>
 <p>
 <p>ChannelableCombined is a skeleton type wrapping Subscribable and Addressable of
-v1alpha1, v1beta1 and v1 duck types. This is not to be used by resource writers and is
+v1alpha1 and v1beta1 duck types. This is not to be used by resource writers and is
 only used by Subscription Controller to synthesize patches and read the Status
 of the Channelable Resources.
 This is not a real resource.</p>
@@ -5527,39 +2165,7 @@ DeliverySpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery
-for the v1beta1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableSpecv1</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpecv1</code> are embedded into this type.)
-</p>
-<p>SubscribableSpecv1 is for the v1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deliveryv1</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpecv1 contains options controlling the event delivery
-for the v1 spec compatibility.</p>
+<p>DeliverySpec contains options controlling the event delivery</p>
 </td>
 </tr>
 </table>
@@ -5639,39 +2245,7 @@ DeliverySpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>DeliverySpec contains options controlling the event delivery
-for the v1beta1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableSpecv1</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableSpec">
-SubscribableSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableSpecv1</code> are embedded into this type.)
-</p>
-<p>SubscribableSpecv1 is for the v1 spec compatibility.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>deliveryv1</code></br>
-<em>
-<a href="#duck.knative.dev/v1.DeliverySpec">
-DeliverySpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DeliverySpecv1 contains options controlling the event delivery
-for the v1 spec compatibility.</p>
+<p>DeliverySpec contains options controlling the event delivery</p>
 </td>
 </tr>
 </tbody>
@@ -5753,22 +2327,6 @@ SubscribableStatus
 (Members of <code>SubscribableStatus</code> are embedded into this type.)
 </p>
 <p>SubscribableStatus is the v1beta1 part of the Subscribers status.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>SubscribableStatusv1</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscribableStatus">
-SubscribableStatus
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>SubscribableStatusv1</code> are embedded into this type.)
-</p>
-<p>SubscribableStatusv1 is the v1 part of the Subscribers status.</p>
 </td>
 </tr>
 <tr>
@@ -6000,19 +2558,6 @@ section of the resource.</p>
 <code>subscribers</code></br>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscriberStatus">
-[]SubscriberStatus
-</a>
-</em>
-</td>
-<td>
-<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>subscribersv1</code></br>
-<em>
-<a href="#duck.knative.dev/v1.SubscriberStatus">
 []SubscriberStatus
 </a>
 </em>
@@ -6255,9 +2800,743 @@ DeliverySpec
 <em>(Optional)</em>
 </td>
 </tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="duck.knative.dev/v1beta1">duck.knative.dev/v1beta1</h2>
+<p>
+<p>Package v1beta1 is the v1beta1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="duck.knative.dev/v1beta1.BackoffPolicyType">BackoffPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec</a>)
+</p>
+<p>
+<p>BackoffPolicyType is the type for backoff policies</p>
+</p>
+<h3 id="duck.knative.dev/v1beta1.Channelable">Channelable
+</h3>
+<p>
+<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
 <tr>
 <td>
-<code>deliveryv1</code></br>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterChannel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
+Failed messages are delivered here.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.DeliverySpec">DeliverySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
+<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>DeliverySpec contains the delivery options for event senders,
+such as channelable and source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterSink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterSink is the sink receiving event that could not be sent to
+a destination.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retry</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retry is the minimum number of retries the sender should attempt when
+sending an event before moving it to the dead letter sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffPolicy</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.BackoffPolicyType">
+BackoffPolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffDelay</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffDelay is the delay before retrying.
+More information on Duration format:
+- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
+<p>For linear policy, backoff delay is the time interval between retries.
+For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.DeliveryStatus">DeliveryStatus
+</h3>
+<p>
+<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterChannel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
+where failed events are sent to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.Subscribable">Subscribable
+</h3>
+<p>
+<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1beta1.SubscribableSpec">SubscribableSpec</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
+<p>At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberURI is the endpoint for the subscriber</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyURI is the endpoint for the reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1beta1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1beta1.SubscriberStatus">SubscriberStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus</a>)
+</p>
+<p>
+<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A human readable message indicating details of Ready status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="eventing.knative.dev/v1">eventing.knative.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#eventing.knative.dev/v1.Broker">Broker</a>
+</li><li>
+<a href="#eventing.knative.dev/v1.Trigger">Trigger</a>
+</li></ul>
+<h3 id="eventing.knative.dev/v1.Broker">Broker
+</h3>
+<p>
+<p>Broker collects a pool of events that are consumable using Triggers. Brokers
+provide a well-known endpoint for event delivery that senders can use with
+minimal knowledge of the event routing strategy. Subscribers use Triggers to
+request delivery of events from a Broker&rsquo;s pool to a specific URL or
+Addressable endpoint.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Broker</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.BrokerSpec">
+BrokerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Broker.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>config</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Config is a KReference to the configuration that specifies
+configuration options for this Broker. For example, this could be
+a pointer to a ConfigMap.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -6266,6 +3545,387 @@ DeliverySpec
 </td>
 <td>
 <em>(Optional)</em>
+<p>Delivery is the delivery specification for Events within the Broker mesh.
+This includes things like retries, DLQ, etc.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.BrokerStatus">
+BrokerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Broker. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1.Trigger">Trigger
+</h3>
+<p>
+<p>Trigger represents a request to have events delivered to a subscriber from a
+Broker&rsquo;s event pool.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+eventing.knative.dev/v1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Trigger</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.TriggerSpec">
+TriggerSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec defines the desired state of the Trigger.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>broker</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Broker is the broker that this trigger receives events from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.TriggerFilter">
+TriggerFilter
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
+filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
+is required.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.TriggerStatus">
+TriggerStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status represents the current state of the Trigger. This data may be out of
+date.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1.BrokerSpec">BrokerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.Broker">Broker</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>config</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Config is a KReference to the configuration that specifies
+configuration options for this Broker. For example, this could be
+a pointer to a ConfigMap.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Delivery is the delivery specification for Events within the Broker mesh.
+This includes things like retries, DLQ, etc.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1.BrokerStatus">BrokerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.Broker">Broker</a>)
+</p>
+<p>
+<p>BrokerStatus represents the current state of a Broker.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Broker that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>address</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Addressable
+</em>
+</td>
+<td>
+<p>Broker is Addressable. It exposes the endpoint as an URI to get events
+delivered into the Broker mesh.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1.TriggerFilter">TriggerFilter
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.TriggerSpec">TriggerSpec</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>attributes</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.TriggerFilterAttributes">
+TriggerFilterAttributes
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Attributes filters events by exact match on event context attributes.
+Each key in the map is compared with the equivalent key in the event
+context. An event passes the filter if all values are equal to the
+specified values.</p>
+<p>Nested context attributes are not supported as keys. Only string values are supported.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1.TriggerFilterAttributes">TriggerFilterAttributes
+(<code>map[string]string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.TriggerFilter">TriggerFilter</a>)
+</p>
+<p>
+<p>TriggerFilterAttributes is a map of context attribute names to values for
+filtering by equality. Only exact matches will pass the filter. You can use the value &ldquo;
+to indicate all strings match.</p>
+</p>
+<h3 id="eventing.knative.dev/v1.TriggerSpec">TriggerSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.Trigger">Trigger</a>)
+</p>
+<p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>broker</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Broker is the broker that this trigger receives events from.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>filter</code></br>
+<em>
+<a href="#eventing.knative.dev/v1.TriggerFilter">
+TriggerFilter
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Filter is the filter to apply against all events from the Broker. Only events that pass this
+filter will be sent to the Subscriber. If not specified, will default to allowing all events.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriber</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<p>Subscriber is the addressable that receives events from the Broker that pass the Filter. It
+is required.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="eventing.knative.dev/v1.TriggerStatus">TriggerStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.Trigger">Trigger</a>)
+</p>
+<p>
+<p>TriggerStatus represents the current state of a Trigger.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Trigger that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<p>SubscriberURI is the resolved URI of the receiver for this Trigger.</p>
 </td>
 </tr>
 </tbody>
@@ -7875,6 +5535,644 @@ knative.dev/pkg/apis.Condition
 </tbody>
 </table>
 <hr/>
+<h2 id="duck.knative.dev/v1">duck.knative.dev/v1</h2>
+<p>
+<p>Package v1 is the v1 version of the API.</p>
+</p>
+Resource Types:
+<ul></ul>
+<h3 id="duck.knative.dev/v1.BackoffPolicyType">BackoffPolicyType
+(<code>string</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.DeliverySpec">DeliverySpec</a>)
+</p>
+<p>
+<p>BackoffPolicyType is the type for backoff policies</p>
+</p>
+<h3 id="duck.knative.dev/v1.Channelable">Channelable
+</h3>
+<p>
+<p>Channelable is a skeleton type wrapping Subscribable and Addressable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+Channelable ObjectReferences and access their subscription and address data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1.ChannelableSpec">
+ChannelableSpec
+</a>
+</em>
+</td>
+<td>
+<p>Spec is the part where the Channelable fulfills the Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1.ChannelableStatus">
+ChannelableStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.ChannelableSpec">ChannelableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
+</p>
+<p>
+<p>ChannelableSpec contains Spec of the Channelable object</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SubscribableSpec</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.ChannelableStatus">ChannelableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>, 
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
+</p>
+<p>
+<p>ChannelableStatus contains the Status of a Channelable object.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>Status</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Status
+</em>
+</td>
+<td>
+<p>
+(Members of <code>Status</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 Status, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current state.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>AddressStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.AddressStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>AddressStatus</code> are embedded into this type.)
+</p>
+<p>AddressStatus is the part where the Channelable fulfills the Addressable contract.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>SubscribableStatus</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SubscribableStatus</code> are embedded into this type.)
+</p>
+<p>Subscribers is populated with the statuses of each of the Channelable&rsquo;s subscribers.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>deadLetterChannel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference and is set by the channel when it supports native error handling via a channel
+Failed messages are delivered here.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.DeliverySpec">DeliverySpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
+<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
+<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
+</p>
+<p>
+<p>DeliverySpec contains the delivery options for event senders,
+such as channelable and source.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterSink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterSink is the sink receiving event that could not be sent to
+a destination.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>retry</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Retry is the minimum number of retries the sender should attempt when
+sending an event before moving it to the dead letter sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffPolicy</code></br>
+<em>
+<a href="#duck.knative.dev/v1.BackoffPolicyType">
+BackoffPolicyType
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffPolicy is the retry backoff policy (linear, exponential).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>backoffDelay</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BackoffDelay is the delay before retrying.
+More information on Duration format:
+- <a href="https://www.iso.org/iso-8601-date-and-time-format.html">https://www.iso.org/iso-8601-date-and-time-format.html</a>
+- <a href="https://en.wikipedia.org/wiki/ISO_8601">https://en.wikipedia.org/wiki/ISO_8601</a></p>
+<p>For linear policy, backoff delay is the time interval between retries.
+For exponential policy , backoff delay is backoffDelay*2^<numberOfRetries>.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.DeliveryStatus">DeliveryStatus
+</h3>
+<p>
+<p>DeliveryStatus contains the Status of an object supporting delivery options.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>deadLetterChannel</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.KReference
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeadLetterChannel is a KReference that is the reference to the native, platform specific channel
+where failed events are sent to.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.Subscribable">Subscribable
+</h3>
+<p>
+<p>Subscribable is a skeleton type wrapping Subscribable in the manner we expect resource writers
+defining compatible resources to embed it. We will typically use this type to deserialize
+SubscribableType ObjectReferences and access the Subscription data.  This is not a real resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">
+SubscribableSpec
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableSpec is the part where Subscribable object is
+configured as to be compatible with Subscribable contract.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscribableStatus">
+SubscribableStatus
+</a>
+</em>
+</td>
+<td>
+<p>SubscribableStatus is the part where SubscribableStatus object is
+configured as to be compatible with Subscribable contract.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscribableSpec">SubscribableSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableSpec shows how we expect folks to embed Subscribable in their Spec field.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscriberSpec">
+[]SubscriberSpec
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscriptions for this subscribable.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscribableStatus">SubscribableStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
+<a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
+</p>
+<p>
+<p>SubscribableStatus is the schema for the subscribable&rsquo;s status portion of the status
+section of the resource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>subscribers</code></br>
+<em>
+<a href="#duck.knative.dev/v1.SubscriberStatus">
+[]SubscriberStatus
+</a>
+</em>
+</td>
+<td>
+<p>This is the list of subscription&rsquo;s statuses for this channel.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscriberSpec">SubscriberSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.SubscribableSpec">SubscribableSpec</a>)
+</p>
+<p>
+<p>SubscriberSpec defines a single subscriber to a Subscribable.</p>
+<p>At least one of SubscriberURI and ReplyURI must be present</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>generation</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>subscriberUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubscriberURI is the endpoint for the subscriber</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>replyUri</code></br>
+<em>
+knative.dev/pkg/apis.URL
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ReplyURI is the endpoint for the reply</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>delivery</code></br>
+<em>
+<a href="#duck.knative.dev/v1.DeliverySpec">
+DeliverySpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DeliverySpec contains options controlling the event delivery</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="duck.knative.dev/v1.SubscriberStatus">SubscriberStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#duck.knative.dev/v1.SubscribableStatus">SubscribableStatus</a>)
+</p>
+<p>
+<p>SubscriberStatus defines the status of a single subscriber to a Channel.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>uid</code></br>
+<em>
+k8s.io/apimachinery/pkg/types.UID
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UID is used to understand the origin of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>observedGeneration</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Generation of the origin of the subscriber with uid:UID.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ready</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
+Kubernetes core/v1.ConditionStatus
+</a>
+</em>
+</td>
+<td>
+<p>Status of the subscriber.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>message</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>A human readable message indicating details of Ready status.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <h2 id="messaging.knative.dev/v1">messaging.knative.dev/v1</h2>
 <p>
 <p>Package v1 is the v1 version of the API.</p>
@@ -8688,6 +6986,1597 @@ knative.dev/pkg/apis.URL
 </td>
 <td>
 <p>ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.knative.dev/v1alpha1">sources.knative.dev/v1alpha1</h2>
+<p>
+<p>Package v1alpha1 contains API Schema definitions for the sources v1alpha1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>
+</li></ul>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource
+</h3>
+<p>
+<p>ApiServerSource is the Schema for the apiserversources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ApiServerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">
+ApiServerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
+[]ApiServerResource
+</a>
+</em>
+</td>
+<td>
+<p>Resources is the list of resources to watch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ceOverrides</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CloudEventOverrides defines overrides to control the output format and
+modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
+<code>Ref</code> sends only the reference to the resource.
+<code>Resource</code> send the full resource.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceStatus">
+ApiServerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.SinkBinding">SinkBinding
+</h3>
+<p>
+<p>SinkBinding describes a Binding that is also a Source.
+The <code>sink</code> (from the Source duck) is resolved to a URL and
+then projected into the <code>subject</code> by augmenting the runtime
+contract of the referenced containers to have a <code>K_SINK</code>
+environment variable holding the endpoint to which to send
+cloud events.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>SinkBinding</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.SinkBindingSpec">
+SinkBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.SinkBindingStatus">
+SinkBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerResource">ApiServerResource
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>ApiServerResource defines the resource to watch</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>labelSelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<p>LabelSelector restricts this source to objects with the selected labels
+More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controllerSelector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ownerreference-v1-meta">
+Kubernetes meta/v1.OwnerReference
+</a>
+</em>
+</td>
+<td>
+<p>ControllerSelector restricts this source to objects with a controlling owner reference of the specified kind.
+Only apiVersion and kind are used. Both are optional.
+Deprecated: Per-resource owner refs will no longer be supported in
+v1alpha2, please use Spec.Owner as a GKV.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>controller</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>If true, send an event referencing the object controlling the resource
+Deprecated: Per-resource controller flag will no longer be supported in
+v1alpha2, please use Spec.Owner as a GKV.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerResource">
+[]ApiServerResource
+</a>
+</em>
+</td>
+<td>
+<p>Resources is the list of resources to watch</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>sink</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1beta1.Destination
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Sink is a reference to an object that will resolve to a domain name to use as the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>ceOverrides</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>CloudEventOverrides defines overrides to control the output format and
+modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Mode is the mode the receive adapter controller runs under: Ref or Resource.
+<code>Ref</code> sends only the reference to the resource.
+<code>Resource</code> send the full resource.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.ApiServerSourceStatus">ApiServerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.SinkBindingSpec">SinkBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha1.SinkBindingStatus">SinkBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
+<h2 id="sources.knative.dev/v1alpha2">sources.knative.dev/v1alpha2</h2>
+<p>
+<p>Package v1alpha2 contains API Schema definitions for the sources v1beta1 API group</p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>
+</li><li>
+<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>
+</li></ul>
+<h3 id="sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource
+</h3>
+<p>
+<p>ApiServerSource is the Schema for the apiserversources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ApiServerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">
+ApiServerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
+[]APIVersionKindSelector
+</a>
+</em>
+</td>
+<td>
+<p>Resource are the resources this source will track and send related
+lifecycle events from the Kubernetes ApiServer, with an optional label
+selector to help filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EventMode controls the format of the event.
+<code>Reference</code> sends a dataref event type for the resource under watch.
+<code>Resource</code> send the full resource lifecycle event.
+Defaults to <code>Reference</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source. Defaults to default if not set.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceStatus">
+ApiServerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ContainerSource">ContainerSource
+</h3>
+<p>
+<p>ContainerSource is the Schema for the containersources API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>ContainerSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSourceSpec">
+ContainerSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the pods that will be created</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSourceStatus">
+ContainerSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.PingSource">PingSource
+</h3>
+<p>
+<p>PingSource is the Schema for the PingSources API.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>PingSource</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.PingSourceSpec">
+PingSourceSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedule</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>jsonData</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>JsonData is json encoded data used as the body of the event posted to
+the sink. Default is empty. If set, datacontenttype will also be set
+to &ldquo;application/json&rdquo;.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.PingSourceStatus">
+PingSourceStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.SinkBinding">SinkBinding
+</h3>
+<p>
+<p>SinkBinding describes a Binding that is also a Source.
+The <code>sink</code> (from the Source duck) is resolved to a URL and
+then projected into the <code>subject</code> by augmenting the runtime
+contract of the referenced containers to have a <code>K_SINK</code>
+environment variable holding the endpoint to which to send
+cloud events.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+sources.knative.dev/v1alpha2
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>SinkBinding</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.SinkBindingSpec">
+SinkBindingSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
+* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
+should be augmented by Binding implementations.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.SinkBindingStatus">
+SinkBindingStatus
+</a>
+</em>
+</td>
+<td>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.APIVersionKind">APIVersionKind
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>, 
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>APIVersionKind is an APIVersion and Kind tuple.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIVersion - the API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.APIVersionKindSelector">APIVersionKindSelector
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
+</p>
+<p>
+<p>APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>APIVersion - the API version of the resource to watch.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Kind of the resource to watch.
+More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds">https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LabelSelector filters this source to objects to those resources pass the
+label selector.
+More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceSpec defines the desired state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>resources</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
+[]APIVersionKindSelector
+</a>
+</em>
+</td>
+<td>
+<p>Resource are the resources this source will track and send related
+lifecycle events from the Kubernetes ApiServer, with an optional label
+selector to help filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>owner</code></br>
+<em>
+<a href="#sources.knative.dev/v1alpha2.APIVersionKind">
+APIVersionKind
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResourceOwner is an additional filter to only track resources that are
+owned by a specific resource type. If ResourceOwner matches Resources[n]
+then Resources[n] is allowed to pass the ResourceOwner filter.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>mode</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EventMode controls the format of the event.
+<code>Reference</code> sends a dataref event type for the resource under watch.
+<code>Resource</code> send the full resource lifecycle event.
+Defaults to <code>Reference</code></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>serviceAccountName</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceAccountName is the name of the ServiceAccount to use to run this
+source. Defaults to default if not set.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ApiServerSourceStatus">ApiServerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ApiServerSource">ApiServerSource</a>)
+</p>
+<p>
+<p>ApiServerSourceStatus defines the observed state of ApiServerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ContainerSourceSpec">ContainerSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceSpec defines the desired state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
+Kubernetes core/v1.PodTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the pods that will be created</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.ContainerSourceStatus">ContainerSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.ContainerSource">ContainerSource</a>)
+</p>
+<p>
+<p>ContainerSourceStatus defines the observed state of ContainerSource</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.PingSourceSpec">PingSourceSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
+</p>
+<p>
+<p>PingSourceSpec defines the desired state of the PingSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>schedule</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Schedule is the cronjob schedule. Defaults to <code>* * * * *</code>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>jsonData</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>JsonData is json encoded data used as the body of the event posted to
+the sink. Default is empty. If set, datacontenttype will also be set
+to &ldquo;application/json&rdquo;.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.PingSourceStatus">PingSourceStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.PingSource">PingSource</a>)
+</p>
+<p>
+<p>PingSourceStatus defines the observed state of PingSource.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.SinkBindingSpec">SinkBindingSpec
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingSpec holds the desired state of the SinkBinding (from the client).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceSpec, which currently provides:
+* Sink - a reference to an object that will resolve to a domain name or
+a URI directly to use as the sink.
+* CloudEventOverrides - defines overrides to control the output format
+and modifications of the event sent to the sink.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>BindingSpec</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</em>
+</td>
+<td>
+<p>
+(Members of <code>BindingSpec</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1alpha1 BindingSpec, which currently provides:
+* Subject - Subject references the resource(s) whose &ldquo;runtime contract&rdquo;
+should be augmented by Binding implementations.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="sources.knative.dev/v1alpha2.SinkBindingStatus">SinkBindingStatus
+</h3>
+<p>
+(<em>Appears on:</em>
+<a href="#sources.knative.dev/v1alpha2.SinkBinding">SinkBinding</a>)
+</p>
+<p>
+<p>SinkBindingStatus communicates the observed state of the SinkBinding (from the controller).</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>SourceStatus</code></br>
+<em>
+knative.dev/pkg/apis/duck/v1.SourceStatus
+</em>
+</td>
+<td>
+<p>
+(Members of <code>SourceStatus</code> are embedded into this type.)
+</p>
+<p>inherits duck/v1 SourceStatus, which currently provides:
+* ObservedGeneration - the &lsquo;Generation&rsquo; of the Service that was last
+processed by the controller.
+* Conditions - the latest available observations of a resource&rsquo;s current
+state.
+* SinkURI - the current active sink URI that has been configured for the
+Source.</p>
 </td>
 </tr>
 </tbody>
@@ -9743,5 +9632,5 @@ Source.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>9f3fb3ff</code>.
+on git commit <code>74b9bed2</code>.
 </em></p>

--- a/docs/reference/api/serving.md
+++ b/docs/reference/api/serving.md
@@ -466,8 +466,8 @@ ServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
-<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>, 
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>,
+<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>,
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -501,7 +501,7 @@ RevisionTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>,
 <a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>)
 </p>
 <p>
@@ -549,7 +549,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.ConfigurationStatus">ConfigurationStatus</a>, 
+<a href="#serving.knative.dev/v1.ConfigurationStatus">ConfigurationStatus</a>,
 <a href="#serving.knative.dev/v1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -636,9 +636,9 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
-<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
-<a href="#serving.knative.dev/v1alpha1.RevisionSpec">RevisionSpec</a>, 
+<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>,
+<a href="#serving.knative.dev/v1.Revision">Revision</a>,
+<a href="#serving.knative.dev/v1alpha1.RevisionSpec">RevisionSpec</a>,
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
@@ -702,7 +702,7 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1.Revision">Revision</a>,
 <a href="#serving.knative.dev/v1beta1.Revision">Revision</a>)
 </p>
 <p>
@@ -897,8 +897,8 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Route">Route</a>, 
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1.Route">Route</a>,
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>,
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -933,7 +933,7 @@ revisions and configurations.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>,
 <a href="#serving.knative.dev/v1.Route">Route</a>)
 </p>
 <p>
@@ -981,7 +981,7 @@ RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.RouteStatus">RouteStatus</a>, 
+<a href="#serving.knative.dev/v1.RouteStatus">RouteStatus</a>,
 <a href="#serving.knative.dev/v1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -1050,7 +1050,7 @@ LatestReadyRevisionName that we last observed.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1.Service">Service</a>,
 <a href="#serving.knative.dev/v1beta1.Service">Service</a>)
 </p>
 <p>
@@ -1111,7 +1111,7 @@ defaults).</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1.Service">Service</a>,
 <a href="#serving.knative.dev/v1beta1.Service">Service</a>)
 </p>
 <p>
@@ -1178,8 +1178,8 @@ specific to RouteStatus.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.RouteSpec">RouteSpec</a>, 
-<a href="#serving.knative.dev/v1.RouteStatusFields">RouteStatusFields</a>, 
+<a href="#serving.knative.dev/v1.RouteSpec">RouteSpec</a>,
+<a href="#serving.knative.dev/v1.RouteStatusFields">RouteStatusFields</a>,
 <a href="#serving.knative.dev/v1alpha1.TrafficTarget">TrafficTarget</a>)
 </p>
 <p>
@@ -1947,10 +1947,10 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1alpha1.Configuration">Configuration</a>, 
-<a href="#serving.knative.dev/v1alpha1.PinnedType">PinnedType</a>, 
-<a href="#serving.knative.dev/v1alpha1.ReleaseType">ReleaseType</a>, 
-<a href="#serving.knative.dev/v1alpha1.RunLatestType">RunLatestType</a>, 
+<a href="#serving.knative.dev/v1alpha1.Configuration">Configuration</a>,
+<a href="#serving.knative.dev/v1alpha1.PinnedType">PinnedType</a>,
+<a href="#serving.knative.dev/v1alpha1.ReleaseType">ReleaseType</a>,
+<a href="#serving.knative.dev/v1alpha1.RunLatestType">RunLatestType</a>,
 <a href="#serving.knative.dev/v1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -2079,7 +2079,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1alpha1.ConfigurationStatus">ConfigurationStatus</a>, 
+<a href="#serving.knative.dev/v1alpha1.ConfigurationStatus">ConfigurationStatus</a>,
 <a href="#serving.knative.dev/v1alpha1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -2295,7 +2295,7 @@ come from a single configuration.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1alpha1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1alpha1.Revision">Revision</a>,
 <a href="#serving.knative.dev/v1alpha1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
@@ -2599,7 +2599,7 @@ environment:
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1alpha1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1alpha1.Route">Route</a>,
 <a href="#serving.knative.dev/v1alpha1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -2696,7 +2696,7 @@ RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1alpha1.RouteStatus">RouteStatus</a>, 
+<a href="#serving.knative.dev/v1alpha1.RouteStatus">RouteStatus</a>,
 <a href="#serving.knative.dev/v1alpha1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -3018,7 +3018,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1alpha1.RouteSpec">RouteSpec</a>, 
+<a href="#serving.knative.dev/v1alpha1.RouteSpec">RouteSpec</a>,
 <a href="#serving.knative.dev/v1alpha1.RouteStatusFields">RouteStatusFields</a>)
 </p>
 <p>

--- a/docs/reference/api/serving.md
+++ b/docs/reference/api/serving.md
@@ -636,8 +636,8 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
 <a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
 <a href="#serving.knative.dev/v1alpha1.RevisionSpec">RevisionSpec</a>, 
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
@@ -933,8 +933,8 @@ revisions and configurations.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Route">Route</a>, 
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>)
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1.Route">Route</a>)
 </p>
 <p>
 <p>RouteStatus communicates the observed state of the Route (from the controller).</p>
@@ -1111,8 +1111,8 @@ defaults).</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>, 
-<a href="#serving.knative.dev/v1.Service">Service</a>)
+<a href="#serving.knative.dev/v1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceStatus represents the Status stanza of the Service resource.</p>

--- a/docs/reference/api/serving.md
+++ b/docs/reference/api/serving.md
@@ -1,468 +1,15 @@
 <p>Packages:</p>
 <ul>
 <li>
-<a href="#serving.knative.dev%2fv1beta1">serving.knative.dev/v1beta1</a>
-</li>
-<li>
 <a href="#serving.knative.dev%2fv1">serving.knative.dev/v1</a>
 </li>
 <li>
 <a href="#serving.knative.dev%2fv1alpha1">serving.knative.dev/v1alpha1</a>
 </li>
+<li>
+<a href="#serving.knative.dev%2fv1beta1">serving.knative.dev/v1beta1</a>
+</li>
 </ul>
-<h2 id="serving.knative.dev/v1beta1">serving.knative.dev/v1beta1</h2>
-<p>
-</p>
-Resource Types:
-<ul><li>
-<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>
-</li><li>
-<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>
-</li><li>
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>
-</li><li>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>
-</li></ul>
-<h3 id="serving.knative.dev/v1beta1.Configuration">Configuration
-</h3>
-<p>
-<p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions.
-Users create new Revisions by updating the Configuration&rsquo;s spec.
-The &ldquo;latest created&rdquo; revision&rsquo;s name is available under status, as is the
-&ldquo;latest ready&rdquo; revision&rsquo;s name.
-See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration">https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Configuration</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ConfigurationSpec">
-ConfigurationSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>template</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RevisionTemplateSpec">
-RevisionTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Template holds the latest specification for the Revision to be stamped out.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ConfigurationStatus">
-ConfigurationStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="serving.knative.dev/v1beta1.Revision">Revision
-</h3>
-<p>
-<p>Revision is an immutable snapshot of code and configuration.  A revision
-references a container image. Revisions are created by updates to a
-Configuration.</p>
-<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision">https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Revision</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RevisionSpec">
-RevisionSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>PodSpec</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
-Kubernetes core/v1.PodSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>PodSpec</code> are embedded into this type.)
-</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>containerConcurrency</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
-requests per container of the Revision.  Defaults to <code>0</code> which means
-concurrency to the application is not limited, and the system decides the
-target concurrency for the autoscaler.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>timeoutSeconds</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>TimeoutSeconds holds the max duration the instance is allowed for
-responding to a request.  If unspecified, a system default will
-be provided.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RevisionStatus">
-RevisionStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="serving.knative.dev/v1beta1.Route">Route
-</h3>
-<p>
-<p>Route is responsible for configuring ingress over a collection of Revisions.
-Some of the Revisions a Route distributes traffic over may be specified by
-referencing the Configuration responsible for creating them; in these cases
-the Route is additionally responsible for monitoring the Configuration for
-&ldquo;latest ready revision&rdquo; changes, and smoothly rolling out latest revisions.
-See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#route">https://github.com/knative/serving/blob/master/docs/spec/overview.md#route</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Route</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RouteSpec">
-RouteSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Spec holds the desired state of the Route (from the client).</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>traffic</code></br>
-<em>
-<a href="#serving.knative.dev/v1.TrafficTarget">
-[]TrafficTarget
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Traffic specifies how to distribute traffic over a collection of
-revisions and configurations.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RouteStatus">
-RouteStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Status communicates the observed state of the Route (from the controller).</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="serving.knative.dev/v1beta1.Service">Service
-</h3>
-<p>
-<p>Service acts as a top-level container that manages a Route and Configuration
-which implement a network service. Service exists to provide a singular
-abstraction which can be access controlled, reasoned about, and which
-encapsulates software lifecycle decisions such as rollout policy and
-team resource ownership. Service acts only as an orchestrator of the
-underlying Routes and Configurations (much as a kubernetes Deployment
-orchestrates ReplicaSets), and its usage is optional but recommended.</p>
-<p>The Service&rsquo;s controller will track the statuses of its owned Configuration
-and Route, reflecting their statuses and conditions as its own.</p>
-<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#service">https://github.com/knative/serving/blob/master/docs/spec/overview.md#service</a></p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>apiVersion</code></br>
-string</td>
-<td>
-<code>
-serving.knative.dev/v1beta1
-</code>
-</td>
-</tr>
-<tr>
-<td>
-<code>kind</code></br>
-string
-</td>
-<td><code>Service</code></td>
-</tr>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ServiceSpec">
-ServiceSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>ConfigurationSpec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ConfigurationSpec">
-ConfigurationSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>ConfigurationSpec</code> are embedded into this type.)
-</p>
-<p>ServiceSpec inlines an unrestricted ConfigurationSpec.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>RouteSpec</code></br>
-<em>
-<a href="#serving.knative.dev/v1.RouteSpec">
-RouteSpec
-</a>
-</em>
-</td>
-<td>
-<p>
-(Members of <code>RouteSpec</code> are embedded into this type.)
-</p>
-<p>ServiceSpec inlines RouteSpec and restricts/defaults its fields
-via webhook.  In particular, this spec can only reference this
-Service&rsquo;s configuration and revisions (which also influences
-defaults).</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#serving.knative.dev/v1.ServiceStatus">
-ServiceStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-</tbody>
-</table>
-<hr/>
 <h2 id="serving.knative.dev/v1">serving.knative.dev/v1</h2>
 <p>
 </p>
@@ -919,8 +466,8 @@ ServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
 <a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>, 
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>,
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -954,8 +501,8 @@ RevisionTemplateSpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>,
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>)
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
+<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>)
 </p>
 <p>
 <p>ConfigurationStatus communicates the observed state of the Configuration (from the controller).</p>
@@ -1046,14 +593,14 @@ Configuration. It might not be ready yet, for that use LatestReadyRevisionName.<
 </tr>
 </tbody>
 </table>
-<h3 id="serving.knative.dev/v1.ContainerStatuses">ContainerStatuses
+<h3 id="serving.knative.dev/v1.ContainerStatus">ContainerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
 <a href="#serving.knative.dev/v1.RevisionStatus">RevisionStatus</a>)
 </p>
 <p>
-<p>ContainerStatuses holds the information of container name and image digest value</p>
+<p>ContainerStatus holds the information of container name and image digest value</p>
 </p>
 <table>
 <thead>
@@ -1089,8 +636,8 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
 <a href="#serving.knative.dev/v1beta1.Revision">Revision</a>, 
-<a href="#serving.knative.dev/v1.Revision">Revision</a>,
 <a href="#serving.knative.dev/v1alpha1.RevisionSpec">RevisionSpec</a>, 
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
@@ -1155,8 +702,8 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>,
-<a href="#serving.knative.dev/v1.Revision">Revision</a>)
+<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
+<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>)
 </p>
 <p>
 <p>RevisionStatus communicates the observed state of the Revision (from the controller).</p>
@@ -1233,8 +780,8 @@ ref <a href="https://kubernetes.io/docs/reference/using-api/deprecation-policy">
 <td>
 <code>containerStatuses</code></br>
 <em>
-<a href="#serving.knative.dev/v1.ContainerStatuses">
-[]ContainerStatuses
+<a href="#serving.knative.dev/v1.ContainerStatus">
+[]ContainerStatus
 </a>
 </em>
 </td>
@@ -1350,8 +897,8 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
+<a href="#serving.knative.dev/v1.Route">Route</a>, 
 <a href="#serving.knative.dev/v1beta1.Route">Route</a>, 
-<a href="#serving.knative.dev/v1.Route">Route</a>,
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -1386,8 +933,8 @@ revisions and configurations.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Route">Route</a>,
-<a href="#serving.knative.dev/v1.Route">Route</a>)
+<a href="#serving.knative.dev/v1.Route">Route</a>, 
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>)
 </p>
 <p>
 <p>RouteStatus communicates the observed state of the Route (from the controller).</p>
@@ -1503,8 +1050,8 @@ LatestReadyRevisionName that we last observed.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>,
-<a href="#serving.knative.dev/v1.Service">Service</a>)
+<a href="#serving.knative.dev/v1.Service">Service</a>, 
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>)
 </p>
 <p>
 <p>ServiceSpec represents the configuration for the Service object.
@@ -1564,7 +1111,7 @@ defaults).</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1beta1.Service">Service</a>,
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>, 
 <a href="#serving.knative.dev/v1.Service">Service</a>)
 </p>
 <p>
@@ -2116,7 +1663,7 @@ RouteSpec
 <table>
 <tr>
 <td>
-<code>generation</code></br>
+<code>DeprecatedGeneration</code></br>
 <em>
 int64
 </em>
@@ -2576,14 +2123,14 @@ Configuration. It might not be ready yet, for that use LatestReadyRevisionName.<
 </tr>
 </tbody>
 </table>
-<h3 id="serving.knative.dev/v1alpha1.ContainerStatuses">ContainerStatuses
+<h3 id="serving.knative.dev/v1alpha1.ContainerStatus">ContainerStatus
 </h3>
 <p>
 (<em>Appears on:</em>
 <a href="#serving.knative.dev/v1alpha1.RevisionStatus">RevisionStatus</a>)
 </p>
 <p>
-<p>ContainerStatuses holds the information of container name and image digest value</p>
+<p>ContainerStatus holds the information of container name and image digest value</p>
 </p>
 <table>
 <thead>
@@ -2912,8 +2459,8 @@ ref <a href="https://kubernetes.io/docs/reference/using-api/deprecation-policy">
 <td>
 <code>containerStatuses</code></br>
 <em>
-<a href="#serving.knative.dev/v1alpha1.ContainerStatuses">
-[]ContainerStatuses
+<a href="#serving.knative.dev/v1alpha1.ContainerStatus">
+[]ContainerStatus
 </a>
 </em>
 </td>
@@ -3068,7 +2615,7 @@ environment:
 <tbody>
 <tr>
 <td>
-<code>generation</code></br>
+<code>DeprecatedGeneration</code></br>
 <em>
 int64
 </em>
@@ -3518,7 +3065,460 @@ Ultimately all non-v1 fields will be deprecated.</p>
 </tbody>
 </table>
 <hr/>
+<h2 id="serving.knative.dev/v1beta1">serving.knative.dev/v1beta1</h2>
+<p>
+</p>
+Resource Types:
+<ul><li>
+<a href="#serving.knative.dev/v1beta1.Configuration">Configuration</a>
+</li><li>
+<a href="#serving.knative.dev/v1beta1.Revision">Revision</a>
+</li><li>
+<a href="#serving.knative.dev/v1beta1.Route">Route</a>
+</li><li>
+<a href="#serving.knative.dev/v1beta1.Service">Service</a>
+</li></ul>
+<h3 id="serving.knative.dev/v1beta1.Configuration">Configuration
+</h3>
+<p>
+<p>Configuration represents the &ldquo;floating HEAD&rdquo; of a linear history of Revisions.
+Users create new Revisions by updating the Configuration&rsquo;s spec.
+The &ldquo;latest created&rdquo; revision&rsquo;s name is available under status, as is the
+&ldquo;latest ready&rdquo; revision&rsquo;s name.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration">https://github.com/knative/serving/blob/master/docs/spec/overview.md#configuration</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Configuration</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.ConfigurationSpec">
+ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>template</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RevisionTemplateSpec">
+RevisionTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Template holds the latest specification for the Revision to be stamped out.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#serving.knative.dev/v1.ConfigurationStatus">
+ConfigurationStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.knative.dev/v1beta1.Revision">Revision
+</h3>
+<p>
+<p>Revision is an immutable snapshot of code and configuration.  A revision
+references a container image. Revisions are created by updates to a
+Configuration.</p>
+<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision">https://github.com/knative/serving/blob/master/docs/spec/overview.md#revision</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Revision</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RevisionSpec">
+RevisionSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>PodSpec</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
+Kubernetes core/v1.PodSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>PodSpec</code> are embedded into this type.)
+</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>containerConcurrency</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+requests per container of the Revision.  Defaults to <code>0</code> which means
+concurrency to the application is not limited, and the system decides the
+target concurrency for the autoscaler.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>timeoutSeconds</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TimeoutSeconds holds the max duration the instance is allowed for
+responding to a request.  If unspecified, a system default will
+be provided.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RevisionStatus">
+RevisionStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.knative.dev/v1beta1.Route">Route
+</h3>
+<p>
+<p>Route is responsible for configuring ingress over a collection of Revisions.
+Some of the Revisions a Route distributes traffic over may be specified by
+referencing the Configuration responsible for creating them; in these cases
+the Route is additionally responsible for monitoring the Configuration for
+&ldquo;latest ready revision&rdquo; changes, and smoothly rolling out latest revisions.
+See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#route">https://github.com/knative/serving/blob/master/docs/spec/overview.md#route</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Route</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RouteSpec">
+RouteSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Spec holds the desired state of the Route (from the client).</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>traffic</code></br>
+<em>
+<a href="#serving.knative.dev/v1.TrafficTarget">
+[]TrafficTarget
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Traffic specifies how to distribute traffic over a collection of
+revisions and configurations.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RouteStatus">
+RouteStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Status communicates the observed state of the Route (from the controller).</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serving.knative.dev/v1beta1.Service">Service
+</h3>
+<p>
+<p>Service acts as a top-level container that manages a Route and Configuration
+which implement a network service. Service exists to provide a singular
+abstraction which can be access controlled, reasoned about, and which
+encapsulates software lifecycle decisions such as rollout policy and
+team resource ownership. Service acts only as an orchestrator of the
+underlying Routes and Configurations (much as a kubernetes Deployment
+orchestrates ReplicaSets), and its usage is optional but recommended.</p>
+<p>The Service&rsquo;s controller will track the statuses of its owned Configuration
+and Route, reflecting their statuses and conditions as its own.</p>
+<p>See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/overview.md#service">https://github.com/knative/serving/blob/master/docs/spec/overview.md#service</a></p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+serving.knative.dev/v1beta1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>Service</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.ServiceSpec">
+ServiceSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>ConfigurationSpec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.ConfigurationSpec">
+ConfigurationSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>ConfigurationSpec</code> are embedded into this type.)
+</p>
+<p>ServiceSpec inlines an unrestricted ConfigurationSpec.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>RouteSpec</code></br>
+<em>
+<a href="#serving.knative.dev/v1.RouteSpec">
+RouteSpec
+</a>
+</em>
+</td>
+<td>
+<p>
+(Members of <code>RouteSpec</code> are embedded into this type.)
+</p>
+<p>ServiceSpec inlines RouteSpec and restricts/defaults its fields
+via webhook.  In particular, this spec can only reference this
+Service&rsquo;s configuration and revisions (which also influences
+defaults).</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#serving.knative.dev/v1.ServiceStatus">
+ServiceStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+</td>
+</tr>
+</tbody>
+</table>
+<hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>427b2bf86</code>.
+on git commit <code>0a890efa0</code>.
 </em></p>

--- a/docs/reference/relnotes/_index.md
+++ b/docs/reference/relnotes/_index.md
@@ -3,6 +3,7 @@ title: "Knative Release Notes"
 linkTitle: "Release notes"
 weight: 10
 type: "docs"
+showlandingtoc: "false"
 ---
 
 For details about the Knative releases, see the following pages:


### PR DESCRIPTION
https://github.com/knative/docs/tree/master/docs/reference/api

KNATIVE_SERVING_COMMIT=v0.18.0 \
KNATIVE_EVENTING_COMMIT=v0.18.0 \
KNATIVE_EVENTING_CONTRIB_COMMIT=v0.18.0 \
./gen-api-reference-docs.sh

Fixes: #1883
