### PR TITLE
Removed the Go path link from the ./eventing/event-delivery.md

### DIFF
--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -72,7 +72,33 @@ after the specified number of retries.
 
 ## Common Delivery Parameters
 
-The `delivery` value must be a Delivery Spec.
+The `delivery` value must be a Delivery Spec, which is a partial schema that is embedded in resources like `Broker`, `Trigger` and `Subscription`.
+
+```yaml
+# DeadLetterSink is the sink receiving event that could not be sent to
+# a destination.
+deadLetterSink:
+  ref:
+    apiVersion: v1
+    kind: Service
+    name: my-service
+  uri: /my-path
+
+# Retry is the minimum number of retries the sender should attempt when
+# sending an event before moving it to the dead letter sink.
+retry: 5
+
+// BackoffPolicy is the retry backoff policy (linear, exponential).
+backoffPolicy: exponential
+
+# BackoffDelay is the delay before retrying.
+# More information on Duration format:
+#  - https://www.iso.org/iso-8601-date-and-time-format.html
+#  - https://en.wikipedia.org/wiki/ISO_8601
+#
+# For linear policy, backoff delay is backoffDelay*<numberOfRetries>.
+# For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.
+backoffDelay: PT2S```
 
 ### deadLetterSink
 

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -98,7 +98,8 @@ backoffPolicy: exponential
 #
 # For linear policy, backoff delay is backoffDelay*<numberOfRetries>.
 # For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.
-backoffDelay: PT2S```
+backoffDelay: PT2S
+```
 
 ### deadLetterSink
 
@@ -108,12 +109,14 @@ In case of failure, the event is dropped and an error is logged into the system.
 The `deadLetterSink` value must be a Destination.
 
 ```yaml
-spec:
-  delivery:
-    deadLetterSink: <Destination>
-    retry: <number of retries>
-    backoffPolicy: <linear or exponential>
-    backoffDelay: <ISO8601 duration>
+# DeadLetterSink is the sink receiving event that could not be sent to
+# a destination.
+deadLetterSink:
+  ref:
+    apiVersion: v1
+    kind: Service
+    name: my-service
+  uri: /my-path
 ```
 
 Failed events may, depending on the specific Channel implementation in use, be

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -72,14 +72,14 @@ after the specified number of retries.
 
 ## Common Delivery Parameters
 
-The `delivery` value must be a [Delivery Spec](https://pkg.go.dev/knative.dev/eventing/pkg/apis/duck/v1?tab=doc#DeliverySpec)
+The `delivery` value must be a Delivery Spec.
 
 ### deadLetterSink
 
 When present, events that failed to be consumed are sent to the `deadLetterSink`.
 In case of failure, the event is dropped and an error is logged into the system.
 
-The `deadLetterSink` value must be a [Destination](https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination).
+The `deadLetterSink` value must be a Destination.
 
 ```yaml
 spec:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the master branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the master branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

For more information on contributing to the Knative Docs, see:
https://www.knative.dev/community/contributing/

 -->

Fixes #3309 - Remove links to Go code

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Removed the Go path link for Delivery Spec
- Removed the Go path link for Destination
