### PR TITLE
Fix links to slack and zendesk event sources

### DIFF
--- a/docs/eventing/sources/_index.md
+++ b/docs/eventing/sources/_index.md
@@ -73,9 +73,9 @@ kn source list
 [Konnek](https://konnek.github.io/docs/#/) | Active Development | None | Retrieves events from cloud platforms (like AWS and GCP) and transforms them into CloudEvents for consumption in Knative.
 [K8s](https://github.com/Harwayne/auto-container-source/tree/master/k8s-event-source) | Proof of Concept | None | Brings Kubernetes cluster events into Knative. Uses AutoContainerSource for underlying infrastructure.
 [RedisSource](https://github.com/lionelvillard/eventing-redis/tree/master/source) | v1alpha1 | None | Brings Redis Stream into Knative.
-[Slack](https://github.com/triggermesh/knative-sources) | v1alpha1 | TriggerMesh | Subscribes to events from Slack.
+[Slack](https://github.com/triggermesh/knative-sources/tree/master/cmd/slacksource-adapter) | v1alpha1 | TriggerMesh | Subscribes to events from Slack.
 [VMware](https://github.com/vmware-tanzu/sources-for-knative/blob/master/README.md) | Active Development | None | Brings [vSphere](https://www.vmware.com/products/vsphere.html) events into Knative.
-[Zendesk](https://github.com/triggermesh/knative-sources) | v1alpha1 | TriggerMesh | Subscribes to events from Zendesk.
+[Zendesk](https://github.com/triggermesh/knative-sources/tree/master/cmd/zendesksource-adapter) | v1alpha1 | TriggerMesh | Subscribes to events from Zendesk.
 
 ## Additional resources
 


### PR DESCRIPTION
## Proposed Changes 
- Fixes the links to the knative & zendesk sources in the triggermesh knative-sources repo
