### PR TITLE
Replace xip.io with sslip.io

### DIFF
--- a/blog/articles/set-up-a-local-knative-environment-with-kind.md
+++ b/blog/articles/set-up-a-local-knative-environment-with-kind.md
@@ -218,15 +218,15 @@ kourier.ingress.networking.knative.dev
 
 To get the same experience that you would when using a cluster that has DNS names set up, you can add a “magic” DNS provider.
 
-_nip.io_ provides a wildcard DNS setup that will automatically resolve to the IP address you put in front of nip.io.
+_sslip.io_ provides a wildcard DNS setup that will automatically resolve to the IP address you put in front of sslip.io.
 
-To patch the domain configuration for Knative Serving using nip.io, enter the command:
+To patch the domain configuration for Knative Serving using sslip.io, enter the command:
 
 ```bash
 $ kubectl patch configmap/config-domain \
   --namespace knative-serving \
   --type merge \
-  --patch '{"data":{"127.0.0.1.nip.io":""}}'
+  --patch '{"data":{"127.0.0.1.sslip.io":""}}'
 ```
 
 If you want to validate that the patch command was successful, run the command:
@@ -239,7 +239,7 @@ $ kubectl describe configmap/config-domain --namespace knative-serving
 ... (abbreviated for readability)
 Data
 ====
-127.0.0.1.nip.io:
+127.0.0.1.sslip.io:
 ----
 ...
 ```
@@ -329,12 +329,12 @@ $ kubectl get ksvc
 
 ```bash
 NAME            URL                                             LATESTCREATED         LATESTREADY   READY     REASON
-helloworld-go   http://helloworld-go.default.127.0.0.1.nip.io   helloworld-go-fqqs6                 Unknown   RevisionMissing
+helloworld-go   http://helloworld-go.default.127.0.0.1.sslip.io   helloworld-go-fqqs6                 Unknown   RevisionMissing
 ```
 
 ```bash
 NAME            URL                                             LATESTCREATED         LATESTREADY           READY   REASON
-helloworld-go   http://helloworld-go.default.127.0.0.1.nip.io   helloworld-go-fqqs6   helloworld-go-fqqs6   True
+helloworld-go   http://helloworld-go.default.127.0.0.1.sslip.io   helloworld-go-fqqs6   helloworld-go-fqqs6   True
 ```
 
 The final step is to test your application, by checking that the code returns what you expect. You can do this by sending a cURL request to the URL listed above.
@@ -342,7 +342,7 @@ The final step is to test your application, by checking that the code returns wh
 Because this example mapped port 80 of the host to be forwarded to the cluster and set the DNS, you can use the exact URL.
 
 ```bash
-$ curl -v http://helloworld-go.default.127.0.0.1.nip.io
+$ curl -v http://helloworld-go.default.127.0.0.1.sslip.io
 ```
 
 ```bash

--- a/community/samples/serving/helloworld-clojure/index.md
+++ b/community/samples/serving/helloworld-clojure/index.md
@@ -142,14 +142,14 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-clojure --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-clojure  http://helloworld-clojure.default.1.2.3.4.xip.io
+   helloworld-clojure  http://helloworld-clojure.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-clojure.default.1.2.3.4.xip.io
+   curl http://helloworld-clojure.default.1.2.3.4.sslip.io
    Hello World!
    ```
 

--- a/community/samples/serving/helloworld-dart/index.md
+++ b/community/samples/serving/helloworld-dart/index.md
@@ -140,14 +140,14 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-dart  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME             URL
-   helloworld-dart  http://helloworld-dart.default.1.2.3.4.xip.io
+   helloworld-dart  http://helloworld-dart.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-dart.default.1.2.3.4.xip.io
+   curl http://helloworld-dart.default.1.2.3.4.sslip.io
    Hello Dart Sample v1
    ```
 

--- a/community/samples/serving/helloworld-deno/index.md
+++ b/community/samples/serving/helloworld-deno/index.md
@@ -121,20 +121,20 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-deno        http://helloworld-deno.default.1.2.3.4.xip.io
+   helloworld-deno        http://helloworld-deno.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-deno.default.1.2.3.4.xip.io
+   curl http://helloworld-deno.default.1.2.3.4.sslip.io
    ```
 
    Example:
 
    ```shell
-   curl http://helloworld-deno.default.1.2.3.4.xip.io
+   curl http://helloworld-deno.default.1.2.3.4.sslip.io
    [1] "Hello R Sample v1!"
    ```
 

--- a/community/samples/serving/helloworld-elixir/index.md
+++ b/community/samples/serving/helloworld-elixir/index.md
@@ -166,14 +166,14 @@ above.
     kubectl get ksvc helloworld-elixir --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
     NAME                URL
-    helloworld-elixir   http://helloworld-elixir.default.1.2.3.4.xip.io
+    helloworld-elixir   http://helloworld-elixir.default.1.2.3.4.sslip.io
     ```
 
 1.  Now you can make a request to your app to see the results. Replace
     `{IP_ADDRESS}` with the address you see returned in the previous step.
 
         ```shell
-        curl http://helloworld-elixir.default.1.2.3.4.xip.io
+        curl http://helloworld-elixir.default.1.2.3.4.sslip.io
 
         ...
         # HTML from your application is returned.

--- a/community/samples/serving/helloworld-haskell/index.md
+++ b/community/samples/serving/helloworld-haskell/index.md
@@ -168,14 +168,14 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-haskell  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                   URL
-   helloworld-haskell     http://helloworld-haskell.default.1.2.3.4.xip.io
+   helloworld-haskell     http://helloworld-haskell.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-haskell.default.1.2.3.4.xip.io
+   curl http://helloworld-haskell.default.1.2.3.4.sslip.io
    Hello world: Haskell Sample v1
    ```
 

