### PR TITLE
Make feature flag doc less misleading

### DIFF
--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -74,7 +74,8 @@ An extension may surface details of a specific Knative implementation or feature
 * **ConfigMap key:** `multi-container`
 
 This flag allows specifying multiple "user containers" in a Knative Service spec.
-Only one container can handle the requests. Knative picks the first container with a port specified.
+Only one container can handle the requests, and therefore exactly one container must
+have a `port` specified.
 
 ```yaml
 apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
While it's technically true that we pick the first container with a port, this is because we only allow exactly one container to _have_ a port (if there is more than one container with a port, or no containers with a port, we throw a validation error).