### PR TITLE
Update calendar and drive links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ issue in the [`knative/website` repo](https://github.com/knative/website/issues)
 The
 [Knative Documentation Working Group](https://github.com/knative/community/blob/master/working-groups/WORKING-GROUPS.md#documentation)
 meets biweekly on Tuesdays at 9:30am PT.
-[Click here](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com)
+[Click here](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com)
 to see the exact dates on the Knative working group calendar.
 
 If you're interested in becoming more involved in Knative's documentation, start

--- a/community/calendar/_index.md
+++ b/community/calendar/_index.md
@@ -6,8 +6,8 @@ showlandingtoc: "false"
 type: "docs"
 ---
 
-The [Knative Community Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_tcut0tbk016g22csq1ced9lqd8@group.calendar.google.com) contain events that provides the opportunity to learn more about Knative and meet other Knative users and contributors.
+The [Knative Community Calendar](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com) contain events that provides the opportunity to learn more about Knative and meet other Knative users and contributors.
 
 Events don't have to be organized by the Knative project to be added to the calendar. If you want to add an event to the calendar please send an email to [knative-steering@googlegroups.com](mailto:knative-steering@googlegroups.com) or post to the #community channel in the Knative [Slack](https://slack.knative.dev) workspace.
 
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=Y190Y3V0MHRiazAxNmcyMmNzcTFjZWQ5bHFkOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&amp;color=%23D81B60" style="border:solid 1px #777" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/community/meetup/README.md
+++ b/community/meetup/README.md
@@ -6,7 +6,7 @@ Catch up with past community meetups on our [YouTube channel](https://www.youtub
 
 Here we will list all the information related to past and future events.
 
-Stay tuned for new events by subscribing to our [calendar](https://calendar.google.com/calendar/embed?src=google.com_18un4fuh6rokqf8hmfftm5oqq4%40group.calendar.google.com) ([iCal export file](https://calendar.google.com/calendar/ical/google.com_18un4fuh6rokqf8hmfftm5oqq4@group.calendar.google.com/public/basic.ics)) and following us on [Twitter](https://twitter.com/KnativeProject).
+Stay tuned for new events by subscribing to our [calendar](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com&ctz=America%2FLos_Angeles) ([iCal export file](https://calendar.google.com/calendar/ical/knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com/public/basic.ics)) and following us on [Twitter](https://twitter.com/KnativeProject).
 
 ---
 

--- a/docs/eventing/samples/writing-event-source/01-theory.md
+++ b/docs/eventing/samples/writing-event-source/01-theory.md
@@ -61,7 +61,7 @@ To ease writing a new event source, the eventing subsystem has offloaded several
 
 ![Simplified Controller](https://raw.githubusercontent.com/knative/docs/master/docs/eventing/samples/writing-event-source/simplified-controller.png)
 
-Fig 1. - Via shared [Knative Dependency Injection](https://docs.google.com/presentation/d/1uCqumTg4Nl4SApGnbo01KqNwVfRA1QFy3xl3V42ZqEI/edit?resourcekey=0-mf6dN2vu9SS3bo2TUeCk9Q#slide=id.g596dcbbefb_0_40)
+Fig 1. - Via shared [Knative Dependency Injection](https://docs.google.com/presentation/d/e/2PACX-1vQbpISBvY7jqzu2wy2t1_0R4LSBEBS0JrUS7M7V3BMVqy2K1Zk_0Xhy7WPPaeANLHE0yqtz1DuWlSAl/pub?resourcekey=0-mf6dN2vu9SS3bo2TUeCk9Q&slide=id.g596dcbbefb_0_40)
 
 
 Specifically, the `clientset`, `cache`, `informers`, and `listers` can all be generated and shared. Thus, they can be generated, imported, and assigned to the underlying reconciler when creating a new controller source implementation:

--- a/docs/eventing/samples/writing-event-source/01-theory.md
+++ b/docs/eventing/samples/writing-event-source/01-theory.md
@@ -61,7 +61,7 @@ To ease writing a new event source, the eventing subsystem has offloaded several
 
 ![Simplified Controller](https://raw.githubusercontent.com/knative/docs/master/docs/eventing/samples/writing-event-source/simplified-controller.png)
 
-Fig 1. - Via shared [Knative Dependency Injection](https://docs.google.com/presentation/d/1aK5xCBv7wbfdDZAvnUE4vGWGk77EYZ6AbL0OR1vKPq8/edit#slide=id.g596dcbbefb_0_40)
+Fig 1. - Via shared [Knative Dependency Injection](https://docs.google.com/presentation/d/1uCqumTg4Nl4SApGnbo01KqNwVfRA1QFy3xl3V42ZqEI/edit?resourcekey=0-mf6dN2vu9SS3bo2TUeCk9Q#slide=id.g596dcbbefb_0_40)
 
 
 Specifically, the `clientset`, `cache`, `informers`, and `listers` can all be generated and shared. Thus, they can be generated, imported, and assigned to the underlying reconciler when creating a new controller source implementation:

--- a/docs/reference/api/serving.md
+++ b/docs/reference/api/serving.md
@@ -24,7 +24,7 @@ Resource Types:
 <p>PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
 components instantiate autoscalers.  This definition is an abstraction that may be backed
 by multiple definitions.  For more information, see the Knative Pluggability presentation:
-<a href="https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit">https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit</a></p>
+<a href="https://docs.google.com/presentation/d/e/2PACX-1vQ4kT92QNXvBF9dJzVfF_zqUROoG1wZXf-ATMKi8d43htvt3Osq6k-1YUWAO9M27gZ8C-cGBQA8-bwJ/pub">https://docs.google.com/presentation/d/e/2PACX-1vQ4kT92QNXvBF9dJzVfF_zqUROoG1wZXf-ATMKi8d43htvt3Osq6k-1YUWAO9M27gZ8C-cGBQA8-bwJ/pub</a></p>
 </p>
 <table>
 <thead>

--- a/docs/serving/tag-resolution.md
+++ b/docs/serving/tag-resolution.md
@@ -9,10 +9,7 @@ Knative serving resolves image tags to a digest when you create a revision. This
 gives knative revisions some very nice properties, e.g. your deployments will be
 consistent, you don't have to worry about "immutable tags", etc. For more info,
 see
-[Why we resolve tags in Knative](https://docs.google.com/presentation/d/1gjcVniYD95H1DmGM_n7dYJ69vD9d6KgJiA-D9dydWGU/edit?usp=sharing)
-(join
-[`knative-users@googlegroups.com`](https://groups.google.com/d/forum/knative-users)
-for access).
+[Why we resolve tags in Knative](https://docs.google.com/presentation/d/e/2PACX-1vTgyp2lGDsLr_bohx3Ym_2mrTcMoFfzzd6jocUXdmWQFdXydltnraDMoLxvEe6WY9pNPpUUvM-geJ-g/pub).
 
 Unfortunately, this means that the knative serving controller needs to be
 configured to access your container registry.


### PR DESCRIPTION
Updates doc and calendar links to point to the `knative.team` drive and calendar, rather than the `google.com` hosted one.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Switch slides to web-published versions, visible without auth, to reduce the amount of access requests needed.
- Switch CONTRIBUTING.md to point to new Google doc, since that link is most useful to people already in `knative-dev`.
- Switch community/calendar to point to new Knative.Team calendar for now; we may want to have an additional calendar for non-official events of interest to the community at some future point.


/assign @macruzbar 
