### PR TITLE
Fix broken numbering in procedure

### DIFF
--- a/docs/install/install-kn.md
+++ b/docs/install/install-kn.md
@@ -29,18 +29,21 @@ You must place the executable binary in your system path, and make sure that it 
 ## Install `kn` using Go
 **Prerequisite:** Building `kn` requires Go v1.14 or newer. You will first need a working Go environment.
 1. Check out the [Client repository](https://github.com/knative/client):
-  ```bash
-  git clone https://github.com/knative/client.git
-  cd client/
-  ```
+
+   ```bash
+   git clone https://github.com/knative/client.git
+   cd client/
+   ```
 1. Build an executable binary:
-  ```bash
-  hack/build.sh -f
-  ```
+
+   ```bash
+   hack/build.sh -f
+   ```
 1. Move `kn` into your system path, and verify that `kn` commands are working properly. For example:
-  ```bash
-  kn version
-  ```
+
+   ```bash
+   kn version
+   ```
 
 ## Install `kn` using brew
 


### PR DESCRIPTION
Add correct spacing in markdown to fix broken numbering in the "Install kn using Go" section of the page.