### PR TITLE
[release-0.17] Change event type in Sequence with Broker example (#2897)

### DIFF
--- a/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/samples/sequence/sequence-with-broker-trigger/README.md
@@ -79,7 +79,8 @@ spec:
           env:
             - name: MESSAGE
               value: " - Handled by 2"
-
+            - name: TYPE
+              value: "samples.http.mod3"
 ---
 
 ```


### PR DESCRIPTION
If the type of the event isn't changed by the last step in the
sequence the event will be resent to the Trigger that targets
the sequence creating an unwanted loop.

Fixes #2851

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Backport change event type in Sequence with Broker example (#2897)
