### PR TITLE
Update any-kubernetes-cluster.md

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -57,7 +57,7 @@ Follow the procedure for the networking layer of your choice:
 <!-- TODO: Link to document/diagram describing what is a networking layer.  -->
 <!-- This indentation is important for things to render properly. -->
 
-   {{< tabs name="serving_networking" default="Istio" >}}
+   {{< tabs name="serving_networking" default="Kourier" >}}
    {{% tab name="Ambassador" %}}
 
 The following commands install Ambassador and enable its Knative integration.
@@ -386,7 +386,7 @@ Refer to the "Real DNS" method for a permanent solution.
 
 Follow the steps for any Serving extensions you want to install:
 
-{{< tabs name="serving_extensions" default="TLS via HTTP01" >}}
+{{< tabs name="serving_extensions" >}}
 
 {{% tab name="HPA autoscaling" %}}
 


### PR DESCRIPTION
Closes #3374

Also changes default networking to Kourier since many people have trouble with Istio (based on User Interviews and site exit data). 

Kourier was voted best Networking layer in this unofficial poll: https://knative.slack.com/archives/C93E33SN8/p1614889580106400

Want to see if changing this has any influence on exit rates. It will almost certainly influence which Networking layer people choose. 