### PR TITLE
setting a custom resource as sink doc

### DIFF
--- a/docs/eventing/sink/_index.md
+++ b/docs/eventing/sink/_index.md
@@ -48,10 +48,12 @@ spec:
 To allow a Custom Resource to act as a sink for events, there are two things needed: 
 
 #### 1. Make the resource Addressable
-To make a Custom Resource Addresable, it needs to contain a `status.address.url`. More information about [Addressable resources](https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md#addressable).
+To make a Custom Resource Addressable, it needs to contain a `status.address.url`. More information about [Addressable resources](https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md#addressable).
 
 #### 2. Create an addressable-resolver ClusterRole
 An addressable-resolver ClusterRole is needed in order to obtain the necessary RBAC rules for the sink to receive events.
+
+For example, we can create a `kafkasinks-addressable-resolver` ClusterRole to allow `get`, `list`, and `watch` access to `kafkasinks` and `kafkasinks/status`
 ```yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/eventing/sink/_index.md
+++ b/docs/eventing/sink/_index.md
@@ -44,6 +44,35 @@ spec:
       name: my-kafka-sink
 ```
 
+## Setting up a Custom Resource to be used as a sink
+To allow a Custom Resource to act as a sink for events, there are two things needed: 
+
+#### 1. Make the resource Addressable
+To make a Custom Resource Addresable, it needs to contain a `status.address.url`. More information about [Addressable resources](https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md#addressable).
+
+#### 2. Create an addressable-resolver ClusterRole
+An addressable-resolver ClusterRole is needed in order to obtain the necessary RBAC rules for the sink to receive events.
+```yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kafkasinks-addressable-resolver
+  labels:
+    kafka.eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+  - apiGroups:
+      - eventing.knative.dev
+    resources:
+      - kafkasinks
+      - kafkasinks/status
+    verbs:
+      - get
+      - list
+      - watch
+ ```
+
 ## Knative Sinks
 
 | Name | Maintainer | Description |


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Adding documentation on how to set up a Custom Resource in order to be used as a sink.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds a section [here](https://knative.dev/docs/eventing/sink) to explain the steps necessary to use a custom resource as a sink

