### PR TITLE
Removed the Go path link from the ./eventing/accessing-traces.md

### DIFF
--- a/docs/eventing/accessing-traces.md
+++ b/docs/eventing/accessing-traces.md
@@ -93,8 +93,7 @@ traces are provided in the Knative Serving observability section:
 ### Example
 
 The following demonstrates how to trace requests in Knative Eventing with Zipkin, using the
-[`TestBrokerTracing`](https://github.com/knative/eventing/blob/main/test/conformance/broker_tracing_test.go)
-End-to-End test.
+[`TestBrokerTracing`](https://github.com/knative/eventing/blob/master/test/conformance/broker_tracing_test.go) End-to-End test.
 
 For this example, assume the following details:
 - Everything happens in the `includes-incoming-trace-id-2qszn` namespace.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #3309 - Remove links to Go code

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Removed the Go path link for TestBrokerTracing