--- a/community/samples/serving/helloworld-java-micronaut/index.md
+++ b/community/samples/serving/helloworld-java-micronaut/index.md
@@ -261,14 +261,14 @@ To verify that your sample app has been successfully deployed:
 
    ```shell
    NAME                          URL
-   helloworld-java-micronaut     http://helloworld-java-micronaut.default.1.2.3.4.xip.io
+   helloworld-java-micronaut     http://helloworld-java-micronaut.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-java-micronaut.default.1.2.3.4.xip.io
+   curl http://helloworld-java-micronaut.default.1.2.3.4.sslip.io
    ```
 
    Example result:

--- a/community/samples/serving/helloworld-java-quarkus/index.md
+++ b/community/samples/serving/helloworld-java-quarkus/index.md
@@ -255,14 +255,14 @@ folder) you're ready to build and deploy the sample app.
    kubectl get ksvc helloworld-java-quarkus
 
    NAME                     URL
-   helloworld-java-quarkus  http://helloworld-java-quarkus.default.1.2.3.4.xip.io
+   helloworld-java-quarkus  http://helloworld-java-quarkus.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-java-quarkus.default.1.2.3.4.xip.io
+   curl http://helloworld-java-quarkus.default.1.2.3.4.sslip.io
 
    Namaste Knative World!
    ```

--- a/community/samples/serving/helloworld-r/index.md
+++ b/community/samples/serving/helloworld-r/index.md
@@ -169,20 +169,20 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-r        http://helloworld-r.default.1.2.3.4.xip.io
+   helloworld-r        http://helloworld-r.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-r.default.1.2.3.4.xip.io
+   curl http://helloworld-r.default.1.2.3.4.sslip.io
    ```
 
    Example:
 
    ```shell
-   curl http://helloworld-r.default.1.2.3.4.xip.io
+   curl http://helloworld-r.default.1.2.3.4.sslip.io
    [1] "Hello R Sample v1!"
    ```
 

--- a/community/samples/serving/helloworld-rserver/index.md
+++ b/community/samples/serving/helloworld-rserver/index.md
@@ -140,20 +140,20 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-r    http://helloworld-r.default.1.2.3.4.xip.io
+   helloworld-r    http://helloworld-r.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-rserver.default.1.2.3.4.xip.io
+   curl http://helloworld-rserver.default.1.2.3.4.sslip.io
    ```
 
    Example:
 
    ```shell
-   curl http://helloworld-rserver.default.1.2.3.4.xip.io
+   curl http://helloworld-rserver.default.1.2.3.4.sslip.io
    [1] "Hello R Sample v1!"
    ```
 

--- a/community/samples/serving/helloworld-rust/index.md
+++ b/community/samples/serving/helloworld-rust/index.md
@@ -169,14 +169,14 @@ folder) you're ready to build and deploy the sample app.
    ```shell
    kubectl get ksvc helloworld-rust  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-rust     http://helloworld-rust.default.1.2.3.4.xip.io
+   helloworld-rust     http://helloworld-rust.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-rust.default.1.2.3.4.xip.io
+   curl http://helloworld-rust.default.1.2.3.4.sslip.io
    Hello World!
    ```
 

--- a/community/samples/serving/helloworld-swift/index.md
+++ b/community/samples/serving/helloworld-swift/index.md
@@ -149,14 +149,14 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-swift  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME               URL
-   helloworld-swift   http://helloworld-swift.default.1.2.3.4.xip.io
+   helloworld-swift   http://helloworld-swift.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-swift.default.1.2.3.4.xip.io
+   curl http://helloworld-swift.default.1.2.3.4.sslip.io
    Hello Swift
    ```
 

--- a/community/samples/serving/helloworld-vertx/index.md
+++ b/community/samples/serving/helloworld-vertx/index.md
@@ -229,14 +229,14 @@ To verify that your sample app has been successfully deployed:
 
    ```shell
    NAME                URL
-   helloworld-vertx    http://helloworld-vertx.default.1.2.3.4.xip.io
+   helloworld-vertx    http://helloworld-vertx.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-vertx.default.1.2.3.4.xip.io
+   curl http://helloworld-vertx.default.1.2.3.4.sslip.io
    ```
 
    Example result:

--- a/docs/eventing/samples/container-source/index.md
+++ b/docs/eventing/samples/container-source/index.md
@@ -69,7 +69,7 @@ The status of the created service can be seen using:
 kubectl get ksvc
 
 NAME            URL                                           LATESTCREATED         LATESTREADY           READY   REASON
