### PR TITLE
Add global configuration for target-burst-capacity and some corrections

### DIFF
--- a/docs/serving/autoscaling/target-burst-capacity.md
+++ b/docs/serving/autoscaling/target-burst-capacity.md
@@ -21,8 +21,8 @@ Target burst capacity can be configured using a combination of the following par
 
 * **Global key:** `target-burst-capacity`
 * **Per-revision annotation key:** `autoscaling.knative.dev/targetBurstCapacity`
-* **Possible values:** float
-* **Default:** `70`
+* **Possible values:** float (`0` means the Activator is only in path when scaled to 0, `-1` means the Activator is always in path)
+* **Default:** `200`
 
 **Note:** If the activator is in the routing path, it will fully load all replicas up to `containerConcurrency`. It currently applies target utilization only on revision level.
 
@@ -40,7 +40,7 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/targetBurstCapacity: "150"
+        autoscaling.knative.dev/targetBurstCapacity: "70"
 ```
 {{< /tab >}}
 {{% tab name="Global (ConfigMap)" %}}
@@ -51,7 +51,7 @@ metadata:
   name: config-autoscaler
   namespace: knative-serving
 data:
-  target-burst-capacity: "150"
+  target-burst-capacity: "70"
 ```
 {{< /tab >}}
 {{% tab name="Global (Operator)" %}}
@@ -63,7 +63,7 @@ metadata:
 spec:
   config:
     autoscaler:
-      target-burst-capacity: "150"
+      target-burst-capacity: "70"
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/serving/autoscaling/target-burst-capacity.md
+++ b/docs/serving/autoscaling/target-burst-capacity.md
@@ -15,11 +15,11 @@ Target burst capacity can be configured using a combination of the following par
 
 * Setting the targeted concurrency limits for the revision. For more information, see the documentation on [concurrency](./concurrency.md).
 * Setting the target utilization parameters. For more information, see the documentation on [target utilization](./concurrency.md#target-utilization).
-* Setting the target burst capacity per revision.
+* Setting the target burst capacity.
 
-## Setting the target burst capacity per revision
+## Setting the target burst capacity
 
-* **Global key:** No global key.
+* **Global key:** `target-burst-capacity`
 * **Per-revision annotation key:** `autoscaling.knative.dev/targetBurstCapacity`
 * **Possible values:** float
 * **Default:** `70`
@@ -40,8 +40,30 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: "2"
-        autoscaling.knative.dev/targetBurstCapacity: "70"
+        autoscaling.knative.dev/targetBurstCapacity: "150"
+```
+{{< /tab >}}
+{{% tab name="Global (ConfigMap)" %}}
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+data:
+  target-burst-capacity: "150"
+```
+{{< /tab >}}
+{{% tab name="Global (Operator)" %}}
+```yaml
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    autoscaler:
+      target-burst-capacity: "150"
 ```
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

As per title really. This setting has a global setting too and some of the info in this doc was outdated so gave it a scrub while at it.
