### PR TITLE
Fix typo in istio authorization docs

### DIFF
--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -87,7 +87,7 @@ spec:
  rules:
  - from:
    - source:
-      namespaces: ["serving-tests"]
+      namespaces: ["serving-tests", "knative-serving"]
 ```
 
 ## Health checking and metrics collection


### PR DESCRIPTION
Forgot to add the knative-serving namespace, which is mentioned in the previous paragraph.