### PR TITLE
Remove note about cluster-local-gateway and istio-knative-extras.yaml

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -516,13 +516,6 @@ guide. You can also find a number of samples for Knative Serving
    kubectl apply --filename {{< artifact repo="eventing" file="eventing-core.yaml" >}}
    ```
 
-   _Note_: If your Kubernetes cluster comes with pre-installed Istio, make sure
-   it has `cluster-local-gateway`
-   [deployed](https://github.com/knative/serving/blob/master/DEVELOPMENT.md#deploy-istio).
-   Depending on which Istio version you have, you'd need to apply the
-   `istio-knative-extras.yaml` in the corresponding version folder at
-   [here](https://github.com/knative/serving/tree/{{< branch >}}/third_party).
-
 1. Install a default Channel (messaging) layer (alphabetical).
 
       <!-- This indentation is important for things to render properly. -->


### PR DESCRIPTION
`istio-knative-extras.yaml` does not exist since long time ago.
And `cluster-local-gateway` was removed and `knative-local-gateway` is always deployed when `net-istio` is used.

This patch removes the note.

Fixes https://github.com/knative/docs/issues/3271