### PR TITLE
Describe new ce-knativedispatcherr cloudevent extension attribute

### DIFF
--- a/docs/eventing/channels/channels-crds.md
+++ b/docs/eventing/channels/channels-crds.md
@@ -28,8 +28,8 @@ Name | Status | Support | Description
 --- | --- | --- | ---
 [GCP PubSub](https://github.com/google/knative-gcp) | Proof of Concept | None | Channels are backed by [GCP PubSub](https://cloud.google.com/pubsub/).
 [InMemoryChannel](https://github.com/knative/eventing/tree/{{< branch >}}/config/channels/in-memory-channel/README.md) | Proof of Concept | None | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
-[KafkaChannel](https://github.com/knative-sandbox/eventing-kafka/tree/{{< branch >}}/pkg/channel/consolidated/README.md) | Proof of Concept | None | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
-[Knative sandbox channel that uses Confluent Go Client, and the librdkafka C library](https://github.com/knative-sandbox/eventing-kafka) | Proof of Concept | None | Kafka Channel implementation, contributed by SAP's Kyma project, is a Knative Eventing implementation of a Kafka backed channel which provides advanced functionality and production grade qualities as an alternative to what the eventing-contrib/kafka implementation offers.
+[KafkaChannel - Consolidated](https://github.com/knative-sandbox/eventing-kafka/tree/{{< branch >}}/pkg/channel/consolidated/README.md) | Proof of Concept | None | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics. The original Knative KafkaChannel implementation which utilizes a single combined Kafka Producer / Consumer deployment.
+[KafkaChannel - Distributed](https://github.com/knative-sandbox/eventing-kafka/tree/{{< branch >}}/pkg/channel/distributed/README.md) | Proof of Concept | None | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics. An alternate KafkaChannel implementation, contributed by SAP's [Kyma](https://kyma-project.io/) project, which provides a more granular deployment of Producers / Consumers.
 [NatssChannel](https://github.com/knative-sandbox/eventing-natss/tree/{{< branch >}}/config/README.md) | Proof of Concept | None | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
 
 

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -90,6 +90,21 @@ spec:
     backoffDelay: <ISO8601 duration>
 ```
 
+Failed events may, depending on the specific Channel implementation, be
+enhanced with an extension attribute prior to forwarding to the`deadLetterSink`.
+The attribute is named `ce-knativedispatcherr` and will contain the HTTP
+Response **StatusCode** and **Body** bytes from the failed dispatch attempt as
+an encoded JSON string such as 
+`eyJjb2RlIjogNTAwLCAiZGF0YSI6ICJTVzUwWlhKdVlXd2dVMlZ5ZG1WeUlFVnljbTl5In0=`
+which can be decoded as...
+
+```json
+{"code": 500, "data": "SW50ZXJuYWwgU2VydmVyIEVycm9y"}
+```
+
+...where the **data** bytes representing the HTTP Response Body can be further
+decoded as `Internal Server Error`.
+
 ## Channel Support
 
 The table below summarizes what delivery parameters are supported for each channel implementation.

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -90,20 +90,31 @@ spec:
     backoffDelay: <ISO8601 duration>
 ```
 
-Failed events may, depending on the specific Channel implementation, be
-enhanced with an extension attribute prior to forwarding to the`deadLetterSink`.
-The attribute is named `ce-knativedispatcherr` and will contain the HTTP
-Response **StatusCode** and **Body** bytes from the failed dispatch attempt as
-an encoded JSON string such as
-`eyJjb2RlIjogNTAwLCAiZGF0YSI6ICJTVzUwWlhKdVlXd2dVMlZ5ZG1WeUlFVnljbTl5In0=`
-which can be decoded as...
+Failed events may, depending on the specific Channel implementation in use, be
+enhanced with extension attributes prior to forwarding to the`deadLetterSink`.
+These extension attributes are as follows...
 
-```json
-{"code": 500, "data": "SW50ZXJuYWwgU2VydmVyIEVycm9y"}
-```
+- **knativeerrorcode**
+    - **Type:** Int
+    - **Description:** The HTTP Response **StatusCode** from the final event
+      dispatch attempt.
+    - **Constraints:** Should always be present as every HTTP Response contains
+      a **StatusCode**.
+    - **Examples:**
+        - "500"
+        - ...any HTTP StatusCode...
 
-...where the **data** bytes representing the HTTP Response Body can be further
-decoded as `Internal Server Error`.
+- **knativeerrordata**
+    - **Type:** String
+    - **Description:** The HTTP Response **Body** from the final event dispatch
+      attempt.
+    - **Constraints:** Will not be present if the HTTP Response **Body** was
+      empty. Will be truncated to a maximum length of 1024 bytes which could
+      render JSON payloads invalid / incomplete.
+    - **Examples:**
+        - 'Internal Server Error: Failed to process event.'
+        - '{"key": "value"}'
+        - ...any HTTP Response Body...
 
 ## Channel Support
 

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -92,7 +92,7 @@ spec:
 
 Failed events may, depending on the specific Channel implementation in use, be
 enhanced with extension attributes prior to forwarding to the`deadLetterSink`.
-These extension attributes are as follows...
+These extension attributes are as follows:
 
 - **knativeerrorcode**
     - **Type:** Int
@@ -108,9 +108,8 @@ These extension attributes are as follows...
     - **Type:** String
     - **Description:** The HTTP Response **Body** from the final event dispatch
       attempt.
-    - **Constraints:** Will not be present if the HTTP Response **Body** was
-      empty. Will be truncated to a maximum length of 1024 bytes which could
-      render JSON payloads invalid / incomplete.
+    - **Constraints:** Will be empty if the HTTP Response **Body** was empty,
+      and might be truncated if the length is excessive.
     - **Examples:**
         - 'Internal Server Error: Failed to process event.'
         - '{"key": "value"}'

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -94,7 +94,7 @@ Failed events may, depending on the specific Channel implementation, be
 enhanced with an extension attribute prior to forwarding to the`deadLetterSink`.
 The attribute is named `ce-knativedispatcherr` and will contain the HTTP
 Response **StatusCode** and **Body** bytes from the failed dispatch attempt as
-an encoded JSON string such as 
+an encoded JSON string such as
 `eyJjb2RlIjogNTAwLCAiZGF0YSI6ICJTVzUwWlhKdVlXd2dVMlZ5ZG1WeUlFVnljbTl5In0=`
 which can be decoded as...
 


### PR DESCRIPTION
This PR is associated with the [knative-eventing PR 4760](https://github.com/knative/eventing/pull/4760) which is adding an extension attribute to CloudEvents prior to sending them to the dead letter sink.

## Proposed Changes
- Cleanup KafkaChannel descriptions to reflect the latest implementations.
- Add brief description of new CloudEvent extension attribute `ce-knativedispatcherr` to event-delivery documentation.

