### PR TITLE
Add readfile to Knative multi-container samples

### DIFF
--- a/docs/serving/samples/multi-container/index.md
+++ b/docs/serving/samples/multi-container/index.md
@@ -1,6 +1,8 @@
 ---
 title: "Knative multi-container samples"
-linkTitle: "A simple golang web app"
+linkTitle: "multi-container samples"
 weight: 1
 type: "docs"
 ---
+
+{{% readfile file="README.md" %}}


### PR DESCRIPTION
This patch adds `{{% readfile file="README.md" %}}` to `index.md` for multi-container.
Current page is blank as https://github.com/knative/docs/issues/3195 reported.

Fix https://github.com/knative/docs/issues/3195

/cc @savitaashture @abrennan89 