-event-display   http://event-display.default.1.2.3.4.xip.io   event-display-gqjbw   event-display-gqjbw   True
+event-display   http://event-display.default.1.2.3.4.sslip.io   event-display-gqjbw   event-display-gqjbw   True
 ```
 
 ### Create a ContainerSource using the heartbeats image

--- a/docs/install/install-serving-with-yaml.md
+++ b/docs/install/install-serving-with-yaml.md
@@ -283,11 +283,11 @@ Follow the procedure for the DNS of your choice:
 
 <!-- This indentation is important for things to render properly. -->
 
-   {{< tabs name="serving_dns" default="Magic DNS (xip.io)" >}}
-   {{% tab name="Magic DNS (xip.io)" %}}
+   {{< tabs name="serving_dns" default="Magic DNS (sslip.io)" >}}
+   {{% tab name="Magic DNS (sslip.io)" %}}
 
 We ship a simple Kubernetes Job called "default domain" that will (see caveats)
-configure Knative Serving to use <a href="http://xip.io">xip.io</a> as the
+configure Knative Serving to use <a href="http://sslip.io">sslip.io</a> as the
 default DNS suffix.
 
 ```bash
@@ -338,7 +338,7 @@ kubectl patch configmap/config-domain \
 
 If you are using `curl` to access the sample
 applications, or your own Knative app, and are unable to use the "Magic DNS
-(xip.io)" or "Real DNS" methods, there is a temporary approach. This is useful
+(sslip.io)" or "Real DNS" methods, there is a temporary approach. This is useful
 for those who wish to evaluate Knative without altering their DNS configuration,
 as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using,
 for example, minikube locally or IPv6 clusters.

--- a/docs/install/installation-files.md
+++ b/docs/install/installation-files.md
@@ -23,7 +23,7 @@ The table below describes the installation files in the Knative Serving release:
 | --- | --- | --- |
 | serving-core.yaml | Required: Knative Serving core components. | serving-crds.yaml |
 | serving-crds.yaml | Required: Knative Serving core CRDs. | none |
