### PR TITLE
Drop the `-alpine` for dotnet, it isn't multi-arch.

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-csharp/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-csharp/Dockerfile
@@ -1,6 +1,5 @@
 # Use Microsoft's official build .NET image.
-# https://hub.docker.com/_/microsoft-dotnet-core-sdk/
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 WORKDIR /app
 
 # Install production dependencies.
@@ -17,8 +16,7 @@ RUN dotnet publish -c Release -o out
 
 
 # Use Microsoft's official runtime .NET image.
-# https://hub.docker.com/_/microsoft-dotnet-core-aspnet/
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
 WORKDIR /app
 COPY --from=build /app/out ./
 

--- a/docs/serving/samples/hello-world/helloworld-csharp/README.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/README.md
@@ -74,8 +74,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-csharp
 
    ```docker
    # Use Microsoft's official build .NET image.
-   # https://hub.docker.com/_/microsoft-dotnet-core-sdk/
-   FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
+   FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
    WORKDIR /app
  
    # Install production dependencies.
@@ -91,8 +90,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-csharp
    RUN dotnet publish -c Release -o out
 
    # Use Microsoft's official runtime .NET image.
-   # https://hub.docker.com/_/microsoft-dotnet-core-aspnet/
-   FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine AS runtime
+   FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
    WORKDIR /app
    COPY --from=build /app/out ./
 


### PR DESCRIPTION
This is serving from a Graviton EKS cluster built with this sample: https://helloworld-csharp.default.mink.dev

/assign @csantanapr @abrennan89 