### PR TITLE
Remove prometheus addon from Istio installation instructions

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -73,8 +73,6 @@ spec:
   addonComponents:
     pilot:
       enabled: true
-    prometheus:
-      enabled: false
 
   components:
     ingressGateways:

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -78,23 +78,6 @@ spec:
     ingressGateways:
       - name: istio-ingressgateway
         enabled: true
-      - name: cluster-local-gateway
-        enabled: true
-        label:
-          istio: cluster-local-gateway
-          app: cluster-local-gateway
-        k8s:
-          service:
-            type: ClusterIP
-            ports:
-            - port: 15020
-              name: status-port
-            - port: 80
-              targetPort: 8080
-              name: http2
-            - port: 443
-              targetPort: 8443
-              name: https
 EOF
 
 istioctl install -f istio-minimal-operator.yaml


### PR DESCRIPTION
Fixes knative/serving#10221

## Proposed Changes <!-- Describe the changes the PR makes. -->

- This addon is no longer supported in Istio 1.8. Remove it since it was disabled anyways.