### PR TITLE
Update the version configuration for Knative Operator

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -31,11 +31,11 @@ spec:
   version: "0.19"
 ```
 
-Knative versions is compliant with the semantic versioning format. You can specify the field `spec.version` with a version in
+Knative versions are compliant with the semantic versioning format. You can specify the field `spec.version` with a version in
 the format of either `Major.Minor.Patch` or `Major.Minor`. If `spec.version` is not specified, the Knative Operator will
 install the latest available version of Knative Eventing. If `spec.version` is specified in the format of `Major.Minor`,
 Knative Operator will install the latest available version of Knative Eventing under the same `Major.Minor` number. For
-example, if `spec.version` is set to "0.19", Knative Operator will install the latest "0.19.x", which is available in the
+example, if `spec.version` is set to "0.19", Knative Operator will install the latest "0.19.x" version that is available in the
 operator.
 
 If Knative Eventing is already managed by the Operator, updating the `spec.version` field in the `KnativeEventing` resource

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -19,7 +19,7 @@ __NOTE:__ Kubernetes spec level policies cannot be configured using the Knative 
 ## Version Configuration
 
 Cluster administrators can install a specific version of Knative Eventing by using the `spec.version` field. For example,
-if you want to install Knative Eventing 0.16.0, you can apply the following `KnativeEventing` custom resource:
+if you want to install Knative Eventing 0.19, you can apply the following `KnativeEventing` custom resource:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1
@@ -28,19 +28,21 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  version: 0.16.0
+  version: "0.19"
 ```
 
-If `spec.version` is not specified, the Knative Operator will install the latest available version of Knative Eventing.
-If users specify an invalid or unavailable version, the Knative Operator will do nothing. The Knative Operator always
-includes the latest 3 minor release versions. For example, if the current version of the Knative Operator is 0.16.x, the
-earliest version of Knative Eventing available through the Operator is 0.14.0.
+Knative versions is compliant with the semantic versioning format. You can specify the field `spec.version` with a version in
+the format of either `Major.Minor.Patch` or `Major.Minor`. If `spec.version` is not specified, the Knative Operator will
+install the latest available version of Knative Eventing. If `spec.version` is specified in the format of `Major.Minor`,
+Knative Operator will install the latest available version of Knative Eventing under the same `Major.Minor` number. For
+example, if `spec.version` is set to "0.19", Knative Operator will install the latest "0.19.x", which is available in the
+operator.
 
 If Knative Eventing is already managed by the Operator, updating the `spec.version` field in the `KnativeEventing` resource
 enables upgrading or downgrading the Knative Eventing version, without needing to change the Operator.
 
 Note that the Knative Operator only permits upgrades or downgrades by one minor release version at a time. For example,
-if the current Knative Eventing deployment is version 0.14.x, you must upgrade to 0.15.x before upgrading to 0.16.x.
+if the current Knative Eventing deployment is version 0.17.x, you must upgrade to 0.18.x before upgrading to 0.19.x.
 
 ## Eventing Configuration by ConfigMap
 

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -20,7 +20,7 @@ The Knative Serving operator can be configured with these options:
 ## Version Configuration
 
 Cluster administrators can install a specific version of Knative Serving by using the `spec.version` field. For example,
-if you want to install Knative Serving 0.16.0, you can apply the following `KnativeServing` custom resource:
+if you want to install Knative Serving 0.19, you can apply the following `KnativeServing` custom resource:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1
@@ -29,19 +29,25 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  version: 0.16.0
+  version: "0.19"
 ```
 
-If `spec.version` is not specified, the Knative Operator will install the latest available version of Knative Serving.
+Knative versions is compliant with the semantic versioning format. You can specify the field `spec.version` with a version in
+the format of either `Major.Minor.Patch` or `Major.Minor`. If `spec.version` is not specified, the Knative Operator will
+install the latest available version of Knative Serving. If `spec.version` is specified in the format of `Major.Minor`,
+Knative Operator will install the latest available version of Knative Serving under the same `Major.Minor` number. For
+example, if `spec.version` is set to "0.19", Knative Operator will install the latest "0.19.x", which is available in the
+operator.
+
 If users specify an invalid or unavailable version, the Knative Operator will do nothing. The Knative Operator always
-includes the latest 3 minor release versions. For example, if the current version of the Knative Operator is 0.16.x, the
-earliest version of Knative Serving available through the Operator is 0.14.0.
+includes the latest 3 minor release versions. For example, if the current version of the Knative Operator is 0.19.x, the
+earliest version of Knative Serving available through the Operator is 0.16.0.
 
 If Knative Serving is already managed by the Operator, updating the `spec.version` field in the `KnativeServing` resource
 enables upgrading or downgrading the Knative Serving version, without needing to change the Operator.
 
 Note that the Knative Operator only permits upgrades or downgrades by one minor release version at a time. For example,
-if the current Knative Serving deployment is version 0.14.x, you must upgrade to 0.15.x before upgrading to 0.16.x.
+if the current Knative Serving deployment is version 0.17.x, you must upgrade to 0.18.x before upgrading to 0.19.x.
 
 ## Serving Configuration by ConfigMap
 

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -32,11 +32,11 @@ spec:
   version: "0.19"
 ```
 
-Knative versions is compliant with the semantic versioning format. You can specify the field `spec.version` with a version in
+Knative versions are compliant with the semantic versioning format. You can specify the field `spec.version` with a version in
 the format of either `Major.Minor.Patch` or `Major.Minor`. If `spec.version` is not specified, the Knative Operator will
 install the latest available version of Knative Serving. If `spec.version` is specified in the format of `Major.Minor`,
 Knative Operator will install the latest available version of Knative Serving under the same `Major.Minor` number. For
-example, if `spec.version` is set to "0.19", Knative Operator will install the latest "0.19.x", which is available in the
+example, if `spec.version` is set to "0.19", Knative Operator will install the latest "0.19.x" version that is available in the
 operator.
 
 If users specify an invalid or unavailable version, the Knative Operator will do nothing. The Knative Operator always


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Knative Operator updates the docs about how to configure spec.version for the latest 0.19 release.
- The field `spec.version` supports the format `Major.Minor` as of 0.19.0.
