### PR TITLE
sample: Convert to BusyBox httpd for the shell sample

### DIFF
--- a/docs/serving/samples/hello-world/helloworld-shell/Dockerfile
+++ b/docs/serving/samples/hello-world/helloworld-shell/Dockerfile
@@ -1,13 +1,12 @@
-# Use the official Alpine image for a lean production container.
-# https://hub.docker.com/_/alpine
-FROM alpine:3
+# Busybox image that contains the simple 'httpd'
+# https://git.busybox.net/busybox/tree/networking/httpd.c
+FROM busybox
 
-# Update & install netcat (nc)
-RUN apk update \
- && apk add netcat-openbsd
+# Serve from this directory
+WORKDIR /httpd
 
 # Copy over the service script
-COPY script.sh /
+COPY script.sh /httpd
 
 # Start up the webserver
-CMD [ "/bin/sh", "/script.sh" ]
+CMD [ "/bin/sh", "/httpd/script.sh" ]

--- a/docs/serving/samples/hello-world/helloworld-shell/script.sh
+++ b/docs/serving/samples/hello-world/helloworld-shell/script.sh
@@ -1,4 +1,16 @@
 #!/bin/sh
-while true ; do
-  echo -e "HTTP/1.1 200\n\n Hello ${TARGET:=World}!\n" | nc -l -p 8080 -q 1;
-done
+
+# Welcome message to show, evaluation TARGET env but fallback to "World"
+message="Hello ${TARGET:=World}!"
+
+# Set the configuration to server the index file
+echo "I:index.txt" > httpd.conf
+
+# Prepare index file that should be served
+echo $message > index.txt
+
+# Start up busybox's httpd service, listen on port 8080 and
+# stay in the foreground. Prints out verbose logs, too.
+# See https://git.busybox.net/busybox/tree/networking/httpd.c for
+# details
+httpd -vv -p 8080 -f


### PR DESCRIPTION
nc has issues because of the constant listen and unlisten on port 8080.
Therefor switching over to busybox's [httpd](https://git.busybox.net/busybox/tree/networking/httpd.c)
which is should be much more robust.

The shell example still stays simple and reuses an existing command.