### PR TITLE
update gen-api-reference-docs script

### DIFF
--- a/docs/reference/api/eventing/eventing.md
+++ b/docs/reference/api/eventing/eventing.md
@@ -69,7 +69,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -79,14 +79,14 @@ configs.internal.knative.dev/v1alpha1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ConfigMapPropagation</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -101,7 +101,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationSpec">
 ConfigMapPropagationSpec
@@ -115,7 +115,7 @@ ConfigMapPropagationSpec
 <table>
 <tr>
 <td>
-<code>originalNamespace</code></br>
+<code>originalNamespace</code><br/>
 <em>
 string
 </em>
@@ -126,7 +126,7 @@ string
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -143,7 +143,7 @@ Kubernetes meta/v1.LabelSelector
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatus">
 ConfigMapPropagationStatus
@@ -176,7 +176,7 @@ This data may be out of date.</p>
 <tbody>
 <tr>
 <td>
-<code>originalNamespace</code></br>
+<code>originalNamespace</code><br/>
 <em>
 string
 </em>
@@ -187,7 +187,7 @@ string
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -220,7 +220,7 @@ Kubernetes meta/v1.LabelSelector
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -236,7 +236,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>copyConfigmaps</code></br>
+<code>copyConfigmaps</code><br/>
 <em>
 <a href="#configs.internal.knative.dev/v1alpha1.ConfigMapPropagationStatusCopyConfigMap">
 []ConfigMapPropagationStatusCopyConfigMap
@@ -269,7 +269,7 @@ knative.dev/pkg/apis/duck/v1.Status
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br/>
 <em>
 string
 </em>
@@ -280,7 +280,7 @@ string
 </tr>
 <tr>
 <td>
-<code>source</code></br>
+<code>source</code><br/>
 <em>
 string
 </em>
@@ -291,7 +291,7 @@ string
 </tr>
 <tr>
 <td>
-<code>operation</code></br>
+<code>operation</code><br/>
 <em>
 string
 </em>
@@ -302,7 +302,7 @@ string
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 string
 </em>
@@ -313,7 +313,7 @@ string
 </tr>
 <tr>
 <td>
-<code>reason</code></br>
+<code>reason</code><br/>
 <em>
 string
 </em>
@@ -324,7 +324,7 @@ string
 </tr>
 <tr>
 <td>
-<code>resourceVersionFromSource</code></br>
+<code>resourceVersionFromSource</code><br/>
 <em>
 string
 </em>
@@ -383,7 +383,7 @@ Channelable ObjectReferences and access their subscription and address data.  Th
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -397,7 +397,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
@@ -411,7 +411,7 @@ ChannelableSpec
 <table>
 <tr>
 <td>
-<code>SubscribableSpec</code></br>
+<code>SubscribableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscribableSpec">
 SubscribableSpec
@@ -426,7 +426,7 @@ SubscribableSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -445,7 +445,7 @@ global delivery spec.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableStatus">
 ChannelableStatus
@@ -461,9 +461,9 @@ ChannelableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>,
-<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>,
-<a href="#messaging.knative.dev/v1.ChannelTemplateSpecInternalSpec">ChannelTemplateSpecInternalSpec</a>,
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>, 
+<a href="#messaging.knative.dev/v1.ChannelTemplateSpecInternalSpec">ChannelTemplateSpecInternalSpec</a>, 
 <a href="#messaging.knative.dev/v1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
 </p>
 <p>
@@ -479,7 +479,7 @@ ChannelableStatus
 <tbody>
 <tr>
 <td>
-<code>SubscribableSpec</code></br>
+<code>SubscribableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscribableSpec">
 SubscribableSpec
@@ -494,7 +494,7 @@ SubscribableSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -514,8 +514,8 @@ global delivery spec.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.Channelable">Channelable</a>,
-<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>,
+<a href="#duck.knative.dev/v1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1.ChannelStatus">ChannelStatus</a>, 
 <a href="#messaging.knative.dev/v1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
 </p>
 <p>
@@ -531,7 +531,7 @@ global delivery spec.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -547,7 +547,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
@@ -561,7 +561,7 @@ knative.dev/pkg/apis/duck/v1.AddressStatus
 </tr>
 <tr>
 <td>
-<code>SubscribableStatus</code></br>
+<code>SubscribableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscribableStatus">
 SubscribableStatus
@@ -577,7 +577,7 @@ SubscribableStatus
 </tr>
 <tr>
 <td>
-<code>deadLetterChannel</code></br>
+<code>deadLetterChannel</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -594,11 +594,11 @@ Failed messages are delivered here.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>,
-<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>,
-<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>,
-<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>,
-<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>,
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#eventing.knative.dev/v1.BrokerSpec">BrokerSpec</a>, 
+<a href="#flows.knative.dev/v1.ParallelBranch">ParallelBranch</a>, 
+<a href="#flows.knative.dev/v1.SequenceStep">SequenceStep</a>, 
 <a href="#messaging.knative.dev/v1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
 <p>
@@ -615,7 +615,7 @@ such as channelable and source.</p>
 <tbody>
 <tr>
 <td>
-<code>deadLetterSink</code></br>
+<code>deadLetterSink</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -628,7 +628,7 @@ a destination.</p>
 </tr>
 <tr>
 <td>
-<code>retry</code></br>
+<code>retry</code><br/>
 <em>
 int32
 </em>
@@ -641,7 +641,7 @@ sending an event before moving it to the dead letter sink.</p>
 </tr>
 <tr>
 <td>
-<code>backoffPolicy</code></br>
+<code>backoffPolicy</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.BackoffPolicyType">
 BackoffPolicyType
@@ -655,7 +655,7 @@ BackoffPolicyType
 </tr>
 <tr>
 <td>
-<code>backoffDelay</code></br>
+<code>backoffDelay</code><br/>
 <em>
 string
 </em>
@@ -687,7 +687,7 @@ For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 <tbody>
 <tr>
 <td>
-<code>deadLetterChannel</code></br>
+<code>deadLetterChannel</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -717,7 +717,7 @@ SubscribableType ObjectReferences and access the Subscription data.  This is not
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -731,7 +731,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscribableSpec">
 SubscribableSpec
@@ -746,7 +746,7 @@ configured as to be compatible with Subscribable contract.</p>
 <table>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscriberSpec">
 []SubscriberSpec
@@ -762,7 +762,7 @@ configured as to be compatible with Subscribable contract.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscribableStatus">
 SubscribableStatus
@@ -780,7 +780,7 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>,
+<a href="#duck.knative.dev/v1.ChannelableSpec">ChannelableSpec</a>, 
 <a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -796,7 +796,7 @@ configured as to be compatible with Subscribable contract.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscriberSpec">
 []SubscriberSpec
@@ -813,7 +813,7 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>,
+<a href="#duck.knative.dev/v1.ChannelableStatus">ChannelableStatus</a>, 
 <a href="#duck.knative.dev/v1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -830,7 +830,7 @@ section of the resource.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.SubscriberStatus">
 []SubscriberStatus
@@ -863,7 +863,7 @@ section of the resource.</p>
 <tbody>
 <tr>
 <td>
-<code>uid</code></br>
+<code>uid</code><br/>
 <em>
 k8s.io/apimachinery/pkg/types.UID
 </em>
@@ -875,7 +875,7 @@ k8s.io/apimachinery/pkg/types.UID
 </tr>
 <tr>
 <td>
-<code>generation</code></br>
+<code>generation</code><br/>
 <em>
 int64
 </em>
@@ -887,7 +887,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>subscriberUri</code></br>
+<code>subscriberUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -899,7 +899,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>replyUri</code></br>
+<code>replyUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -911,7 +911,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -944,7 +944,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>uid</code></br>
+<code>uid</code><br/>
 <em>
 k8s.io/apimachinery/pkg/types.UID
 </em>
@@ -956,7 +956,7 @@ k8s.io/apimachinery/pkg/types.UID
 </tr>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br/>
 <em>
 int64
 </em>
@@ -968,7 +968,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -981,7 +981,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br/>
 <em>
 string
 </em>
@@ -1017,7 +1017,7 @@ Channelable ObjectReferences and access their subscription and address data.  Th
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1031,7 +1031,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.ChannelableSpec">
 ChannelableSpec
@@ -1045,7 +1045,7 @@ ChannelableSpec
 <table>
 <tr>
 <td>
-<code>SubscribableTypeSpec</code></br>
+<code>SubscribableTypeSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
@@ -1060,7 +1060,7 @@ SubscribableTypeSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1077,7 +1077,7 @@ DeliverySpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.ChannelableStatus">
 ChannelableStatus
@@ -1108,7 +1108,7 @@ This is not a real resource.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1122,7 +1122,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">
 ChannelableCombinedSpec
@@ -1136,7 +1136,7 @@ ChannelableCombinedSpec
 <table>
 <tr>
 <td>
-<code>SubscribableTypeSpec</code></br>
+<code>SubscribableTypeSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
@@ -1152,7 +1152,7 @@ SubscribableTypeSpec
 </tr>
 <tr>
 <td>
-<code>SubscribableSpec</code></br>
+<code>SubscribableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableSpec">
 SubscribableSpec
@@ -1168,7 +1168,7 @@ SubscribableSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1185,7 +1185,7 @@ DeliverySpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">
 ChannelableCombinedStatus
@@ -1216,7 +1216,7 @@ ChannelableCombinedStatus
 <tbody>
 <tr>
 <td>
-<code>SubscribableTypeSpec</code></br>
+<code>SubscribableTypeSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
@@ -1232,7 +1232,7 @@ SubscribableTypeSpec
 </tr>
 <tr>
 <td>
-<code>SubscribableSpec</code></br>
+<code>SubscribableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableSpec">
 SubscribableSpec
@@ -1248,7 +1248,7 @@ SubscribableSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1281,7 +1281,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -1297,7 +1297,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </em>
@@ -1311,7 +1311,7 @@ knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </tr>
 <tr>
 <td>
-<code>SubscribableTypeStatus</code></br>
+<code>SubscribableTypeStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
@@ -1327,7 +1327,7 @@ SubscribableTypeStatus
 </tr>
 <tr>
 <td>
-<code>SubscribableStatus</code></br>
+<code>SubscribableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableStatus">
 SubscribableStatus
@@ -1343,7 +1343,7 @@ SubscribableStatus
 </tr>
 <tr>
 <td>
-<code>errorChannel</code></br>
+<code>errorChannel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -1376,7 +1376,7 @@ Kubernetes core/v1.ObjectReference
 <tbody>
 <tr>
 <td>
-<code>SubscribableTypeSpec</code></br>
+<code>SubscribableTypeSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
@@ -1391,7 +1391,7 @@ SubscribableTypeSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1424,7 +1424,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -1440,7 +1440,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </em>
@@ -1454,7 +1454,7 @@ knative.dev/pkg/apis/duck/v1alpha1.AddressStatus
 </tr>
 <tr>
 <td>
