### PR TITLE
Update path for config-domain configmap

### DIFF
--- a/docs/serving/using-a-custom-domain.md
+++ b/docs/serving/using-a-custom-domain.md
@@ -21,7 +21,7 @@ To change the {default-domain} value there are a few steps involved:
    ```
 
    This command opens your default text editor and allows you to edit the [config
-   map](https://github.com/knative/serving/blob/master/config/config-domain.yaml).
+   map](https://github.com/knative/serving/blob/master/config/core/configmaps/domain.yaml).
 
    ```yaml
    apiVersion: v1


### PR DESCRIPTION
Fixes https://github.com/knative/docs/issues/3222

`config-domain.yaml` has a symlink before https://github.com/knative/serving/blob/release-0.17/config/config-domain.yaml, but the symlink was removed.

So this patch fixes the yaml path to the original file https://github.com/knative/serving/blob/master/config/core/configmaps/domain.yaml.

