### PR TITLE
Polish the auto TLS related docs

### DIFF
--- a/docs/serving/installing-cert-manager.md
+++ b/docs/serving/installing-cert-manager.md
@@ -27,11 +27,11 @@ You must meet the following requirements to install cert-manager for Knative:
   component, see the [Knative installation guides](../install/).
 - You must configure your Knative cluster to use a
   [custom domain](./using-a-custom-domain.md).
-- Knative currently supports cert-manager version `1.0.0` or higher.
+- Knative currently supports cert-manager version `1.0.0` and higher.
 
 ## Downloading and installing cert-manager
 
-Follow the steps in the official `cert-manager` website to download and install cert-manager
+Follow the steps from the official `cert-manager` website to download and install cert-manager
 
    [Installation steps](https://cert-manager.io/docs/installation/kubernetes/)
 

--- a/docs/serving/installing-cert-manager.md
+++ b/docs/serving/installing-cert-manager.md
@@ -31,9 +31,6 @@ You must meet the following requirements to install cert-manager for Knative:
 
 ## Downloading and installing cert-manager
 
-Use the following steps to download, install, and configure cert-manager for
-your Knative cluster environment:
-
 Follow the steps in the official `cert-manager` website to download and install cert-manager
 
    [Installation steps](https://cert-manager.io/docs/installation/kubernetes/)

--- a/docs/serving/installing-cert-manager.md
+++ b/docs/serving/installing-cert-manager.md
@@ -27,45 +27,17 @@ You must meet the following requirements to install cert-manager for Knative:
   component, see the [Knative installation guides](../install/).
 - You must configure your Knative cluster to use a
   [custom domain](./using-a-custom-domain.md).
-- Knative currently supports cert-manager version `0.12.0` or higher.
+- Knative currently supports cert-manager version `1.0.0` or higher.
 
 ## Downloading and installing cert-manager
 
 Use the following steps to download, install, and configure cert-manager for
 your Knative cluster environment:
 
-1. Follow the steps in the official `cert-manager` website to download and install cert-manager
+Follow the steps in the official `cert-manager` website to download and install cert-manager
 
    [Installation steps](https://cert-manager.io/docs/installation/kubernetes/)
 
-1. Configure which DNS provider is used to validate the DNS-01 challenge
-   requests.
-
-   By default, the [Let's Encrypt](https://letsencrypt.org) is used to
-   demonstrate how to configure cert-manager, but you can use other supported
-   CA's that issue certificates with the ACME protocol. However, you must use
-   the
-   [`DNS-01` challenge type](https://letsencrypt.org/docs/challenge-types/#dns-01-challenge)
-   to validate requests.
-
-   Instructions about configuring cert-manager for any of the supported DNS
-   providers are provided in
-   [DNS01 challenge providers and configuration instructions](https://docs.cert-manager.io/en/latest/tasks/acme/configuring-dns01/index.html#supported-dns01-providers).
-
-   Example:
-
-   See how the Google Cloud DNS is defined as the provider:
-   [Configuring HTTPS with cert-manager and Google Cloud DNS](./using-cert-manager-on-gcp.md#adding-your-service-account-to-cert-manager)
-
-1. Post-install cleanup
-
-   Run the following commands to remove the cert-manager install packages:
-
-   ```shell
-   cd ../
-   rm -rf cert-manager-${CERT_MANAGER_VERSION}
-   rm v${CERT_MANAGER_VERSION}.tar.gz
-   ```
 
 ## Completing the Knative configuration for TLS support
 

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -44,7 +44,7 @@ You must meet the following prerequisites to enable auto TLS:
     [Contour, version 1.1 or higher](../install/any-kubernetes-cluster.md#installing-the-serving-component),
     or [Gloo, version 0.18.16 or higher](https://docs.solo.io/gloo/latest/installation/knative/).
     Note: Currently, [Ambassador](https://github.com/datawire/ambassador) is unsupported.
-  - [cert-manager version `0.12.0` or higher](./installing-cert-manager.md).
+- [cert-manager version `1.0.0` or higher](./installing-cert-manager.md).
 - Your Knative cluster must be configured to use a
   [custom domain](./using-a-custom-domain.md).
 - Your DNS provider must be setup and configured to your domain.
@@ -134,6 +134,20 @@ and which DNS provider validates those requests.
     ```
 
     Result: The `Status.Conditions` should include `Ready=True`.
+
+### DNS-01 challenge only: Configure your DNS provider
+
+If you choose to use DNS-01 challenge, configure which DNS provider is used to
+validate the DNS-01 challenge requests.
+
+Instructions about configuring cert-manager for any of the supported DNS
+providers are provided in
+[DNS01 challenge providers and configuration instructions](https://cert-manager.io/docs/configuration/acme/dns01/#supported-dns01-providers).
+
+Example:
+
+See how the Google Cloud DNS is defined as the provider:
+[Configuring HTTPS with cert-manager and Google Cloud DNS](./using-cert-manager-on-gcp.md#creating-a-service-account-and-using-a-kubernetes-secret)
 
 
 ### Install networking-certmanager deployment

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -44,7 +44,7 @@ You must meet the following prerequisites to enable auto TLS:
     [Contour, version 1.1 or higher](../install/any-kubernetes-cluster.md#installing-the-serving-component),
     or [Gloo, version 0.18.16 or higher](https://docs.solo.io/gloo/latest/installation/knative/).
     Note: Currently, [Ambassador](https://github.com/datawire/ambassador) is unsupported.
-- [cert-manager version `1.0.0` or higher](./installing-cert-manager.md).
+- [cert-manager version `1.0.0` and higher](./installing-cert-manager.md).
 - Your Knative cluster must be configured to use a
   [custom domain](./using-a-custom-domain.md).
 - Your DNS provider must be setup and configured to your domain.
@@ -140,8 +140,8 @@ and which DNS provider validates those requests.
 If you choose to use DNS-01 challenge, configure which DNS provider is used to
 validate the DNS-01 challenge requests.
 
-Instructions about configuring cert-manager for any of the supported DNS
-providers are provided in
+Instructions about configuring cert-manager, for all the supported DNS
+providers, are provided in
 [DNS01 challenge providers and configuration instructions](https://cert-manager.io/docs/configuration/acme/dns01/#supported-dns01-providers).
 
 Example:


### PR DESCRIPTION


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Bump the min version of cert-manager to 1.0.0
- Remove the stale content used for installing cert-manager
- Move the part of configuring DNS challenge into auto TLS docs.