-<code>SubscribableTypeStatus</code></br>
+<code>SubscribableTypeStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
@@ -1470,7 +1470,7 @@ SubscribableTypeStatus
 </tr>
 <tr>
 <td>
-<code>errorChannel</code></br>
+<code>errorChannel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -1500,7 +1500,7 @@ arbitrary other resources (such as any Source or Addressable). This is not a rea
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1534,7 +1534,7 @@ section of the resource.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscriberSpec">
 []SubscriberSpec
@@ -1567,7 +1567,7 @@ section of the resource.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscriberStatus">
 []SubscriberStatus
@@ -1597,7 +1597,7 @@ SubscribableType ObjectReferences and access the Subscription data.  This is not
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1611,7 +1611,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeSpec">
 SubscribableTypeSpec
@@ -1626,7 +1626,7 @@ configured as to be compatible with Subscribable contract.</p>
 <table>
 <tr>
 <td>
-<code>subscribable</code></br>
+<code>subscribable</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.Subscribable">
 Subscribable
@@ -1641,7 +1641,7 @@ Subscribable
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableTypeStatus">
 SubscribableTypeStatus
@@ -1659,8 +1659,8 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>,
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
 <a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
 </p>
 <p>
@@ -1676,7 +1676,7 @@ configured as to be compatible with Subscribable contract.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribable</code></br>
+<code>subscribable</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.Subscribable">
 Subscribable
@@ -1692,8 +1692,8 @@ Subscribable
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>,
-<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableStatus">ChannelableStatus</a>, 
 <a href="#duck.knative.dev/v1alpha1.SubscribableType">SubscribableType</a>)
 </p>
 <p>
@@ -1709,7 +1709,7 @@ Subscribable
 <tbody>
 <tr>
 <td>
-<code>subscribableStatus</code></br>
+<code>subscribableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1alpha1.SubscribableStatus">
 SubscribableStatus
@@ -1744,7 +1744,7 @@ At least one of SubscriberURI and ReplyURI must be present</p>
 <tbody>
 <tr>
 <td>
-<code>uid</code></br>
+<code>uid</code><br/>
 <em>
 k8s.io/apimachinery/pkg/types.UID
 </em>
@@ -1756,7 +1756,7 @@ k8s.io/apimachinery/pkg/types.UID
 </tr>
 <tr>
 <td>
-<code>generation</code></br>
+<code>generation</code><br/>
 <em>
 int64
 </em>
@@ -1768,7 +1768,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>subscriberURI</code></br>
+<code>subscriberURI</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -1779,7 +1779,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>replyURI</code></br>
+<code>replyURI</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -1790,7 +1790,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>deadLetterSink</code></br>
+<code>deadLetterSink</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -1801,7 +1801,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1862,7 +1862,7 @@ Channelable ObjectReferences and access their subscription and address data.  Th
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1876,7 +1876,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableSpec">
 ChannelableSpec
@@ -1890,7 +1890,7 @@ ChannelableSpec
 <table>
 <tr>
 <td>
-<code>SubscribableSpec</code></br>
+<code>SubscribableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableSpec">
 SubscribableSpec
@@ -1905,7 +1905,7 @@ SubscribableSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1922,7 +1922,7 @@ DeliverySpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableStatus">
 ChannelableStatus
@@ -1938,8 +1938,8 @@ ChannelableStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>,
-<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>,
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>, 
 <a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">InMemoryChannelSpec</a>)
 </p>
 <p>
@@ -1955,7 +1955,7 @@ ChannelableStatus
 <tbody>
 <tr>
 <td>
-<code>SubscribableSpec</code></br>
+<code>SubscribableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableSpec">
 SubscribableSpec
@@ -1970,7 +1970,7 @@ SubscribableSpec
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -1988,8 +1988,8 @@ DeliverySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>,
-<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>,
+<a href="#duck.knative.dev/v1beta1.Channelable">Channelable</a>, 
+<a href="#messaging.knative.dev/v1beta1.ChannelStatus">ChannelStatus</a>, 
 <a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">InMemoryChannelStatus</a>)
 </p>
 <p>
@@ -2005,7 +2005,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -2021,7 +2021,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
@@ -2035,7 +2035,7 @@ knative.dev/pkg/apis/duck/v1.AddressStatus
 </tr>
 <tr>
 <td>
-<code>SubscribableStatus</code></br>
+<code>SubscribableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableStatus">
 SubscribableStatus
@@ -2051,7 +2051,7 @@ SubscribableStatus
 </tr>
 <tr>
 <td>
-<code>deadLetterChannel</code></br>
+<code>deadLetterChannel</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -2068,14 +2068,14 @@ Failed messages are delivered here.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>,
-<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>,
-<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>,
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>,
-<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>,
-<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>,
-<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>,
-<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1alpha1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.SubscriberSpec">SubscriberSpec</a>, 
+<a href="#eventing.knative.dev/v1beta1.BrokerSpec">BrokerSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.ParallelBranch">ParallelBranch</a>, 
+<a href="#flows.knative.dev/v1beta1.SequenceStep">SequenceStep</a>, 
 <a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">SubscriptionSpec</a>)
 </p>
 <p>
@@ -2092,7 +2092,7 @@ such as channelable and source.</p>
 <tbody>
 <tr>
 <td>
-<code>deadLetterSink</code></br>
+<code>deadLetterSink</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -2105,7 +2105,7 @@ a destination.</p>
 </tr>
 <tr>
 <td>
-<code>retry</code></br>
+<code>retry</code><br/>
 <em>
 int32
 </em>
@@ -2118,7 +2118,7 @@ sending an event before moving it to the dead letter sink.</p>
 </tr>
 <tr>
 <td>
-<code>backoffPolicy</code></br>
+<code>backoffPolicy</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.BackoffPolicyType">
 BackoffPolicyType
@@ -2132,7 +2132,7 @@ BackoffPolicyType
 </tr>
 <tr>
 <td>
-<code>backoffDelay</code></br>
+<code>backoffDelay</code><br/>
 <em>
 string
 </em>
@@ -2164,7 +2164,7 @@ For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 <tbody>
 <tr>
 <td>
-<code>deadLetterChannel</code></br>
+<code>deadLetterChannel</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -2194,7 +2194,7 @@ SubscribableType ObjectReferences and access the Subscription data.  This is not
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2208,7 +2208,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableSpec">
 SubscribableSpec
@@ -2223,7 +2223,7 @@ configured as to be compatible with Subscribable contract.</p>
 <table>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscriberSpec">
 []SubscriberSpec
@@ -2239,7 +2239,7 @@ configured as to be compatible with Subscribable contract.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscribableStatus">
 SubscribableStatus
@@ -2257,8 +2257,8 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>,
-<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedSpec">ChannelableCombinedSpec</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableSpec">ChannelableSpec</a>, 
 <a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -2274,7 +2274,7 @@ configured as to be compatible with Subscribable contract.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscriberSpec">
 []SubscriberSpec
@@ -2291,8 +2291,8 @@ configured as to be compatible with Subscribable contract.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>,
-<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>,
+<a href="#duck.knative.dev/v1alpha1.ChannelableCombinedStatus">ChannelableCombinedStatus</a>, 
+<a href="#duck.knative.dev/v1beta1.ChannelableStatus">ChannelableStatus</a>, 
 <a href="#duck.knative.dev/v1beta1.Subscribable">Subscribable</a>)
 </p>
 <p>
@@ -2309,7 +2309,7 @@ section of the resource.</p>
 <tbody>
 <tr>
 <td>
-<code>subscribers</code></br>
+<code>subscribers</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.SubscriberStatus">
 []SubscriberStatus
@@ -2342,7 +2342,7 @@ section of the resource.</p>
 <tbody>
 <tr>
 <td>
-<code>uid</code></br>
+<code>uid</code><br/>
 <em>
 k8s.io/apimachinery/pkg/types.UID
 </em>
@@ -2354,7 +2354,7 @@ k8s.io/apimachinery/pkg/types.UID
 </tr>
 <tr>
 <td>
-<code>generation</code></br>
+<code>generation</code><br/>
 <em>
 int64
 </em>
@@ -2366,7 +2366,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>subscriberUri</code></br>
+<code>subscriberUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -2378,7 +2378,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>replyUri</code></br>
+<code>replyUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -2390,7 +2390,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -2408,7 +2408,7 @@ DeliverySpec
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>,
+<a href="#duck.knative.dev/v1alpha1.SubscribableStatus">SubscribableStatus</a>, 
 <a href="#duck.knative.dev/v1beta1.SubscribableStatus">SubscribableStatus</a>)
 </p>
 <p>
@@ -2424,7 +2424,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>uid</code></br>
+<code>uid</code><br/>
 <em>
 k8s.io/apimachinery/pkg/types.UID
 </em>
@@ -2436,7 +2436,7 @@ k8s.io/apimachinery/pkg/types.UID
 </tr>
 <tr>
 <td>
-<code>observedGeneration</code></br>
+<code>observedGeneration</code><br/>
 <em>
 int64
 </em>
@@ -2448,7 +2448,7 @@ int64
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#conditionstatus-v1-core">
 Kubernetes core/v1.ConditionStatus
@@ -2461,7 +2461,7 @@ Kubernetes core/v1.ConditionStatus
 </tr>
 <tr>
 <td>
-<code>message</code></br>
+<code>message</code><br/>
 <em>
 string
 </em>
@@ -2503,7 +2503,7 @@ Addressable endpoint.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -2513,14 +2513,14 @@ eventing.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Broker</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2535,7 +2535,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.BrokerSpec">
 BrokerSpec
@@ -2549,7 +2549,7 @@ BrokerSpec
 <table>
 <tr>
 <td>
-<code>config</code></br>
+<code>config</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -2563,7 +2563,7 @@ a pointer to a ConfigMap.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -2581,7 +2581,7 @@ This includes things like retries, DLQ, etc.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.BrokerStatus">
 BrokerStatus
@@ -2612,7 +2612,7 @@ Broker&rsquo;s event pool.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -2622,14 +2622,14 @@ eventing.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Trigger</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2644,7 +2644,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.TriggerSpec">
 TriggerSpec
@@ -2658,7 +2658,7 @@ TriggerSpec
 <table>
 <tr>
 <td>
-<code>broker</code></br>
+<code>broker</code><br/>
 <em>
 string
 </em>
@@ -2669,7 +2669,7 @@ string
 </tr>
 <tr>
 <td>
-<code>filter</code></br>
+<code>filter</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.TriggerFilter">
 TriggerFilter
@@ -2684,7 +2684,7 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -2699,7 +2699,7 @@ is required.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.TriggerStatus">
 TriggerStatus
@@ -2732,7 +2732,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>config</code></br>
+<code>config</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -2746,7 +2746,7 @@ a pointer to a ConfigMap.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -2780,7 +2780,7 @@ This includes things like retries, DLQ, etc.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -2796,7 +2796,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>address</code></br>
+<code>address</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Addressable
 </em>
@@ -2826,7 +2826,7 @@ delivered into the Broker mesh.</p>
 <tbody>
 <tr>
 <td>
