### PR TITLE
Update writing-event-source/07-knative-sandbox.md weight

### DIFF
--- a/docs/eventing/samples/writing-event-source/07-knative-sandbox.md
+++ b/docs/eventing/samples/writing-event-source/07-knative-sandbox.md
@@ -1,7 +1,7 @@
 ---
 title: "Moving the event source to knative-sandbox"
 linkTitle: "Moving to knative-sandbox"
-weight: 10
+weight: 70
 type: "docs"
 ---
 


### PR DESCRIPTION
## Proposed Changes
- set weight to 70 so it shows as the last link in the list. This would
  then match the intended order in the [README.md file](https://github.com/knative/docs/blob/master/docs/eventing/samples/writing-event-source/README.md#steps)