-| serving-default-domain.yaml | Configures Knative Serving to use [http://xip.io](http://xip.io) as the default DNS suffix. | serving-core.yaml |
+| serving-default-domain.yaml | Configures Knative Serving to use [http://sslip.io](http://sslip.io) as the default DNS suffix. | serving-core.yaml |
 | serving-domainmapping-crds.yaml | CRDs used by the Domain Mapping feature. | none |
 | serving-domainmapping.yaml | Components used by the Domain Mapping feature. | serving-domainmapping-crds.yaml |
 | serving-hpa.yaml | Components to autoscale Knative revisions through the Kubernetes Horizontal Pod Autoscaler. | serving-core.yaml |

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -174,7 +174,7 @@ istio-pilot             ClusterIP      10.0.3.27    <none>         15010/TCP,150
 ```
 
 This external IP can be used with your DNS provider with a wildcard `A` record. However, for a basic non-production set
-up, this external IP address can be used with `xip.io` in the `config-domain` ConfigMap in `knative-serving`.
+up, this external IP address can be used with `sslip.io` in the `config-domain` ConfigMap in `knative-serving`.
 
 You can edit this by using the following command:
 
@@ -191,9 +191,9 @@ metadata:
   name: config-domain
   namespace: knative-serving
 data:
-  # xip.io is a "magic" DNS provider, which resolves all DNS lookups for:
-  # *.{ip}.xip.io to {ip}.
-  34.83.80.117.xip.io: ""
+  # sslip.io is a "magic" DNS provider, which resolves all DNS lookups for:
+  # *.{ip}.sslip.io to {ip}.
+  34.83.80.117.sslip.io: ""
 ```
 
 ## Istio resources

--- a/docs/install/knative-with-operators.md
+++ b/docs/install/knative-with-operators.md
@@ -443,9 +443,9 @@ The following commands install Kourier and enable its Knative integration.
 
       <!-- This indentation is important for things to render properly. -->
 
-   {{< tabs name="serving_dns" >}} {{% tab name="Magic DNS (xip.io)" %}} We ship
+   {{< tabs name="serving_dns" >}} {{% tab name="Magic DNS (sslip.io)" %}} We ship
    a simple Kubernetes Job called "default domain" that will (see caveats)
-   configure Knative Serving to use <a href="http://xip.io">xip.io</a> as the
+   configure Knative Serving to use <a href="http://sslip.io">sslip.io</a> as the
    default DNS suffix.
 
 ```bash
@@ -496,7 +496,7 @@ spec:
 
 {{% tab name="Temporary DNS" %}} If you are using `curl` to access the sample
 applications, or your own Knative app, and are unable to use the "Magic DNS
-(xip.io)" or "Real DNS" methods, there is a temporary approach. This is useful
+(sslip.io)" or "Real DNS" methods, there is a temporary approach. This is useful
 for those who wish to evaluate Knative without altering their DNS configuration,
 as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using,
 for example, minikube locally or IPv6 clusters.

--- a/docs/serving/autoscaling/autoscale-go/index.md
+++ b/docs/serving/autoscaling/autoscale-go/index.md
@@ -34,7 +34,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
    ```
    $ kubectl get ksvc autoscale-go
    NAME            URL                                                LATESTCREATED         LATESTREADY           READY   REASON
-   autoscale-go    http://autoscale-go.default.1.2.3.4.xip.io    autoscale-go-96dtk    autoscale-go-96dtk    True
+   autoscale-go    http://autoscale-go.default.1.2.3.4.sslip.io    autoscale-go-96dtk    autoscale-go-96dtk    True
    ```
 
 ## Load the Service
@@ -42,7 +42,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 1. Make a request to the autoscale app to see it consume some resources.
 
    ```shell
-   curl "http://autoscale-go.default.1.2.3.4.xip.io?sleep=100&prime=10000&bloat=5"
+   curl "http://autoscale-go.default.1.2.3.4.sslip.io?sleep=100&prime=10000&bloat=5"
    ```
 
    ```
@@ -55,7 +55,7 @@ A demonstration of the autoscaling capabilities of a Knative Serving Revision.
 
    ```shell
    hey -z 30s -c 50 \
-     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=100&prime=10000&bloat=5" \
+     "http://autoscale-go.default.1.2.3.4.sslip.io?sleep=100&prime=10000&bloat=5" \
      && kubectl get pods
    ```
 
@@ -220,21 +220,21 @@ customization (32 minutes).
 
    ```shell
    hey -z 60s -c 100 \
-     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=100&prime=10000&bloat=5"
+     "http://autoscale-go.default.1.2.3.4.sslip.io?sleep=100&prime=10000&bloat=5"
    ```
 
 1. Send 60 seconds of traffic maintaining 100 qps with short requests (10 ms).
 
    ```shell
    hey -z 60s -q 100 \
-     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=10"
+     "http://autoscale-go.default.1.2.3.4.sslip.io?sleep=10"
    ```
 
 1. Send 60 seconds of traffic maintaining 100 qps with long requests (1 sec).
 
    ```shell
    hey -z 60s -q 100 \
-     "http://autoscale-go.default.1.2.3.4.xip.io?sleep=1000"
+     "http://autoscale-go.default.1.2.3.4.sslip.io?sleep=1000"
    ```
 
 1. Send 60 seconds of traffic with heavy CPU usage (~1 cpu/sec/request, total
@@ -242,7 +242,7 @@ customization (32 minutes).
 
    ```shell
    hey -z 60s -q 100 \
-     "http://autoscale-go.default.1.2.3.4.xip.io?prime=40000000"
+     "http://autoscale-go.default.1.2.3.4.sslip.io?prime=40000000"
    ```
 
 1. Send 60 seconds of traffic with heavy memory usage (1 gb/request, total 5
@@ -250,7 +250,7 @@ customization (32 minutes).
 
    ```shell
    hey -z 60s -c 5 \
-     "http://autoscale-go.default.1.2.3.4.xip.io?bloat=1000"
+     "http://autoscale-go.default.1.2.3.4.sslip.io?bloat=1000"
    ```
 
 ## Cleanup

--- a/docs/serving/getting-started-knative-app.md
+++ b/docs/serving/getting-started-knative-app.md
@@ -131,7 +131,7 @@ To see if your app has been deployed successfully, you need the URL created by K
    Name        helloworld-go
    Namespace   default
    Age         12m
-   URL         http://helloworld-go.default.34.83.80.117.xip.io
+   URL         http://helloworld-go.default.34.83.80.117.sslip.io
 
    Revisions:
      100%  @latest (helloworld-go-dyqsj-1) [1] (39s)
@@ -155,14 +155,14 @@ To see if your app has been deployed successfully, you need the URL created by K
 
    ```shell
    NAME            URL                                                LATESTCREATED         LATESTREADY           READY   REASON
-   helloworld-go   http://helloworld-go.default.34.83.80.117.xip.io   helloworld-go-96dtk   helloworld-go-96dtk   True
+   helloworld-go   http://helloworld-go.default.34.83.80.117.sslip.io   helloworld-go-96dtk   helloworld-go-96dtk   True
    ```
 
   {{< /tab >}}
   {{< /tabs >}}
 
    > Note: If your URL includes `example.com` then consult the setup instructions for
-   > configuring DNS (e.g. with `xip.io`), or [using a Custom Domain](../serving/using-a-custom-domain).
+   > configuring DNS (e.g. with `sslip.io`), or [using a Custom Domain](../serving/using-a-custom-domain).
 
    If you changed the name from `helloworld-go` to something else when creating
    the `.yaml` file, replace `helloworld-go` in the above commands with the name you entered.
@@ -171,7 +171,7 @@ To see if your app has been deployed successfully, you need the URL created by K
    the URL with the one returned by the command in the previous step.
 
    ```shell
-   # curl http://helloworld-go.default.34.83.80.117.xip.io
+   # curl http://helloworld-go.default.34.83.80.117.sslip.io
    Hello World: Go Sample v1!
    ```
 

--- a/docs/serving/samples/cloudevents/cloudevents-go/index.md
+++ b/docs/serving/samples/cloudevents/cloudevents-go/index.md
@@ -132,7 +132,7 @@ Get the URL for your Service with:
 ```shell
 $ kubectl get ksvc
 NAME             URL                                            LATESTCREATED          LATESTREADY            READY   REASON
-cloudevents-go   http://cloudevents-go.default.1.2.3.4.xip.io   cloudevents-go-ss5pj   cloudevents-go-ss5pj   True
+cloudevents-go   http://cloudevents-go.default.1.2.3.4.sslip.io   cloudevents-go-ss5pj   cloudevents-go-ss5pj   True
 ```
 
 Then send a cloud event to it with:
@@ -145,7 +145,7 @@ $ curl -X POST \
     -H "ce-type: curl.demo"  \
     -H "ce-id: 123-abc"  \
     -d '{"name":"Dave"}' \
-    http://cloudevents-go.default.1.2.3.4.xip.io
+    http://cloudevents-go.default.1.2.3.4.sslip.io
 ```
 
 You will get back:

--- a/docs/serving/samples/cloudevents/cloudevents-nodejs/index.md
+++ b/docs/serving/samples/cloudevents/cloudevents-nodejs/index.md
@@ -90,7 +90,7 @@ Get the URL for your Service with:
 ```shell
 $ kubectl get ksvc
 NAME                 URL                                                LATESTCREATED              LATESTREADY                READY   REASON
-cloudevents-nodejs   http://cloudevents-nodejs.default.1.2.3.4.xip.io   cloudevents-nodejs-ss5pj   cloudevents-nodejs-ss5pj   True
+cloudevents-nodejs   http://cloudevents-nodejs.default.1.2.3.4.sslip.io   cloudevents-nodejs-ss5pj   cloudevents-nodejs-ss5pj   True
 ```
 
 Then send a cloud event to it with:
@@ -103,7 +103,7 @@ $ curl -X POST \
     -H "ce-type: curl.demo"  \
     -H "ce-id: 123-abc"  \
     -d '{"name":"Dave"}' \
-    http://cloudevents-nodejs.default.1.2.3.4.xip.io
+    http://cloudevents-nodejs.default.1.2.3.4.sslip.io
 ```
 
 You will get back:

--- a/docs/serving/samples/cloudevents/cloudevents-rust/index.md
+++ b/docs/serving/samples/cloudevents/cloudevents-rust/index.md
@@ -84,7 +84,7 @@ Get the URL for your Service with:
 ```shell
 $ kubectl get ksvc
 NAME                URL                                            LATESTCREATED             LATESTREADY               READY   REASON
-cloudevents-rust    http://cloudevents-rust.xip.io                 cloudevents-rust-vl8fq    cloudevents-rust-vl8fq    True
+cloudevents-rust    http://cloudevents-rust.sslip.io                 cloudevents-rust-vl8fq    cloudevents-rust-vl8fq    True
 ```
 
 Then send a CloudEvent to it with:
@@ -98,7 +98,7 @@ $ curl \
     -H "ce-type: curl.demo"  \
     -H "ce-id: 123-abc"  \
     -d '{"name":"Dave"}' \
-    http://cloudevents-rust.xip.io
+    http://cloudevents-rust.sslip.io
 ```
 
 You can also send CloudEvents spawning a temporary curl pod in your cluster with:

--- a/docs/serving/samples/cloudevents/cloudevents-spring/index.md
+++ b/docs/serving/samples/cloudevents/cloudevents-spring/index.md
@@ -61,7 +61,7 @@ Get the URL for your Service with:
 ```shell
 $ kubectl get ksvc
 NAME                URL                                            LATESTCREATED             LATESTREADY               READY   REASON
-cloudevents-spring   http://cloudevents-java.xip.io                 cloudevents-spring-86h28   cloudevents-spring-86h28   True
+cloudevents-spring   http://cloudevents-java.sslip.io                 cloudevents-spring-86h28   cloudevents-spring-86h28   True
 ```
 
 Then send a CloudEvent to it with:
@@ -75,7 +75,7 @@ $ curl \
     -H "ce-type: curl.demo"  \
     -H "ce-id: 123-abc"  \
     -d '{"name":"Dave"}' \
-    http://cloudevents-java.xip.io
+    http://cloudevents-java.sslip.io
 ```
 
 You can also send CloudEvents spawning a temporary curl pod in your cluster

--- a/docs/serving/samples/cloudevents/cloudevents-vertx/index.md
+++ b/docs/serving/samples/cloudevents/cloudevents-vertx/index.md
@@ -75,7 +75,7 @@ Get the URL for your Service with:
 ```shell
 $ kubectl get ksvc
 NAME                URL                                            LATESTCREATED             LATESTREADY               READY   REASON
-cloudevents-vertx   http://cloudevents-java.xip.io                 cloudevents-vertx-86h28   cloudevents-vertx-86h28   True
+cloudevents-vertx   http://cloudevents-java.sslip.io                 cloudevents-vertx-86h28   cloudevents-vertx-86h28   True
 ```
 
 Then send a CloudEvent to it with:
@@ -89,7 +89,7 @@ $ curl \
     -H "ce-type: curl.demo"  \
     -H "ce-id: 123-abc"  \
     -d '{"name":"Dave"}' \
-    http://cloudevents-java.xip.io
+    http://cloudevents-java.sslip.io
 ```
 
 You can also send CloudEvents spawning a temporary curl pod in your cluster

--- a/docs/serving/samples/grpc-ping-go/index.md
+++ b/docs/serving/samples/grpc-ping-go/index.md
@@ -108,7 +108,7 @@ Replace `{username}` with your Docker Hub user name and run the command:
 ```shell
 docker run --rm {username}/grpc-ping-go \
   /client \
-  -server_addr="grpc-ping.default.1.2.3.4.xip.io:80" \
+  -server_addr="grpc-ping.default.1.2.3.4.sslip.io:80" \
   -insecure
 ```
 

--- a/docs/serving/samples/hello-world/helloworld-csharp/index.md
+++ b/docs/serving/samples/hello-world/helloworld-csharp/index.md
@@ -173,14 +173,14 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-csharp  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-csharp   http://helloworld-csharp.default.1.2.3.4.xip.io
+   helloworld-csharp   http://helloworld-csharp.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-csharp.default.1.2.3.4.xip.io
+   curl http://helloworld-csharp.default.1.2.3.4.sslip.io
    Hello C# Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-go/index.md
+++ b/docs/serving/samples/hello-world/helloworld-go/index.md
@@ -170,7 +170,7 @@ You will need:
 
       ```shell
        NAME                URL
-       helloworld-go       http://helloworld-go.default.1.2.3.4.xip.io
+       helloworld-go       http://helloworld-go.default.1.2.3.4.sslip.io
       ```
 
    {{< /tab >}}
@@ -196,7 +196,7 @@ You will need:
     16.237s Ready to serve.
 
    Service 'helloworld-go' created to latest revision 'helloworld-go-jjzgd-1' is available at URL:
-   http://helloworld-go.default.1.2.3.4.xip.io
+   http://helloworld-go.default.1.2.3.4.sslip.io
    ```
 
    You can then access your service through the resulting URL.
@@ -211,7 +211,7 @@ You will need:
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-go.default.1.2.3.4.xip.io
+   curl http://helloworld-go.default.1.2.3.4.sslip.io
    Hello Go Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-java-spark/index.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spark/index.md
@@ -142,7 +142,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-java
    Example:
 
    ```shell
-   http://helloworld-java.default.1.2.3.4.xip.io
+   http://helloworld-java.default.1.2.3.4.sslip.io
    ```
    {{< /tab >}}
    {{% tab name="kubectl" %}}
@@ -154,7 +154,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-java
 
    ```shell
    NAME                      URL
-   helloworld-java    http://helloworld-java.default.1.2.3.4.xip.io
+   helloworld-java    http://helloworld-java.default.1.2.3.4.sslip.io
    ```
 
    {{< /tab >}}
@@ -166,7 +166,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-java
    Example:
 
    ```shell
-   curl http://helloworld-java.default.1.2.3.4.xip.io
+   curl http://helloworld-java.default.1.2.3.4.sslip.io
    Hello SparkJava Sample v1!
    # Even easier with kn:
    curl $(kn service describe helloworld-java -o url)

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -174,14 +174,14 @@ folder) you're ready to build and deploy the sample app.
       --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
    NAME                       URL
-   helloworld-java-spring     http://helloworld-java-spring.default.1.2.3.4.xip.io
+   helloworld-java-spring     http://helloworld-java-spring.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-java-spring.default.1.2.3.4.xip.io
+   curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
    Hello Spring Boot Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-java-spring/index.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/index.md
@@ -197,7 +197,7 @@ After the build has completed and the container is pushed to Docker Hub, you can
 
    ```shell
    NAME                      URL
-   helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.xip.io
+   helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.sslip.io
    ```
 
    {{< /tab >}}
@@ -210,7 +210,7 @@ After the build has completed and the container is pushed to Docker Hub, you can
    Example:
 
    ```shell
-   http://helloworld-java-spring.default.1.2.3.4.xip.io
+   http://helloworld-java-spring.default.1.2.3.4.sslip.io
    ```
    {{< /tab >}}
    {{< /tabs >}}
@@ -221,7 +221,7 @@ After the build has completed and the container is pushed to Docker Hub, you can
    Example:
 
    ```shell
-   curl http://helloworld-java-spring.default.1.2.3.4.xip.io
+   curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
    Hello Java Spring Sample v1!
 
    # Even easier with kn:

--- a/docs/serving/samples/hello-world/helloworld-kotlin/index.md
+++ b/docs/serving/samples/hello-world/helloworld-kotlin/index.md
@@ -178,14 +178,14 @@ folder) you're ready to build and deploy the sample app.
    kubectl get ksvc helloworld-kotlin  --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
    NAME                URL
-   helloworld-kotlin   http://helloworld-kotlin.default.1.2.3.4.xip.io
+   helloworld-kotlin   http://helloworld-kotlin.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-kotlin.default.1.2.3.4.xip.io
+   curl http://helloworld-kotlin.default.1.2.3.4.sslip.io
    Hello Kotlin Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-nodejs/index.md
+++ b/docs/serving/samples/hello-world/helloworld-nodejs/index.md
@@ -185,14 +185,14 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-nodejs  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-nodejs   http://helloworld-nodejs.default.1.2.3.4.xip.io
+   helloworld-nodejs   http://helloworld-nodejs.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-nodejs.default.1.2.3.4.xip.io
+   curl http://helloworld-nodejs.default.1.2.3.4.sslip.io
    Hello Node.js Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-php/index.md
+++ b/docs/serving/samples/hello-world/helloworld-php/index.md
@@ -146,7 +146,7 @@ folder) you're ready to build and deploy the sample app.
     8.398s Ready to serve.
 
   Service 'helloworld-php' created to latest revision 'helloworld-php-akhft-1' is available at URL:
-  http://helloworld-php.default.1.2.3.4.xip.io
+  http://helloworld-php.default.1.2.3.4.sslip.io
   ```
 
    {{< /tab >}}
@@ -167,7 +167,7 @@ folder) you're ready to build and deploy the sample app.
    ```
    kubectl get ksvc helloworld-php  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
-   helloworld-php      http://helloworld-php.default.1.2.3.4.xip.io
+   helloworld-php      http://helloworld-php.default.1.2.3.4.sslip.io
    ```
 
 {{< /tab >}}
@@ -180,7 +180,7 @@ folder) you're ready to build and deploy the sample app.
    Example:
 
    ```shell
-   http://helloworld-php.default.1.2.3.4.xip.io
+   http://helloworld-php.default.1.2.3.4.sslip.io
    ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -189,7 +189,7 @@ folder) you're ready to build and deploy the sample app.
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://helloworld-php.default.1.2.3.4.xip.io
+   curl http://helloworld-php.default.1.2.3.4.sslip.io
    Hello PHP Sample v1!
    ```
 

--- a/docs/serving/samples/hello-world/helloworld-python/index.md
+++ b/docs/serving/samples/hello-world/helloworld-python/index.md
@@ -172,7 +172,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
 
 1. Run one of the followings commands to find the domain URL for your service.
    > Note: If your URL includes `example.com` then consult the setup instructions for
-   > configuring DNS (e.g. with `xip.io`), or [using a Custom Domain](../serving/using-a-custom-domain).
+   > configuring DNS (e.g. with `sslip.io`), or [using a Custom Domain](../serving/using-a-custom-domain).
 
    {{< tabs name="service_url" default="kn" >}} {{% tab name="kubectl" %}}
 
@@ -184,7 +184,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
 
    ```shell
    NAME                      URL
-   helloworld-python    http://helloworld-python.default.1.2.3.4.xip.io
+   helloworld-python    http://helloworld-python.default.1.2.3.4.sslip.io
    ```
 
    {{< /tab >}} {{% tab name="kn" %}}
@@ -196,7 +196,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    Example:
 
    ```shell
-   http://helloworld-python.default.1.2.3.4.xip.io
+   http://helloworld-python.default.1.2.3.4.sslip.io
    ```
 
    {{< /tab >}} {{< /tabs >}}
@@ -207,7 +207,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-python
    Example:
 
    ```shell
-   curl http://helloworld-python.default.1.2.3.4.xip.io
+   curl http://helloworld-python.default.1.2.3.4.sslip.io
    Hello Python Sample v1!
 
    # Even easier with kn:

--- a/docs/serving/samples/hello-world/helloworld-ruby/index.md
+++ b/docs/serving/samples/hello-world/helloworld-ruby/index.md
@@ -167,7 +167,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
     8.398s Ready to serve.
 
   Service 'helloworld-ruby' created to latest revision 'helloworld-ruby-akhft-1' is available at URL:
-  http://helloworld-ruby.default.1.2.3.4.xip.io
+  http://helloworld-ruby.default.1.2.3.4.sslip.io
   ```
 
 {{< /tab >}}
@@ -194,7 +194,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
 
    ```shell
    NAME                URL
-   helloworld-ruby    http://helloworld-ruby.default.1.2.3.4.xip.io
+   helloworld-ruby    http://helloworld-ruby.default.1.2.3.4.sslip.io
    ```
 
 {{< /tab >}}
@@ -207,7 +207,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
    Example:
 
    ```shell
-   http://helloworld-ruby.default.1.2.3.4.xip.io
+   http://helloworld-ruby.default.1.2.3.4.sslip.io
    ```
    {{< /tab >}}
    {{< /tabs >}}
@@ -218,7 +218,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-ruby
    Example:
 
    ```shell
-   curl http://helloworld-ruby.default.1.2.3.4.xip.io
+   curl http://helloworld-ruby.default.1.2.3.4.sslip.io
    Hello Ruby Sample v1!
 
    # Even easier with kn:

--- a/docs/serving/samples/hello-world/helloworld-scala/index.md
+++ b/docs/serving/samples/hello-world/helloworld-scala/index.md
@@ -140,7 +140,7 @@ kubectl apply --filename helloworld-scala.yaml
     8.398s Ready to serve.
 
   Service 'helloworld-scala' created to latest revision 'helloworld-scala-abcd-1' is available at URL:
-  http://helloworld-scala.default.1.2.3.4.xip.io
+  http://helloworld-scala.default.1.2.3.4.sslip.io
   ```
 
 {{< /tab >}}
@@ -157,13 +157,13 @@ kubectl get ksvc helloworld-scala \
 
 # It will print something like this, the URL is what you're looking for.
 # NAME                URL
-# helloworld-scala    http://helloworld-scala.default.1.2.3.4.xip.io
+# helloworld-scala    http://helloworld-scala.default.1.2.3.4.sslip.io
 ```
 
 Finally, to try your service, use the obtained URL:
 
 ```shell
-curl -v http://helloworld-scala.default.1.2.3.4.xip.io
+curl -v http://helloworld-scala.default.1.2.3.4.sslip.io
 ```
 
 {{< /tab >}}
@@ -176,13 +176,13 @@ curl -v http://helloworld-scala.default.1.2.3.4.xip.io
    Example:
 
    ```shell
-   http://helloworld-scala.default.1.2.3.4.xip.io
+   http://helloworld-scala.default.1.2.3.4.sslip.io
    ```
 
 Finally, to try your service, use the obtained URL:
 
 ```shell
-curl -v http://helloworld-scala.default.1.2.3.4.xip.io
+curl -v http://helloworld-scala.default.1.2.3.4.sslip.io
 ```
 
 {{< /tab >}}

--- a/docs/serving/samples/hello-world/helloworld-shell/index.md
+++ b/docs/serving/samples/hello-world/helloworld-shell/index.md
@@ -144,7 +144,7 @@ folder) you're ready to build and deploy the sample app.
     8.398s Ready to serve.
 
   Service 'helloworld-shell' created to latest revision 'helloworld-shell-kwdpt-1' is available at URL:
