### PR TITLE
Update getting-started-knative-app.md

### DIFF
--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -14,7 +14,7 @@ using cURL requests.
 
 You need:
 
-- A Kubernetes cluster with [Knative installed](../install/README.md).
+- A Kubernetes cluster with [Knative Serving installed](../install/README.md).
 - An image of the app that you'd like to deploy available on a container registry. The image of the sample app used in this guide is available on
   Google Container Registry.
 


### PR DESCRIPTION
# Problem
Since the install instructions breakdown installing Knative "Serving" and "Eventing" as standalone components, the pre-requisite of requiring "Knative" is generic.
We can be more specific here to clarify what is required for App Deployment

# Proposed Changes 
Change the pre-requisite to reference "Serving"