### PR TITLE
Switch the base JRE to one that supports multiple architectures.

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-java-spring/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/Dockerfile
@@ -10,11 +10,10 @@ COPY src ./src
 # Build a release artifact.
 RUN mvn package -DskipTests
 
-# Use AdoptOpenJDK for base image.
-# It's important to use OpenJDK 8u191 or above that has container support enabled.
-# https://hub.docker.com/r/adoptopenjdk/openjdk8
+# Use the Official OpenJDK image for a lean production stage of our multi-stage build.
+# https://hub.docker.com/_/openjdk
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM adoptopenjdk/openjdk8:jdk8u202-b08-alpine-slim
+FROM openjdk:8-jre-alpine
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -102,11 +102,10 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-java-spring
    # Build a release artifact.
    RUN mvn package -DskipTests
 
-   # Use AdoptOpenJDK for base image.
-   # It's important to use OpenJDK 8u191 or above that has container support enabled.
-   # https://hub.docker.com/r/adoptopenjdk/openjdk8
+   # Use the Official OpenJDK image for a lean production stage of our multi-stage build.
+   # https://hub.docker.com/_/openjdk
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-   FROM adoptopenjdk/openjdk8:jdk8u202-b08-alpine-slim
+   FROM openjdk:8-jre-alpine
 
    # Copy the jar to the production image from the builder stage.
    COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar

--- a/docs/serving/samples/hello-world/helloworld-kotlin/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/Dockerfile
@@ -9,11 +9,10 @@ COPY src ./src
 # Build a release artifact.
 RUN gradle clean build --no-daemon
 
-# Use AdoptOpenJDK for base image.
-# It's important to use OpenJDK 8u191 or above that has container support enabled.
-# https://hub.docker.com/r/adoptopenjdk/openjdk8
+# Use the Official OpenJDK image for a lean production stage of our multi-stage build.
+# https://hub.docker.com/_/openjdk
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM adoptopenjdk/openjdk8:jdk8u202-b08-alpine-slim
+FROM openjdk:8-jre-alpine
 
 # Copy the jar to the production image from the builder stage.
 COPY --from=builder /home/gradle/build/libs/gradle.jar /helloworld.jar

--- a/docs/serving/samples/hello-world/helloworld-kotlin/README.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/README.md
@@ -123,11 +123,10 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-kotlin
    # Build a release artifact.
    RUN gradle clean build --no-daemon
 
-   # Use AdoptOpenJDK for base image.
-   # It's important to use OpenJDK 8u191 or above that has container support enabled.
-   # https://hub.docker.com/r/adoptopenjdk/openjdk8
+   # Use the Official OpenJDK image for a lean production stage of our multi-stage build.
+   # https://hub.docker.com/_/openjdk
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-   FROM adoptopenjdk/openjdk8:jdk8u202-b08-alpine-slim
+   FROM openjdk:8-jre-alpine
 
    # Copy the jar to the production image from the builder stage.
    COPY --from=builder /home/gradle/build/libs/gradle.jar /helloworld.jar


### PR DESCRIPTION
I'm biasing here towards "works most places".

With this, I can build and run all of our helloworld samples (except dotnet) on an arm64 cluster.

Note that this image was already in use by the spark image, so this also improves our consistency.

cc @saturnism for thoughts.