-  http://helloworld-shell.default.1.2.3.4.xip.io
+  http://helloworld-shell.default.1.2.3.4.sslip.io
   ```
 
    {{< /tab >}}
@@ -171,7 +171,7 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME                URL
-   helloworld-shell    http://helloworld-shell.default.1.2.3.4.xip.io
+   helloworld-shell    http://helloworld-shell.default.1.2.3.4.sslip.io
    ```
 
    {{< /tab >}}
@@ -184,7 +184,7 @@ folder) you're ready to build and deploy the sample app.
    Example:
 
    ```shell
-   http://helloworld-shell.default.1.2.3.4.xip.io
+   http://helloworld-shell.default.1.2.3.4.sslip.io
    ```
    {{< /tab >}}
    {{< /tabs >}}
@@ -195,7 +195,7 @@ folder) you're ready to build and deploy the sample app.
    Example:
 
    ```shell
-   curl http://helloworld-shell.default.1.2.3.4.xip.io
+   curl http://helloworld-shell.default.1.2.3.4.sslip.io
    Hello Shell Sample v1!
 
    # Even easier with kn:

--- a/docs/serving/samples/multi-container/index.md
+++ b/docs/serving/samples/multi-container/index.md
@@ -244,14 +244,14 @@ After you have modified the sample code files you can build and deploy the sampl
 
    ```shell
     NAME                URL
