### PR TITLE
Update the email to be relevant

### DIFF
--- a/docs/serving/spec/knative-api-specification-1.0.md
+++ b/docs/serving/spec/knative-api-specification-1.0.md
@@ -1,7 +1,5 @@
 # Knative Serving API Specification
 
-Authors: [evana@vmware.com](mailto:evana@vmware.com),
-[dangerd@google.com](mailto:dangerd@google.com)
 
 <table>
   <tr>
@@ -2847,3 +2845,9 @@ Max: 1
   </tr>
 
 </table>
+
+## Authors
+
+[Dan Gerdesmeier](mailto:dangerd@google.com)
+[Doug Davis](dug@us.ibm.com)
+[Evan Anderson](mailto:evana@vmware.com),

--- a/docs/serving/spec/knative-api-specification-1.0.md
+++ b/docs/serving/spec/knative-api-specification-1.0.md
@@ -2850,4 +2850,4 @@ Max: 1
 
 [Dan Gerdesmeier](mailto:dangerd@google.com)
 [Doug Davis](dug@us.ibm.com)
-[Evan Anderson](mailto:evana@vmware.com),
+[Evan Anderson](mailto:evana@vmware.com)

--- a/docs/serving/spec/knative-api-specification-1.0.md
+++ b/docs/serving/spec/knative-api-specification-1.0.md
@@ -1,6 +1,6 @@
 # Knative Serving API Specification
 
-Authors: [argent@google.com](mailto:argent@google.com),
+Authors: [evana@vmware.com](mailto:evana@vmware.com),
 [dangerd@google.com](mailto:dangerd@google.com)
 
 <table>


### PR DESCRIPTION
I kept Dan since he's still the author of the latest version. And fixed
Evan't email to be a routable one.


/assign @evankanderson mattmoor