### PR TITLE
[KafkaSink] Fix auth secret reference

### DIFF
--- a/docs/eventing/sink/kafka-sink.md
+++ b/docs/eventing/sink/kafka-sink.md
@@ -77,7 +77,10 @@ spec:
    topic: mytopic
    bootstrapServers:
       - my-cluster-kafka-bootstrap.kafka:9092
-   auth.secret.ref.name: my_secret
+   auth:
+     secret:
+       ref:
+         name: my_secret
 ```
 
 The `Secret` `my_secret` must exist in the same namespace of the `KafkaSink`, in this case: `default`.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

The YAML key for the secret reference is wrong.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix auth secret reference
