### PR TITLE
Hide CONTRIBUTING.md from the website

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+---
+_build:
+  render: never
+  list: never
+---
 (This guide only appears on GitHub, not the website, because it
 **intentionally** does not include YAML front-matter.)
 


### PR DESCRIPTION
## Proposed Changes

- Add Hugo 0.76+ front-matter to prevent CONTRIBUTING.md from appearing on the site:

  https://gohugo.io/content-management/build-options/#render
