### PR TITLE
Add vagababov to eng-approvers and sort and trim people not longer in Knative project

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -35,13 +35,6 @@ aliases:
   - steuhs
   - yt3liu
 
-  serving-eng-reviewers:
-  - dprotaso
-  - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
-
   eventing-eng-approvers:
   - grantr
   - lionelvillard

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,14 +1,15 @@
 aliases:
   eng-approvers:
   - averikitsch
+  - csantanapr
   - dprotaso
   - evankanderson
   - grantr
   - markusthoemmes
   - mattmoor
   - tcnghia
+  - vagababov
   - vaikas
-  - csantanapr
 
   docs-approvers:
   - carieshmarie
@@ -67,16 +68,14 @@ aliases:
 
   install-eng-reviewers:
   - dprotaso
-  - markusthoemmes
-  - mattmoor
-  - tcnghia
-  - vagababov
   - evankanderson
   - grantr
-  - vaikas
-  - n3wscott
-  - matzew
-  - nachocano
-  - lionelvillard
-  - bbrowning
   - houshengbo
+  - lionelvillard
+  - markusthoemmes
+  - mattmoor
+  - matzew
+  - n3wscott
+  - tcnghia
+  - vagababov
+  - vaikas

--- a/docs/serving/OWNERS
+++ b/docs/serving/OWNERS
@@ -1,4 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
+approvers:
+- eng-approvers
+
 reviewers:
 - serving-eng-reviewers

--- a/docs/serving/OWNERS
+++ b/docs/serving/OWNERS
@@ -2,6 +2,3 @@
 
 approvers:
 - eng-approvers
-
-reviewers:
-- serving-eng-reviewers


### PR DESCRIPTION
Also add `eng-approvers` as approvers to the serving docs.
Since that seems the reason for this group in the first place.


/assign mattmoor @abrennan89 