### PR TITLE
Fix API doc generator to properly link to duck, networking

### DIFF
--- a/docs/reference/api/eventing/eventing.md
+++ b/docs/reference/api/eventing/eventing.md
@@ -229,7 +229,9 @@ global delivery spec.</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -245,7 +247,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>AddressStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
 knative.dev/pkg/apis/duck/v1.AddressStatus
+</a>
 </em>
 </td>
 <td>
@@ -275,7 +279,9 @@ SubscribableStatus
 <td>
 <code>deadLetterChannel</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -307,7 +313,9 @@ such as channelable and source.</p>
 <td>
 <code>deadLetterSink</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -379,7 +387,9 @@ For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 <td>
 <code>deadLetterChannel</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -574,7 +584,9 @@ int64
 <td>
 <code>subscriberUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -586,7 +598,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>replyUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -863,7 +877,9 @@ DeliverySpec
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -879,7 +895,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>AddressStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
 knative.dev/pkg/apis/duck/v1.AddressStatus
+</a>
 </em>
 </td>
 <td>
@@ -909,7 +927,9 @@ SubscribableStatus
 <td>
 <code>deadLetterChannel</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -941,7 +961,9 @@ such as channelable and source.</p>
 <td>
 <code>deadLetterSink</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -1013,7 +1035,9 @@ For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.</p>
 <td>
 <code>deadLetterChannel</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -1208,7 +1232,9 @@ int64
 <td>
 <code>subscriberUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -1220,7 +1246,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>replyUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -1389,7 +1417,9 @@ BrokerSpec
 <td>
 <code>config</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -1525,7 +1555,9 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -1586,7 +1618,9 @@ date.</p>
 <td>
 <code>config</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -1634,7 +1668,9 @@ global delivery spec.</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1650,7 +1686,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>address</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Addressable">
 knative.dev/pkg/apis/duck/v1.Addressable
+</a>
 </em>
 </td>
 <td>
@@ -1750,7 +1788,9 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -1794,7 +1834,9 @@ DeliverySpec
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1810,7 +1852,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>subscriberUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -1900,7 +1944,9 @@ BrokerSpec
 <td>
 <code>config</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -2019,7 +2065,9 @@ string
 <td>
 <code>source</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2031,7 +2079,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>schema</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2191,7 +2241,9 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2252,7 +2304,9 @@ date.</p>
 <td>
 <code>config</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -2299,7 +2353,9 @@ This includes things like retries, DLQ, etc.</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -2315,7 +2371,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>address</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Addressable">
 knative.dev/pkg/apis/duck/v1.Addressable
+</a>
 </em>
 </td>
 <td>
@@ -2355,7 +2413,9 @@ string
 <td>
 <code>source</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2367,7 +2427,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>schema</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2437,7 +2499,9 @@ string
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -2542,7 +2606,9 @@ filter will be sent to the Subscriber. If not specified, will default to allowin
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2586,7 +2652,9 @@ DeliverySpec
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -2602,7 +2670,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>subscriberUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2694,7 +2764,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2742,7 +2814,9 @@ date.</p>
 <td>
 <code>filter</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2754,7 +2828,9 @@ knative.dev/pkg/apis/duck/v1.Destination
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2765,7 +2841,9 @@ knative.dev/pkg/apis/duck/v1.Destination
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2936,7 +3014,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -2967,7 +3047,9 @@ when the case does not have a Reply</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -3010,7 +3092,9 @@ Matches the Spec.Branches array in the order.</p>
 <td>
 <code>AddressStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
 knative.dev/pkg/apis/duck/v1.AddressStatus
+</a>
 </em>
 </td>
 <td>
@@ -3141,7 +3225,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3258,7 +3344,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3288,7 +3376,9 @@ knative.dev/pkg/apis/duck/v1.Destination
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -3332,7 +3422,9 @@ Matches the Spec.Steps array in the order.</p>
 <td>
 <code>AddressStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
 knative.dev/pkg/apis/duck/v1.AddressStatus
+</a>
 </em>
 </td>
 <td>
