### PR TITLE
Use a unique name for the scale-to-zero-retention tabs

### DIFF
--- a/docs/serving/autoscaling/scale-to-zero.md
+++ b/docs/serving/autoscaling/scale-to-zero.md
@@ -98,7 +98,7 @@ This contrasts with the `scale-to-zero-grace-period` flag, which determines the 
 * **Default:** `0s`
 
 **Example:**
-{{< tabs name="scale-to-zero-grace" default="Global (ConfigMap)" >}}
+{{< tabs name="scale-to-zero-retention" default="Global (ConfigMap)" >}}
 {{% tab name="Per Revision" %}}
 ```yaml
 apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

The tabs of the retention period are currently broken because they actually point at the tabs from the grace period. This fixes that.