### PR TITLE
Adding a bit more of clarfication on default channel configs

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -48,7 +48,9 @@ The `spec.config` in the KnativeEventing CR has one `<name>` entry for each Conf
 
 ### Setting a default channel
 
-If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be default you can change the default behavior by updating the `default-ch-webhook` ConfigMap. You can do this by modifying the KnativeEventing CR:
+If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be the default configuration, you can change the default behavior by updating the `default-ch-webhook` ConfigMap. 
+
+You can do this by modifying the KnativeEventing CR:
 
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -51,6 +51,7 @@ The `spec.config` in the KnativeEventing CR has one `<name>` entry for each Conf
 If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be the default configuration, you can change the default behavior by updating the `default-ch-webhook` ConfigMap. 
 
 You can do this by modifying the KnativeEventing CR:
+
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -46,9 +46,9 @@ All Knative Eventing ConfigMaps are created in the same namespace as the Knative
 Knative Eventing has multiple ConfigMaps that are named with the prefix `config-`.
 The `spec.config` in the KnativeEventing CR has one `<name>` entry for each ConfigMap, named `config-<name>`, with a value which will be used for the ConfigMap `data`.
 
-### Setting the default channel for the broker
+### Setting a default channel
 
-If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. You can do this by modifying the KnativeEventing CR:
+If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be default you can change the default behavior by updating the `default-ch-webhook` ConfigMap. You can do this by modifying the KnativeEventing CR:
 
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1
@@ -78,6 +78,27 @@ spec:
 ```
 
 **NOTE:** The `clusterDefault` setting determines the global, cluster-wide default channel type. You can configure channel defaults for individual namespaces by using the `namespaceDefaults` setting.
+
+### Setting the default channel for the broker
+
+If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. You can do this by modifying the KnativeEventing CR:
+
+```yaml
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    config-br-default-channel:
+      channelTemplateSpec: |
+        apiVersion: messaging.knative.dev/v1beta1
+        kind: KafkaChannel
+        spec:
+          numPartitions: 6
+          replicationFactor: 1
+```
 
 ## Private repository and private secrets
 

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -83,7 +83,9 @@ spec:
 
 ### Setting the default channel for the broker
 
-If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. You can do this by modifying the KnativeEventing CR:
+If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. 
+
+You can do this by modifying the KnativeEventing CR:
 
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -85,7 +85,6 @@ spec:
 If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. 
 
 You can do this by modifying the KnativeEventing CR:
-
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -51,7 +51,6 @@ The `spec.config` in the KnativeEventing CR has one `<name>` entry for each Conf
 If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be the default configuration, you can change the default behavior by updating the `default-ch-webhook` ConfigMap. 
 
 You can do this by modifying the KnativeEventing CR:
-
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -86,6 +86,7 @@ spec:
 If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. 
 
 You can do this by modifying the KnativeEventing CR:
+
 ```yaml
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

- adding a explicit section for setting some specific channel implementation for the default broker (the one that's there OOTB in eventing)
- and changing the section for the default channel to be more explict about options
