### PR TITLE
Add .gitattributes for docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# This file is documented at https://git-scm.com/docs/gitattributes.
+# Linguist-specific attributes are documented at
+# https://github.com/github/linguist.
+
+/vendor/** linguist-vendored
+*.ai binary
+*.pdf binary
+*.png binary
+
+# coverage-excluded is an attribute used to explicitly exclude a path from being
+# included in code coverage. If a path is marked as linguist-generated already,
+# it will be implicitly excluded and there is no need to add the
+# coverage-excluded attribute
+/vendor/** coverage-excluded=true
+/test/** coverage-excluded=true


### PR DESCRIPTION
Cleanup to indicate git attributes so that we can make lint checks depend on Git attributes rather than ad-hoc patterns.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Set `git` attributes, mark certain graphics files as `binary`.
