### PR TITLE
Update Eventing README

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -31,7 +31,7 @@ both Channels and Brokers.
 
 Knative Eventing is designed around the following goals:
 
-1. Knative Eventing services are loosely coupled. These services can be
+1. The Knative Eventing resources are loosely coupled. These resources can be
    developed and deployed independently on, and across a variety of platforms
    (for example Kubernetes, VMs, SaaS or FaaS).
 1. Event producers and event consumers are independent. Any producer (or


### PR DESCRIPTION
## Proposed Changes

Switch `service` to `building block` when referring to internal Knative Eventing.

### Why 
Disambiguate `service` to refer to an abstraction which has an http endpoint and primarily referring to a K8s Service or Knative Service.
Here, also calling Knative Eventing build blocks as `services` creates confusion even if the usage is technically correct.