### PR TITLE
Add metrics api docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -51,6 +51,12 @@ These components are delivered as Kubernetes custom resource definitions (CRDs),
 - [All samples for serving](./serving/samples/)
 - [All samples for eventing](./eventing/samples/)
 
+### Observability
+
+- [Serving Metrics API](./serving/metrics/)
+- [Eventing Metrics API](./eventing/metrics/)
+- [Collecting metrics](./install/collecting-metrics)
+
 ### Debugging
 
 - [Debugging application issues](./serving/debugging-application-issues/)

--- a/docs/eventing/_index.md
+++ b/docs/eventing/_index.md
@@ -98,3 +98,7 @@ resources:
 
 1. **[Sequence](./flows/sequence)** provides a way to define an in-order list of functions.
 1. **[Parallel](./flows/parallel)** provides a way to define a list of branches for events.
+
+## Observability
+
+- [Eventing Metrics API](./metrics.md)

--- a/docs/eventing/metrics.md
+++ b/docs/eventing/metrics.md
@@ -8,20 +8,12 @@ type: "docs"
 
 **NOTE:** The metrics API may change in the future, this serves as a snapshot of the current metrics.
 
+## Admin
 
-## Eventing sources
+Administrators can monitor Eventing based on the metrics exposed by each Eventing component.
+Metrics are listed next.
 
-Every source exposes by default a number of metrics to help user monitor events dispatched. Use the following metrics
-to verify that events have been delivered from the source side, thus verifying that the source and any connection with the source work as expected.
-
-| Metric Name | Description | Type | Tags | Unit | Status |
-|:-|:-|:-|:-|:-|:-|
-| event_count | Number of events sent by the source | Counter | event_source<br>event_type<br>name<br>namespace_name<br>resource_group<br>response_code<br>response_code_class<br>response_error<br>response_timeout | Dimensionless  | Stable |
-| retry_event_count | Number of events sent by the source in retries | Counter | event_source<br>event_type<br>name<br>namespace_name<br>resource_group<br>response_code<br>response_code_class<br>response_error<br>response_timeout | Dimensionless | Stable
-
-## Broker
-
-### Ingress
+### Broker - Ingress
 
 Use the following metrics to debug how broker ingress performs and what events are dispacthed via the ingress component.
 By aggregating the metrics over the http code, events can be separated into two classes, successful (2xx) and failed events (5xx).
@@ -31,7 +23,7 @@ By aggregating the metrics over the http code, events can be separated into two 
 | event_count | Number of events received by a Broker | Counter | broker_name<br>event_type<br>namespace_name<br>response_code<br>response_code_class<br>unique_name | Dimensionless | Stable
 | event_dispatch_latencies | The time spent dispatching an event to a Channel | Histogram | broker_name<br>event_type<br>namespace_name<br>response_code<br>response_code_class<br>unique_name | Milliseconds | Stable
 
-### Filter
+### Broker - Filter
 
 Use the following metrics to debug how broker filter performs and what events are dispatched via the filter component.
 Also user can measure the latency of the actual filtering action on an event.
@@ -43,7 +35,7 @@ By aggregating the metrics over the http code, events can be separated into two 
 | event_dispatch_latencies | The time spent dispatching an event to a Channel | Histogram | broker_name<br>container_name<br>filter_type<br>namespace_name<br>response_code<br>response_code_class<br>trigger_name<br>unique_name | Milliseconds | Stable
 | event_processing_latencies | The time spent processing an event before it is dispatched to a Trigger subscriber | Histogram | broker_name<br>container_name<br>filter_type<br>namespace_name<br>trigger_name<br>unique_name | Milliseconds | Stable
 
-## In-memory Dispatcher
+### In-memory Dispatcher
 
 In-memory channel can be evaluated via the following metrics.
 By aggregating the metrics over the http code, events can be separated into two classes, successful (2xx) and failed events (5xx).
