### PR TITLE
config-tracing configmap fix

### DIFF
--- a/docs/eventing/accessing-traces.md
+++ b/docs/eventing/accessing-traces.md
@@ -41,7 +41,7 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
 data:
-  enable: "true"
+  backend: "zipkin"
   zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
   sample-rate: "0.1"
 ```


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"
Noticed that the key `enable` is not even in the structure of tracing config: 
```
type Config struct {
    Backend              BackendType
    ZipkinEndpoint       string
    StackdriverProjectID string
    Debug                bool
    SampleRate           float64
}
```
also noticed here: https://github.com/knative/eventing/issues/1889#issuecomment-753998185
also its not mentioned in the `configuration options` in the doc, so I figured it might be something left over from previous versions. Let me know if it really is required? 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- just replaced `enable` key with `backend`
-
-
