### PR TITLE
Update Rust version and installation commands

### DIFF
--- a/community/samples/serving/helloworld-rust/Dockerfile
+++ b/community/samples/serving/helloworld-rust/Dockerfile
@@ -1,13 +1,13 @@
 # Use the official Rust image.
 # https://hub.docker.com/_/rust
-FROM rust:1.27.0
+FROM rust:1.50.0
 
 # Copy local code to the container image.
 WORKDIR /usr/src/app
 COPY . .
 
 # Install production dependencies and build a release artifact.
-RUN cargo install
+RUN cargo install --path .
 
 # Run the web service on container startup.
 CMD ["hellorust"]


### PR DESCRIPTION
Fixes helloworld-rust example to be buildable. 

## Proposed Changes

Updates installation command based on reported error when building

```
warning: To build the current package use `cargo build`, to install the current package run `cargo install --path .`
```

Updates Rust version from 1.27 to current latest 1.50, which makes the sample build successfully without any other package version changes. 

Successfully builds with these changes. 