### PR TITLE
Updated trigger link in eventing docs

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -15,7 +15,7 @@ also possible to combine the components in novel ways.
    configuration from your application.
 
 1. **I just want to consume events like X, I don't care how they are
-   published.** Use a [Trigger](broker/README.md) to consume events from a Broker based
+   published.** Use a [Trigger](triggers/README.md) to consume events from a Broker based
    on CloudEvents attributes. Your application will receive the events as an
    HTTP POST.
 


### PR DESCRIPTION
The link previously went to Broker, which does have basic information about triggers. Might need a review to see which is more relevant:

https://knative.dev/docs/eventing/broker/index.html#trigger

or

https://knative.dev/docs/eventing/triggers/

Fixes #2941 

## Proposed Changes

- Updated trigger link from the broker page to the triggers page
- Need a review on whether we should link to the triggers page or the trigger section in broker

