### PR TITLE
Bump golang versions to align all samples

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-go/go.mod
+++ b/docs/serving/samples/hello-world/helloworld-go/go.mod
@@ -1,3 +1,3 @@
 module github.com/knative/docs/docs/serving/samples/hello-world/helloworld-go
 
-go 1.13
+go 1.14

--- a/docs/serving/samples/hello-world/helloworld-shell/go.mod
+++ b/docs/serving/samples/hello-world/helloworld-shell/go.mod
@@ -1,3 +1,3 @@
 module github.com/knative/docs/docs/serving/samples/hello-world/helloworld-shell
 
-go 1.13
+go 1.14


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

The eventing sample uses go 1.14 already and we're using it everywhere, across the board. This is mostly for consistency.
