### PR TITLE
Better doc for channel config via operator

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -46,11 +46,44 @@ if the current Knative Eventing deployment is version 0.14.x, you must upgrade t
 The Knative Eventing operator CR is configured the same way as the Knative Serving operator CR. Because the operator manages
 the Knative Eventing installation, it will overwrite any updates to the `ConfigMaps` which are used to configure Knative
 Eventing. The `KnativeEventing` custom resource allows you to set values for these ConfigMaps via the operator. Knative
-Eventing has multiple ConfigMaps named with the prefix `config-`. The `spec.config` in `KnativeEventing` has one entry
+Eventing has multiple ConfigMaps, most of them are named with the prefix `config-`. The `spec.config` in `KnativeEventing` has one entry
 `<name>` for each ConfigMap named `config-<name>`, with a value which will be used for the ConfigMap's `data`.
 
+### Setting the default channel
+
 For example, if you would like to change your default channel from `InMemoryChannel` into `KafkaChannel`, here is what
-your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
+your Eventing CR looks like, to modify the ConfigMap `default-ch-webhook`:
+
+```
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    default-ch-webhook:
+      default-ch-config: |
+        clusterDefault:
+          apiVersion: messaging.knative.dev/v1beta1
+          kind: KafkaChannel
+          spec:
+            numPartitions: 10
+            replicationFactor: 1
+        namespaceDefaults:
+          my-namespace:
+            apiVersion: messaging.knative.dev/v1beta1
+            kind: KafkaChannel
+            spec:
+              numPartitions: 10
+              replicationFactor: 1
+```
+
+The `clusterDefault` sets the global, cluster based default. Inside the `namespaceDefaults` you can configure the channel defaults on a per namespace base.
+
+### Setting the default channel for the broker
+
+For example, if you are using a Channel-based Broker and you would like to change the brokers default channel from `InMemoryChannel` into `KafkaChannel`, here is what your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -75,7 +75,7 @@ spec:
             apiVersion: messaging.knative.dev/v1beta1
             kind: KafkaChannel
             spec:
-              numPartitions: 10
+              numPartitions: 1
               replicationFactor: 1
 ```
 
@@ -83,7 +83,7 @@ The `clusterDefault` sets the global, cluster based default. Inside the `namespa
 
 ### Setting the default channel for the broker
 
-For example, if you are using a Channel-based Broker and you would like to change the brokers default channel from `InMemoryChannel` into `KafkaChannel`, here is what your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
+If you are using a Channel-based Broker and you would like to change the brokers default channel from `InMemoryChannel` into `KafkaChannel`, here is what your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1
@@ -98,7 +98,7 @@ spec:
         apiVersion: messaging.knative.dev/v1beta1
         kind: KafkaChannel
         spec:
-          numPartitions: 10
+          numPartitions: 5
           replicationFactor: 1
 ```
 

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -83,7 +83,7 @@ The `clusterDefault` sets the global, cluster based default. Inside the `namespa
 
 ### Setting the default channel for the broker
 
-If you are using a Channel-based Broker and you would like to change the brokers default channel from `InMemoryChannel` into `KafkaChannel`, here is what your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
+If you are using a channel-based broker and you would like to change the brokers default channel from `InMemoryChannel` into `KafkaChannel`, here is what your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -72,11 +72,13 @@ spec:
             replicationFactor: 1
         namespaceDefaults:
           my-namespace:
-            apiVersion: messaging.knative.dev/v1beta1
-            kind: KafkaChannel
+            apiVersion: messaging.knative.dev/v1
+            kind: InMemoryChannel
             spec:
-              numPartitions: 1
-              replicationFactor: 1
+              delivery:
+                backoffDelay: PT0.5S
+                backoffPolicy: exponential
+                retry: 5
 ```
 
 The `clusterDefault` sets the global, cluster based default. Inside the `namespaceDefaults` you can configure the channel defaults on a per namespace base.

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -81,7 +81,7 @@ spec:
                 retry: 5
 ```
 
-The `clusterDefault` sets the global, cluster based default. Inside the `namespaceDefaults` you can configure the channel defaults on a per namespace base.
+The `clusterDefault` sets the global, cluster based default. Inside the `namespaceDefaults` you can configure the channel defaults on a per namespace basis.
 
 ### Setting the default channel for the broker
 

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -85,7 +85,7 @@ The `clusterDefault` sets the global, cluster based default. Inside the `namespa
 
 ### Setting the default channel for the broker
 
-If you are using a channel-based broker and you would like to change the brokers default channel from `InMemoryChannel` into `KafkaChannel`, here is what your Eventing CR looks like, to modify the ConfigMap `config-br-default-channel`:
+If you are using a channel-based broker and you would like to change the brokers default channel, from `InMemoryChannel` to `KafkaChannel`, here is an example of what your Eventing CR would look like when modifying the ConfigMap `config-br-default-channel`:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

Adding a little bit more context for the different "default" channel configs.

The `current` text on master is incorrectly saying that the `` CM will configure the default channel. However it is only setting the deefault for what the configured broker uses (if we use a channel based broker).

Adding text that shows howto set the default channel via the `default-ch-webhook` configmap