### PR TITLE
Fix HPA allowed metrics

### DIFF
--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -13,7 +13,7 @@ For [per-revision](./autoscaling-concepts.md) configuration, this is determined 
 The possible metric types that can be configured per revision depend on the type of Autoscaler implementation you are using:
 
 * The default KPA Autoscaler supports the `concurrency` and `rps` metrics.
-* The HPA Autoscaler supports the `concurrency`, `rps` and `cpu` metrics.
+* The HPA Autoscaler supports the `cpu` metric.
 
 <!-- TODO: Add details about different metrics types, how concurrency and rps differ. Explain cpu. -->
 


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->
- Updates the listed metrics used with HPA (according to current code [only cpu](https://github.com/knative/serving/blob/0e8410a81e9609b979d5bc3cb9e602c3a4f4af02/pkg/apis/autoscaling/annotation_validation.go#L217) is allowed)
- Currently if you set any other metric you get a validation error: `invalid value: rps: spec.template.metadata.annotations.autoscaling.knative.dev/metric`

