### PR TITLE
[release-0.18] Update tested Istio version to v1.7

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -18,13 +18,13 @@ instructions.
 You need:
 
 - A Kubernetes cluster created.
-- [`istioctl`](https://istio.io/docs/setup/install/istioctl/) (v1.4.10 or later) installed.
+- [`istioctl`](https://istio.io/docs/setup/install/istioctl/) (v1.7 or later) installed.
 
 ## Supported Istio versions
 
-The current known-to-be-stable version of Istio tested in conjunction with Knative is **v1.4.10**.
-Versions in the 1.4 line generally be fine too.
-Versions above the 1.4 line are under test but have not stabilized yet.
+The current known-to-be-stable version of Istio tested in conjunction with Knative is **v1.7.1**.
+Versions in the 1.7 line generally be fine too.
+Versions above the 1.7 line are under test but have not stabilized yet.
 
 ## Installing Istio
 


### PR DESCRIPTION
The installation manifest uses `istioctl` command but it mentioned the
tested version is Istio v1.4.

This patch fixes the tested version to v1.7 in release 0.18 branch.

Fixes https://github.com/knative/docs/issues/3048

/cc @ZhiminXiang @JRBANCEL @arturenault 