@@ -55,3 +47,17 @@ By aggregating the metrics over the http code, events can be separated into two 
 
 
 **NOTE:** A number of metrics eg. controller, Go runtime and others are omitted here as they are common across most components. For more about these metrics check the [Serving metrics API section](../serving/metrics.md#controller).
+
+
+## Developer metrics
+
+### Eventing sources
+
+Eventing sources are created by users so they can trigger their applications with events.
+Every source exposes by default a number of metrics to help user monitor events dispatched. Use the following metrics
+to verify that events have been delivered from the source side, thus verifying that the source and any connection with the source work as expected.
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| event_count | Number of events sent by the source | Counter | event_source<br>event_type<br>name<br>namespace_name<br>resource_group<br>response_code<br>response_code_class<br>response_error<br>response_timeout | Dimensionless  | Stable |
+| retry_event_count | Number of events sent by the source in retries | Counter | event_source<br>event_type<br>name<br>namespace_name<br>resource_group<br>response_code<br>response_code_class<br>response_error<br>response_timeout | Dimensionless | Stable

--- a/docs/eventing/metrics.md
+++ b/docs/eventing/metrics.md
@@ -1,0 +1,52 @@
+---
+title: "Metrics API"
+weight: 99
+type: "docs"
+---
+
+## Eventing sources
+
+Every source exposes by default a number of metrics to help user monitor events dispatched. Use the following metrics
+to verify that events have been delivered from the source side, thus verifying that the source and any connection with the source work as expected.
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| event_count | Number of events sent by the source | Counter | event_source<br>event_type<br>name<br>namespace_name<br>resource_group<br>response_code<br>response_code_class<br>response_error<br>response_timeout | Dimensionless  | Stable |
+| retry_event_count | Number of events sent by the source in retries | Counter | event_source<br>event_type<br>name<br>namespace_name<br>resource_group<br>response_code<br>response_code_class<br>response_error<br>response_timeout | Dimensionless | Stable
+
+## Broker
+
+### Ingress
+
+Use the following metrics to debug how broker ingress performs and what events are dispacthed via the ingress component.
+By aggregating the metrics over the http code, events can be separated into two classes, successful (2xx) and failed events (5xx).
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| event_count | Number of events received by a Broker | Counter | broker_name<br>event_type<br>namespace_name<br>response_code<br>response_code_class<br>unique_name | Dimensionless | Stable
+| event_dispatch_latencies | The time spent dispatching an event to a Channel | Histogram | broker_name<br>event_type<br>namespace_name<br>response_code<br>response_code_class<br>unique_name | Milliseconds | Stable
+
+### Filter
+
+Use the following metrics to debug how broker filter performs and what events are dispatched via the filter component.
+Also user can measure the latency of the actual filtering action on an event.
+By aggregating the metrics over the http code, events can be separated into two classes, successful (2xx) and failed events (5xx).
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| event_count | Number of events received by a Broker | Counter | broker_name<br>container_name=<br>filter_type<br>namespace_name<br>response_code<br>response_code_class<br>trigger_name<br>unique_name | Dimensionless | Stable
+| event_dispatch_latencies | The time spent dispatching an event to a Channel | Histogram | broker_name<br>container_name<br>filter_type<br>namespace_name<br>response_code<br>response_code_class<br>trigger_name<br>unique_name | Milliseconds | Stable
+| event_processing_latencies | The time spent processing an event before it is dispatched to a Trigger subscriber | Histogram | broker_name<br>container_name<br>filter_type<br>namespace_name<br>trigger_name<br>unique_name | Milliseconds | Stable
+
+## In-memory Dispatcher
+
+In-memory channel can be evaluated via the following metrics.
+By aggregating the metrics over the http code, events can be separated into two classes, successful (2xx) and failed events (5xx).
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| event_count | Number of events dispatched by the in-memory channel | Counter | container_name<br>event_type=<br>namespace_name=<br>response_code<br>response_code_class<br>unique_name | Dimensionless | Stable
+| event_dispatch_latencies | The time spent dispatching an event from a in-memory Channel | Histogram | container_name<br>event_type<br>namespace_name=<br>response_code<br>response_code_class<br>unique_name | Milliseconds | Stable
+
+
+Note: A number of metrics eg. controller, Go runtime and others are omitted here as they are common across most components. For more about these metrics check the [Serving metrics API section](../serving/metrics/).

--- a/docs/eventing/metrics.md
+++ b/docs/eventing/metrics.md
@@ -4,6 +4,11 @@ weight: 99
 type: "docs"
 ---
 
+<br>
+
+**NOTE:** The metrics API may change in the future, this serves as a snapshot of the current metrics.
+
+
 ## Eventing sources
 
 Every source exposes by default a number of metrics to help user monitor events dispatched. Use the following metrics
@@ -49,4 +54,4 @@ By aggregating the metrics over the http code, events can be separated into two 
 | event_dispatch_latencies | The time spent dispatching an event from a in-memory Channel | Histogram | container_name<br>event_type<br>namespace_name=<br>response_code<br>response_code_class<br>unique_name | Milliseconds | Stable
 
 
-Note: A number of metrics eg. controller, Go runtime and others are omitted here as they are common across most components. For more about these metrics check the [Serving metrics API section](../serving/metrics/).
+**NOTE:** A number of metrics eg. controller, Go runtime and others are omitted here as they are common across most components. For more about these metrics check the [Serving metrics API section](../serving/metrics.md#controller).

--- a/docs/eventing/metrics.md
+++ b/docs/eventing/metrics.md
@@ -49,11 +49,9 @@ By aggregating the metrics over the http code, events can be separated into two 
 **NOTE:** A number of metrics eg. controller, Go runtime and others are omitted here as they are common across most components. For more about these metrics check the [Serving metrics API section](../serving/metrics.md#controller).
 
 
-## Developer metrics
-
 ### Eventing sources
 
-Eventing sources are created by users so they can trigger their applications with events.
+Eventing sources are created by users who own the related system, so they can trigger applications with events.
 Every source exposes by default a number of metrics to help user monitor events dispatched. Use the following metrics
 to verify that events have been delivered from the source side, thus verifying that the source and any connection with the source work as expected.
 

--- a/docs/serving/_index.md
+++ b/docs/serving/_index.md
@@ -77,6 +77,10 @@ in the Knative Serving repository.
 - [Assigning a static IP address for Knative on Google Kubernetes Engine](./gke-assigning-static-ip-address.md)
 - [Using subroutes](./using-subroutes.md)
 
+## Observability
+
+- [Serving Metrics API](./metrics.md)
+
 ## Known Issues
 
 See the [Knative Serving Issues](https://github.com/knative/serving/issues) page

--- a/docs/serving/metrics.md
+++ b/docs/serving/metrics.md
@@ -7,20 +7,30 @@ type: "docs"
 <br>
 
 **NOTE:** The metrics API may change in the future, this serves as a snapshot of the current metrics.
+<br>
 
+## Admin
 
-## Activator
+Administrators can monitor Serving control plane based on the metrics exposed by each Serving component.
+Metrics are listed next.
 
+### Activator
+
+The following metrics allow the user to understand how application responds when traffic goes through the activator eg. scaling from zero. For example high request latency means that requests are taken too much time be fulfilled.
+<br>
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
 | request_concurrency | Concurrent requests that are routed to Activator<br>These are requests reported by the concurrency reporter which may not be done yet.<br> This is the average concurrency over a reporting period | Gauge | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>revision_name<br>service_name | Dimensionless | Stable |
 | request_count | The number of requests that are routed to Activator.<br>These are requests that have been fulfilled from the activator handler. | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
 | request_latencies | The response time in millisecond for the fulfilled routed requests | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
 
-## Autoscaler
+### Autoscaler
 
-Generic
-
+Autoscaler component exposes a number of metrics related to its decisions per revision.
+For example at any given time user can monitor the desired pods the Autoscaler wants to allocate for
+a service, the average number of requests per second during the stable window, whether autoscaler is in panic mode (KPA) etc.
+To read more about how autoscaler works check [here](https://github.com/knative/serving/blob/main/docs/scaling/SYSTEM.md).
+<br>
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
 | desired_pods | Number of pods autoscaler wants to allocate | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
@@ -32,31 +42,17 @@ Generic
 | panic_requests_per_second | Average requests-per-second per observed pod over the panic window | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
 | target_requests_per_second | The desired requests-per-second for each pod | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
 | panic_mode | 1 if autoscaler is in panic mode, 0 otherwise | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
-
-KPA
-
-| Metric Name | Description | Type | Tags | Unit | Status |
-|:-|:-|:-|:-|:-|:-|
 | requested_pods | Number of pods autoscaler requested from Kubernetes | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
-| actual_pods | Number of pods that are allocated currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name |  Dimensionless | Stable |
+| actual_pods | Number of pods that are allocated currently in ready state | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name |  Dimensionless | Stable |
 | not_ready_pods | Number of pods that are not ready currently | Gauge | configuration_name=<br>namespace_name=<br>revision_name<br>service_name |  Dimensionless | Stable |
 | pending_pods | Number of pods that are pending currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
 | terminating_pods | Number of pods that are terminating currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name<br> | Dimensionless | Stable |
 
-## Queue proxy
+### Controller
 
-Requests endpoint
-
-| Metric Name | Description | Type | Tags | Unit | Status |
-|:-|:-|:-|:-|:-|:-|
-| revision_request_count | The number of requests that are routed to queue-proxy | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
-| revision_request_latencies | The response time in millisecond | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name |  Milliseconds | Stable |
-| revision_app_request_count | The number of requests that are routed to user-container | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
-| revision_app_request_latencies | The response time in millisecond |  Histogram | configuration_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
-| revision_queue_depth | The current number of items in the serving and waiting queue, or not reported if unlimited concurrency | Gauge | configuration_name<br>event-display<br>container_name<br>namespace_name<br>pod_name<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
-
-
-## Controller
+The following metrics are emitted by any component that implements a controller logic.
+The metrics show details about the reconciliation operations and the workqueue behavior on which
+reconciliation requests are enqueued.
 
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
@@ -71,20 +67,24 @@ Requests endpoint
 | workqueue_unfinished_work_seconds | How long in seconds the outstanding workqueue items have been in flight (total). | Histogram | name | Seconds | Stable |
 | workqueue_longest_running_processor_seconds | How long in seconds the longest outstanding workqueue item has been in flight | Histogram | name | Seconds | Stable |
 
-## Webhook
+### Webhook
 
+Webhook metrics report useful info about operations eg. CREATE on Serving resources and if admission was allowed.
+For example if a big number of operations fail this could be an issue with the submitted user resource.
+<br>
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
 | request_count | The number of requests that are routed to webhook | Counter |  admission_allowed<br>kind_group<br>kind_kind<br>kind_version<br>request_operation<br>resource_group<br>resource_namespace<br>resource_resource<br>resource_version | Dimensionless | Stable |
 | request_latencies | The response time in milliseconds | Histogram |  admission_allowed<br>kind_group<br>kind_kind<br>kind_version<br>request_operation<br>resource_group<br>resource_namespace<br>resource_resource<br>resource_version | Milliseconds | Stable |
 
-## Go Runtime - memstats
+### Go Runtime - memstats
 
-Each process emits a number of memory statistics from the go runtime.
-
+Each Knative Serving control plane process emits a number of Go runtime [memory statistics](https://golang.org/pkg/runtime/#MemStats) (shown next).
+As a baseline for monitoring purproses, user could start with a subset of the metrics: current allocations (go_alloc), total allocations (go_total_alloc), system memory (go_sys), mallocs (go_mallocs), frees (go_frees) and garbage collection total pause time (total_gc_pause_ns), next gc target heap size (go_next_gc) and number of garbage collection cycles (num_gc).
+<br>
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
-| go_alloc | The number of bytes of allocated heap objects | Gauge | name | Dimensionless | Stable |
+| go_alloc | The number of bytes of allocated heap objects (same as heap_alloc) | Gauge | name | Dimensionless | Stable |
 | go_total_alloc | The cumulative bytes allocated for heap objects | Gauge | name | Dimensionless | Stable |
 | go_sys | The total bytes of memory obtained from the OS | Gauge | name | Dimensionless | Stable |
 | go_lookups | The number of pointer lookups performed by the runtime | Gauge | name | Dimensionless | Stable |
@@ -113,3 +113,21 @@ Each process emits a number of memory statistics from the go runtime.
 | go_gc_cpu_fraction | The fraction of this program's available CPU time used by the GC since the program started | Gauge | name | Dimensionless | Stable |
 
 **NOTE:** name tag is empty.
+
+## Developer - User Services
+
+Every Knative service has a proxy container that proxies the connections to the application container.
+A number of metrics are reported for the queue peroxy performance. Using the following metrics application
+developers, devops and others, could measure if requests are queued at the proxy side (need for backpressure) and what is the actual delay in serving requests at the application side.
+
+### Queue proxy
+
+Requests endpoint
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| revision_request_count | The number of requests that are routed to queue-proxy | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
+| revision_request_latencies | The response time in millisecond | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name |  Milliseconds | Stable |
+| revision_app_request_count | The number of requests that are routed to user-container | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
+| revision_app_request_latencies | The response time in millisecond |  Histogram | configuration_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
+| revision_queue_depth | The current number of items in the serving and waiting queue, or not reported if unlimited concurrency | Gauge | configuration_name<br>event-display<br>container_name<br>namespace_name<br>pod_name<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |

--- a/docs/serving/metrics.md
+++ b/docs/serving/metrics.md
@@ -4,7 +4,12 @@ weight: 99
 type: "docs"
 ---
 
-### Activator
+<br>
+
+**NOTE:** The metrics API may change in the future, this serves as a snapshot of the current metrics.
+
+
+## Activator
 
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
@@ -12,7 +17,7 @@ type: "docs"
 | request_count | The number of requests that are routed to Activator.<br>These are requests that have been fulfilled from the activator handler. | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
 | request_latencies | The response time in millisecond for the fulfilled routed requests | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
 
-### Autoscaler
+## Autoscaler
 
 Generic
 
@@ -38,7 +43,7 @@ KPA
 | pending_pods | Number of pods that are pending currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
 | terminating_pods | Number of pods that are terminating currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name<br> | Dimensionless | Stable |
 
-### QUEUE proxy
+## Queue proxy
 
 Requests endpoint
 
@@ -51,7 +56,7 @@ Requests endpoint
 | revision_queue_depth | The current number of items in the serving and waiting queue, or not reported if unlimited concurrency | Gauge | configuration_name<br>event-display<br>container_name<br>namespace_name<br>pod_name<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
 
 
-### Controller
+## Controller
 
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
@@ -66,14 +71,14 @@ Requests endpoint
 | workqueue_unfinished_work_seconds | How long in seconds the outstanding workqueue items have been in flight (total). | Histogram | name | Seconds | Stable |
 | workqueue_longest_running_processor_seconds | How long in seconds the longest outstanding workqueue item has been in flight | Histogram | name | Seconds | Stable |
 
-### Webhook
+## Webhook
 
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|
 | request_count | The number of requests that are routed to webhook | Counter |  admission_allowed<br>kind_group<br>kind_kind<br>kind_version<br>request_operation<br>resource_group<br>resource_namespace<br>resource_resource<br>resource_version | Dimensionless | Stable |
 | request_latencies | The response time in milliseconds | Histogram |  admission_allowed<br>kind_group<br>kind_kind<br>kind_version<br>request_operation<br>resource_group<br>resource_namespace<br>resource_resource<br>resource_version | Milliseconds | Stable |
 
-### Go Runtime - memstats
+## Go Runtime - memstats
 
 Each process emits a number of memory statistics from the go runtime.
 
@@ -107,4 +112,4 @@ Each process emits a number of memory statistics from the go runtime.
 | go_num_forced_gc | The number of GC cycles that were forced by the application calling the GC function. | Gauge | name | Dimensionless | Stable |
 | go_gc_cpu_fraction | The fraction of this program's available CPU time used by the GC since the program started | Gauge | name | Dimensionless | Stable |
 
-Note: name tag is empty.
+**NOTE:** name tag is empty.

--- a/docs/serving/metrics.md
+++ b/docs/serving/metrics.md
@@ -1,0 +1,110 @@
+---
+title: "Metrics API"
+weight: 99
+type: "docs"
+---
+
+### Activator
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| request_concurrency | Concurrent requests that are routed to Activator<br>These are requests reported by the concurrency reporter which may not be done yet.<br> This is the average concurrency over a reporting period | Gauge | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| request_count | The number of requests that are routed to Activator.<br>These are requests that have been fulfilled from the activator handler. | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
+| request_latencies | The response time in millisecond for the fulfilled routed requests | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
+
+### Autoscaler  
+
+Generic
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| desired_pods | Number of pods autoscaler wants to allocate | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| excess_burst_capacity | Excess burst capacity overserved over the stable window | Gauge |  configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| stable_request_concurrency | Average of requests count per observed pod over the stable window | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| panic_request_concurrency | Average of requests count per observed pod over the panic window | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| target_concurrency_per_pod | The desired number of concurrent requests for each pod | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| stable_requests_per_second | Average requests-per-second per observed pod over the stable window | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| panic_requests_per_second | Average requests-per-second per observed pod over the panic window | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| target_requests_per_second | The desired requests-per-second for each pod | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| panic_mode | 1 if autoscaler is in panic mode, 0 otherwise | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+
+KPA
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| requested_pods | Number of pods autoscaler requested from Kubernetes | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| actual_pods | Number of pods that are allocated currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name |  Dimensionless | Stable |
+| not_ready_pods | Number of pods that are not ready currently | Gauge | configuration_name=<br>namespace_name=<br>revision_name<br>service_name |  Dimensionless | Stable |
+| pending_pods | Number of pods that are pending currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name | Dimensionless | Stable |
+| terminating_pods | Number of pods that are terminating currently | Gauge | configuration_name<br>namespace_name<br>revision_name<br>service_name<br> | Dimensionless | Stable |
+
+### QUEUE proxy
+
+Requests endpoint
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| revision_request_count | The number of requests that are routed to queue-proxy | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
+| revision_request_latencies | The response time in millisecond | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name |  Milliseconds | Stable |
+| revision_app_request_count | The number of requests that are routed to user-container | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
+| revision_app_request_latencies | The response time in millisecond |  Histogram | configuration_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
+| revision_queue_depth | The current number of items in the serving and waiting queue, or not reported if unlimited concurrency | Gauge | configuration_name<br>event-display<br>container_name<br>namespace_name<br>pod_name<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
+
+
+### Controller
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| work_queue_depth | Depth of the work queue | Gauge | reconciler | Dimensionless | Stable |
+| reconcile_count | Number of reconcile operations | Counter | reconciler<br>success<br> | Dimensionless | Stable |
+| reconcile_latency | Latency of reconcile operations | Histogram | reconciler<br>success<br> | Milliseconds | Stable |
+| workqueue_adds_total | Total number of adds handled by workqueue | Counter | name | Dimensionless | Stable |
+| workqueue_depth | Current depth of workqueue | Gauge | reconciler | Dimensionless | Stable |
+| workqueue_queue_latency_seconds | How long in seconds an item stays in workqueue before being requested | Histogram | name | Seconds | Stable |
+| workqueue_retries_total | Total number of retries handled by workqueue | Counter | name | Dimensionless | Stable |
+| workqueue_work_duration_seconds | How long in seconds processing an item from a workqueue takes. | Histogram | name | Seconds| Stable |
+| workqueue_unfinished_work_seconds | How long in seconds the outstanding workqueue items have been in flight (total). | Histogram | name | Seconds | Stable |
+| workqueue_longest_running_processor_seconds | How long in seconds the longest outstanding workqueue item has been in flight | Histogram | name | Seconds | Stable |
+
+### Webhook
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| request_count | The number of requests that are routed to webhook | Counter |  admission_allowed<br>kind_group<br>kind_kind<br>kind_version<br>request_operation<br>resource_group<br>resource_namespace<br>resource_resource<br>resource_version | Dimensionless | Stable |
+| request_latencies | The response time in milliseconds | Histogram |  admission_allowed<br>kind_group<br>kind_kind<br>kind_version<br>request_operation<br>resource_group<br>resource_namespace<br>resource_resource<br>resource_version | Milliseconds | Stable |
+
+### Go Runtime - memstats
+
+Each process emits a number of memory statistics from the go runtime.
+
+| Metric Name | Description | Type | Tags | Unit | Status |
+|:-|:-|:-|:-|:-|:-|
+| go_alloc | The number of bytes of allocated heap objects | Gauge | name | Dimensionless | Stable |
+| go_total_alloc | The cumulative bytes allocated for heap objects | Gauge | name | Dimensionless | Stable |
+| go_sys | The total bytes of memory obtained from the OS | Gauge | name | Dimensionless | Stable |
+| go_lookups | The number of pointer lookups performed by the runtime | Gauge | name | Dimensionless | Stable |
+| go_mallocs | The cumulative count of heap objects allocated | Gauge | name | Dimensionless | Stable |
+| go_frees | The cumulative count of heap objects freed | Gauge | name | Dimensionless | Stable |
+| go_heap_alloc | The number of bytes of allocated heap objects | Gauge | name | Dimensionless | Stable |
+| go_heap_sys | The number of bytes of heap memory obtained from the OS | Gauge | name | Dimensionless | Stable |
+| go_heap_idle | The number of bytes in idle (unused) spans | Gauge | name | Dimensionless | Stable |
+| go_heap_in_use | The number of bytes in in-use spans | Gauge | name | Dimensionless | Stable |
+| go_heap_released | The number of bytes of physical memory returned to the OS | Gauge | name | Dimensionless | Stable |
+| go_heap_objects | The number of allocated heap objects | Gauge | name | Dimensionless | Stable |
+| go_stack_in_use | The number of bytes in stack spans | Gauge | name | Dimensionless | Stable |
+| go_stack_sys | The number of bytes of stack memory obtained from the OS | Gauge | name | Dimensionless | Stable |
+| go_mspan_in_use | The number of bytes of allocated mspan structures | Gauge | name | Dimensionless | Stable |
+| go_mspan_sys | The number of bytes of memory obtained from the OS for mspan structures | Gauge | name | Dimensionless | Stable |
+| go_mcache_in_use | The number of bytes of allocated mcache structures | Gauge | name | Dimensionless | Stable |
+| go_mcache_sys | The number of bytes of memory obtained from the OS for mcache structures | Gauge | name | Dimensionless | Stable |
+| go_bucket_hash_sys | The number of bytes of memory in profiling bucket hash tables. | Gauge | name | Dimensionless | Stable |
+| go_gc_sys | The number of bytes of memory in garbage collection metadata | Gauge | name | Dimensionless | Stable |
+| go_other_sys | The number of bytes of memory in miscellaneous off-heap runtime allocations | Gauge | name | Dimensionless | Stable |
+| go_next_gc | The target heap size of the next GC cycle | Gauge | name | Dimensionless | Stable |
+| go_last_gc | The time the last garbage collection finished, as nanoseconds since 1970 (the UNIX epoch) | Gauge | name | Nanoseconds | Stable |
+| go_total_gc_pause_ns | The cumulative nanoseconds in GC stop-the-world pauses since the program started | Gauge | name | Nanoseconds | Stable |
+| go_num_gc | The number of completed GC cycles. | Gauge | name | Dimensionless | Stable |
+| go_num_forced_gc | The number of GC cycles that were forced by the application calling the GC function. | Gauge | name | Dimensionless | Stable |
+| go_gc_cpu_fraction | The fraction of this program's available CPU time used by the GC since the program started | Gauge | name | Dimensionless | Stable |
+
+Note: name tag is empty.

--- a/docs/serving/metrics.md
+++ b/docs/serving/metrics.md
@@ -12,7 +12,7 @@ type: "docs"
 | request_count | The number of requests that are routed to Activator.<br>These are requests that have been fulfilled from the activator handler. | Counter | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Dimensionless | Stable |
 | request_latencies | The response time in millisecond for the fulfilled routed requests | Histogram | configuration_name<br>container_name<br>namespace_name<br>pod_name<br>response_code<br>response_code_class<br>revision_name<br>service_name | Milliseconds | Stable |
 
-### Autoscaler  
+### Autoscaler
 
 Generic
 


### PR DESCRIPTION
Fixes #1792 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds serving, eventing metrics api documentation
- Each metric has a lifecycle status following the [k8s approach](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/#metric-lifecycle)
- Adds some guidelines on how to use the metrics.

Screenshots bellow:
![image](https://user-images.githubusercontent.com/7945591/115258802-fc1e8b00-a139-11eb-95a1-223d225143b4.png)
![image](https://user-images.githubusercontent.com/7945591/115258833-02ad0280-a13a-11eb-861c-7de577cd24f0.png)

Note: tables can be improved with some custom table shortcode etc (goes beyond of this PR). Also in the future info could
be extracted from a cvs file (common practice with hugo).
/cc @matzew @markusthoemmes  @evankanderson 