@@ -3365,7 +3457,9 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <td>
 <code>Destination</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3515,7 +3609,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3563,7 +3659,9 @@ date.</p>
 <td>
 <code>filter</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3575,7 +3673,9 @@ knative.dev/pkg/apis/duck/v1.Destination
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3586,7 +3686,9 @@ knative.dev/pkg/apis/duck/v1.Destination
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3758,7 +3860,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -3789,7 +3893,9 @@ when the case does not have a Reply</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -3832,7 +3938,9 @@ Matches the Spec.Branches array in the order.</p>
 <td>
 <code>AddressStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
 knative.dev/pkg/apis/duck/v1.AddressStatus
+</a>
 </em>
 </td>
 <td>
@@ -3963,7 +4071,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4080,7 +4190,9 @@ for the namespace (or cluster, in case there are no defaults for the namespace).
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4110,7 +4222,9 @@ knative.dev/pkg/apis/duck/v1.Destination
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -4154,7 +4268,9 @@ Matches the Spec.Steps array in the order.</p>
 <td>
 <code>AddressStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#AddressStatus">
 knative.dev/pkg/apis/duck/v1.AddressStatus
+</a>
 </em>
 </td>
 <td>
@@ -4187,7 +4303,9 @@ It generally has the form {channel}.{namespace}.svc.{cluster domain name}</p>
 <td>
 <code>Destination</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4561,7 +4679,9 @@ etc.)</p>
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4575,7 +4695,9 @@ sent to a Destination as specified by the Reply.</p>
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4706,7 +4828,9 @@ ChannelableStatus
 <td>
 <code>channel</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -4877,7 +5001,9 @@ etc.)</p>
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4891,7 +5017,9 @@ sent to a Destination as specified by the Reply.</p>
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -4936,7 +5064,9 @@ DeliverySpec
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -4984,7 +5114,9 @@ Subscription.</p>
 <td>
 <code>subscriberUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -4995,7 +5127,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>replyUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -5006,7 +5140,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>deadLetterSinkUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -5321,7 +5457,9 @@ etc.)</p>
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -5335,7 +5473,9 @@ sent to a Destination as specified by the Reply.</p>
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -5466,7 +5606,9 @@ ChannelableStatus
 <td>
 <code>channel</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -5637,7 +5779,9 @@ etc.)</p>
 <td>
 <code>subscriber</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -5651,7 +5795,9 @@ sent to a Destination as specified by the Reply.</p>
 <td>
 <code>reply</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Destination">
 knative.dev/pkg/apis/duck/v1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -5696,7 +5842,9 @@ DeliverySpec
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -5744,7 +5892,9 @@ Subscription.</p>
 <td>
 <code>subscriberUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -5755,7 +5905,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>replyUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -5766,7 +5918,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>deadLetterSinkUri</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -5849,7 +6003,9 @@ ApiServerSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6000,7 +6156,9 @@ ContainerSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6110,7 +6268,9 @@ SinkBindingSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6128,7 +6288,9 @@ and modifications of the event sent to the sink.</p>
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#BindingSpec">
 knative.dev/pkg/apis/duck/v1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -6275,7 +6437,9 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6370,7 +6534,9 @@ source. Defaults to default if not set.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -6408,7 +6574,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6457,7 +6625,9 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -6495,7 +6665,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6513,7 +6685,9 @@ and modifications of the event sent to the sink.</p>
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#BindingSpec">
 knative.dev/pkg/apis/duck/v1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -6547,7 +6721,9 @@ should be augmented by Binding implementations.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -6663,7 +6839,9 @@ source.</p>
 <td>
 <code>sink</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1beta1#Destination">
 knative.dev/pkg/apis/duck/v1beta1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -6675,7 +6853,9 @@ knative.dev/pkg/apis/duck/v1beta1.Destination
 <td>
 <code>ceOverrides</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#CloudEventOverrides">
 knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+</a>
 </em>
 </td>
 <td>
@@ -6796,7 +6976,9 @@ SinkBindingSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -6809,7 +6991,9 @@ knative.dev/pkg/apis/duck/v1.SourceSpec
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1alpha1#BindingSpec">
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -6965,7 +7149,9 @@ source.</p>
 <td>
 <code>sink</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1beta1#Destination">
 knative.dev/pkg/apis/duck/v1beta1.Destination
+</a>
 </em>
 </td>
 <td>
@@ -6977,7 +7163,9 @@ knative.dev/pkg/apis/duck/v1beta1.Destination
 <td>
 <code>ceOverrides</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#CloudEventOverrides">
 knative.dev/pkg/apis/duck/v1.CloudEventOverrides
