### PR TITLE
change name for menu item for preview

### DIFF
--- a/help/contributor/publishing.md
+++ b/help/contributor/publishing.md
@@ -1,6 +1,6 @@
 ---
 title: "Staging and publishing Knative documentation"
-linkTitle: "Website help"
+linkTitle: "Preview Website"
 weight: "60"
 type: "docs"
 ---


### PR DESCRIPTION
I was not able to find the instructions on how to preview the website locally.
The contributor docs are now on the website, but the menu item was not clear

Change "Website help"

![image](https://user-images.githubusercontent.com/1094878/117204570-7566e080-adbe-11eb-88ed-58b77ce6cf7b.png)
