### PR TITLE
Promote net-kourier to stable

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -269,7 +269,7 @@ The following commands install Kong and enable its Knative integration.
 
 {{% tab name="Kourier" %}}
 
-{{% feature-state version="v0.17" state="beta" %}}
+{{% feature-state version="v0.21" state="stable" %}}
 
 The following commands install Kourier and enable its Knative integration.
 


### PR DESCRIPTION
As [testgrid](https://testgrid.knative.dev/net-kourier#continuous&exclude-non-failed-tests=50&sort-by-flakiness=50&width=20) shows, kourier does not have any non-flaky test failure and all features including alpha are implemented.

Hence this patch promotes net-kourier to stable.

/assign @tcnghia @ZhiminXiang 
/cc @mattmoor @davidor @jmprusi @markusthoemmes