-    multi-container       http://multi-container.default.1.2.3.4.xip.io
+    multi-container       http://multi-container.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://multi-container.default.1.2.3.4.xip.io
+   curl http://multi-container.default.1.2.3.4.sslip.io
    Yay!! multi-container works
    ```
 

--- a/docs/serving/samples/rest-api-go/index.md
+++ b/docs/serving/samples/rest-api-go/index.md
@@ -158,7 +158,7 @@ and then you run `curl` commands to send request with your stock symbol.
    ```shell
    kubectl get ksvc stock-service-example  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                    URL
-   stock-service-example   http://stock-service-example.default.1.2.3.4.xip.io
+   stock-service-example   http://stock-service-example.default.1.2.3.4.sslip.io
    ```
 
 2. Send requests to the service using `curl`:
@@ -166,7 +166,7 @@ and then you run `curl` commands to send request with your stock symbol.
    1. Send a request to the index endpoint:
 
       ```shell
-      curl http://stock-service-example.default.1.2.3.4.xip.io
+      curl http://stock-service-example.default.1.2.3.4.sslip.io
       ```
 
       Response body: `Welcome to the stock app!`
@@ -174,7 +174,7 @@ and then you run `curl` commands to send request with your stock symbol.
    2. Send a request to the `/stock` endpoint:
 
       ```shell
