### PR TITLE
Fix obsolete links in debugging guide

### DIFF
--- a/docs/serving/debugging-application-issues.md
+++ b/docs/serving/debugging-application-issues.md
@@ -133,8 +133,7 @@ conditions:
 If you see this condition, check the following to continue debugging:
 
 - [Check Pod status](#check-pod-status)
-- [Check application logs](#check-application-logs)
-- [Check Istio routing](#check-clusteringressistio-routing)
+- [Check Istio routing](#check-ingressistio-routing)
 
 If you see other conditions, look up the meaning of the conditions in Knative
 [Error Conditions and Reporting](https://github.com/knative/serving/blob/main/docs/spec/errors.md).


### PR DESCRIPTION
This patch fixes obsolete links in debugging guide.

- `Check application logs` is removed by 15153b3e469931b7dcf79aa56fcc0fcf23a42f13 so remove link as well.
- `Check Istio routing` is updated to `Check Ingress/Istio routing` by bbda7cf64b2859ef6fd68d90e82ef05fa458fdcd so rename the link as well.

Fix https://github.com/knative/docs/issues/3337