### PR TITLE
fix dead link in config-trace

### DIFF
--- a/docs/serving/accessing-traces.md
+++ b/docs/serving/accessing-traces.md
@@ -11,7 +11,7 @@ visualize and trace your requests.
 
 ## Configuring Traces
 
-You can update the configuration file for tracing in [config-tracing.yaml](https://github.com/knative/serving/blob/master/config/config-tracing.yaml).
+You can update the configuration file for tracing in [config-tracing.yaml](https://github.com/knative/serving/blob/master/config/core/configmaps/tracing.yaml).
 
 Follow the instructions in the file to set your configuration options. This file includes options such as sample rate (to determine what percentage of requests to trace), debug mode, and backend selection (zipkin or stackdriver).
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #2987 

dead link in https://knative.dev/docs/serving/accessing-traces/#configuring-traces