-<code>attributes</code></br>
+<code>attributes</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.TriggerFilterAttributes">
 TriggerFilterAttributes
@@ -2873,7 +2873,7 @@ to indicate all strings match.</p>
 <tbody>
 <tr>
 <td>
-<code>broker</code></br>
+<code>broker</code><br/>
 <em>
 string
 </em>
@@ -2884,7 +2884,7 @@ string
 </tr>
 <tr>
 <td>
-<code>filter</code></br>
+<code>filter</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1.TriggerFilter">
 TriggerFilter
@@ -2899,7 +2899,7 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -2930,7 +2930,7 @@ is required.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -2946,7 +2946,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>subscriberUri</code></br>
+<code>subscriberUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -2989,7 +2989,7 @@ Addressable endpoint.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -2999,14 +2999,14 @@ eventing.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Broker</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3021,7 +3021,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.BrokerSpec">
 BrokerSpec
@@ -3035,7 +3035,7 @@ BrokerSpec
 <table>
 <tr>
 <td>
-<code>config</code></br>
+<code>config</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -3049,7 +3049,7 @@ a pointer to a ConfigMap.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -3067,7 +3067,7 @@ This includes things like retries, DLQ, etc.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.BrokerStatus">
 BrokerStatus
@@ -3097,7 +3097,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -3107,14 +3107,14 @@ eventing.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>EventType</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3129,7 +3129,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.EventTypeSpec">
 EventTypeSpec
@@ -3143,7 +3143,7 @@ EventTypeSpec
 <table>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br/>
 <em>
 string
 </em>
@@ -3154,7 +3154,7 @@ string
 </tr>
 <tr>
 <td>
-<code>source</code></br>
+<code>source</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -3166,7 +3166,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>schema</code></br>
+<code>schema</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -3179,7 +3179,7 @@ It may be a JSON schema, a protobuf schema, etc. It is optional.</p>
 </tr>
 <tr>
 <td>
-<code>schemaData</code></br>
+<code>schemaData</code><br/>
 <em>
 string
 </em>
@@ -3193,7 +3193,7 @@ The contents are not validated or manipulated by the system.</p>
 </tr>
 <tr>
 <td>
-<code>broker</code></br>
+<code>broker</code><br/>
 <em>
 string
 </em>
@@ -3206,7 +3206,7 @@ Broker refers to the Broker that can provide the EventType.</p>
 </tr>
 <tr>
 <td>
-<code>description</code></br>
+<code>description</code><br/>
 <em>
 string
 </em>
@@ -3221,7 +3221,7 @@ string
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.EventTypeStatus">
 EventTypeStatus
@@ -3253,7 +3253,7 @@ Broker&rsquo;s event pool.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -3263,14 +3263,14 @@ eventing.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Trigger</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3285,7 +3285,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.TriggerSpec">
 TriggerSpec
@@ -3299,7 +3299,7 @@ TriggerSpec
 <table>
 <tr>
 <td>
-<code>broker</code></br>
+<code>broker</code><br/>
 <em>
 string
 </em>
@@ -3311,7 +3311,7 @@ to &lsquo;default&rsquo;.</p>
 </tr>
 <tr>
 <td>
-<code>filter</code></br>
+<code>filter</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.TriggerFilter">
 TriggerFilter
@@ -3326,7 +3326,7 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -3341,7 +3341,7 @@ is required.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.TriggerStatus">
 TriggerStatus
@@ -3374,7 +3374,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>config</code></br>
+<code>config</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -3388,7 +3388,7 @@ a pointer to a ConfigMap.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -3422,7 +3422,7 @@ This includes things like retries, DLQ, etc.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -3438,7 +3438,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>address</code></br>
+<code>address</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Addressable
 </em>
@@ -3468,7 +3468,7 @@ delivered into the Broker mesh.</p>
 <tbody>
 <tr>
 <td>
-<code>type</code></br>
+<code>type</code><br/>
 <em>
 string
 </em>
@@ -3479,7 +3479,7 @@ string
 </tr>
 <tr>
 <td>
-<code>source</code></br>
+<code>source</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -3491,7 +3491,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>schema</code></br>
+<code>schema</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -3504,7 +3504,7 @@ It may be a JSON schema, a protobuf schema, etc. It is optional.</p>
 </tr>
 <tr>
 <td>
-<code>schemaData</code></br>
+<code>schemaData</code><br/>
 <em>
 string
 </em>
@@ -3518,7 +3518,7 @@ The contents are not validated or manipulated by the system.</p>
 </tr>
 <tr>
 <td>
-<code>broker</code></br>
+<code>broker</code><br/>
 <em>
 string
 </em>
@@ -3531,7 +3531,7 @@ Broker refers to the Broker that can provide the EventType.</p>
 </tr>
 <tr>
 <td>
-<code>description</code></br>
+<code>description</code><br/>
 <em>
 string
 </em>
@@ -3562,7 +3562,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -3596,7 +3596,7 @@ knative.dev/pkg/apis/duck/v1.Status
 <tbody>
 <tr>
 <td>
-<code>attributes</code></br>
+<code>attributes</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.TriggerFilterAttributes">
 TriggerFilterAttributes
@@ -3643,7 +3643,7 @@ to indicate all strings match.</p>
 <tbody>
 <tr>
 <td>
-<code>broker</code></br>
+<code>broker</code><br/>
 <em>
 string
 </em>
@@ -3655,7 +3655,7 @@ to &lsquo;default&rsquo;.</p>
 </tr>
 <tr>
 <td>
-<code>filter</code></br>
+<code>filter</code><br/>
 <em>
 <a href="#eventing.knative.dev/v1beta1.TriggerFilter">
 TriggerFilter
@@ -3670,7 +3670,7 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -3701,7 +3701,7 @@ is required.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -3717,7 +3717,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>subscriberUri</code></br>
+<code>subscriberUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -3751,7 +3751,7 @@ series through Channels and Subscriptions.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -3766,7 +3766,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelSpec">
 ParallelSpec
@@ -3780,7 +3780,7 @@ ParallelSpec
 <table>
 <tr>
 <td>
-<code>branches</code></br>
+<code>branches</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelBranch">
 []ParallelBranch
@@ -3793,7 +3793,7 @@ ParallelSpec
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -3808,7 +3808,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -3824,7 +3824,7 @@ when the case does not have a Reply</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelStatus">
 ParallelStatus
@@ -3857,7 +3857,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>filter</code></br>
+<code>filter</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -3869,7 +3869,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -3880,7 +3880,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -3893,7 +3893,7 @@ If not specified, sent the result to the Parallel Reply</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -3927,7 +3927,7 @@ This includes things like retries, DLQ, etc.</p>
 <tbody>
 <tr>
 <td>
-<code>filterSubscriptionStatus</code></br>
+<code>filterSubscriptionStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelSubscriptionStatus">
 ParallelSubscriptionStatus
@@ -3940,7 +3940,7 @@ ParallelSubscriptionStatus
 </tr>
 <tr>
 <td>
-<code>filterChannelStatus</code></br>
+<code>filterChannelStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelChannelStatus">
 ParallelChannelStatus
@@ -3953,7 +3953,7 @@ ParallelChannelStatus
 </tr>
 <tr>
 <td>
-<code>subscriberSubscriptionStatus</code></br>
+<code>subscriberSubscriptionStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelSubscriptionStatus">
 ParallelSubscriptionStatus
@@ -3970,7 +3970,7 @@ ParallelSubscriptionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>,
+<a href="#flows.knative.dev/v1.ParallelBranchStatus">ParallelBranchStatus</a>, 
 <a href="#flows.knative.dev/v1.ParallelStatus">ParallelStatus</a>)
 </p>
 <p>
@@ -3985,7 +3985,7 @@ ParallelSubscriptionStatus
 <tbody>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -3998,7 +3998,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -4027,7 +4027,7 @@ knative.dev/pkg/apis.Condition
 <tbody>
 <tr>
 <td>
-<code>branches</code></br>
+<code>branches</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelBranch">
 []ParallelBranch
@@ -4040,7 +4040,7 @@ knative.dev/pkg/apis.Condition
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -4055,7 +4055,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4087,7 +4087,7 @@ when the case does not have a Reply</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -4103,7 +4103,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>ingressChannelStatus</code></br>
+<code>ingressChannelStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelChannelStatus">
 ParallelChannelStatus
@@ -4116,7 +4116,7 @@ ParallelChannelStatus
 </tr>
 <tr>
 <td>
-<code>branchStatuses</code></br>
+<code>branchStatuses</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.ParallelBranchStatus">
 []ParallelBranchStatus
@@ -4130,7 +4130,7 @@ Matches the Spec.Branches array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
@@ -4164,7 +4164,7 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <tbody>
 <tr>
 <td>
-<code>subscription</code></br>
+<code>subscription</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -4177,7 +4177,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -4204,7 +4204,7 @@ series through Channels and Subscriptions.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -4219,7 +4219,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.SequenceSpec">
 SequenceSpec
@@ -4233,7 +4233,7 @@ SequenceSpec
 <table>
 <tr>
 <td>
-<code>steps</code></br>
+<code>steps</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.SequenceStep">
 []SequenceStep
@@ -4247,7 +4247,7 @@ provided. Each step has its own delivery options</p>
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -4262,7 +4262,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4277,7 +4277,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.SequenceStatus">
 SequenceStatus
@@ -4310,7 +4310,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -4323,7 +4323,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -4352,7 +4352,7 @@ knative.dev/pkg/apis.Condition
 <tbody>
 <tr>
 <td>
-<code>steps</code></br>
+<code>steps</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.SequenceStep">
 []SequenceStep
@@ -4366,7 +4366,7 @@ provided. Each step has its own delivery options</p>
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -4381,7 +4381,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4412,7 +4412,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -4428,7 +4428,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>subscriptionStatuses</code></br>
+<code>subscriptionStatuses</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.SequenceSubscriptionStatus">
 []SequenceSubscriptionStatus
@@ -4442,7 +4442,7 @@ Matches the Spec.Steps array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>channelStatuses</code></br>
+<code>channelStatuses</code><br/>
 <em>
 <a href="#flows.knative.dev/v1.SequenceChannelStatus">
 []SequenceChannelStatus
@@ -4456,7 +4456,7 @@ Matches the Spec.Steps array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
@@ -4490,7 +4490,7 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <tbody>
 <tr>
 <td>
-<code>Destination</code></br>
+<code>Destination</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4504,7 +4504,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -4537,7 +4537,7 @@ This includes things like retries, DLQ, etc.</p>
 <tbody>
 <tr>
 <td>
-<code>subscription</code></br>
+<code>subscription</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -4550,7 +4550,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -4584,7 +4584,7 @@ series through Channels and Subscriptions.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -4599,7 +4599,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelSpec">
 ParallelSpec
@@ -4613,7 +4613,7 @@ ParallelSpec
 <table>
 <tr>
 <td>
-<code>branches</code></br>
+<code>branches</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelBranch">
 []ParallelBranch
