### PR TITLE
fix: change PingSource api version badge to v1beta2

### DIFF
--- a/docs/eventing/sources/pingsource.md
+++ b/docs/eventing/sources/pingsource.md
@@ -5,7 +5,7 @@ weight: 31
 type: "docs"
 ---
 
-![version](https://img.shields.io/badge/API_Version-v1beta1-red?style=flat-square)
+![version](https://img.shields.io/badge/API_Version-v1beta2-red?style=flat-square)
 
 A PingSource produces events with a fixed payload on a specified cron schedule.
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->



## Proposed Changes <!-- Describe the changes the PR makes. -->

- change PingSource api version badge to v1beta2
-
-
