### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - docs-writers
-- toc
+- technical-oversight-committee
 - steering-committee
 reviewers:
 - docs-writers

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eng-approvers
-- docs-approvers
+- docs-writers
+- toc
+- steering-committee
 reviewers:
-- docs-approvers
+- docs-writers
 - docs-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,7 +27,7 @@ aliases:
   productivity-writers
   - chizhg
   - n3wscott
-  
+ 
   productivity-reviewers:
   - coryrc
   - steuhs
@@ -98,3 +98,4 @@ aliases:
   ux-wg-leads:
   - csantanapr
   - omerbensaadon
+

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,7 +11,7 @@ aliases:
   - vagababov
   - vaikas
 
-  docs-approvers:
+  docs-writers:
   - carieshmarie
   - richieescarez
   - abrennan89
@@ -24,41 +24,40 @@ aliases:
   - RichardJJG
   - snneji
 
-  blog-approvers:
-  - macruzbar
-
-  productivity-approvers:
-  - chaodaiG
+  productivity-writers
   - chizhg
-
+  - n3wscott
+  
   productivity-reviewers:
-  - chaodaiG
   - coryrc
-  - chizhg
   - steuhs
-  - yt3liu
-
-  eventing-eng-approvers:
-  - grantr
-  - lionelvillard
-  - vaikas
-
-  eventing-eng-reviewers:
   - evankanderson
+
+  eventing-writers:
+  - akashrv
+  - antoineco
+  - devguyio
+  - grantr
+  - lberk
+  - lionelvillard
+  - matzew
+  - n3wscott
+  - slinkydeveloper
+  - vaikas
+  - zhongduo
+
+  eventing-wg-leads
   - grantr
   - lionelvillard
-  - matzew
-  - n3wscott
-  - nachocano
   - vaikas
 
-  eventing-channels-eng-approvers:
+  channel-wg-leads:
   - matzew
+  - slinkydeveloper
 
-  eventing-sources-eng-approvers:
+  source-wg-leads
   - lionelvillard
   - n3wscott
-  - nachocano
   - vaikas
 
   install-eng-reviewers:
@@ -74,3 +73,21 @@ aliases:
   - tcnghia
   - vagababov
   - vaikas
+
+  serving-writers:
+  - ZhiminXiang
+  - dprotaso
+  - markusthoemmes
+  - nak3
+  - tcnghia
+  - vagababov
+
+  steering-committee:
+  - bsnchan
+  - mbehrendt
+  - pmorie
+  - thisisnotapril
+  - vaikas
+  ux-wg-leads:
+  - csantanapr
+  - omerbensaadon

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,11 +27,14 @@ aliases:
   productivity-writers
   - chizhg
   - n3wscott
- 
+
   productivity-reviewers:
   - coryrc
-  - steuhs
+  - efiturri
   - evankanderson
+  - peterfeifanchen
+  - steuhs
+  - yt3liu
 
   eventing-writers:
   - akashrv

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -88,6 +88,13 @@ aliases:
   - pmorie
   - thisisnotapril
   - vaikas
+
+  technical-oversight-committee:
+  - evankanderson
+  - grantr
+  - markusthoemmes
+  - rhuss
+
   ux-wg-leads:
   - csantanapr
   - omerbensaadon

--- a/blog/OWNERS
+++ b/blog/OWNERS
@@ -1,2 +1,4 @@
+# Maria is managing Knative community matters from Google.
 approvers:
-- blog-approvers
+- macruzbar
+

--- a/docs/eventing/OWNERS
+++ b/docs/eventing/OWNERS
@@ -1,6 +1,9 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eventing-eng-approvers
+- eventing-wg-leads
 reviewers:
-- eventing-eng-reviewers
+- eventing-wg-leads
+- source-wg-leads
+- channel-wg-leads
+

--- a/docs/eventing/channels/OWNERS
+++ b/docs/eventing/channels/OWNERS
@@ -1,4 +1,4 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eventing-channels-eng-approvers
+- channel-wg-leads

--- a/docs/eventing/sink/OWNERS
+++ b/docs/eventing/sink/OWNERS
@@ -1,5 +1,5 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eventing-sources-eng-approvers
-- eventing-channels-eng-approvers
+- source-wg-leads
+- channel-wg-leads

--- a/docs/eventing/sources/OWNERS
+++ b/docs/eventing/sources/OWNERS
@@ -1,4 +1,4 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eventing-sources-eng-approvers
+- source-wg-leads

--- a/docs/install/OWNERS
+++ b/docs/install/OWNERS
@@ -3,3 +3,4 @@
 reviewers:
 - eventing-writers
 - serving-writers
+

--- a/docs/install/OWNERS
+++ b/docs/install/OWNERS
@@ -1,4 +1,5 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 reviewers:
-- install-eng-reviewers
+- eventing-writers
+- serving-writers

--- a/docs/serving/OWNERS
+++ b/docs/serving/OWNERS
@@ -1,4 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- eng-approvers
+- serving-writers
+reviwers:
+- serving-writers

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