@@ -4626,7 +4626,7 @@ ParallelSpec
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -4641,7 +4641,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4657,7 +4657,7 @@ when the case does not have a Reply</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelStatus">
 ParallelStatus
@@ -4690,7 +4690,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>filter</code></br>
+<code>filter</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4702,7 +4702,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4713,7 +4713,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4726,7 +4726,7 @@ If not specified, sent the result to the Parallel Reply</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -4761,7 +4761,7 @@ Needed for Roundtripping v1alpha1 &lt;-&gt; v1beta1.</p>
 <tbody>
 <tr>
 <td>
-<code>filterSubscriptionStatus</code></br>
+<code>filterSubscriptionStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
 ParallelSubscriptionStatus
@@ -4774,7 +4774,7 @@ ParallelSubscriptionStatus
 </tr>
 <tr>
 <td>
-<code>filterChannelStatus</code></br>
+<code>filterChannelStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
 ParallelChannelStatus
@@ -4787,7 +4787,7 @@ ParallelChannelStatus
 </tr>
 <tr>
 <td>
-<code>subscriberSubscriptionStatus</code></br>
+<code>subscriberSubscriptionStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelSubscriptionStatus">
 ParallelSubscriptionStatus
@@ -4804,7 +4804,7 @@ ParallelSubscriptionStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>,
+<a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">ParallelBranchStatus</a>, 
 <a href="#flows.knative.dev/v1beta1.ParallelStatus">ParallelStatus</a>)
 </p>
 <p>
@@ -4819,7 +4819,7 @@ ParallelSubscriptionStatus
 <tbody>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -4832,7 +4832,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -4861,7 +4861,7 @@ knative.dev/pkg/apis.Condition
 <tbody>
 <tr>
 <td>
-<code>branches</code></br>
+<code>branches</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelBranch">
 []ParallelBranch
@@ -4874,7 +4874,7 @@ knative.dev/pkg/apis.Condition
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -4889,7 +4889,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -4921,7 +4921,7 @@ when the case does not have a Reply</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -4937,7 +4937,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>ingressChannelStatus</code></br>
+<code>ingressChannelStatus</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelChannelStatus">
 ParallelChannelStatus
@@ -4950,7 +4950,7 @@ ParallelChannelStatus
 </tr>
 <tr>
 <td>
-<code>branchStatuses</code></br>
+<code>branchStatuses</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.ParallelBranchStatus">
 []ParallelBranchStatus
@@ -4964,7 +4964,7 @@ Matches the Spec.Branches array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
@@ -4998,7 +4998,7 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <tbody>
 <tr>
 <td>
-<code>subscription</code></br>
+<code>subscription</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -5011,7 +5011,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -5038,7 +5038,7 @@ series through Channels and Subscriptions.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5053,7 +5053,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.SequenceSpec">
 SequenceSpec
@@ -5067,7 +5067,7 @@ SequenceSpec
 <table>
 <tr>
 <td>
-<code>steps</code></br>
+<code>steps</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.SequenceStep">
 []SequenceStep
@@ -5081,7 +5081,7 @@ provided. Each step has its own delivery options</p>
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -5096,7 +5096,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -5111,7 +5111,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.SequenceStatus">
 SequenceStatus
@@ -5144,7 +5144,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -5157,7 +5157,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -5186,7 +5186,7 @@ knative.dev/pkg/apis.Condition
 <tbody>
 <tr>
 <td>
-<code>steps</code></br>
+<code>steps</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.SequenceStep">
 []SequenceStep
@@ -5200,7 +5200,7 @@ provided. Each step has its own delivery options</p>
 </tr>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -5215,7 +5215,7 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -5246,7 +5246,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -5262,7 +5262,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>subscriptionStatuses</code></br>
+<code>subscriptionStatuses</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.SequenceSubscriptionStatus">
 []SequenceSubscriptionStatus
@@ -5276,7 +5276,7 @@ Matches the Spec.Steps array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>channelStatuses</code></br>
+<code>channelStatuses</code><br/>
 <em>
 <a href="#flows.knative.dev/v1beta1.SequenceChannelStatus">
 []SequenceChannelStatus
@@ -5290,7 +5290,7 @@ Matches the Spec.Steps array in the order.</p>
 </tr>
 <tr>
 <td>
-<code>AddressStatus</code></br>
+<code>AddressStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.AddressStatus
 </em>
@@ -5324,7 +5324,7 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <tbody>
 <tr>
 <td>
-<code>Destination</code></br>
+<code>Destination</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -5338,7 +5338,7 @@ knative.dev/pkg/apis/duck/v1.Destination
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -5371,7 +5371,7 @@ This includes things like retries, DLQ, etc.</p>
 <tbody>
 <tr>
 <td>
-<code>subscription</code></br>
+<code>subscription</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -5384,7 +5384,7 @@ Kubernetes core/v1.ObjectReference
 </tr>
 <tr>
 <td>
-<code>ready</code></br>
+<code>ready</code><br/>
 <em>
 knative.dev/pkg/apis.Condition
 </em>
@@ -5423,7 +5423,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -5433,14 +5433,14 @@ messaging.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Channel</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5455,7 +5455,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelSpec">
 ChannelSpec
@@ -5469,7 +5469,7 @@ ChannelSpec
 <table>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -5483,7 +5483,7 @@ This is immutable after creation. Normally this is set by the Channel defaulter,
 </tr>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
@@ -5502,7 +5502,7 @@ ChannelableSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelStatus">
 ChannelStatus
@@ -5532,7 +5532,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -5542,14 +5542,14 @@ messaging.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>InMemoryChannel</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5564,7 +5564,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.InMemoryChannelSpec">
 InMemoryChannelSpec
@@ -5578,7 +5578,7 @@ InMemoryChannelSpec
 <table>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
@@ -5597,7 +5597,7 @@ ChannelableSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.InMemoryChannelStatus">
 InMemoryChannelStatus
@@ -5628,7 +5628,7 @@ corresponds to the subscriptions.channels.knative.dev CRD.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -5638,14 +5638,14 @@ messaging.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Subscription</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5659,7 +5659,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.SubscriptionSpec">
 SubscriptionSpec
@@ -5672,7 +5672,7 @@ SubscriptionSpec
 <table>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -5699,7 +5699,7 @@ etc.)</p>
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -5713,7 +5713,7 @@ sent to a Destination as specified by the Reply.</p>
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -5726,7 +5726,7 @@ the Subscriber target.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -5743,7 +5743,7 @@ DeliverySpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.SubscriptionStatus">
 SubscriptionStatus
@@ -5781,7 +5781,7 @@ It also defines the ChannelTemplate to use in order to create the CRD Channel ba
 <tbody>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -5795,7 +5795,7 @@ This is immutable after creation. Normally this is set by the Channel defaulter,
 </tr>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
@@ -5830,7 +5830,7 @@ ChannelableSpec
 <tbody>
 <tr>
 <td>
-<code>ChannelableStatus</code></br>
+<code>ChannelableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableStatus">
 ChannelableStatus
@@ -5846,7 +5846,7 @@ ChannelableStatus
 </tr>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -5861,8 +5861,8 @@ knative.dev/pkg/apis/duck/v1.KReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1.ParallelSpec">ParallelSpec</a>,
-<a href="#flows.knative.dev/v1.SequenceSpec">SequenceSpec</a>,
+<a href="#flows.knative.dev/v1.ParallelSpec">ParallelSpec</a>, 
+<a href="#flows.knative.dev/v1.SequenceSpec">SequenceSpec</a>, 
 <a href="#messaging.knative.dev/v1.ChannelSpec">ChannelSpec</a>)
 </p>
 <p>
@@ -5877,7 +5877,7 @@ knative.dev/pkg/apis/duck/v1.KReference
 <tbody>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 k8s.io/apimachinery/pkg/runtime.RawExtension
 </em>
@@ -5910,7 +5910,7 @@ we can easily create new Channels off of it.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -5925,7 +5925,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.ChannelTemplateSpecInternalSpec">
 ChannelTemplateSpecInternalSpec
@@ -5963,7 +5963,7 @@ Note that this struct properly implements only Marshalling, unmarshalling doesn&
 <tbody>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
@@ -5976,7 +5976,7 @@ ChannelableSpec
 </tr>
 <tr>
 <td>
-<code>PhysicalChannelSpec</code></br>
+<code>PhysicalChannelSpec</code><br/>
 <em>
 k8s.io/apimachinery/pkg/runtime.RawExtension
 </em>
@@ -6010,7 +6010,7 @@ arguments for a Channel.</p>
 <tbody>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableSpec">
 ChannelableSpec
@@ -6045,7 +6045,7 @@ ChannelableSpec
 <tbody>
 <tr>
 <td>
-<code>ChannelableStatus</code></br>
+<code>ChannelableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.ChannelableStatus">
 ChannelableStatus
@@ -6091,7 +6091,7 @@ channel &ndash;&gt; reply</p>
 <tbody>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -6118,7 +6118,7 @@ etc.)</p>
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -6132,7 +6132,7 @@ sent to a Destination as specified by the Reply.</p>
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -6145,7 +6145,7 @@ the Subscriber target.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1.DeliverySpec">
 DeliverySpec
@@ -6178,7 +6178,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -6194,7 +6194,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>physicalSubscription</code></br>
+<code>physicalSubscription</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1.SubscriptionStatusPhysicalSubscription">
 SubscriptionStatusPhysicalSubscription
@@ -6227,7 +6227,7 @@ Subscription.</p>
 <tbody>
 <tr>
 <td>
-<code>subscriberUri</code></br>
+<code>subscriberUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -6238,7 +6238,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>replyUri</code></br>
+<code>replyUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -6249,7 +6249,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>deadLetterSinkUri</code></br>
+<code>deadLetterSinkUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -6288,7 +6288,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -6298,14 +6298,14 @@ messaging.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Channel</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -6320,7 +6320,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelSpec">
 ChannelSpec
@@ -6334,7 +6334,7 @@ ChannelSpec
 <table>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -6348,7 +6348,7 @@ This is immutable after creation. Normally this is set by the Channel defaulter,
 </tr>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableSpec">
 ChannelableSpec
@@ -6367,7 +6367,7 @@ ChannelableSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelStatus">
 ChannelStatus
@@ -6397,7 +6397,7 @@ date.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -6407,14 +6407,14 @@ messaging.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>InMemoryChannel</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -6429,7 +6429,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.InMemoryChannelSpec">
 InMemoryChannelSpec
@@ -6443,7 +6443,7 @@ InMemoryChannelSpec
 <table>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableSpec">
 ChannelableSpec
@@ -6462,7 +6462,7 @@ ChannelableSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.InMemoryChannelStatus">
 InMemoryChannelStatus
@@ -6493,7 +6493,7 @@ corresponds to the subscriptions.channels.knative.dev CRD.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -6503,14 +6503,14 @@ messaging.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Subscription</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -6524,7 +6524,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.SubscriptionSpec">
 SubscriptionSpec
