### PR TITLE
Do not add visibility label to Route

### DIFF
--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -38,12 +38,6 @@ To label the KService:
 kubectl label kservice ${KSVC_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
-To label a route:
-
-```shell
-kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local
-```
-
 To label a Kubernetes service:
 
 ```shell

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -38,7 +38,7 @@ To label the KService:
 kubectl label kservice ${KSVC_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
-To label a route when you used Route directory without KService:
+To label a route when you used Route directly without KService:
 
 ```shell
 kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -38,6 +38,12 @@ To label the KService:
 kubectl label kservice ${KSVC_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
+To label a route:
+
+```shell
+kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local
+```
+
 To label a Kubernetes service:
 
 ```shell

--- a/docs/serving/cluster-local-route.md
+++ b/docs/serving/cluster-local-route.md
@@ -38,7 +38,7 @@ To label the KService:
 kubectl label kservice ${KSVC_NAME} serving.knative.dev/visibility=cluster-local
 ```
 
-To label a route:
+To label a route when you used Route directory without KService:
 
 ```shell
 kubectl label route ${ROUTE_NAME} serving.knative.dev/visibility=cluster-local


### PR DESCRIPTION
Although https://knative.dev/docs/serving/cluster-local-route/
explains to add the visibility label to `Route`, the label on `Route` is
removed because Route takes over Ksvc's label.

Please see:
```
$ kubectl label route hello-example serving.knative.dev/visibility=cluster-local
route.serving.knative.dev/hello-example labeled

$ kubectl get rt --show-labels
NAME            URL                                        READY   REASON   LABELS
hello-example   http://hello-example.default.example.com   True             serving.knative.dev/service=hello-example
```

If users deployed the app by Route + Configuration instead of Ksvc
this makes sense but it is very rare (I think) and we should remove
this instruction.

/cc @ZhiminXiang @tcnghia 