### PR TITLE
Add a note on replication factor value

### DIFF
--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -105,8 +105,7 @@ The above `ConfigMap` is installed in the cluster. You can edit
 the configuration or create a new one with the same values
 depending on your needs.
 
-_Note: `default.topic.replication.factor` must be less than or equal to the number of
-brokers of your Kafka cluster._
+**NOTE:** The `default.topic.replication.factor` value must be less than or equal to the number of Kafka broker instances in your cluster. For example, if you only have one Kafka broker, the `default.topic.replication.factor` value should not be more than `1`.
 
 ## Set as default broker implementation
 

--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -105,6 +105,9 @@ The above `ConfigMap` is installed in the cluster. You can edit
 the configuration or create a new one with the same values
 depending on your needs.
 
+_Note: `default.topic.replication.factor` must be less than or equal to the number of
+brokers of your Kafka cluster._
+
 ## Set as default broker implementation
 
 To set the Kafka broker as the default implementation for all brokers in the Knative deployment,


### PR DESCRIPTION
We've got a bug [1] report for a misconfiguration of 
`default.topic.replication.factor`.
This PR adds a note that could alert users on the
value of this configuration.

[1] https://github.com/knative-sandbox/eventing-kafka-broker/issues/720

<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documenation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add a note on replication factor value


