### PR TITLE
Add clarifying info about what to install

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -21,6 +21,7 @@ showlandingtoc: "false"
 ---
 
 You can install Knative by applying YAML files using the `kubectl` CLI.
+You can install the Serving component, Eventing component, or both on your cluster.
 
 ## Prerequisites
 

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -6,6 +6,7 @@ showlandingtoc: "false"
 ---
 
 Knative provides a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to install, configure and manage Knative.
+You can install the Serving component, Eventing component, or both on your cluster.
 
 **NOTE:** The Knative Operator is still in Alpha phase. It has not been tested in a production environment, and should be used
 for development or test purposes only.


### PR DESCRIPTION
Adds a sentence to installing topics to clarify that you don't have to install both Serving and Eventing components. 

Fixes #3355 