### PR TITLE
Separate prototyping and production concerns in any-kubernetes-cluster.md

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -23,7 +23,7 @@ showlandingtoc: "false"
 You can install Knative by applying YAML files using the `kubectl` CLI.
 You can install the Serving component, Eventing component, or both on your cluster.
 
-## System Minimum Requirements 
+## System Minimum Requirements
 For prototyping purposes, Knative can work on local deployments of Kubernetes (minikube, kind, etc.).
 
 For production purposes, we recommend:

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -23,15 +23,15 @@ showlandingtoc: "false"
 You can install Knative by applying YAML files using the `kubectl` CLI.
 You can install the Serving component, Eventing component, or both on your cluster.
 
-## Recommended System Requirement
-For prototyping purposes, Knative will work on most local deployments of Kubernetes. For example, you shouldn't have any issues spinning up a local one node clister with 2 CPU and 4GB of memory.
+## System requirements
+For prototyping purposes, Knative will work on most local deployments of Kubernetes. For example, you can use a local, one-node cluster that has 2 CPU and 4GB of memory.
 
-For production purposes, we recommend:
+For production purposes, it is recommended that:
 - If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.
 - If you have multiple nodes in your cluster, for each node you will need at least 2 CPUs, 4 GB of memory, and 20 GB of disk storage.
 <!--TODO: Verify these requirements-->
 
-These "Recommended System Requirements" are just that, recommendations. Your mileage may vary depending on your choice of Networking layer, whether or not you use a service mesh, etc.
+**NOTE:** The system requirements provided are recommendations only. The requirements for your installation may vary, depending on whether you use optional components, such as a networking layer.
 
 ## Prerequisites
 

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -23,8 +23,8 @@ showlandingtoc: "false"
 You can install Knative by applying YAML files using the `kubectl` CLI.
 You can install the Serving component, Eventing component, or both on your cluster.
 
-## Recommended System Requirement 
-For prototyping purposes, Knative will work on most local deployments of Kubernetes. For example, you shouldn't have any issues spinning up a local one node clister with 2 CPU and 4GB of memory. 
+## Recommended System Requirement
+For prototyping purposes, Knative will work on most local deployments of Kubernetes. For example, you shouldn't have any issues spinning up a local one node clister with 2 CPU and 4GB of memory.
 
 For production purposes, we recommend:
 - If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -23,15 +23,20 @@ showlandingtoc: "false"
 You can install Knative by applying YAML files using the `kubectl` CLI.
 You can install the Serving component, Eventing component, or both on your cluster.
 
+## System Minimum Requirements 
+For prototyping purposes, Knative can work on local deployments of Kubernetes (minikube, kind, etc.).
+
+For production purposes, we recommend:
+- If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.
+- If you have multiple nodes in your cluster, for each node you will need at least 2 CPUs, 4 GB of memory, and 20 GB of disk storage.
+<!--TODO: Verify these requirements-->
+
 ## Prerequisites
 
 Before installation, you must meet the following prerequisites:
 
 - You have a cluster that uses Kubernetes v1.18 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-- If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.
-- If you have multiple nodes in your cluster, for each node you will need at least 2 CPUs, 4 GB of memory, and 20 GB of disk storage.
-<!--TODO: Verify these requirements-->
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images.
 
 ## Installing the Serving component

--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -23,13 +23,15 @@ showlandingtoc: "false"
 You can install Knative by applying YAML files using the `kubectl` CLI.
 You can install the Serving component, Eventing component, or both on your cluster.
 
-## System Minimum Requirements
-For prototyping purposes, Knative can work on local deployments of Kubernetes (minikube, kind, etc.).
+## Recommended System Requirement 
+For prototyping purposes, Knative will work on most local deployments of Kubernetes. For example, you shouldn't have any issues spinning up a local one node clister with 2 CPU and 4GB of memory. 
 
 For production purposes, we recommend:
 - If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.
 - If you have multiple nodes in your cluster, for each node you will need at least 2 CPUs, 4 GB of memory, and 20 GB of disk storage.
 <!--TODO: Verify these requirements-->
+
+These "Recommended System Requirements" are just that, recommendations. Your mileage may vary depending on your choice of Networking layer, whether or not you use a service mesh, etc.
 
 ## Prerequisites
 


### PR DESCRIPTION
Want to separate the system requirements out and add "for prototyping purposes" bit so folks don't think you need to run this only in the cloud.