### PR TITLE
Updating install flow with minor changes to reflect desired prototype in UX/11

### DIFF
--- a/docs/client/install-kn.md
+++ b/docs/client/install-kn.md
@@ -8,6 +8,15 @@ aliases:
 
 This guide provides details about how you can set up the Knative `kn` CLI.
 
+## Install kn using brew
+
+For macOS, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
+
+```
+brew install kn
+```
+
+
 ## Install kn using a binary
 
 You can install `kn` by downloading the executable binary for your system and placing it in the system path.
@@ -46,10 +55,6 @@ Links to the latest nightly-built executable binaries are available here:
       ```
       kn version
       ```
-
-## Install kn using brew
-
-For macOs, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">brew</a>.
 
 ## Running kn using container images
 

--- a/docs/install/_index.md
+++ b/docs/install/_index.md
@@ -23,9 +23,7 @@ showlandingtoc: "false"
 
 You can install the Serving component, Eventing component, or both on your cluster by using one of the following deployment options:
 
-- Using a YAML-based installation:
-  - [Installing Serving using YAML files](./install-serving-with-yaml)
-  - [Installing Eventing using YAML files](./install-eventing-with-yaml)
+- Using a [YAML-based installation](./prerequisites.md)
 - Using the [Knative Operator](./knative-with-operators).
 - Following the documentation for vendor managed [Knative offerings](../knative-offerings).
 

--- a/docs/install/install-eventing-with-yaml.md
+++ b/docs/install/install-eventing-with-yaml.md
@@ -222,5 +222,7 @@ data:
 After installing Knative Eventing:
 
 - To easily interact with Knative Eventing Components, [download the `kn` CLI](/docs/client/install-kn.md)
+
 - If you want to add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md)
+
 - [Installing Knative Serving using YAML files](./install-serving-with-yaml.md)

--- a/docs/install/install-eventing-with-yaml.md
+++ b/docs/install/install-eventing-with-yaml.md
@@ -31,6 +31,9 @@ To install the Eventing component:
    kubectl apply -f {{< artifact repo="eventing" file="eventing-core.yaml" >}}
    ```
 
+For information about the YAML files in the Knative Serving and Eventing releases, see
+[Installation files](./installation-files.md).
+
 
 ## Verify the installation
 

--- a/docs/install/install-eventing-with-yaml.md
+++ b/docs/install/install-eventing-with-yaml.md
@@ -221,6 +221,6 @@ data:
 
 After installing Knative Eventing:
 
-- If you want to add extra features to your installation, see [Installing optional extensions](./install-extensions.md).
+- To easily interact with Knative Eventing Components, [download the `kn` CLI](/docs/client/install-kn.md)
+- If you want to add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md)
 - [Installing Knative Serving using YAML files](./install-serving-with-yaml.md)
-

--- a/docs/install/install-eventing-with-yaml.md
+++ b/docs/install/install-eventing-with-yaml.md
@@ -219,5 +219,5 @@ data:
 After installing Knative Eventing:
 
 - If you want to add extra features to your installation, see [Installing optional extensions](./install-extensions.md).
-- If you want to install the Knative Serving component, see [Installing Serving using YAML files](./install-serving-with-yaml.md)
-- Install the [Knative CLI](./install-kn) to use `kn` commands.
+- [Installing Knative Serving using YAML files](./install-serving-with-yaml.md)
+

--- a/docs/install/install-eventing-with-yaml.md
+++ b/docs/install/install-eventing-with-yaml.md
@@ -221,8 +221,8 @@ data:
 
 After installing Knative Eventing:
 
-- To easily interact with Knative Eventing Components, [download the `kn` CLI](/docs/client/install-kn.md)
+- To easily interact with Knative Eventing components, [install the `kn` CLI](/docs/client/install-kn.md)
 
-- If you want to add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md)
+- To add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md)
 
 - [Installing Knative Serving using YAML files](./install-serving-with-yaml.md)

--- a/docs/install/install-extensions.md
+++ b/docs/install/install-extensions.md
@@ -17,7 +17,7 @@ For information about the YAML files in the Knative Serving and Eventing release
 
 Before you install any optional extensions, you must install Knative Serving or Eventing.
 See [Installing Serving using YAML files](./install-serving-with-yaml.md)
-and [Installing Eventing using YAML files](./install/install-eventing-with-yaml.md).
+and [Installing Eventing using YAML files](./install-eventing-with-yaml.md).
 
 
 ## Install optional Serving extensions

--- a/docs/install/install-extensions.md
+++ b/docs/install/install-extensions.md
@@ -276,3 +276,7 @@ To learn more about the VMware sources and bindings, try
 {{< /tab >}}
 
 {{< /tabs >}}
+
+## Next steps
+
+- To easily interact with Knative Services and Eventing Components, [download the `kn` CLI](/docs/client/install-kn.md)

--- a/docs/install/install-extensions.md
+++ b/docs/install/install-extensions.md
@@ -279,4 +279,4 @@ To learn more about the VMware sources and bindings, try
 
 ## Next steps
 
-- To easily interact with Knative Services and Eventing Components, [download the `kn` CLI](/docs/client/install-kn.md)
+- To easily interact with Knative Services and Eventing components, [install the `kn` CLI](/docs/client/install-kn.md)

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -371,6 +371,8 @@ Refer to the "Real DNS" method for a permanent solution.
 
 ## Next steps
 
+After installing Knative Serving:
+
 - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
 - **If you're not interested in installing Knative Eventing (recommended)** and looking for things like TLS for Knative Serving, see [Installing optional extensions](./install-extensions.md).

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -30,6 +30,8 @@ To install the serving component:
    ```bash
    kubectl apply -f {{< artifact repo="serving" file="serving-core.yaml" >}}
    ```
+For information about the YAML files in the Knative Serving and Eventing releases, see
+[Installation files](./installation-files.md).
 
 
 ## Install a networking layer

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -377,4 +377,4 @@ After installing Knative Serving:
 
 - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
-- If you want to add extra features to your installation (like TLS), see [Installing optional extensions](./install-extensions.md).
+- If you want to add extra features to your installation, see [Installing optional extensions](./install-extensions.md).

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -25,7 +25,7 @@ To install the serving component:
    kubectl apply -f {{< artifact repo="serving" file="serving-crds.yaml" >}}
    ```
 
