### PR TITLE
Update Github action to build with hugo and mkdocs

### DIFF
--- a/.github/workflows/knative-mkdocs.yaml
+++ b/.github/workflows/knative-mkdocs.yaml
@@ -17,9 +17,15 @@ jobs:
         with:
           python-version: '3.9'
 
-      - uses: actions/setup-node@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
         with:
           node-version: '14'
+      
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.83.1'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/knative-mkdocs.yaml
+++ b/.github/workflows/knative-mkdocs.yaml
@@ -2,7 +2,7 @@ name: Publish MkDocs
 
 on:
   push:
-    branches: [ gh-pages-blog ]
+    branches: [ mkdocs ]
 
 jobs:
   mkdocs:

--- a/.github/workflows/knative-mkdocs.yaml
+++ b/.github/workflows/knative-mkdocs.yaml
@@ -2,7 +2,7 @@ name: Publish MkDocs
 
 on:
   push:
-    branches: [ mkdocs ]
+    branches: [ gh-pages-blog ]
 
 jobs:
   mkdocs:
@@ -15,17 +15,26 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: '3.9'
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
 
       - name: Install dependencies
         run: |
           pip install mkdocs mkdocs-macros-plugin mkdocs-exclude mike
-
-      - name: Setup doc deploy
-        run: |
-          git config --global user.name "Knative Automation"
-          git config --global user.email automation@knative.team
-
+          npm install
+      
       - name: Build docs 
         run: |
-          mike deploy dev --push
+          ./hack/build-with-blog.sh 
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          user_name: Knative Automation'
+          user_email: automation@knative.team
+

--- a/.github/workflows/knative-mkdocs.yaml
+++ b/.github/workflows/knative-mkdocs.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: '0.83.1'
+          extended: true
 
       - name: Install dependencies
         run: |

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -33,6 +33,9 @@ cp -r temp/community/* temp/website/content/en/community/contributing/
 rm -r temp/website/content/en/community/contributing/elections/2021-TOC # Temp fix for markdown that confuses hugo.
 
 # Run the hugo build as normal!
+
+# need postcss cli in PATH
+PATH=${PATH}:${PWD}/node_modules/.bin
 pushd temp/website
 hugo
 popd

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -58,14 +58,14 @@ cat << EOF > site/index.html
   <meta charset="utf-8">
   <title>Redirecting</title>
   <noscript>
-    <meta http-equiv="refresh" content="1; url=../dev/" />
+    <meta http-equiv="refresh" content="1; url=docs/" />
   </noscript>
   <script>
-    window.location.replace("/docs/");
+   window.location.replace(window.location.href+"docs/");
   </script>
 </head>
 <body>
-  Redirecting to <a href="/docs/">/docs/</a>...
+  Redirecting to <a href="docs/">docs/</a>...
 </body>
 </html>
 EOF

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,8 +196,8 @@ nav:
       - Installing kn: client/install-kn.md
       - Customizing kn: client/configure-kn.md
       - kn plugins: client/kn-plugins.md
-    - "Join the Community ➠": /community/
-    - "Read the Blog ➠": /blog/
+    - "Join the Community ➠": ../community/
+    - "Read the Blog ➠": ../blog/
 
 theme:
   name: material


### PR DESCRIPTION
- Update gh action to build with mkdocs and hugo
- Handle better redirects to be compatible with personal forks with different names than `docs`
- Handle the requirement of having postcss in the PATH