### PR TITLE
Fix liks on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,9 @@ There are a couple of different ways to get started with contributing to the Kna
   in the backlog.
 
 - Try out Knative and send us feedback. For example, run through the
-  [install guides](docs/install/) and then try
-  [Getting Started with Knative Serving](docs/serving/getting-started-knative-app.md)
-  or [Getting Started With Eventing](docs/eventing/getting-started.md).
+  [install guides](https://knative.dev/docs/install/) and then try
+  [Getting Started with Knative Serving](https://knative.dev/docs/serving/getting-started-knative-app/)
+  or [Getting Started With Eventing](https://knative.dev/docs/eventing/getting-started/).
 
   You should keep a
   [friction log](https://devrel.net/developer-experience/an-introduction-to-friction-logging)


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes https://github.com/knative/docs/issues/2845

## Proposed Changes <!-- Describe the changes the PR makes. -->

- As described in the issue, It seems that links on the CONTRIBUTING.md do not work so why don't we just use the `knative.dev` URLs instead?

