### PR TITLE
Blog post announcing the TOC election kick-off for 2021.

### DIFF
--- a/blog/steering/[BLOG]-toc-2021-election-announcement.md
+++ b/blog/steering/[BLOG]-toc-2021-election-announcement.md
@@ -27,7 +27,7 @@ Here are a few important deadlines to keep in mind:
 - May 11: Election Closes
 - May 13: Announcement of Results
 
-For this election, we will be trying a new voting tool called Elekto.
+For this election, we will be trying a new voting tool called [Elekto](https://github.com/elekto-io/elekto).
 Commissioned by the CNCF for the Kubernetes project, Elekto has the advantage of
 not requiring any email for voting, just your Github login.  However, this will
 be the first time a project other than Kubernetes is using Elekto, so please be
@@ -35,7 +35,8 @@ prepared for some hiccups.
 
 For more details, please visit the [TOC election](
 https://github.com/knative/community/tree/main/elections/2021-TOC) document in
-our GitHub repository.
+our GitHub repository, and if you have questions for us, please reach out
+by emailing elections@knative.team.
 
 Dawn Foster and Josh Berkus, TOC Election Officers
 

--- a/blog/steering/[BLOG]-toc-2021-election-announcement.md
+++ b/blog/steering/[BLOG]-toc-2021-election-announcement.md
@@ -13,10 +13,7 @@ nomination
 process](https://github.com/knative/community/tree/main/elections/2021-TOC#candidacy-process).
 2) If
 you want to vote in the election, please read the [eligibility
-criteria](https://github.com/knative/community/blob/main/mechanics/TOC.md#voter-eligibility). If you think you are eligible to vote, please make sure that your GitHub id appears
-in the voters.yaml file, and if not, please use the [voter exception
-process](https://github.com/knative/community/tree/main/elections/2021-TOC)
-in our voting tool, Elekto.
+criteria](https://github.com/knative/community/blob/main/mechanics/TOC.md#voter-eligibility). If you think you are eligible to vote, please check the Elekto application to see if you are eligible, and if not, [request a voter exception](https://test.elekto.io/app/elections/2021-TOC/exception).  See the [voter guide](https://github.com/knative/community/tree/main/elections/2021-TOC) for more information on how voting works.
 
 Here are a few important deadlines to keep in mind:
 
@@ -38,4 +35,3 @@ our GitHub repository, and if you have questions for us, please reach out
 by emailing elections@knative.team.
 
 Dawn Foster and Josh Berkus, TOC Election Officers
-

--- a/blog/steering/[BLOG]-toc-2021-election-announcement.md
+++ b/blog/steering/[BLOG]-toc-2021-election-announcement.md
@@ -1,0 +1,41 @@
+It’s time to kick off the Knative Technical Oversight Committee (TOC) elections
+again for 2021, and we are ready to accept nominations! 
+
+This election will shape the future of Knative as a community and project. While
+WGs help shape the individual direction of the project, the [TOC covers the
+technical direction, health of the project and community as a
+whole](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md#charter). 
+There are 2
+seats up for election and each of those seats will be held for two year terms.
+
+Right now, there are 2 things we need each Knative community member to do: 
+
+1) If you want to stand for election, we have [detailed instructions for the
+nomination
+process](https://github.com/knative/community/tree/main/elections/2021-TOC#candidacy-process).
+2) If
+you want to vote in the election, please read the [eligibility
+criteria](https://github.com/knative/community/blob/main/mechanics/TOC.md#voter-eligibility). If you think you are eligible to vote, please make sure that your GitHub id appears
+in the voters.yaml file, and if not, please use the [voter exception
+process](https://github.com/knative/community/tree/main/elections/2021-TOC)
+in our voting tool, Elekto.
+
+Here are a few important deadlines to keep in mind: 
+
+- April 23: All candidate nominations and voting exceptions due 
+- April 27: Election Begins 
+- May 11: Election Closes 
+- May 13: Announcement of Results
+
+For this election, we will be trying a new voting tool called Elekto.
+Commissioned by the CNCF for the Kubernetes project, Elekto has the advantage of
+not requiring any email for voting, just your Github login.  However, this will
+be the first time a project other than Kubernetes is using Elekto, so please be
+prepared for some hiccups.
+
+For more details, please visit the [TOC election](
+https://github.com/knative/community/tree/main/elections/2021-TOC) document in
+our GitHub repository.
+
+Dawn Foster and Josh Berkus, TOC Election Officers
+

--- a/blog/steering/[BLOG]-toc-2021-election-announcement.md
+++ b/blog/steering/[BLOG]-toc-2021-election-announcement.md
@@ -1,11 +1,9 @@
-It’s time to kick off the Knative Technical Oversight Committee (TOC) elections
+It’s time to kick off the Knative [Technical Oversight Committee](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md) (TOC) elections
 again for 2021, and we are ready to accept nominations!
 
 This election will shape the future of Knative as a community and project. While
-WGs help shape the individual direction of the project, the [TOC covers the
-technical direction, health of the project and community as a
-whole](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md#charter).
-There are 2
+WGs help shape the individual direction of the project, the [TOC](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md#charter) covers the
+technical direction, health of the project and community as a whole. There are 2
 seats up for election and each of those seats will be held for two year terms.
 
 Right now, there are 2 things we need each Knative community member to do:
@@ -22,8 +20,9 @@ in our voting tool, Elekto.
 
 Here are a few important deadlines to keep in mind:
 
-- April 23: All candidate nominations and voting exceptions due
+- April 23: All candidate nominations
 - April 27: Election Begins
+- May 9: Voter exception requests due
 - May 11: Election Closes
 - May 13: Announcement of Results
 

--- a/blog/steering/[BLOG]-toc-2021-election-announcement.md
+++ b/blog/steering/[BLOG]-toc-2021-election-announcement.md
@@ -1,14 +1,14 @@
 It’s time to kick off the Knative Technical Oversight Committee (TOC) elections
-again for 2021, and we are ready to accept nominations! 
+again for 2021, and we are ready to accept nominations!
 
 This election will shape the future of Knative as a community and project. While
 WGs help shape the individual direction of the project, the [TOC covers the
 technical direction, health of the project and community as a
-whole](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md#charter). 
+whole](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md#charter).
 There are 2
 seats up for election and each of those seats will be held for two year terms.
 
-Right now, there are 2 things we need each Knative community member to do: 
+Right now, there are 2 things we need each Knative community member to do:
 
 1) If you want to stand for election, we have [detailed instructions for the
 nomination
@@ -20,11 +20,11 @@ in the voters.yaml file, and if not, please use the [voter exception
 process](https://github.com/knative/community/tree/main/elections/2021-TOC)
 in our voting tool, Elekto.
 
-Here are a few important deadlines to keep in mind: 
+Here are a few important deadlines to keep in mind:
 
-- April 23: All candidate nominations and voting exceptions due 
-- April 27: Election Begins 
-- May 11: Election Closes 
+- April 23: All candidate nominations and voting exceptions due
+- April 27: Election Begins
+- May 11: Election Closes
 - May 13: Announcement of Results
 
 For this election, we will be trying a new voting tool called Elekto.


### PR DESCRIPTION
This is a blog post to kick off the TOC election for 2021. The target is to announce the election tomorrow (April 13), but we are still working on a few details, so it's important that this does not get published until:
- We merge [this PR](https://github.com/knative/community/pull/562) from @jberkus.
- And the voters.yaml (community/elections/2021-TOC/voters.yaml) file is populated with GH ids for voters.

The safest bet is probably to make sure we get the OK from @jberkus before it goes live.

@bsnchan and @thisisnotapril - since the 2 of you suggested making this a blog post - is there anything you'd like to add? Right now, this is mostly the text that will go out via email with a few tweaks to make it read better as a blog post.