### PR TITLE
fix: cronjob.yaml indent two spaces

### DIFF
--- a/docs/eventing/sources/sinkbinding.md
+++ b/docs/eventing/sources/sinkbinding.md
@@ -189,10 +189,10 @@ kn source binding create bind-heartbeat \
           matchLabels:
             app: heartbeat-cron
         sink:
-        ref:
-          apiVersion: serving.knative.dev/v1
-          kind: Service
-          name: event-display
+          ref:
+            apiVersion: serving.knative.dev/v1
+            kind: Service
+            name: event-display
     ```
 2. Apply the file:
     ```bash


### PR DESCRIPTION
Change-Id: Iad1e74b9e58a9a194a4e6ef71fcfbd82d9b3fb57

<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #3218

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