-      curl http://stock-service-example.default.1.2.3.4.xip.io/stock
+      curl http://stock-service-example.default.1.2.3.4.sslip.io/stock
       ```
 
       Response body: `stock ticker not found!, require /stock/{ticker}`
@@ -183,7 +183,7 @@ and then you run `curl` commands to send request with your stock symbol.
       "[stock symbol](https://www.marketwatch.com/tools/quotes/lookup.asp)":
 
       ```shell
-      curl http://stock-service-example.default.1.2.3.4.xip.io/stock/<SYMBOL>
+      curl http://stock-service-example.default.1.2.3.4.sslip.io/stock/<SYMBOL>
       ```
 
       where `<SYMBOL>` is your "stock symbol".
@@ -195,7 +195,7 @@ and then you run `curl` commands to send request with your stock symbol.
       Request:
 
       ```shell
-      curl http://stock-service-example.default.1.2.3.4.xip.io/stock/FAKE
+      curl http://stock-service-example.default.1.2.3.4.sslip.io/stock/FAKE
       ```
 
       Response: `stock price for ticker FAKE is 0.00`

--- a/docs/serving/samples/secrets-go/index.md
+++ b/docs/serving/samples/secrets-go/index.md
@@ -237,14 +237,14 @@ folder) you're ready to build and deploy the sample app.
 
    ```shell
    NAME             URL
-   secrets-go       http://secrets-go.default.1.2.3.4.xip.io
+   secrets-go       http://secrets-go.default.1.2.3.4.sslip.io
    ```
 
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
    ```shell
-   curl http://secrets-go.default.1.2.3.4.xip.io
+   curl http://secrets-go.default.1.2.3.4.sslip.io
    bucket knative-secrets-sample, created at 2019-02-01 14:44:05.804 +0000 UTC, is located in US with storage class MULTI_REGIONAL
    ```
 


### PR DESCRIPTION
## Proposed Changes

`xip.io` doesn't seem to be working anymore. This change replaces it with `sslip.io`.
-
-
-
