### PR TITLE
Fix autoscale-go sample's yaml file path

### DIFF
--- a/docs/serving/autoscaling/autoscale-go/README.md
+++ b/docs/serving/autoscaling/autoscale-go/README.md
@@ -19,7 +19,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 1. Deploy the [sample](./service.yaml) Knative Service:
 
    ```
-   kubectl apply --filename docs/serving/samples/autoscale-go/service.yaml
+   kubectl apply --filename docs/serving/autoscaling/autoscale-go/service.yaml
    ```
 
 1. Obtain the URL of the service (once `Ready`):
@@ -261,7 +261,7 @@ kubectl port-forward --namespace knative-monitoring $(kubectl get pods --namespa
 ## Cleanup
 
 ```
-kubectl delete --filename docs/serving/samples/autoscale-go/service.yaml
+kubectl delete --filename docs/serving/autoscaling/autoscale-go/service.yaml
 ```
 
 ## Further reading


### PR DESCRIPTION
The filepath was changed since https://github.com/knative/docs/commit/b3ffdbfcb47ba2c51b42b9340da0fd93cc82aa2e.
This patch fixes it.

/cc @abrennan89 