### PR TITLE
Small typo in docs/eventing/getting-started.md

### DIFF
--- a/docs/eventing/getting-started.md
+++ b/docs/eventing/getting-started.md
@@ -320,7 +320,7 @@ EOF
          -d '{"msg":"Hello Knative! Goodbye Knative!"}'
        ```
        When the broker receives your event, `hello-display` and `goodbye-display`
-       will activate and send the event to the event consumer of the same name.
+       will activate and send the event to the event consumers of the same name.
        If the event has been received, you will receive a `202 Accepted` response
        similar to the one below:
        ```


### PR DESCRIPTION
## Proposed Changes
Fix small typo - pluralize consumers