### PR TITLE
Change tag header based routing config to config-features

### DIFF
--- a/docs/serving/samples/tag-header-based-routing/README.md
+++ b/docs/serving/samples/tag-header-based-routing/README.md
@@ -24,7 +24,7 @@ cd $GOPATH/src/github.com/knative/docs
 This feature is disabled by default. To enable this feature, run the following command:
 
 ```
-kubectl patch cm config-network -n knative-serving -p '{"data":{"tagHeaderBasedRouting":"Enabled"}}'
+kubectl patch cm config-features -n knative-serving -p '{"data":{"tag-header-based-routing":"Enabled"}}'
 ```
 
 ## Build images


### PR DESCRIPTION
Since the configuration was moved by https://github.com/knative/serving/commit/b564cda38a6468703e85c3f544eacb12baecd1fc,
this patch updates the doc.

/cc @ZhiminXiang @tcnghia @JRBANCEL  

