### PR TITLE
Add annotation "autoscaling.knative.dev/metric: rps" when configuragi…

### DIFF
--- a/docs/serving/autoscaling/rps-target.md
+++ b/docs/serving/autoscaling/rps-target.md
@@ -26,6 +26,7 @@ spec:
     metadata:
       annotations:
         autoscaling.knative.dev/target: "150"
+        autoscaling.knative.dev/metric: "rps"
     spec:
       containers:
         - image: gcr.io/knative-samples/helloworld-go


### PR DESCRIPTION
…ng RPS

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2947 

Add annotation `autoscaling.knative.dev/metric: rps` when configuraging RPS, because metric annotation default is `concurrency` 
https://knative.dev/docs/serving/autoscaling/rps-target/