### PR TITLE
Add frontmatter to avoid rendering infrastructure description files

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,11 @@
+---
+_build:
+  render: never
+  list: never
+---
+(This guide only appears on GitHub, not the website, because it
+**intentionally** does not include YAML front-matter.)
+
 # Development
 
 This doc explains how to setup a development environment so you can get started

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+---
+_build:
+  render: never
+  list: never
+---
+(This guide only appears on GitHub, not the website, because it
+**intentionally** does not include YAML front-matter.)
+
 # Knative documentation
 
 Welcome to the source file repository for our documentation on

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,3 +1,9 @@
+---
+_build:
+  render: never
+  list: never
+---
+
 # Knative blog
 
 The Knative blog is owned by the [Documentation working group](https://knative.dev/community/contributing/working-groups/working-groups/#documentation) and run by the [Editorial Team](#leadership).

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,9 @@
+---
+_build:
+  render: never
+  list: never
+---
+
 # Test
 
 This directory contains tests and testing docs.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Similar to the change we made to `CONTRIBUTING.md`, ask hugo not to render other "how to do docs" files.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Avoid building files that aren't intended for the website.