@@ -6537,7 +6537,7 @@ SubscriptionSpec
 <table>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -6564,7 +6564,7 @@ etc.)</p>
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -6578,7 +6578,7 @@ sent to a Destination as specified by the Reply.</p>
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -6591,7 +6591,7 @@ the Subscriber target.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -6608,7 +6608,7 @@ DeliverySpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.SubscriptionStatus">
 SubscriptionStatus
@@ -6646,7 +6646,7 @@ It also defines the ChannelTemplate to use in order to create the CRD Channel ba
 <tbody>
 <tr>
 <td>
-<code>channelTemplate</code></br>
+<code>channelTemplate</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.ChannelTemplateSpec">
 ChannelTemplateSpec
@@ -6660,7 +6660,7 @@ This is immutable after creation. Normally this is set by the Channel defaulter,
 </tr>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableSpec">
 ChannelableSpec
@@ -6695,7 +6695,7 @@ ChannelableSpec
 <tbody>
 <tr>
 <td>
-<code>ChannelableStatus</code></br>
+<code>ChannelableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableStatus">
 ChannelableStatus
@@ -6711,7 +6711,7 @@ ChannelableStatus
 </tr>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -6726,8 +6726,8 @@ knative.dev/pkg/apis/duck/v1.KReference
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>,
-<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>,
+<a href="#flows.knative.dev/v1beta1.ParallelSpec">ParallelSpec</a>, 
+<a href="#flows.knative.dev/v1beta1.SequenceSpec">SequenceSpec</a>, 
 <a href="#messaging.knative.dev/v1beta1.ChannelSpec">ChannelSpec</a>)
 </p>
 <p>
@@ -6742,7 +6742,7 @@ knative.dev/pkg/apis/duck/v1.KReference
 <tbody>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 k8s.io/apimachinery/pkg/runtime.RawExtension
 </em>
@@ -6775,7 +6775,7 @@ we can easily create new Channels off of it.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -6790,7 +6790,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 k8s.io/apimachinery/pkg/runtime.RawExtension
 </em>
@@ -6828,7 +6828,7 @@ arguments for a Channel.</p>
 <tbody>
 <tr>
 <td>
-<code>ChannelableSpec</code></br>
+<code>ChannelableSpec</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableSpec">
 ChannelableSpec
@@ -6863,7 +6863,7 @@ ChannelableSpec
 <tbody>
 <tr>
 <td>
-<code>ChannelableStatus</code></br>
+<code>ChannelableStatus</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.ChannelableStatus">
 ChannelableStatus
@@ -6909,7 +6909,7 @@ channel &ndash;&gt; reply</p>
 <tbody>
 <tr>
 <td>
-<code>channel</code></br>
+<code>channel</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -6936,7 +6936,7 @@ etc.)</p>
 </tr>
 <tr>
 <td>
-<code>subscriber</code></br>
+<code>subscriber</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -6950,7 +6950,7 @@ sent to a Destination as specified by the Reply.</p>
 </tr>
 <tr>
 <td>
-<code>reply</code></br>
+<code>reply</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Destination
 </em>
@@ -6963,7 +6963,7 @@ the Subscriber target.</p>
 </tr>
 <tr>
 <td>
-<code>delivery</code></br>
+<code>delivery</code><br/>
 <em>
 <a href="#duck.knative.dev/v1beta1.DeliverySpec">
 DeliverySpec
@@ -6996,7 +6996,7 @@ DeliverySpec
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -7012,7 +7012,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>physicalSubscription</code></br>
+<code>physicalSubscription</code><br/>
 <em>
 <a href="#messaging.knative.dev/v1beta1.SubscriptionStatusPhysicalSubscription">
 SubscriptionStatusPhysicalSubscription
@@ -7045,7 +7045,7 @@ Subscription.</p>
 <tbody>
 <tr>
 <td>
-<code>subscriberUri</code></br>
+<code>subscriberUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -7056,7 +7056,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>replyUri</code></br>
+<code>replyUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -7067,7 +7067,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>deadLetterSinkUri</code></br>
+<code>deadLetterSinkUri</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -7106,7 +7106,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -7116,14 +7116,14 @@ sources.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ApiServerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -7137,7 +7137,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.ApiServerSourceSpec">
 ApiServerSourceSpec
@@ -7150,7 +7150,7 @@ ApiServerSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -7168,7 +7168,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.APIVersionKindSelector">
 []APIVersionKindSelector
@@ -7183,7 +7183,7 @@ selector to help filter.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.APIVersionKind">
 APIVersionKind
@@ -7199,7 +7199,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -7214,7 +7214,7 @@ Defaults to <code>Reference</code></p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -7230,7 +7230,7 @@ source. Defaults to default if not set.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.ApiServerSourceStatus">
 ApiServerSourceStatus
@@ -7257,7 +7257,7 @@ ApiServerSourceStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -7267,14 +7267,14 @@ sources.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ContainerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -7288,7 +7288,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.ContainerSourceSpec">
 ContainerSourceSpec
@@ -7301,7 +7301,7 @@ ContainerSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -7319,7 +7319,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -7335,7 +7335,7 @@ Kubernetes core/v1.PodTemplateSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.ContainerSourceStatus">
 ContainerSourceStatus
@@ -7367,7 +7367,7 @@ cloud events.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -7377,14 +7377,14 @@ sources.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>SinkBinding</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -7398,7 +7398,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.SinkBindingSpec">
 SinkBindingSpec
@@ -7411,7 +7411,7 @@ SinkBindingSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -7429,7 +7429,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.BindingSpec
 </em>
@@ -7448,7 +7448,7 @@ should be augmented by Binding implementations.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.SinkBindingStatus">
 SinkBindingStatus
@@ -7479,7 +7479,7 @@ SinkBindingStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -7490,7 +7490,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -7521,7 +7521,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -7532,7 +7532,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -7544,7 +7544,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -7579,7 +7579,7 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -7597,7 +7597,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.APIVersionKindSelector">
 []APIVersionKindSelector
@@ -7612,7 +7612,7 @@ selector to help filter.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1.APIVersionKind">
 APIVersionKind
@@ -7628,7 +7628,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -7643,7 +7643,7 @@ Defaults to <code>Reference</code></p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -7675,7 +7675,7 @@ source. Defaults to default if not set.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -7714,7 +7714,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -7732,7 +7732,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -7764,7 +7764,7 @@ Kubernetes core/v1.PodTemplateSpec
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -7803,7 +7803,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -7821,7 +7821,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.BindingSpec
 </em>
@@ -7856,7 +7856,7 @@ should be augmented by Binding implementations.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -7902,7 +7902,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -7912,14 +7912,14 @@ sources.knative.dev/v1alpha1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ApiServerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -7933,7 +7933,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">
 ApiServerSourceSpec
@@ -7946,7 +7946,7 @@ ApiServerSourceSpec
 <table>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha1.ApiServerResource">
 []ApiServerResource
@@ -7959,7 +7959,7 @@ ApiServerSourceSpec
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -7972,7 +7972,7 @@ source.</p>
 </tr>
 <tr>
 <td>
-<code>sink</code></br>
+<code>sink</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1beta1.Destination
 </em>
@@ -7984,7 +7984,7 @@ knative.dev/pkg/apis/duck/v1beta1.Destination
 </tr>
 <tr>
 <td>
-<code>ceOverrides</code></br>
+<code>ceOverrides</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.CloudEventOverrides
 </em>
@@ -7997,7 +7997,7 @@ modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.APIVersionKind">
 APIVersionKind
@@ -8013,7 +8013,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -8029,7 +8029,7 @@ string
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha1.ApiServerSourceStatus">
 ApiServerSourceStatus
@@ -8061,7 +8061,7 @@ cloud events.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -8071,14 +8071,14 @@ sources.knative.dev/v1alpha1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>SinkBinding</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -8092,7 +8092,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha1.SinkBindingSpec">
 SinkBindingSpec
@@ -8105,7 +8105,7 @@ SinkBindingSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -8118,7 +8118,7 @@ knative.dev/pkg/apis/duck/v1.SourceSpec
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 </em>
@@ -8134,7 +8134,7 @@ knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha1.SinkBindingStatus">
 SinkBindingStatus
@@ -8165,7 +8165,7 @@ SinkBindingStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -8176,7 +8176,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -8188,7 +8188,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 </tr>
 <tr>
 <td>
-<code>labelSelector</code></br>
+<code>labelSelector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -8202,7 +8202,7 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 </tr>
 <tr>
 <td>
-<code>controllerSelector</code></br>
+<code>controllerSelector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#ownerreference-v1-meta">
 Kubernetes meta/v1.OwnerReference
@@ -8218,7 +8218,7 @@ v1alpha2, please use Spec.Owner as a GKV.</p>
 </tr>
 <tr>
 <td>
-<code>controller</code></br>
+<code>controller</code><br/>
 <em>
 bool
 </em>
@@ -8250,7 +8250,7 @@ v1alpha2, please use Spec.Owner as a GKV.</p>
 <tbody>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha1.ApiServerResource">
 []ApiServerResource
@@ -8263,7 +8263,7 @@ v1alpha2, please use Spec.Owner as a GKV.</p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -8276,7 +8276,7 @@ source.</p>
 </tr>
 <tr>
 <td>
-<code>sink</code></br>
+<code>sink</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1beta1.Destination
 </em>
@@ -8288,7 +8288,7 @@ knative.dev/pkg/apis/duck/v1beta1.Destination
 </tr>
 <tr>
 <td>
-<code>ceOverrides</code></br>
+<code>ceOverrides</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.CloudEventOverrides
 </em>
@@ -8301,7 +8301,7 @@ modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.APIVersionKind">
 APIVersionKind
@@ -8317,7 +8317,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -8349,7 +8349,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -8388,7 +8388,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -8401,7 +8401,7 @@ knative.dev/pkg/apis/duck/v1.SourceSpec
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 </em>
@@ -8433,7 +8433,7 @@ knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -8476,7 +8476,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -8486,14 +8486,14 @@ sources.knative.dev/v1alpha2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ApiServerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -8507,7 +8507,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">
 ApiServerSourceSpec
@@ -8520,7 +8520,7 @@ ApiServerSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -8538,7 +8538,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
 []APIVersionKindSelector
@@ -8553,7 +8553,7 @@ selector to help filter.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.APIVersionKind">
 APIVersionKind
@@ -8569,7 +8569,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -8584,7 +8584,7 @@ Defaults to <code>Reference</code></p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -8600,7 +8600,7 @@ source. Defaults to default if not set.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.ApiServerSourceStatus">
 ApiServerSourceStatus
@@ -8627,7 +8627,7 @@ ApiServerSourceStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -8637,14 +8637,14 @@ sources.knative.dev/v1alpha2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ContainerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -8658,7 +8658,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.ContainerSourceSpec">
 ContainerSourceSpec
@@ -8671,7 +8671,7 @@ ContainerSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -8689,7 +8689,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -8705,7 +8705,7 @@ Kubernetes core/v1.PodTemplateSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.ContainerSourceStatus">
 ContainerSourceStatus
