### PR TITLE
Update the links for operator docs

### DIFF
--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -17,7 +17,7 @@ a Kubernetes cluster. If you have only one node for your cluster, set CPUs to at
 Disk storage to at least 30 GB. If you have multiple nodes for your cluster, set CPUs to at least 2, Memory to at least
 4.0 GB, Disk storage to at least 20 GB for each node.
 - The Kubernetes cluster must be able to access the internet, since the Knative operator downloads images online.
-- [Download and install Istio](https://knative.dev/development/install/installing-istio).
+- [Download and install Istio](./installing-istio.md).
 
 ## Limitations of Knative Operator:
 

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -49,7 +49,7 @@ Because the operator manages the Knative Serving installation, it will overwrite
 The `KnativeServing` custom resource allows you to set values for these ConfigMaps via the operator. Knative Serving has multiple ConfigMaps named with the prefix
 `config-`. The `spec.config` in `KnativeServing` has one entry `<name>` for each ConfigMap named `config-<name>`, with a value which will be used for the ConfigMap's `data`.
 
-In the [setup a custom domain example](https://knative.dev/development/serving/using-a-custom-domain/), you can see the content of the ConfigMap
+In the [setup a custom domain example](./../../serving/using-a-custom-domain.md), you can see the content of the ConfigMap
 `config-domain` is:
 
 ```
@@ -119,7 +119,7 @@ location. This section is only needed when the registry images do not match the 
 
 - `imagePullSecrets`: a list of Secret names used when pulling Knative container images. The Secrets
 must be created in the same namespace as the Knative Serving Deployments. See [deploying images
-from a private container registry](https://knative.dev/development/serving/deploying/private-registry/) for configuration details.
+from a private container registry](./../../serving/deploying/private-registry.md) for configuration details.
 
 
 ### Download images in a predefined format without secrets:
@@ -241,7 +241,7 @@ spec:
 
 ## SSL certificate for controller
 
-To [enable tag to digest resolution](https://knative.dev/development/serving/tag-resolution/), the Knative Serving controller needs to access the container registry.
+To [enable tag to digest resolution](./../../serving/tag-resolution.md), the Knative Serving controller needs to access the container registry.
 To allow the controller to trust a self-signed registry cert, you can use the Operator to specify the certificate using a ConfigMap or Secret.
 
 Specify the following fields in `spec.controller-custom-certs` to select a custom registry certificate:
@@ -267,7 +267,7 @@ spec:
 
 ## Configuration of Knative ingress gateway
 
-To set up custom ingress gateway, follow [**Step 1: Create Gateway Service and Deployment Instance**](https://knative.dev/development/serving/setting-up-custom-ingress-gateway/).
+To set up custom ingress gateway, follow [**Step 1: Create Gateway Service and Deployment Instance**](./../../serving/setting-up-custom-ingress-gateway.md).
 
 ### Step 2: Update the Knative gateway
 
@@ -312,7 +312,7 @@ Update `spec.cluster-local-gateway` to select the labels of the new cluster-loca
 
 ### Default local gateway name:
 
-Go through the guide [here](https://knative.dev/development/install/installing-istio/#installing-istio-without-sidecar-injection) to use local cluster gateway,
+Go through the guide [here](./../installing-istio.md/#installing-istio-without-sidecar-injection) to use local cluster gateway,
 if you use the default gateway called `cluster-local-gateway`.
 
 ### Non-default local gateway name:

--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -266,4 +266,4 @@ they are no longer active.
 * **Type**: extension
 * **ConfigMap key:** `tag-header-based-routing`
 
-This flags controls whether [tag header based routing](https://knative.dev/development/serving/samples/tag-header-based-routing/) is enabled.
+This flags controls whether [tag header based routing](./samples/tag-header-based-routing/README.md) is enabled.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The internal links for operator docs should connect to the local MD files instead of public links.
