### PR TITLE
EventType is not yet part of the v1 eventing API

### DIFF
--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -60,7 +60,7 @@ kubectl get eventtype dev.knative.source.github.push-34cnb -o yaml
 Omitting irrelevant fields:
 
 ```yaml
-apiVersion: eventing.knative.dev/v1
+apiVersion: eventing.knative.dev/v1beta1
 kind: EventType
 metadata:
   name: dev.knative.source.github.push-34cnb


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

I tried adding an EventType as proposed in the example - but `EventType` still is in `v1beta1`, although the example states it would be in `v1` already.