### PR TITLE
Adding updates to the Event registry doc

### DIFF
--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -46,6 +46,8 @@ dev.knative.kafka.event-tdt48                dev.knative.kafka.event            
 google.pubsub.topic.publish-hrxhh            google.pubsub.topic.publish             //pubsub.googleapis.com/knative/topics/testing                                     dev                        False     BrokerIsNotReady
 ```
 
+**NOTE:** This assumes that the Sources, emitting those events reference a `broker` as their _sink_.
+
 We can see that there are seven different EventTypes in the registry of the
 `default` namespace. Let's pick the first one and see what the EventType yaml
 looks like:
@@ -60,7 +62,8 @@ kind: EventType
 metadata:
   name: dev.knative.source.github.push-34cnb
   namespace: default
-  generateName: dev.knative.source.github.push-
+  labels:
+    eventing.knative.dev/sourceName: github-sample
 spec:
   type: dev.knative.source.github.push
   source: https://github.com/knative/eventing


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

- adding note that the sources need to emit to the broker, otherwise they don't show up in the "eventtypes list"
- we no longer have a `generatedName`, but we have a label of the source name
