### PR TITLE
Kafka broker ordered delivery

### DIFF
--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -297,8 +297,8 @@ To change the logging level to `DEBUG`, you need to:
 
 When dispatching events, Kafka Broker supports two different ordering guarantees:
 
-* `unordered`: Unordered consumer is a non-blocking consumer that potentially deliver messages unordered, while preserving proper offset management. 
-* `ordered`: Ordered consumer is a per-partition blocking consumer that deliver messages in order.
+* `unordered`: Unordered consumer is a non-blocking consumer that potentially delivers messages unordered, while preserving proper offset management. 
+* `ordered`: Ordered consumer is a per-partition blocking consumer that delivers messages in order.
 
 `unordered` is the default ordering guarantee, while **`ordered` is considered unstable, use with caution**.
 

--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -297,12 +297,12 @@ To change the logging level to `DEBUG`, you need to:
 
 When dispatching events, Kafka Broker supports two different ordering guarantees:
 
-* `unordered`: Unordered consumer is a non-blocking consumer that potentially delivers messages unordered, while preserving proper offset management. 
+* `unordered`: Unordered consumer is a non-blocking consumer that potentially delivers messages unordered, while preserving proper offset management.
 * `ordered`: Ordered consumer is a per-partition blocking consumer that delivers messages in order.
 
 `unordered` is the default ordering guarantee, while **`ordered` is considered unstable, use with caution**.
 
-You can configure the delivery order guarantee using the `kafka.eventing.knative.dev/delivery.order` annotation on the `Trigger` instance. 
+You can configure the delivery order guarantee using the `kafka.eventing.knative.dev/delivery.order` annotation on the `Trigger` instance.
 
 For example:
 

--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -293,6 +293,35 @@ To change the logging level to `DEBUG`, you need to:
     kubectl rollout restart deployment -n knative-eventing kafka-broker-dispatcher
     ```
 
+## Events Delivery order
+
+When dispatching events, Kafka Broker supports two different ordering guarantees:
+
+* `unordered`: Unordered consumer is a non-blocking consumer that potentially deliver messages unordered, while preserving proper offset management. 
+* `ordered`: Ordered consumer is a per-partition blocking consumer that deliver messages in order.
+
+`unordered` is the default ordering guarantee, while **`ordered` is considered unstable, use with caution**.
+
+You can configure the delivery order guarantee using the `kafka.eventing.knative.dev/delivery.order` annotation on the `Trigger` instance. 
+
+For example:
+
+```yaml
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: my-service-trigger
+  annotations:
+     kafka.eventing.knative.dev/delivery.order: ordered
+spec:
+  broker: my-kafka-broker
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: my-service
+```
+
 ### Additional information
 
 - To report bugs or add feature requests, open an issue in the [eventing-kafka-broker repository](https://github.com/knative-sandbox/eventing-kafka-broker).

--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -293,18 +293,11 @@ To change the logging level to `DEBUG`, you need to:
     kubectl rollout restart deployment -n knative-eventing kafka-broker-dispatcher
     ```
 
-## Events Delivery order
+## Configuring the order of delivered events
 
-When dispatching events, Kafka Broker supports two different ordering guarantees:
+When dispatching events, the Kafka broker can be configured to support different delivery ordering guarantees. 
 
-* `unordered`: Unordered consumer is a non-blocking consumer that potentially delivers messages unordered, while preserving proper offset management.
-* `ordered`: Ordered consumer is a per-partition blocking consumer that delivers messages in order.
-
-`unordered` is the default ordering guarantee, while **`ordered` is considered unstable, use with caution**.
-
-You can configure the delivery order guarantee using the `kafka.eventing.knative.dev/delivery.order` annotation on the `Trigger` instance.
-
-For example:
+You can configure the delivery order of events using the `kafka.eventing.knative.dev/delivery.order` annotation on the `Trigger` object:
 
 ```yaml
 apiVersion: eventing.knative.dev/v1
@@ -322,6 +315,13 @@ spec:
       name: my-service
 ```
 
+The supported consumer delivery guarantees are:
+
+* `unordered`: Unordered consumer is a non-blocking consumer that potentially delivers messages unordered, while preserving proper offset management.
+* `ordered`: Ordered consumer is a per-partition blocking consumer that delivers messages in order.
+
+`unordered` is the default ordering guarantee, while **`ordered` is considered unstable, use with caution**.
+
 ### Additional information
 
-- To report bugs or add feature requests, open an issue in the [eventing-kafka-broker repository](https://github.com/knative-sandbox/eventing-kafka-broker).
+- To report a bug or request a feature, open an issue in the [eventing-kafka-broker repository](https://github.com/knative-sandbox/eventing-kafka-broker).

--- a/docs/eventing/broker/kafka-broker.md
+++ b/docs/eventing/broker/kafka-broker.md
@@ -295,7 +295,7 @@ To change the logging level to `DEBUG`, you need to:
 
 ## Configuring the order of delivered events
 
-When dispatching events, the Kafka broker can be configured to support different delivery ordering guarantees. 
+When dispatching events, the Kafka broker can be configured to support different delivery ordering guarantees.
 
 You can configure the delivery order of events using the `kafka.eventing.knative.dev/delivery.order` annotation on the `Trigger` object:
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Part of https://github.com/knative-sandbox/eventing-kafka-broker/issues/589

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add doc for new feature https://github.com/knative-sandbox/eventing-kafka-broker/issues/589