### PR TITLE
HA is enabled for Autoscaler too

### DIFF
--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -10,7 +10,7 @@ Active/passive HA in Knative is available through leader election, which can be 
 
 When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required. These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is referred to as the leader.
 
-HA functionality is allowed but not enabled by default for all Knative Serving components.
+Leader election is enabled but HA functionanlity is disabled with 1 replica by default for all Knative Serving components.
 
 ## Disabling leader election
 
@@ -27,7 +27,6 @@ $ kubectl -n knative-serving scale deployment <deployment-name> --replicas=2
 - Setting `--replicas` to a value of `2` enables HA.
 - You can use a higher value if you have a use case that requires more replicas of a deployment. For example, if you require a minimum of 3 `controller` deployments, set `--replicas=3`.
 - Setting `--replicas=1` disables HA.
-- Passing `--disable-ha` to the controller process disables leader election.
 
 NOTE: if you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a period, which can
 be up to the `stable-window` time. This is because when an `autoscaler` pod is terminating, the ownership of the currently owned Revisions will be acquired by

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -29,7 +29,7 @@ $ kubectl -n knative-serving scale deployment <deployment-name> --replicas=2
 - Setting `--replicas=1` disables HA.
 - Passing `--disable-ha` to the controller process disables leader election.
 
-If you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a peroid, which can
+NOTE: if you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a period, which can
 be up to `stable-window` time. This is because when an `autoscaler` pods is terminating, the leadership of its owned Revisions will be gained by
 other standby `autoscaler` pods. The new leader `autoscaler` pods need `stable-window` time to build the scaling metrics state for its newly
 owned Revisions.  
@@ -58,4 +58,3 @@ $ kubectl patch hpa activator -n knative-serving -p '{"spec":{"minReplicas":9,"m
 To set the activator scale to a particular value, just set `minScale` and `maxScale` to the same desired value.
 
 It is recommended for production deployments to run at least 3 `activator` instances for redundancy and avoiding single point of failure if a Knative service needs to be scaled from 0.
-

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -10,7 +10,7 @@ Active/passive HA in Knative is available through leader election, which can be 
 
 When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required. These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is referred to as the leader.
 
-HA functionality is enabled by default for all Knative Serving components.
+HA functionality is allowed but not enabled by default for all Knative Serving components.
 
 ## Disabling leader election
 
@@ -30,9 +30,8 @@ $ kubectl -n knative-serving scale deployment <deployment-name> --replicas=2
 - Passing `--disable-ha` to the controller process disables leader election.
 
 NOTE: if you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a period, which can
-be up to `stable-window` time. This is because when an `autoscaler` pod is terminating, the ownership of the currently owned Revisions will be acquired by
-other standby `autoscaler` pods. The new leader `autoscaler` pods will need then `stable-window` time to build the scaling metrics state for those revisions.
-owned Revisions.  
+be up to the `stable-window` time. This is because when an `autoscaler` pod is terminating, the ownership of the currently owned Revisions will be acquired by
+other standby `autoscaler` pods. The new leader `autoscaler` pods will need the `stable-window` time to build the scaling metrics state for those Revisions.
 
 ## Scaling the data plane
 

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -10,7 +10,7 @@ Active/passive HA in Knative is available through leader election, which can be 
 
 When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required. These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is referred to as the leader.
 
-HA functionality is enabled by default for all Knative Serving components except for the `autoscaler` component.
+HA functionality is enabled by default for all Knative Serving components.
 
 ## Disabling leader election
 
@@ -29,6 +29,10 @@ $ kubectl -n knative-serving scale deployment <deployment-name> --replicas=2
 - Setting `--replicas=1` disables HA.
 - Passing `--disable-ha` to the controller process disables leader election.
 
+If you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a peroid, which can
+be up to `stable-window` time. This is because when an `autoscaler` pods is terminating, the leadership of its owned Revisions will be gained by
+other standby `autoscaler` pods. The new leader `autoscaler` pods need `stable-window` time to build the scaling metrics state for its newly
+owned Revisions.  
 
 ## Scaling the data plane
 

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -30,7 +30,7 @@ $ kubectl -n knative-serving scale deployment <deployment-name> --replicas=2
 - Passing `--disable-ha` to the controller process disables leader election.
 
 NOTE: if you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a period, which can
-be up to `stable-window` time. This is because when an `autoscaler` pods is terminating, the leadership of its owned Revisions will be gained by
+be up to `stable-window` time. This is because when an `autoscaler` pod is terminating, the ownership of the currently owned Revisions will be acquired by
 other standby `autoscaler` pods. The new leader `autoscaler` pods need `stable-window` time to build the scaling metrics state for its newly
 owned Revisions.  
 

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -8,7 +8,8 @@ Active/passive high availability (HA) is a standard feature of Kubernetes APIs t
 
 When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required. These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is referred to as the leader.
 
-Leader election is enabled but HA functionanlity is disabled with 1 replica by default for all Knative Serving components.
+Leader election is enabled by default for all Knative Serving components.
+HA functionality is disabled by default for all Knative Serving components, which are configured with only one replica.
 
 ## Disabling leader election
 

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -31,7 +31,7 @@ $ kubectl -n knative-serving scale deployment <deployment-name> --replicas=2
 
 NOTE: if you scale down the `autoscaler` component, you may get inaccurate autoscaling results for a subset of your Revisions for a period, which can
 be up to `stable-window` time. This is because when an `autoscaler` pod is terminating, the ownership of the currently owned Revisions will be acquired by
-other standby `autoscaler` pods. The new leader `autoscaler` pods need `stable-window` time to build the scaling metrics state for its newly
+other standby `autoscaler` pods. The new leader `autoscaler` pods will need then `stable-window` time to build the scaling metrics state for those revisions.
 owned Revisions.  
 
 ## Scaling the data plane

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -6,8 +6,6 @@ type: "docs"
 
 Active/passive high availability (HA) is a standard feature of Kubernetes APIs that helps to ensure that APIs stay operational if a disruption occurs. In an HA deployment, if an active controller crashes or is deleted, another controller is available to take over processing of the APIs that were being serviced by the controller that is now unavailable.
 
-Active/passive HA in Knative is available through leader election, which can be enabled after Knative Serving control plane is installed.
-
 When using a leader election HA pattern, instances of controllers are already scheduled and running inside the cluster before they are required. These controller instances compete to use a shared resource, known as the leader election lock. The instance of the controller that has access to the leader election lock resource at any given time is referred to as the leader.
 
 Leader election is enabled but HA functionanlity is disabled with 1 replica by default for all Knative Serving components.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #3175 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update the docs for that the HA is enabled by default for autoscaler as well
- Add documents for downsides when scaling down autoscaler components.


/assign @abrennan89 @vagababov 