### PR TITLE
Update eventing/samples/writing-event-source-easy..README.md

### DIFF
--- a/docs/eventing/samples/writing-event-source-easy-way/README.md
+++ b/docs/eventing/samples/writing-event-source-easy-way/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-As stated in [tutorial on writing a Source with a Receive Adapter](../writing-receive-adapter-source/README.md), there are multiple ways to
+As stated in [tutorial on writing a Source with a Receive Adapter](../writing-event-source/README.md), there are multiple ways to
 create event sources. The way in that tutorial is to create an independent event source that has its own CRD.
 
 This tutorial provides a simpler mechanism to build an event source in Javascript and use it with


### PR DESCRIPTION
## Proposed Changes

fix url "tutorial on writing a Source with a Receive Adapter" section to reflect current folder structure.

## Note to reviewer

this should get cherry-picked to the current release branch 0.19 as well as its broken on the [live site ](https://knative.dev/docs/eventing/samples/writing-event-source-easy-way/)
