### PR TITLE
Removed the Go path link from the ./eventing/README.md

### DIFF
--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -105,11 +105,12 @@ To learn how to use the registry, see the
 
 Knative Eventing also defines an event forwarding and persistence layer, called
 a
-[**Channel**](https://github.com/knative/eventing/blob/main/pkg/apis/messaging/v1/channel_types.go#L57).
+[**Channel**](./channels).
 Each channel is a separate Kubernetes [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/).
 Events are delivered to Services or forwarded to other channels
 (possibly of a different type) using
-[Subscriptions](https://github.com/knative/eventing/blob/main/pkg/apis/messaging/v1/subscription_types.go).
+[Subscriptions](./event-delivery.md#configuring-subscription-delivery).
+
 This allows message delivery in a cluster to vary based on requirements, so that
 some events might be handled by an in-memory implementation while others would
 be persisted using Apache Kafka or NATS Streaming.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #3309 - Remove links to Go code

## Proposed Changes <!-- Describe the changes the PR makes. -->

-  Removed the Go path link for Channel and added path https://github.com/knative/docs/tree/master/docs/eventing/channels
-  Removed the Go path link for Subscriptions