### PR TITLE
Set the targetUtilizationPercentage to 100

### DIFF
--- a/docs/serving/autoscaling/autoscale-go/service.yaml
+++ b/docs/serving/autoscaling/autoscale-go/service.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         # Target 10 in-flight-requests per pod.
         autoscaling.knative.dev/target: "10"
+        autoscaling.knative.dev/targetUtilizationPercentage: "100"
     spec:
       containers:
       - image: gcr.io/knative-samples/autoscale-go:0.1


### PR DESCRIPTION
Set the targetUtilizationPercentage to 100 in Autoscale Sample App - Go service.yaml

Signed-off-by: zhongjun <zhongjun0802@gmail.com>

- set the revision targetUtilizationPercentage to 100 so as to override the default value 70.  otherwise the autoscaler will created 8 pods ,not 5 pods according the concurrency algorithm in the page https://knative.dev/docs/serving/autoscaling/autoscale-go/
-
-
