### PR TITLE
Update .../sequence-termina/README.md

### DIFF
--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -105,6 +105,9 @@ spec:
 Change `default` below to create the `Sequence` in the Namespace where you want
 the resources to be created.
 
+Here, if you are using different type of Channel, you need to change the
+spec.channelTemplate to point to your desired Channel.
+
 ```shell
 kubectl -n default create -f ./sequence.yaml
 ```
@@ -129,9 +132,6 @@ spec:
       kind: Sequence
       name: sequence
 ```
-
-Here, if you are using different type of Channel, you need to change the
-spec.channelTemplate to point to your desired Channel.
 
 ```shell
 kubectl -n default create -f ./ping-source.yaml

--- a/docs/eventing/samples/sequence/sequence-terminal/README.md
+++ b/docs/eventing/samples/sequence/sequence-terminal/README.md
@@ -158,6 +158,9 @@ kubectl -n default logs -l serving.knative.dev/service=first -c user-container -
 2020/03/02 21:28:01 Transform the event to:
 2020/03/02 21:28:01 [2020-03-02T21:28:00.0010247Z] /apis/v1/namespaces/default/pingsources/ping-source dev.knative.sources.ping: &{Sequence:0 Message:Hello world! - Handled by 0}
 ```
+And you can see that the initial PingSource message `("Hello World!")` has now
+been modified by the first step in the Sequence to include " - Handled by 0".
+Exciting :)
 
 Then we can look at the output of the second Step in the `Sequence`:
 
@@ -170,10 +173,8 @@ kubectl -n default logs -l serving.knative.dev/service=second -c user-container 
 2020/03/02 21:28:02 Transform the event to:
 2020/03/02 21:28:02 [2020-03-02T21:28:00.0010247Z] /apis/v1/namespaces/default/pingsources/ping-source dev.knative.sources.ping: &{Sequence:0 Message:Hello world! - Handled by 0 - Handled by 1}
 ```
-
-And you can see that the initial PingSource message `("Hello World!")` has now
-been modified by the first step in the Sequence to include " - Handled by 0".
-Exciting :)
+And as expected it's now been handled by both the first and second Step as
+reflected by the Message being now: "Hello world! - Handled by 0 - Handled by 1"
 
 Then we can look at the output of the last Step in the `Sequence`:
 
@@ -187,5 +188,4 @@ kubectl -n default logs -l serving.knative.dev/service=third -c user-container -
 2020/03/02 21:28:03 [2020-03-02T21:28:00.0010247Z] /apis/v1/namespaces/default/pingsources/ping-source dev.knative.sources.ping: &{Sequence:0 Message:Hello world! - Handled by 0 - Handled by 1 - Handled by 2}
 ```
 
-And as expected it's now been handled by both the first and second Step as
-reflected by the Message being now: "Hello world! - Handled by 0 - Handled by 1"
+


### PR DESCRIPTION
## Proposed Changes 
Relocate statement about Sequences to the correct section. It was hiding in the PingSource section ;p
Relocate statements about sequence container outputs in the "Inspecting results" section to the correct locations with their corresponding commands.

This should also be cherry-picked to the release v0.19.0 branch
