### PR TITLE
Make Homebrew installation the first option for `kn`, pull command to install out of Github and into knative.dev site

### DIFF
--- a/docs/client/install-kn.md
+++ b/docs/client/install-kn.md
@@ -8,6 +8,15 @@ aliases:
 
 This guide provides details about how you can set up the Knative `kn` CLI.
 
+## Install kn using brew
+
+For macOs, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
+
+```
+brew install kn
+```
+
+
 ## Install kn using a binary
 
 You can install `kn` by downloading the executable binary for your system and placing it in the system path.
@@ -46,10 +55,6 @@ Links to the latest nightly-built executable binaries are available here:
       ```
       kn version
       ```
-
-## Install kn using brew
-
-For macOs, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">brew</a>.
 
 ## Running kn using container images
 

--- a/docs/client/install-kn.md
+++ b/docs/client/install-kn.md
@@ -10,7 +10,7 @@ This guide provides details about how you can set up the Knative `kn` CLI.
 
 ## Install kn using brew
 
-For macOs, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
+For macOS, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
 
 ```
 brew install kn


### PR DESCRIPTION
Adding brew install kn command directly to page and making it the first option

Actually kind of crazy that we don't already do this