### PR TITLE
Remove responsive-revision-gc config

### DIFF
--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -273,15 +273,6 @@ spec:
         ...
 ```
 
-## Responsive Revision Garbage Collector
-* **Type**: extension
-* **ConfigMap key:** `responsive-revision-gc`
-
-This flag controls whether new responsive garbage collection is enabled. This
-feature labels revisions in real-time as they become referenced and
-dereferenced by Routes. This allows us to reap revisions shortly after
-they are no longer active.
-
 ## Tag Header Based Routing
 * **Type**: extension
 * **ConfigMap key:** `tag-header-based-routing`


### PR DESCRIPTION
Since https://github.com/knative/serving/pull/10084 deleted old GC and
started using responsive GC by default, `responsive-revision-gc` in
`config-feature` is not used at all.

This patch removes the instruction for the configuration.

https://github.com/knative/serving/pull/11309 removes the configuration in serving repo.