@@ -8732,7 +8732,7 @@ ContainerSourceStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -8742,14 +8742,14 @@ sources.knative.dev/v1alpha2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>PingSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -8763,7 +8763,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.PingSourceSpec">
 PingSourceSpec
@@ -8776,7 +8776,7 @@ PingSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -8794,7 +8794,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br/>
 <em>
 string
 </em>
@@ -8806,7 +8806,7 @@ string
 </tr>
 <tr>
 <td>
-<code>jsonData</code></br>
+<code>jsonData</code><br/>
 <em>
 string
 </em>
@@ -8823,7 +8823,7 @@ to &ldquo;application/json&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.PingSourceStatus">
 PingSourceStatus
@@ -8855,7 +8855,7 @@ cloud events.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -8865,14 +8865,14 @@ sources.knative.dev/v1alpha2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>SinkBinding</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -8886,7 +8886,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.SinkBindingSpec">
 SinkBindingSpec
@@ -8899,7 +8899,7 @@ SinkBindingSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -8917,7 +8917,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 </em>
@@ -8936,7 +8936,7 @@ should be augmented by Binding implementations.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.SinkBindingStatus">
 SinkBindingStatus
@@ -8952,7 +8952,7 @@ SinkBindingStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>,
+<a href="#sources.knative.dev/v1alpha1.ApiServerSourceSpec">ApiServerSourceSpec</a>, 
 <a href="#sources.knative.dev/v1alpha2.ApiServerSourceSpec">ApiServerSourceSpec</a>)
 </p>
 <p>
@@ -8968,7 +8968,7 @@ SinkBindingStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -8979,7 +8979,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -9010,7 +9010,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -9021,7 +9021,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -9033,7 +9033,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -9068,7 +9068,7 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9086,7 +9086,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.APIVersionKindSelector">
 []APIVersionKindSelector
@@ -9101,7 +9101,7 @@ selector to help filter.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1alpha2.APIVersionKind">
 APIVersionKind
@@ -9117,7 +9117,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -9132,7 +9132,7 @@ Defaults to <code>Reference</code></p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -9164,7 +9164,7 @@ source. Defaults to default if not set.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -9203,7 +9203,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9221,7 +9221,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -9253,7 +9253,7 @@ Kubernetes core/v1.PodTemplateSpec
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -9292,7 +9292,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9310,7 +9310,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br/>
 <em>
 string
 </em>
@@ -9322,7 +9322,7 @@ string
 </tr>
 <tr>
 <td>
-<code>jsonData</code></br>
+<code>jsonData</code><br/>
 <em>
 string
 </em>
@@ -9355,7 +9355,7 @@ to &ldquo;application/json&rdquo;.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -9394,7 +9394,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9412,7 +9412,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 </em>
@@ -9447,7 +9447,7 @@ should be augmented by Binding implementations.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -9497,7 +9497,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -9507,14 +9507,14 @@ sources.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ApiServerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -9528,7 +9528,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.ApiServerSourceSpec">
 ApiServerSourceSpec
@@ -9541,7 +9541,7 @@ ApiServerSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9559,7 +9559,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.APIVersionKindSelector">
 []APIVersionKindSelector
@@ -9574,7 +9574,7 @@ selector to help filter.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.APIVersionKind">
 APIVersionKind
@@ -9590,7 +9590,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -9605,7 +9605,7 @@ Defaults to <code>Reference</code></p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -9621,7 +9621,7 @@ source. Defaults to default if not set.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.ApiServerSourceStatus">
 ApiServerSourceStatus
@@ -9648,7 +9648,7 @@ ApiServerSourceStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -9658,14 +9658,14 @@ sources.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>ContainerSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -9679,7 +9679,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.ContainerSourceSpec">
 ContainerSourceSpec
@@ -9692,7 +9692,7 @@ ContainerSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9710,7 +9710,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -9726,7 +9726,7 @@ Kubernetes core/v1.PodTemplateSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.ContainerSourceStatus">
 ContainerSourceStatus
@@ -9753,7 +9753,7 @@ ContainerSourceStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -9763,14 +9763,14 @@ sources.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>PingSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -9784,7 +9784,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.PingSourceSpec">
 PingSourceSpec
@@ -9797,7 +9797,7 @@ PingSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9815,7 +9815,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br/>
 <em>
 string
 </em>
@@ -9827,7 +9827,7 @@ string
 </tr>
 <tr>
 <td>
-<code>timezone</code></br>
+<code>timezone</code><br/>
 <em>
 string
 </em>
@@ -9841,7 +9841,7 @@ List of valid timezone values: <a href="https://en.wikipedia.org/wiki/List_of_tz
 </tr>
 <tr>
 <td>
-<code>jsonData</code></br>
+<code>jsonData</code><br/>
 <em>
 string
 </em>
@@ -9858,7 +9858,7 @@ to &ldquo;application/json&rdquo;.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.PingSourceStatus">
 PingSourceStatus
@@ -9890,7 +9890,7 @@ cloud events.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -9900,14 +9900,14 @@ sources.knative.dev/v1beta1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>SinkBinding</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -9921,7 +9921,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.SinkBindingSpec">
 SinkBindingSpec
@@ -9934,7 +9934,7 @@ SinkBindingSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -9952,7 +9952,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1beta1.BindingSpec
 </em>
@@ -9971,7 +9971,7 @@ should be augmented by Binding implementations.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.SinkBindingStatus">
 SinkBindingStatus
@@ -10002,7 +10002,7 @@ SinkBindingStatus
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -10013,7 +10013,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -10044,7 +10044,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 <em>
 string
 </em>
@@ -10055,7 +10055,7 @@ string
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 <em>
 string
 </em>
@@ -10067,7 +10067,7 @@ More info: <a href="https://git.k8s.io/community/contributors/devel/sig-architec
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -10102,7 +10102,7 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -10120,7 +10120,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>resources</code></br>
+<code>resources</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.APIVersionKindSelector">
 []APIVersionKindSelector
@@ -10135,7 +10135,7 @@ selector to help filter.</p>
 </tr>
 <tr>
 <td>
-<code>owner</code></br>
+<code>owner</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta1.APIVersionKind">
 APIVersionKind
@@ -10151,7 +10151,7 @@ then Resources[n] is allowed to pass the ResourceOwner filter.</p>
 </tr>
 <tr>
 <td>
-<code>mode</code></br>
+<code>mode</code><br/>
 <em>
 string
 </em>
@@ -10166,7 +10166,7 @@ Defaults to <code>Reference</code></p>
 </tr>
 <tr>
 <td>
-<code>serviceAccountName</code></br>
+<code>serviceAccountName</code><br/>
 <em>
 string
 </em>
@@ -10198,7 +10198,7 @@ source. Defaults to default if not set.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -10237,7 +10237,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -10255,7 +10255,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -10287,7 +10287,7 @@ Kubernetes core/v1.PodTemplateSpec
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -10326,7 +10326,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -10344,7 +10344,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br/>
 <em>
 string
 </em>
@@ -10356,7 +10356,7 @@ string
 </tr>
 <tr>
 <td>
-<code>timezone</code></br>
+<code>timezone</code><br/>
 <em>
 string
 </em>
@@ -10370,7 +10370,7 @@ List of valid timezone values: <a href="https://en.wikipedia.org/wiki/List_of_tz
 </tr>
 <tr>
 <td>
-<code>jsonData</code></br>
+<code>jsonData</code><br/>
 <em>
 string
 </em>
@@ -10403,7 +10403,7 @@ to &ldquo;application/json&rdquo;.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -10442,7 +10442,7 @@ Source.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -10460,7 +10460,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>BindingSpec</code></br>
+<code>BindingSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1beta1.BindingSpec
 </em>
@@ -10495,7 +10495,7 @@ should be augmented by Binding implementations.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>
@@ -10539,7 +10539,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -10549,14 +10549,14 @@ sources.knative.dev/v1beta2
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>PingSource</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -10570,7 +10570,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta2.PingSourceSpec">
 PingSourceSpec
@@ -10583,7 +10583,7 @@ PingSourceSpec
 <table>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -10601,7 +10601,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br/>
 <em>
 string
 </em>
@@ -10613,7 +10613,7 @@ string
 </tr>
 <tr>
 <td>
-<code>timezone</code></br>
+<code>timezone</code><br/>
 <em>
 string
 </em>
@@ -10627,7 +10627,7 @@ List of valid timezone values: <a href="https://en.wikipedia.org/wiki/List_of_tz
 </tr>
 <tr>
 <td>
-<code>contentType</code></br>
+<code>contentType</code><br/>
 <em>
 string
 </em>
@@ -10639,7 +10639,7 @@ string
 </tr>
 <tr>
 <td>
-<code>data</code></br>
+<code>data</code><br/>
 <em>
 string
 </em>
@@ -10652,7 +10652,7 @@ Mutually exclusive with DataBase64.</p>
 </tr>
 <tr>
 <td>
-<code>dataBase64</code></br>
+<code>dataBase64</code><br/>
 <em>
 string
 </em>
@@ -10668,7 +10668,7 @@ Mutually exclusive with Data.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#sources.knative.dev/v1beta2.PingSourceStatus">
 PingSourceStatus
@@ -10699,7 +10699,7 @@ PingSourceStatus
 <tbody>
 <tr>
 <td>
-<code>SourceSpec</code></br>
+<code>SourceSpec</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceSpec
 </em>
@@ -10717,7 +10717,7 @@ and modifications of the event sent to the sink.</p>
 </tr>
 <tr>
 <td>
-<code>schedule</code></br>
+<code>schedule</code><br/>
 <em>
 string
 </em>
@@ -10729,7 +10729,7 @@ string
 </tr>
 <tr>
 <td>
-<code>timezone</code></br>
+<code>timezone</code><br/>
 <em>
 string
 </em>
@@ -10743,7 +10743,7 @@ List of valid timezone values: <a href="https://en.wikipedia.org/wiki/List_of_tz
 </tr>
 <tr>
 <td>
-<code>contentType</code></br>
+<code>contentType</code><br/>
 <em>
 string
 </em>
@@ -10755,7 +10755,7 @@ string
 </tr>
 <tr>
 <td>
-<code>data</code></br>
+<code>data</code><br/>
 <em>
 string
 </em>
@@ -10768,7 +10768,7 @@ Mutually exclusive with DataBase64.</p>
 </tr>
 <tr>
 <td>
-<code>dataBase64</code></br>
+<code>dataBase64</code><br/>
 <em>
 string
 </em>
@@ -10800,7 +10800,7 @@ Mutually exclusive with Data.</p>
 <tbody>
 <tr>
 <td>
-<code>SourceStatus</code></br>
+<code>SourceStatus</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.SourceStatus
 </em>

