### PR TITLE
Fix cloudevent-nodejs sample to support SDK 4.0

### DIFF
--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/index.js
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/index.js
@@ -19,6 +19,7 @@ const { CloudEvent, Emitter, HTTP } = require('cloudevents')
 const PORT = process.env.PORT || 8080
 const target = process.env.K_SINK
 const app = express()
+const axios = require('axios').default;
 
 const main = () => {
   app.listen(PORT, function () {
@@ -36,42 +37,41 @@ const handle = (data) => {
 // receiveAndSend responds with ack, and send a new event forward
 const receiveAndSend = (cloudEvent, res) => {
   const data = handle(cloudEvent.data)
-  const newCloudEvent = new CloudEvent({
+  const ce = new CloudEvent({
     type: 'dev.knative.docs.sample',
     source: 'https://github.com/knative/docs/docs/serving/samples/cloudevents/cloudevents-nodejs',
-    time: new Date(),
     data
   })
-
-  // With only an endpoint URL, this creates a v1 emitter
-  const emitter = new Emitter({
-    url: target
-  })
+  const message = HTTP.binary(ce); // Or HTTP.structured(ce))
 
   // Reply back to dispatcher/client as soon as possible
   res.status(202).end()
 
-  // Send the new Event to the K_SINK
-  emitter.send(newCloudEvent)
-    .then((res) => {
-      console.log(`Sent event: ${JSON.stringify(newCloudEvent, null, 2)}`)
-      console.log(`K_SINK responded: ${JSON.stringify({ status: res.status, headers: res.headers, data: res.data }, null, 2)}`)
-    })
-    .catch(console.error)
+  axios({
+    method: 'post',
+    url: target,
+    data: message.body,
+    headers: message.headers,
+  })
+  .then((responseSink) => {
+    console.log(`Sent event: ${JSON.stringify(ce, null, 2)}`)
+    console.log(`K_SINK responded: ${JSON.stringify({ status: responseSink.status, headers: responseSink.headers, data: responseSink.data }, null, 2)}`)
+  })
+  .catch(console.error)
+
 }
 
 // receiveAndReply responds with new event
 const receiveAndReply = (cloudEvent, res) => {
   const data = handle(cloudEvent.data)
-  const newCloudEvent = new CloudEvent({
+  const ce = new CloudEvent({
     type: 'dev.knative.docs.sample',
     source: 'https://github.com/knative/docs/docs/serving/samples/cloudevents/cloudevents-nodejs',
-    time: new Date(),
     data
   })
 
-  console.log(`Reply event: ${JSON.stringify(newCloudEvent, null, 2)}`)
-  const message = HTTP.binary(newCloudEvent);
+  console.log(`Reply event: ${JSON.stringify(ce, null, 2)}`)
+  const message = HTTP.binary(ce);
   res.set(message.headers)
   res.status(200).send(message.body)
 }

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/package-lock.json
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "axios": "^0.21.1",
         "cloudevents": "^4.0.0",
         "express": "^4.17.1",
         "nodemon": "^2.0.4"
@@ -264,6 +265,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1462,6 +1471,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
@@ -3984,6 +4012,14 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4981,6 +5017,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/package.json
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "axios": "^0.21.1",
     "cloudevents": "^4.0.0",
     "express": "^4.17.1",
     "nodemon": "^2.0.4"


### PR DESCRIPTION
Closes #3247

The following PR #3136 updated the cloudevent SDK from version 3.x to 4.x and this is a major semantic version, which caused code brakes as the code was not compatible with the new major version of the SDK.
https://github.com/knative/docs/pull/3136/files#diff-8d77ef3aae2dea7cc68b9f32a40ac8f43a211f8f6e7f673d12723ed596eca805R16

## Proposed Changes
This PR updates the sample code to be compatible with the new major version of the SDK
