### PR TITLE
Fix invalid link for autoscaling README

### DIFF
--- a/docs/serving/_index.md
+++ b/docs/serving/_index.md
@@ -12,7 +12,7 @@ and scales to support advanced scenarios.
 The Knative Serving project provides middleware primitives that enable:
 
 - Rapid deployment of serverless containers
-- [Automatic scaling up and down to zero](./autoscaling/README.md)
+- [Automatic scaling up and down to zero](./autoscaling/)
 - Routing and network programming for Istio components
 - Point-in-time snapshots of deployed code and configurations
 


### PR DESCRIPTION
Fix https://github.com/knative/docs/issues/3484

As 4d6d81fbb719f94e1fdd246a9d2b37623d93a84c moved `README.md` to `_index.md`, this patch updates the link.

/cc @evankanderson @abrennan89 @hongshaoyang