--- a/docs/reference/api/serving.md
+++ b/docs/reference/api/serving.md
@@ -36,7 +36,7 @@ by multiple definitions.  For more information, see the Knative Pluggability pre
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -46,14 +46,14 @@ autoscaling.internal.knative.dev/v1alpha1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>PodAutoscaler</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -68,7 +68,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerSpec">
 PodAutoscalerSpec
@@ -83,7 +83,7 @@ PodAutoscalerSpec
 <table>
 <tr>
 <td>
-<code>containerConcurrency</code></br>
+<code>containerConcurrency</code><br/>
 <em>
 int64
 </em>
@@ -97,7 +97,7 @@ Defaults to <code>0</code> which means unlimited concurrency.</p>
 </tr>
 <tr>
 <td>
-<code>scaleTargetRef</code></br>
+<code>scaleTargetRef</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -111,7 +111,7 @@ is responsible for quickly right-sizing.</p>
 </tr>
 <tr>
 <td>
-<code>reachability</code></br>
+<code>reachability</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.ReachabilityType">
 ReachabilityType
@@ -126,7 +126,7 @@ Defaults to <code>ReachabilityUnknown</code></p>
 </tr>
 <tr>
 <td>
-<code>protocolType</code></br>
+<code>protocolType</code><br/>
 <em>
 knative.dev/networking/pkg/apis/networking.ProtocolType
 </em>
@@ -140,7 +140,7 @@ knative.dev/networking/pkg/apis/networking.ProtocolType
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.PodAutoscalerStatus">
 PodAutoscalerStatus
@@ -169,7 +169,7 @@ PodAutoscalerStatus
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -184,7 +184,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.MetricSpec">
 MetricSpec
@@ -199,7 +199,7 @@ MetricSpec
 <table>
 <tr>
 <td>
-<code>stableWindow</code></br>
+<code>stableWindow</code><br/>
 <em>
 time.Duration
 </em>
@@ -210,7 +210,7 @@ time.Duration
 </tr>
 <tr>
 <td>
-<code>panicWindow</code></br>
+<code>panicWindow</code><br/>
 <em>
 time.Duration
 </em>
@@ -221,7 +221,7 @@ time.Duration
 </tr>
 <tr>
 <td>
-<code>scrapeTarget</code></br>
+<code>scrapeTarget</code><br/>
 <em>
 string
 </em>
@@ -235,7 +235,7 @@ string
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.MetricStatus">
 MetricStatus
@@ -268,7 +268,7 @@ MetricStatus
 <tbody>
 <tr>
 <td>
-<code>stableWindow</code></br>
+<code>stableWindow</code><br/>
 <em>
 time.Duration
 </em>
@@ -279,7 +279,7 @@ time.Duration
 </tr>
 <tr>
 <td>
-<code>panicWindow</code></br>
+<code>panicWindow</code><br/>
 <em>
 time.Duration
 </em>
@@ -290,7 +290,7 @@ time.Duration
 </tr>
 <tr>
 <td>
-<code>scrapeTarget</code></br>
+<code>scrapeTarget</code><br/>
 <em>
 string
 </em>
@@ -320,7 +320,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -352,7 +352,7 @@ knative.dev/pkg/apis/duck/v1.Status
 <tbody>
 <tr>
 <td>
-<code>containerConcurrency</code></br>
+<code>containerConcurrency</code><br/>
 <em>
 int64
 </em>
@@ -366,7 +366,7 @@ Defaults to <code>0</code> which means unlimited concurrency.</p>
 </tr>
 <tr>
 <td>
-<code>scaleTargetRef</code></br>
+<code>scaleTargetRef</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectreference-v1-core">
 Kubernetes core/v1.ObjectReference
@@ -380,7 +380,7 @@ is responsible for quickly right-sizing.</p>
 </tr>
 <tr>
 <td>
-<code>reachability</code></br>
+<code>reachability</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.ReachabilityType">
 ReachabilityType
@@ -395,7 +395,7 @@ Defaults to <code>ReachabilityUnknown</code></p>
 </tr>
 <tr>
 <td>
-<code>protocolType</code></br>
+<code>protocolType</code><br/>
 <em>
 knative.dev/networking/pkg/apis/networking.ProtocolType
 </em>
@@ -425,7 +425,7 @@ knative.dev/networking/pkg/apis/networking.ProtocolType
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -438,7 +438,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br/>
 <em>
 string
 </em>
@@ -450,7 +450,7 @@ The service is created and owned by the ServerlessService object owned by this P
 </tr>
 <tr>
 <td>
-<code>metricsServiceName</code></br>
+<code>metricsServiceName</code><br/>
 <em>
 string
 </em>
@@ -462,7 +462,7 @@ The service is managed by the PA object.</p>
 </tr>
 <tr>
 <td>
-<code>desiredScale</code></br>
+<code>desiredScale</code><br/>
 <em>
 int32
 </em>
@@ -473,7 +473,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>actualScale</code></br>
+<code>actualScale</code><br/>
 <em>
 int32
 </em>
@@ -503,7 +503,7 @@ the referenced resources may take.</p>
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -517,7 +517,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.PodScalableSpec">
 PodScalableSpec
@@ -530,7 +530,7 @@ PodScalableSpec
 <table>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br/>
 <em>
 int32
 </em>
@@ -540,7 +540,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -552,7 +552,7 @@ Kubernetes meta/v1.LabelSelector
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -567,7 +567,7 @@ Kubernetes core/v1.PodTemplateSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#autoscaling.internal.knative.dev/v1alpha1.PodScalableStatus">
 PodScalableStatus
@@ -599,7 +599,7 @@ PodScalable (or at least our shared portion).</p>
 <tbody>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br/>
 <em>
 int32
 </em>
@@ -609,7 +609,7 @@ int32
 </tr>
 <tr>
 <td>
-<code>selector</code></br>
+<code>selector</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#labelselector-v1-meta">
 Kubernetes meta/v1.LabelSelector
@@ -621,7 +621,7 @@ Kubernetes meta/v1.LabelSelector
 </tr>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podtemplatespec-v1-core">
 Kubernetes core/v1.PodTemplateSpec
@@ -653,7 +653,7 @@ least our shared portion).</p>
 <tbody>
 <tr>
 <td>
-<code>replicas</code></br>
+<code>replicas</code><br/>
 <em>
 int32
 </em>
@@ -726,7 +726,7 @@ See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/over
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -736,14 +736,14 @@ serving.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Configuration</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -758,7 +758,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ConfigurationSpec">
 ConfigurationSpec
@@ -772,7 +772,7 @@ ConfigurationSpec
 <table>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">
 RevisionTemplateSpec
@@ -789,7 +789,7 @@ RevisionTemplateSpec
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ConfigurationStatus">
 ConfigurationStatus
@@ -820,7 +820,7 @@ Configuration.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -830,14 +830,14 @@ serving.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Revision</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -852,7 +852,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RevisionSpec">
 RevisionSpec
@@ -866,7 +866,7 @@ RevisionSpec
 <table>
 <tr>
 <td>
-<code>PodSpec</code></br>
+<code>PodSpec</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
 Kubernetes core/v1.PodSpec
@@ -881,7 +881,7 @@ Kubernetes core/v1.PodSpec
 </tr>
 <tr>
 <td>
-<code>containerConcurrency</code></br>
+<code>containerConcurrency</code><br/>
 <em>
 int64
 </em>
@@ -896,7 +896,7 @@ target concurrency for the autoscaler.</p>
 </tr>
 <tr>
 <td>
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br/>
 <em>
 int64
 </em>
@@ -913,7 +913,7 @@ be provided.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RevisionStatus">
 RevisionStatus
@@ -946,7 +946,7 @@ See also: <a href="https://github.com/knative/serving/blob/master/docs/spec/over
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -956,14 +956,14 @@ serving.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Route</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -978,7 +978,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RouteSpec">
 RouteSpec
@@ -993,7 +993,7 @@ RouteSpec
 <table>
 <tr>
 <td>
-<code>traffic</code></br>
+<code>traffic</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.TrafficTarget">
 []TrafficTarget
@@ -1011,7 +1011,7 @@ revisions and configurations.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RouteStatus">
 RouteStatus
@@ -1049,7 +1049,7 @@ and Route, reflecting their statuses and conditions as its own.</p>
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -1059,14 +1059,14 @@ serving.knative.dev/v1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>Service</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1081,7 +1081,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ServiceSpec">
 ServiceSpec
@@ -1095,7 +1095,7 @@ ServiceSpec
 <table>
 <tr>
 <td>
-<code>ConfigurationSpec</code></br>
+<code>ConfigurationSpec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ConfigurationSpec">
 ConfigurationSpec
@@ -1111,7 +1111,7 @@ ConfigurationSpec
 </tr>
 <tr>
 <td>
-<code>RouteSpec</code></br>
+<code>RouteSpec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RouteSpec">
 RouteSpec
@@ -1133,7 +1133,7 @@ defaults).</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ServiceStatus">
 ServiceStatus
@@ -1150,7 +1150,7 @@ ServiceStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Configuration">Configuration</a>,
+<a href="#serving.knative.dev/v1.Configuration">Configuration</a>, 
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -1166,7 +1166,7 @@ ServiceStatus
 <tbody>
 <tr>
 <td>
-<code>template</code></br>
+<code>template</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">
 RevisionTemplateSpec
@@ -1199,7 +1199,7 @@ RevisionTemplateSpec
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -1212,7 +1212,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>ConfigurationStatusFields</code></br>
+<code>ConfigurationStatusFields</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ConfigurationStatusFields">
 ConfigurationStatusFields
@@ -1231,7 +1231,7 @@ ConfigurationStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.ConfigurationStatus">ConfigurationStatus</a>,
+<a href="#serving.knative.dev/v1.ConfigurationStatus">ConfigurationStatus</a>, 
 <a href="#serving.knative.dev/v1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -1249,7 +1249,7 @@ other types can readily consume these fields via duck typing.</p>
 <tbody>
 <tr>
 <td>
-<code>latestReadyRevisionName</code></br>
+<code>latestReadyRevisionName</code><br/>
 <em>
 string
 </em>
@@ -1262,7 +1262,7 @@ from this Configuration that has had its &ldquo;Ready&rdquo; condition become &l
 </tr>
 <tr>
 <td>
-<code>latestCreatedRevisionName</code></br>
+<code>latestCreatedRevisionName</code><br/>
 <em>
 string
 </em>
@@ -1294,7 +1294,7 @@ Configuration. It might not be ready yet, for that use LatestReadyRevisionName.<
 <tbody>
 <tr>
 <td>
-<code>name</code></br>
+<code>name</code><br/>
 <em>
 string
 </em>
@@ -1304,7 +1304,7 @@ string
 </tr>
 <tr>
 <td>
-<code>imageDigest</code></br>
+<code>imageDigest</code><br/>
 <em>
 string
 </em>
@@ -1318,7 +1318,7 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Revision">Revision</a>,
+<a href="#serving.knative.dev/v1.Revision">Revision</a>, 
 <a href="#serving.knative.dev/v1.RevisionTemplateSpec">RevisionTemplateSpec</a>)
 </p>
 <p>