-1. Install the core components of Serving:
+1. Install the core components of Knative Serving:
 
    ```bash
    kubectl apply -f {{< artifact repo="serving" file="serving-core.yaml" >}}
@@ -378,3 +378,5 @@ After installing Knative Serving:
 - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
 - If you want to add extra features to your installation, see [Installing optional extensions](./install-extensions.md).
+
+- To easily interact with Knative Services, [download the `kn` CLI](/docs/client/install-kn.md)

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -377,6 +377,6 @@ After installing Knative Serving:
 
 - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
-- If you want to add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md).
+- To add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md).
 
 - To easily interact with Knative Services, [download the `kn` CLI](/docs/client/install-kn.md)

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -377,6 +377,6 @@ After installing Knative Serving:
 
 - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
-- If you want to add extra features to your installation, see [Installing optional extensions](./install-extensions.md).
+- If you want to add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md).
 
 - To easily interact with Knative Services, [download the `kn` CLI](/docs/client/install-kn.md)

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -379,4 +379,4 @@ After installing Knative Serving:
 
 - To add optional enhancements to your installation, see [Installing optional extensions](./install-extensions.md).
 
-- To easily interact with Knative Services, [download the `kn` CLI](/docs/client/install-kn.md)
+- To easily interact with Knative Services, [install the `kn` CLI](/docs/client/install-kn.md)

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -375,4 +375,4 @@ After installing Knative Serving:
 
 - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
-- **If you're not interested in installing Knative Eventing (recommended)** and looking for things like TLS for Knative Serving, see [Installing optional extensions](./install-extensions.md).
+- If you want to add extra features to your installation (like TLS), see [Installing optional extensions](./install-extensions.md).

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -371,8 +371,6 @@ Refer to the "Real DNS" method for a permanent solution.
 
 ## Next steps
 
-After installing Knative Serving:
+- [Installing Knative Eventing using YAML files](./install-eventing-with-yaml.md)
 
-- If you want to add extra features to your installation, see [Installing optional extensions](./install-extensions.md).
-- If you want to install the Knative Eventing component, see [Installing Eventing using YAML files](./install-eventing-with-yaml.md)
-- Install the [Knative CLI](./install-kn) to use `kn` commands.
+- **If you're not interested in installing Knative Eventing (recommended)** and looking for things like TLS for Knative Serving, see [Installing optional extensions](./install-extensions.md).

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -26,10 +26,10 @@ Before installation, you must meet the following prerequisites:
 
 - You have a cluster that uses Kubernetes v1.18 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-- You have installed the [`kn` CLI](./install-kn) (See below)  
+- You have installed the [`kn` CLI](./install-kn). (See below) 
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images. (To pull from a private registry, see [Deploying images from a private container registry](https://knative.dev/docs/serving/deploying/private-registry/))
 
-## Install the Knative CLI 
+## Install the Knative CLI
 
 For macOS, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
 
@@ -37,11 +37,11 @@ For macOS, you can install `kn` by using <a href="https://github.com/knative/hom
 brew install kn
 ```
 
-For other options for installing the `kn` CLI, see the [Setting up kn](./install-kn) 
+For other options for installing the `kn` CLI, see the [Setting up kn](./install-kn)
 
 ## Install Knative Serving and Eventing
 
