### PR TITLE
Update Eventing Readme

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -152,8 +152,7 @@ Learn more about Eventing development in the
 
 ## Getting Started
 
-- [Install the Eventing component](#installation)
-- [Setup Knative Serving](../install/README.md)
+- [Install Knative](../install/README.md)
 - [Run samples](./samples/)
 - [Default Channels](./channels/default-channels.md) provide a way to choose the
   persistence strategy for Channels across the cluster.


### PR DESCRIPTION
## Proposed Changes 
Remove relative link which links to the section directly above. 

### Why
The link doesn't go to the specific Eventing Install docs.
The subsequent link in the list goes to the same general install destination as the section above.
I didn't remove the install section completely as it is used to populate the breadcrumbs on the right.


