### PR TITLE
Fix broken link and tweak wording

### DIFF
--- a/docs/install/any-kubernetes-cluster.md
+++ b/docs/install/any-kubernetes-cluster.md
@@ -382,11 +382,13 @@ Refer to the "Real DNS" method for a permanent solution.
 
     {{< /tab >}} {{< /tabs >}}
 
-### Optional Serving extensions
+### Optional: Install Serving extensions
 
-You can apply extensions to customize your Knative Serving installation.
-For more information about the extensions you can apply, see
-[Installation files](./custom-install/installation-files.md#knative-serving-installation-files).
+To add extra features to your Knative Serving installation, you can install extensions
+by applying YAML files using the `kubectl` CLI.
+
+For information about the YAML files in the Knative Serving release, see
+[Installation files](./installation-files#knative-serving-installation-files).
 
 Follow the steps for any Serving extensions you want to install:
 
@@ -679,11 +681,13 @@ data:
 
 {{< /tabs >}}
 
-### Optional Eventing extensions
+### Optional: Install Eventing extensions
 
-You can apply extensions to customize your Knative Eventing installation.
-For more information about the extensions you can apply, see
-[Installation files](./custom-install/installation-files.md#knative-eventing-installation-files).
+To add extra features to your Knative Eventing installation, you can install extensions
+by applying YAML files using the `kubectl` CLI.
+
+For information about the YAML files in the Knative Eventing release, see
+[Installation files](./installation-files#knative-eventing-installation-files).
 
 Follow the steps for any Eventing extensions you want to install:
 <!-- This indentation is important for things to render properly. -->

--- a/docs/install/installation-files.md
+++ b/docs/install/installation-files.md
@@ -16,7 +16,7 @@ For information about installing these files, see [YAML-based installation](../a
 
 ## Knative Serving installation files
 
-The table below describes the installation files available in the Knative Serving release:
+The table below describes the installation files in the Knative Serving release:
 
 | File name | Description | Dependencies|
 | --- | --- | --- |
@@ -33,7 +33,7 @@ The table below describes the installation files available in the Knative Servin
 
 ## Knative Eventing installation files
 
-The table below describes the installation files available in the Knative Eventing release:
+The table below describes the installation files in the Knative Eventing release:
 
 | File name | Description | Dependencies|
 | --- | --- | --- |


### PR DESCRIPTION
- Fixed a broken link
- Tweaked the serving and eventing extensions headings so that they are more consistent with the other headings on the page
- Changed the wording in optional extension opening sentences