+</a>
 </em>
 </td>
 <td>
@@ -7037,7 +7225,9 @@ string
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -7075,7 +7265,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7088,7 +7280,9 @@ knative.dev/pkg/apis/duck/v1.SourceSpec
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1alpha1#BindingSpec">
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -7119,7 +7313,9 @@ knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -7206,7 +7402,9 @@ ApiServerSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7357,7 +7555,9 @@ ContainerSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7462,7 +7662,9 @@ PingSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7585,7 +7787,9 @@ SinkBindingSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7603,7 +7807,9 @@ and modifications of the event sent to the sink.</p>
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1alpha1#BindingSpec">
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -7750,7 +7956,9 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7845,7 +8053,9 @@ source. Defaults to default if not set.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -7883,7 +8093,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -7932,7 +8144,9 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -7970,7 +8184,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8032,7 +8248,9 @@ to &ldquo;application/json&rdquo;.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -8070,7 +8288,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8088,7 +8308,9 @@ and modifications of the event sent to the sink.</p>
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1alpha1#BindingSpec">
 knative.dev/pkg/apis/duck/v1alpha1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -8122,7 +8344,9 @@ should be augmented by Binding implementations.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -8216,7 +8440,9 @@ ApiServerSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8367,7 +8593,9 @@ ContainerSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8472,7 +8700,9 @@ PingSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8609,7 +8839,9 @@ SinkBindingSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8627,7 +8859,9 @@ and modifications of the event sent to the sink.</p>
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1beta1#BindingSpec">
 knative.dev/pkg/apis/duck/v1beta1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -8774,7 +9008,9 @@ More info: <a href="http://kubernetes.io/docs/concepts/overview/working-with-obj
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8869,7 +9105,9 @@ source. Defaults to default if not set.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -8907,7 +9145,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -8956,7 +9196,9 @@ Kubernetes core/v1.PodTemplateSpec
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -8994,7 +9236,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -9070,7 +9314,9 @@ to &ldquo;application/json&rdquo;.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -9108,7 +9354,9 @@ Source.</p>
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -9126,7 +9374,9 @@ and modifications of the event sent to the sink.</p>
 <td>
 <code>BindingSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1beta1#BindingSpec">
 knative.dev/pkg/apis/duck/v1beta1.BindingSpec
+</a>
 </em>
 </td>
 <td>
@@ -9160,7 +9410,9 @@ should be augmented by Binding implementations.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>
@@ -9248,7 +9500,9 @@ PingSourceSpec
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -9363,7 +9617,9 @@ PingSourceStatus
 <td>
 <code>SourceSpec</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceSpec">
 knative.dev/pkg/apis/duck/v1.SourceSpec
+</a>
 </em>
 </td>
 <td>
@@ -9463,7 +9719,9 @@ Mutually exclusive with Data.</p>
 <td>
 <code>SourceStatus</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#SourceStatus">
 knative.dev/pkg/apis/duck/v1.SourceStatus
+</a>
 </em>
 </td>
 <td>

--- a/docs/reference/api/serving.md
+++ b/docs/reference/api/serving.md
@@ -128,7 +128,9 @@ Defaults to <code>ReachabilityUnknown</code></p>
 <td>
 <code>protocolType</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/networking/pkg/apis/networking#ProtocolType">
 knative.dev/networking/pkg/apis/networking.ProtocolType
+</a>
 </em>
 </td>
 <td>
@@ -201,7 +203,9 @@ MetricSpec
 <td>
 <code>stableWindow</code><br/>
 <em>
+<a href="https://golang.org/pkg/time/#Duration">
 time.Duration
+</a>
 </em>
 </td>
 <td>
@@ -212,7 +216,9 @@ time.Duration
 <td>
 <code>panicWindow</code><br/>
 <em>
+<a href="https://golang.org/pkg/time/#Duration">
 time.Duration
+</a>
 </em>
 </td>
 <td>
@@ -269,7 +275,9 @@ MetricStatus
 <td>
 <code>stableWindow</code><br/>
 <em>
+<a href="https://golang.org/pkg/time/#Duration">
 time.Duration
+</a>
 </em>
 </td>
 <td>
