### PR TITLE
add gh-action to deploy mkdocs to gh-pages

### DIFF
--- a/.github/workflows/knative-mkdocs.yaml
+++ b/.github/workflows/knative-mkdocs.yaml
@@ -1,0 +1,31 @@
+name: Publish MkDocs
+
+on:
+  push:
+    branches: [ mkdocs ]
+
+jobs:
+  mkdocs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-macros-plugin mkdocs-exclude mike
+
+      - name: Setup doc deploy
+        run: |
+          git config --global user.name Docs deploy
+          git config --global user.email docs@dummy.bot.com
+
+      - name: Build docs 
+        run: |
+          mike deploy dev --push

--- a/.github/workflows/knative-mkdocs.yaml
+++ b/.github/workflows/knative-mkdocs.yaml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Setup doc deploy
         run: |
-          git config --global user.name Docs deploy
-          git config --global user.email docs@dummy.bot.com
+          git config --global user.name "Knative Automation"
+          git config --global user.email automation@knative.team
 
       - name: Build docs 
         run: |

--- a/hack/docker/Dockerfile
+++ b/hack/docker/Dockerfile
@@ -1,0 +1,2 @@
+FROM squidfunk/mkdocs-material
+RUN pip install --no-cache-dir mkdocs-macros-plugin mkdocs-exclude mike

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -1,0 +1,19 @@
+# Development notes for working with mkdocs
+
+## Container
+
+Build the container image
+```bash
+./hack/docker/build.sh
+```
+
+Run the livereload site
+```bash
+./hack/docker/run.sh
+```
+
+Remove the container
+```bash
+./hack/docker/clean.sh
+```
+

--- a/hack/docker/build.sh
+++ b/hack/docker/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+IMAGE=${1:-mkdocs}
+
+SCRIPT_DIR=$(cd $(dirname $0); pwd -P)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.."; pwd -P)
+
+docker build -t ${IMAGE} ${SCRIPT_DIR}

--- a/hack/docker/clean.sh
+++ b/hack/docker/clean.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+NAME=${1:-mkdocs}
+
+echo "Cleaning up old container '${NAME}'..."
+docker rm "${NAME}" --force 1> /dev/null 2> /dev/null
+
+echo "Finished clean up"

--- a/hack/docker/mkdocs.sh
+++ b/hack/docker/mkdocs.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+PORT=${2:-8000}
+
+mkdocs serve --config-file "./mkdocs.yml" --livereload -a 0.0.0.0:${PORT}

--- a/hack/docker/run.sh
+++ b/hack/docker/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+NAME=${1:-mkdocs}
+PORT=${2:-8000}
+IMAGE=${3:-mkdocs}
+
+docker run --name "${NAME}" -d -p "${PORT}:${PORT}" -v "${PWD}:/site" mkdocs serve -f /site/mkdocs.yml --livereload -a "0.0.0.0:${PORT}"
+echo "Dev environment running with live reloading enabled. Open http://localhost:${PORT} to see the site"
+echo "For live logs use:" 
+echo "docker logs -f ${NAME}"

--- a/hack/docker/run.sh
+++ b/hack/docker/run.sh
@@ -4,7 +4,7 @@ NAME=${1:-mkdocs}
 PORT=${2:-8000}
 IMAGE=${3:-mkdocs}
 
-docker run --name "${NAME}" -d -p "${PORT}:${PORT}" -v "${PWD}:/site" mkdocs serve -f /site/mkdocs.yml --livereload -a "0.0.0.0:${PORT}"
+docker run --name "${NAME}" -d -p "${PORT}:${PORT}" -v "${PWD}:/site" mkdocs serve -f /site/mkdocs.yml --dirtyreload -a "0.0.0.0:${PORT}"
 echo "Dev environment running with live reloading enabled. Open http://localhost:${PORT} to see the site"
-echo "For live logs use:" 
+echo "For live logs run:" 
 echo "docker logs -f ${NAME}"


### PR DESCRIPTION
Closes #3542 
- Add github action to publish mkdocs site to gh-pages branch
- Add hack script for local livereload for mkdocs under /hack/docker

After this gets merge, someone with admin access to the docs repo needs to go to settings GH Pages and enable the branch `gh-pages` with `/` root
![image](https://user-images.githubusercontent.com/1094878/117915003-5bdc0200-b2b2-11eb-9bbc-8bb307de3aa7.png)

This also allows contributors to publish their `mkdocs` branch in their forks to be published in their own github.io namespace

