### PR TITLE
The Camel artifacts have moved to eventing-camel from eventing-contrib v0.18.4

### DIFF
--- a/docs/eventing/samples/apache-camel-source/README.md
+++ b/docs/eventing/samples/apache-camel-source/README.md
@@ -20,7 +20,7 @@ All Camel Sources use [Apache Camel K](https://github.com/apache/camel-k) as the
    environments, including development clusters.
 
 1. Install the Camel Source from the `camel.yaml` in the
-   [Eventing Sources release page](https://github.com/knative/eventing-contrib/releases):
+   [Eventing Camel release page](https://github.com/knative-sandbox/eventing-camel/releases):
 
    ```shell
    kubectl apply --filename camel.yaml

--- a/docs/eventing/sink/OWNERS
+++ b/docs/eventing/sink/OWNERS
@@ -1,0 +1,5 @@
+# The OWNERS file is used by prow to automatically merge approved PRs.
+
+approvers:
+- eventing-sources-eng-approvers
+- eventing-channels-eng-approvers

--- a/docs/eventing/sink/_index.md
+++ b/docs/eventing/sink/_index.md
@@ -1,0 +1,52 @@
+---
+title: "Sink"
+weight: 60
+type: "docs"
+---
+
+A sink is an Addressable resource that acts as a link
+between the Eventing mesh and an entity or system.
+
+We can connect any source to a sink, such as `PingSource` and `KafkaSink` objects:
+
+```yaml
+apiVersion: sources.knative.dev/v1beta1
+kind: PingSource
+metadata:
+  name: test-ping-source
+spec:
+  schedule: "*/1 * * * *"
+  jsonData: '{"message": "Hello world!"}'
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: KafkaSink
+      name: my-kafka-sink
+```
+
+We can connect a `Trigger` object to a sink, so that we can filter events, before sending them to a sink:
+
+```yaml
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: dev.knative.foo.bar
+      myextension: my-extension-value
+  subscriber:
+    ref:
+      apiVersion: eventing.knative.dev/v1alpha1
+      kind: KafkaSink
+      name: my-kafka-sink
+```
+
+## Knative Sinks
+
+| Name | Maintainer | Description |
+| -- | -- | -- |
+| [KafkaSink](./kafka-sink.md)  | Knative  | Send events to a Kafka topic |
+| [RedisSink](https://github.com/knative-sandbox/eventing-redis/tree/master/sink)  | Knative  | Send events to a Redis Stream |

--- a/docs/eventing/sink/kafka-sink.md
+++ b/docs/eventing/sink/kafka-sink.md
@@ -1,0 +1,103 @@
+---
+title: "Apache Kafka Sink"
+weight: 30
+type: "docs"
+---
+
+This page shows how to install and configure Apache Kafka Sink.
+
+## Prerequisites
+
+[Knative Eventing installation](./../../install/any-kubernetes-cluster.md#installing-the-eventing-component).
+
+## Installation
+
+1. Install the Kafka controller:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-controller.yaml" >}}
+    ```
+
+1. Install the Kafka Sink data plane:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-sink.yaml" >}}
+    ```
+
+1. Verify that `kafka-controller` and `kafka-sink-receiver` are running:
+
+    ```bash
+    kubectl get deployments.apps -n knative-eventing
+    ```
+
+    Example output:
+
+    ```bash
+    NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+    eventing-controller            1/1     1            1           10s
+    eventing-webhook               1/1     1            1           9s
+    kafka-controller               1/1     1            1           3s
+    kafka-sink-receiver            1/1     1            1           5s
+    ```
+
+## Kafka Sink
+
+A `KafkaSink` object looks like this:
+
+```yaml
+apiVersion: eventing.knative.dev/v1alpha1
+kind: KafkaSink
+metadata:
+  name: my-kafka-sink
+  namespace: default
+spec:
+  topic: mytopic
+  bootstrapServers:
+   - my-cluster-kafka-bootstrap.kafka:9092
+```
+
+## Kafka Producer configurations
+
+A Kafka Producer is the component responsible for sending events to the Apache Kafka cluster.
+Knative exposes all available Kafka Producer configurations that can be modified to suit your workloads.
+
+You can change these configurations by modifying the `config-kafka-sink-data-plane` config map in
+the `knative-eventing` namespace.
+
+Documentation for the settings available in this config map is available on the
+[Apache Kafka website](https://kafka.apache.org/documentation/),
+in particular, [Producer configurations](https://kafka.apache.org/documentation/#producerconfigs).
+
+## Enable debug logging for data plane components
+
+To enable debug logging for data plane components change the logging level to `DEBUG` in the `kafka-config-logging` config map.
+
+1. Apply the following `kafka-config-logging` config map:
+
+    ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: kafka-config-logging
+      namespace: knative-eventing
+    data:
+      config.xml: |
+        <configuration>
+          <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+          </appender>
+          <root level="DEBUG">
+            <appender-ref ref="jsonConsoleAppender"/>
+          </root>
+        </configuration>
+    ```
+
+2. Restart the `kafka-sink-receiver`:
+
+    ```bash
+    kubectl rollout restart deployment -n knative-eventing kafka-sink-receiver
+    ```
+
+### Additional information
+
+- To report bugs or add feature requests, open an issue in the [eventing-kafka-broker repository](https://github.com/knative-sandbox/eventing-kafka-broker).

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -493,6 +493,19 @@ kubectl apply --filename {{< artifact repo="serving" file="serving-nscert.yaml" 
 > Note this will not work with HTTP01 either via cert-manager or the net-http01
 > options.
 
+{{% tab name="DomainMapping CRD" %}}
+
+{{% feature-state version="v0.19" state="alpha" %}}
+
+The `DomainMapping` CRD allows a user to map a Domain Name that they own to a
+specific Knative Service.
+
+```bash
+kubectl apply --filename {{< artifact repo="serving" file="serving-domainmapping-crds.yaml" >}}
+kubectl wait --for=condition=Established --all crd
+kubectl apply --filename {{< artifact repo="serving" file="serving-domainmapping.yaml" >}}
+```
+
 {{< /tab >}} {{< /tabs >}}
 
 ### Getting started with Serving

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -712,7 +712,29 @@ At this point, you have a basic installation of Knative Eventing!
 
    <!-- This indentation is important for things to render properly. -->
 
-{{< tabs name="eventing_extensions" >}} {{% tab name="Sugar Controller" %}}
+{{< tabs name="eventing_extensions" >}}
+
+{{% tab name="Apache Kafka Sink" %}}
+
+{{< feature-state version="v0.18" state="alpha" >}}
+
+1. Install the Kafka controller:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-controller.yaml" >}}
+    ```
+
+1. Install the Kafka Sink data plane:
+
+    ```bash
+    kubectl apply --filename {{< artifact org="knative-sandbox" repo="eventing-kafka-broker" file="eventing-kafka-sink.yaml" >}}
+    ```
+
+For more information, see the [Kafka Sink](./../eventing/sink/kafka-sink.md) documentation.
+
+{{< /tab >}}
+
+{{% tab name="Sugar Controller" %}}
 
 <!-- Unclear when this feature came in -->
 

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -493,6 +493,8 @@ kubectl apply --filename {{< artifact repo="serving" file="serving-nscert.yaml" 
 > Note this will not work with HTTP01 either via cert-manager or the net-http01
 > options.
 
+{{< /tab >}}
+
 {{% tab name="DomainMapping CRD" %}}
 
 {{% feature-state version="v0.19" state="alpha" %}}

--- a/docs/install/install-kn.md
+++ b/docs/install/install-kn.md
@@ -62,7 +62,7 @@ You can run `kn` from a container image. For example:
 
 ## Using `kn` with Tekton
 
-You can also [run kn using Tekton](https://github.com/tektoncd/catalog/tree/master/kn).
+You can also [run kn using Tekton](https://github.com/tektoncd/catalog/tree/master/task/kn/0.1).
 
 ## What's next
 To learn more about using `kn`, see the [documentation](https://github.com/knative/client/blob/master/docs/cmd/kn.md).

--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -139,7 +139,7 @@ spec:
 * **Type**: extension
 * **ConfigMap key:** `kubernetes.podspec-tolerations`
 
-This flag controls whether [node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) can be specified.
+This flag controls whether [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) can be specified.
 
 ```yaml
 apiVersion: serving.knative.dev/v1

--- a/docs/serving/samples/rest-api-go/README.md
+++ b/docs/serving/samples/rest-api-go/README.md
@@ -96,7 +96,7 @@ The Knative Service creates the following child resources:
 - Knative Configuration
 - Knative Revision
 - Kubernetes Deployment
-- Kuberentes Service
+- Kubernetes Service
 
 You can inspect the created resources with the following `kubectl` commands:
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #issue-number or description of the problem the PR solves

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The Camel artifacts have moved to [eventing-camel](https://github.com/knative-sandbox/eventing-camel/releases) from [eventing-contrib v0.18.4](https://github.com/knative/eventing-contrib/releases/tag/v0.18.4). So the reference here needs to be updated.
-
-