@@ -280,7 +288,9 @@ time.Duration
 <td>
 <code>panicWindow</code><br/>
 <em>
+<a href="https://golang.org/pkg/time/#Duration">
 time.Duration
+</a>
 </em>
 </td>
 <td>
@@ -320,7 +330,9 @@ string
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -394,7 +406,9 @@ Defaults to <code>ReachabilityUnknown</code></p>
 <td>
 <code>protocolType</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/networking/pkg/apis/networking#ProtocolType">
 knative.dev/networking/pkg/apis/networking.ProtocolType
+</a>
 </em>
 </td>
 <td>
@@ -423,7 +437,9 @@ knative.dev/networking/pkg/apis/networking.ProtocolType
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1191,7 +1207,9 @@ RevisionTemplateSpec
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1383,7 +1401,9 @@ layer will wait for a request delivered to a container to begin replying
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1636,7 +1656,9 @@ revisions and configurations.</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1684,7 +1706,9 @@ other types can readily consume these fields via duck typing.</p>
 <td>
 <code>url</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -1697,7 +1721,9 @@ It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-leve
 <td>
 <code>address</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Addressable">
 knative.dev/pkg/apis/duck/v1.Addressable
+</a>
 </em>
 </td>
 <td>
@@ -1832,7 +1858,9 @@ defaults).</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -1974,7 +2002,9 @@ that particular Revision or Configuration</p>
 <td>
 <code>url</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2065,7 +2095,9 @@ More info: <a href="https://github.com/kubernetes/community/blob/master/contribu
 <td>
 <code>ref</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -2153,7 +2185,9 @@ string
 <td>
 <code>ref</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#KReference">
 knative.dev/pkg/apis/duck/v1.KReference
+</a>
 </em>
 </td>
 <td>
@@ -2188,7 +2222,9 @@ Knative Routes, and by Kubernetes Services.</p>
 <td>
 <code>Status</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Status">
 knative.dev/pkg/apis/duck/v1.Status
+</a>
 </em>
 </td>
 <td>
@@ -2201,7 +2237,9 @@ knative.dev/pkg/apis/duck/v1.Status
 <td>
 <code>url</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis#URL">
 knative.dev/pkg/apis.URL
+</a>
 </em>
 </td>
 <td>
@@ -2213,7 +2251,9 @@ knative.dev/pkg/apis.URL
 <td>
 <code>address</code><br/>
 <em>
+<a href="https://pkg.go.dev/knative.dev/pkg/apis/duck/v1#Addressable">
 knative.dev/pkg/apis/duck/v1.Addressable
+</a>
 </em>
 </td>
 <td>

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -16,8 +16,20 @@
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
-            "typeMatchPrefix": "^github\\.com/knative/pkg/apis/duck/",
-            "docsURLTemplate": "https://godoc.org/github.com/knative/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+            "typeMatchPrefix": "^knative\\.dev/pkg/apis/duck",
+            "docsURLTemplate": "https://pkg.go.dev/knative.dev/pkg/apis/duck/{{arrIndex .PackageSegments -1}}#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^knative\\.dev/pkg/apis\\.URL$",
+            "docsURLTemplate": "https://pkg.go.dev/knative.dev/pkg/apis#URL"
+        },
+        {
+            "typeMatchPrefix": "^knative\\.dev/networking/pkg/apis/networking",
+            "docsURLTemplate": "https://pkg.go.dev/knative.dev/networking/pkg/apis/networking#{{.TypeIdentifier}}"
+        },
+        {
+            "typeMatchPrefix": "^time\\.Duration$",
+            "docsURLTemplate": "https://golang.org/pkg/time/#Duration"
         }
     ],
     "typeDisplayNamePrefixOverrides": {


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

The api reference doc generator's config.json was a bit out of date. It was referencing the duck package as `github.com/knative/pkg` rather than as `knative.dev/pkg` where it now lives (see updated `hack/reference-docs-gen-config.json` in this PR). It also didn't know about the `knative.dev/networking` package since (I suspect) that was created after the config was last updated. There were also a couple other packages that the tool was printing warnings about that I added.

The result is these packages now properly link to the relevant external docs in the output, which appears to have been the original intention here (also ./hack/gen-api-reference-docs.sh no longer complains about "not found external link source for type" \o/).

/assign @evankanderson @abrennan89 
