### PR TITLE
fix: add a reference to eventing sources page instead of having a list

### DIFF
--- a/docs/eventing/samples/writing-event-source/README.md
+++ b/docs/eventing/samples/writing-event-source/README.md
@@ -11,7 +11,7 @@ well as receive adapter, which events can be viewed through a basic
 Just want to see the code? The reference project is
 [https://github.com/knative-sandbox/sample-source](https://github.com/knative-sandbox/sample-source).
 
-[Knative Sources](../../sources/_index.md#knative-sources) can be used as a reference.
+[Knative Sources](../../sources/#knative-sources) can be used as a reference.
 
 ## Other ways
 

--- a/docs/eventing/samples/writing-event-source/README.md
+++ b/docs/eventing/samples/writing-event-source/README.md
@@ -11,7 +11,7 @@ well as receive adapter, which events can be viewed through a basic
 Just want to see the code? The reference project is
 [https://github.com/knative-sandbox/sample-source](https://github.com/knative-sandbox/sample-source).
 
-A variety of event sources are available in Knative [`eventing-sources-page`](https://knative.dev/docs/eventing/sources/#knative-sources)
+[Knative Sources](https://knative.dev/docs/eventing/sources/#knative-sources) can be used as a reference.
 
 ## Other ways
 

--- a/docs/eventing/samples/writing-event-source/README.md
+++ b/docs/eventing/samples/writing-event-source/README.md
@@ -11,7 +11,7 @@ well as receive adapter, which events can be viewed through a basic
 Just want to see the code? The reference project is
 [https://github.com/knative-sandbox/sample-source](https://github.com/knative-sandbox/sample-source).
 
-[Knative Sources](https://knative.dev/docs/eventing/sources/#knative-sources) can be used as a reference.
+[Knative Sources](../../sources/_index.md#knative-sources) can be used as a reference.
 
 ## Other ways
 

--- a/docs/eventing/samples/writing-event-source/README.md
+++ b/docs/eventing/samples/writing-event-source/README.md
@@ -11,10 +11,7 @@ well as receive adapter, which events can be viewed through a basic
 Just want to see the code? The reference project is
 [https://github.com/knative-sandbox/sample-source](https://github.com/knative-sandbox/sample-source).
 
-A variety of event sources are available in Knative [`eventing-contrib`](https://github.com/knative/eventing-contrib/) such as
-[`KafkaSource`](https://github.com/knative/eventing-contrib/tree/master/kafka/source),
-[`GithubSource`](https://github.com/knative/eventing-contrib/tree/master/github) and
-[`AWSSQSSource`](https://github.com/knative/eventing-contrib/tree/master/awssqs) that can be used as a reference.
+A variety of event sources are available in Knative [`eventing-sources-page`](https://knative.dev/docs/eventing/sources/#knative-sources)
 
 ## Other ways
 
@@ -23,7 +20,6 @@ With the approach in this tutorial, you will create a CRD and a controller for t
 You can also write your own event source using a [ContainerSource](../../../eventing/sources/README.md#meta-sources) which
 is an easy way to turn any dispatcher container into an Event Source. Similarly, another option is using [SinkBinding](../../../eventing/sources/README.md#meta-sources)
 which provides a framework for injecting environment variables into any Kubernetes resource which has a `spec.template` that looks like a Pod (aka PodSpecable).
-
 
 ## Target Audience
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2936

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Removes broken links from `eventing/writing-event-source`
- Adds reference to eventing-sources-page