-You can install the Serving component, Eventing component, or both on your cluster. If you're planning on installing both, **we recommend starting with Knative Serving.** 
+You can install the Serving component, Eventing component, or both on your cluster. If you're planning on installing both, **we recommend starting with Knative Serving.**
 
   - [Installing Knative Serving using YAML files](./install-serving-with-yaml)
   - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml)

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -28,7 +28,7 @@ Before installation, you must meet the following prerequisites:
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images. (To pull from a private registry, see [Deploying images from a private container registry](https://knative.dev/docs/serving/deploying/private-registry/))
 
-## Install Knative Serving and Eventing
+## Next Steps: Install Knative Serving and Eventing
 
 You can install the Serving component, Eventing component, or both on your cluster. If you're planning on installing both, **we recommend starting with Knative Serving.**
 

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -26,7 +26,7 @@ Before installation, you must meet the following prerequisites:
 
 - You have a cluster that uses Kubernetes v1.18 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-- You have installed the [`kn` CLI](./install-kn). (See below) 
+- You have installed the [`kn` CLI](./install-kn). (See below)
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images. (To pull from a private registry, see [Deploying images from a private container registry](https://knative.dev/docs/serving/deploying/private-registry/))
 
 ## Install the Knative CLI

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -26,11 +26,22 @@ Before installation, you must meet the following prerequisites:
 
 - You have a cluster that uses Kubernetes v1.18 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-- Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images.
+- You have installed the [`kn` CLI](./install-kn) (See below)  
+- Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images. (To pull from a private registry, see [Deploying images from a private container registry](https://knative.dev/docs/serving/deploying/private-registry/))
+
+## Install the Knative CLI 
+
+For macOS, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
+
+```
+brew install kn
+```
+
+For other installation options, see the [Setting up kn](./install-kn) 
 
 ## Install Knative Serving and Eventing
 
 You can install the Serving component, Eventing component, or both on your cluster. If you're planning on installing both, **we recommend starting with Knative Serving.** 
 
-  - [Installing Serving using YAML files](./install-serving-with-yaml)
-  - [Installing Eventing using YAML files](./install-eventing-with-yaml)
+  - [Installing Knative Serving using YAML files](./install-serving-with-yaml)
+  - [Installing Knative Eventing using YAML files](./install-eventing-with-yaml)

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -37,7 +37,7 @@ For macOS, you can install `kn` by using <a href="https://github.com/knative/hom
 brew install kn
 ```
 
-For other installation options, see the [Setting up kn](./install-kn) 
+For other options for installing the `kn` CLI, see the [Setting up kn](./install-kn) 
 
 ## Install Knative Serving and Eventing
 

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -9,10 +9,10 @@ Before installing Knative, you must meet the following prerequisites:
 
 ## System requirements
 
-For prototyping purposes, Knative will work on most local deployments of Kubernetes.
+**For prototyping purposes**, Knative will work on most local deployments of Kubernetes.
 For example, you can use a local, one-node cluster that has 2 CPU and 4GB of memory.
 
-For production purposes, it is recommended that:
+**For production purposes**, it is recommended that:
 - If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.
 - If you have multiple nodes in your cluster, for each node you will need at least 2 CPUs, 4 GB of memory, and 20 GB of disk storage.
 <!--TODO: Verify these requirements-->
@@ -27,3 +27,10 @@ Before installation, you must meet the following prerequisites:
 - You have a cluster that uses Kubernetes v1.18 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images.
+
+## Install Knative Serving and Eventing
+
+You can install the Serving component, Eventing component, or both on your cluster. If you're planning on installing both, **we recommend starting with Knative Serving.** 
+
+  - [Installing Serving using YAML files](./install-serving-with-yaml)
+  - [Installing Eventing using YAML files](./install-eventing-with-yaml)

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -26,18 +26,7 @@ Before installation, you must meet the following prerequisites:
 
 - You have a cluster that uses Kubernetes v1.18 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-- You have installed the [`kn` CLI](./install-kn). (See below)
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images. (To pull from a private registry, see [Deploying images from a private container registry](https://knative.dev/docs/serving/deploying/private-registry/))
-
-## Install the Knative CLI
-
-For macOS, you can install `kn` by using <a href="https://github.com/knative/homebrew-client" target="_blank">Homebrew</a>.
-
-```
-brew install kn
-```
-
-For other options for installing the `kn` CLI, see the [Setting up kn](./install-kn)
 
 ## Install Knative Serving and Eventing
 


### PR DESCRIPTION
Changes: 
1. Moved Kn CLI to pre-requisite 
2. Added homebrew `brew install kn` command to pre-reqs
2. Changed flow of install from install -> Serving or Eventing to Install -> Pre-Reqs -> Serving or Eventing
3. Added reference to the Install files in each of the Serving and Eventing Installs 
4. Fix broken link
5. Aligned any reference to "Serving" or "Eventing" to [Knative Word and Phrase List](https://docs.google.com/spreadsheets/d/1p1_kBUd6ZvonxHkMcEJPayf6QIpExuFf5cFq0ptar7I/edit#gid=0)