@@ -1334,7 +1334,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>PodSpec</code></br>
+<code>PodSpec</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
 Kubernetes core/v1.PodSpec
@@ -1349,7 +1349,7 @@ Kubernetes core/v1.PodSpec
 </tr>
 <tr>
 <td>
-<code>containerConcurrency</code></br>
+<code>containerConcurrency</code><br/>
 <em>
 int64
 </em>
@@ -1364,7 +1364,7 @@ target concurrency for the autoscaler.</p>
 </tr>
 <tr>
 <td>
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br/>
 <em>
 int64
 </em>
@@ -1397,7 +1397,7 @@ be provided.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -1410,7 +1410,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>serviceName</code></br>
+<code>serviceName</code><br/>
 <em>
 string
 </em>
@@ -1423,7 +1423,7 @@ load balances over the pods backing this Revision.</p>
 </tr>
 <tr>
 <td>
-<code>logUrl</code></br>
+<code>logUrl</code><br/>
 <em>
 string
 </em>
@@ -1436,7 +1436,7 @@ based on the revision url template specified in the controller&rsquo;s config.</
 </tr>
 <tr>
 <td>
-<code>imageDigest</code></br>
+<code>imageDigest</code><br/>
 <em>
 string
 </em>
@@ -1457,7 +1457,7 @@ ref <a href="https://kubernetes.io/docs/reference/using-api/deprecation-policy">
 </tr>
 <tr>
 <td>
-<code>containerStatuses</code></br>
+<code>containerStatuses</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ContainerStatus">
 []ContainerStatus
@@ -1496,7 +1496,7 @@ Based on: <a href="https://github.com/kubernetes/api/blob/e771f807/core/v1/types
 <tbody>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -1511,7 +1511,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RevisionSpec">
 RevisionSpec
@@ -1525,7 +1525,7 @@ RevisionSpec
 <table>
 <tr>
 <td>
-<code>PodSpec</code></br>
+<code>PodSpec</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core">
 Kubernetes core/v1.PodSpec
@@ -1540,7 +1540,7 @@ Kubernetes core/v1.PodSpec
 </tr>
 <tr>
 <td>
-<code>containerConcurrency</code></br>
+<code>containerConcurrency</code><br/>
 <em>
 int64
 </em>
@@ -1555,7 +1555,7 @@ target concurrency for the autoscaler.</p>
 </tr>
 <tr>
 <td>
-<code>timeoutSeconds</code></br>
+<code>timeoutSeconds</code><br/>
 <em>
 int64
 </em>
@@ -1576,7 +1576,7 @@ be provided.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.Route">Route</a>,
+<a href="#serving.knative.dev/v1.Route">Route</a>, 
 <a href="#serving.knative.dev/v1.ServiceSpec">ServiceSpec</a>)
 </p>
 <p>
@@ -1592,7 +1592,7 @@ be provided.</p>
 <tbody>
 <tr>
 <td>
-<code>traffic</code></br>
+<code>traffic</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.TrafficTarget">
 []TrafficTarget
@@ -1626,7 +1626,7 @@ revisions and configurations.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -1639,7 +1639,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>RouteStatusFields</code></br>
+<code>RouteStatusFields</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RouteStatusFields">
 RouteStatusFields
@@ -1658,7 +1658,7 @@ RouteStatusFields
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.RouteStatus">RouteStatus</a>,
+<a href="#serving.knative.dev/v1.RouteStatus">RouteStatus</a>, 
 <a href="#serving.knative.dev/v1.ServiceStatus">ServiceStatus</a>)
 </p>
 <p>
@@ -1676,7 +1676,7 @@ other types can readily consume these fields via duck typing.</p>
 <tbody>
 <tr>
 <td>
-<code>url</code></br>
+<code>url</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -1689,7 +1689,7 @@ It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-leve
 </tr>
 <tr>
 <td>
-<code>address</code></br>
+<code>address</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Addressable
 </em>
@@ -1701,7 +1701,7 @@ knative.dev/pkg/apis/duck/v1.Addressable
 </tr>
 <tr>
 <td>
-<code>traffic</code></br>
+<code>traffic</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.TrafficTarget">
 []TrafficTarget
@@ -1772,7 +1772,7 @@ the appropriate &ldquo;run latest&rdquo; spec.</p>
 <tbody>
 <tr>
 <td>
-<code>ConfigurationSpec</code></br>
+<code>ConfigurationSpec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ConfigurationSpec">
 ConfigurationSpec
@@ -1788,7 +1788,7 @@ ConfigurationSpec
 </tr>
 <tr>
 <td>
-<code>RouteSpec</code></br>
+<code>RouteSpec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RouteSpec">
 RouteSpec
@@ -1826,7 +1826,7 @@ defaults).</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -1839,7 +1839,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>ConfigurationStatusFields</code></br>
+<code>ConfigurationStatusFields</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.ConfigurationStatusFields">
 ConfigurationStatusFields
@@ -1856,7 +1856,7 @@ specific to ConfigurationStatus.</p>
 </tr>
 <tr>
 <td>
-<code>RouteStatusFields</code></br>
+<code>RouteStatusFields</code><br/>
 <em>
 <a href="#serving.knative.dev/v1.RouteStatusFields">
 RouteStatusFields
@@ -1877,7 +1877,7 @@ specific to RouteStatus.</p>
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#serving.knative.dev/v1.RouteSpec">RouteSpec</a>,
+<a href="#serving.knative.dev/v1.RouteSpec">RouteSpec</a>, 
 <a href="#serving.knative.dev/v1.RouteStatusFields">RouteStatusFields</a>)
 </p>
 <p>
@@ -1893,7 +1893,7 @@ specific to RouteStatus.</p>
 <tbody>
 <tr>
 <td>
-<code>tag</code></br>
+<code>tag</code><br/>
 <em>
 string
 </em>
@@ -1906,7 +1906,7 @@ this target exclusively.</p>
 </tr>
 <tr>
 <td>
-<code>revisionName</code></br>
+<code>revisionName</code><br/>
 <em>
 string
 </em>
@@ -1919,7 +1919,7 @@ traffic.  This is mutually exclusive with ConfigurationName.</p>
 </tr>
 <tr>
 <td>
-<code>configurationName</code></br>
+<code>configurationName</code><br/>
 <em>
 string
 </em>
@@ -1936,7 +1936,7 @@ RevisionName.</p>
 </tr>
 <tr>
 <td>
-<code>latestRevision</code></br>
+<code>latestRevision</code><br/>
 <em>
 bool
 </em>
@@ -1951,7 +1951,7 @@ empty; it must be false when RevisionName is non-empty.</p>
 </tr>
 <tr>
 <td>
-<code>percent</code></br>
+<code>percent</code><br/>
 <em>
 int64
 </em>
@@ -1970,7 +1970,7 @@ that particular Revision or Configuration</p>
 </tr>
 <tr>
 <td>
-<code>url</code></br>
+<code>url</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -2011,7 +2011,7 @@ Resource Types:
 <tbody>
 <tr>
 <td>
-<code>apiVersion</code></br>
+<code>apiVersion</code><br/>
 string</td>
 <td>
 <code>
@@ -2021,14 +2021,14 @@ serving.knative.dev/v1alpha1
 </tr>
 <tr>
 <td>
-<code>kind</code></br>
+<code>kind</code><br/>
 string
 </td>
 <td><code>DomainMapping</code></td>
 </tr>
 <tr>
 <td>
-<code>metadata</code></br>
+<code>metadata</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
@@ -2045,7 +2045,7 @@ Refer to the Kubernetes API documentation for the fields of the
 </tr>
 <tr>
 <td>
-<code>spec</code></br>
+<code>spec</code><br/>
 <em>
 <a href="#serving.knative.dev/v1alpha1.DomainMappingSpec">
 DomainMappingSpec
@@ -2061,7 +2061,7 @@ More info: <a href="https://github.com/kubernetes/community/blob/master/contribu
 <table>
 <tr>
 <td>
-<code>ref</code></br>
+<code>ref</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -2076,7 +2076,7 @@ Currently, Ref must be a KSvc.</p>
 </tr>
 <tr>
 <td>
-<code>status</code></br>
+<code>status</code><br/>
 <em>
 <a href="#serving.knative.dev/v1alpha1.DomainMappingStatus">
 DomainMappingStatus
@@ -2106,7 +2106,7 @@ More info: <a href="https://github.com/kubernetes/community/blob/master/contribu
 <tbody>
 <tr>
 <td>
-<code>Message</code></br>
+<code>Message</code><br/>
 <em>
 string
 </em>
@@ -2116,7 +2116,7 @@ string
 </tr>
 <tr>
 <td>
-<code>Field</code></br>
+<code>Field</code><br/>
 <em>
 string
 </em>
@@ -2145,7 +2145,7 @@ string
 <tbody>
 <tr>
 <td>
-<code>ref</code></br>
+<code>ref</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.KReference
 </em>
@@ -2176,7 +2176,7 @@ Currently, Ref must be a KSvc.</p>
 <tbody>
 <tr>
 <td>
-<code>Status</code></br>
+<code>Status</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Status
 </em>
@@ -2189,7 +2189,7 @@ knative.dev/pkg/apis/duck/v1.Status
 </tr>
 <tr>
 <td>
-<code>url</code></br>
+<code>url</code><br/>
 <em>
 knative.dev/pkg/apis.URL
 </em>
@@ -2201,7 +2201,7 @@ knative.dev/pkg/apis.URL
 </tr>
 <tr>
 <td>
-<code>address</code></br>
+<code>address</code><br/>
 <em>
 knative.dev/pkg/apis/duck/v1.Addressable
 </em>

--- a/hack/gen-api-reference-docs.sh
+++ b/hack/gen-api-reference-docs.sh
@@ -23,7 +23,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 REFDOCS_PKG="github.com/ahmetb/gen-crd-api-reference-docs"
 REFDOCS_REPO="https://${REFDOCS_PKG}.git"
-REFDOCS_VER="df869c1245d4ba97142a224ab81e5ced86094bba"
+REFDOCS_VER="v0.3.0"
 
 KNATIVE_SERVING_REPO="github.com/knative/serving"
 KNATIVE_SERVING_IMPORT_PATH="knative.dev/serving"
@@ -69,16 +69,6 @@ repo_tarball_url() {
     repo="$1"
     commit="$2"
     echo "https://$repo/archive/$commit.tar.gz"
-}
-
-dl_and_extract() {
-    # TODO(ahmetb) remove this function. no longer dl'ing tarballs since they
-    # won't have a .git dir to infer the commit ID from to be used by refdocs.
-    local url dest
-    url="$1"
-    dest="$2"
-    mkdir -p "${dest}"
-    curl -sSLf "$url" | tar zxf - --directory="$dest"  --strip 1
 }
 
 clone_at_commit() {


### PR DESCRIPTION
Updating the tool version to v0.3.0 tag.
Ran locally against v0.20.0 tag for serving/eventing repos, seems to be
working fine.

cc: @RichieEscarez 