### PR TITLE
Fix broken links

### DIFF
--- a/docs/eventing/accessing-traces.md
+++ b/docs/eventing/accessing-traces.md
@@ -11,7 +11,7 @@ visualize and trace your requests.
 
 ## Before you begin
 
-You must have a Knative cluster running with the Eventing component installed. [Learn more](../install/README.md)
+You must have a Knative cluster running with the Eventing component installed. [Learn more](../install/)
 
 ## Configuring tracing
 

--- a/docs/eventing/channels/channel-types-defaults.md
+++ b/docs/eventing/channels/channel-types-defaults.md
@@ -10,7 +10,7 @@ Knative provides the InMemoryChannel channel implementation by default. This def
 **NOTE:** InMemoryChannel channels should not be used in production environments.
 
 The default channel implementation is specified in the `default-ch-webhook` ConfigMap in the `knative-eventing` namespace.
-For more information about modifying ConfigMaps, see [Configuring the Eventing Operator custom resource](./docs/install/configuring-eventing-cr/).
+For more information about modifying ConfigMaps, see [Configuring the Eventing Operator custom resource](../../../docs/install/operator/configuring-eventing-cr).
 
 In the following example, the cluster default channel implementation is InMemoryChannel, while the namespace default channel implementation for the `example-namespace` is KafkaChannel.
 

--- a/docs/eventing/debugging/index.md
+++ b/docs/eventing/debugging/index.md
@@ -11,12 +11,12 @@ setup.
 ## Audience
 
 This document is intended for people that are familiar with the object model of
-[Knative Eventing](../README.md). You don't need to be an expert, but do need to
+[Knative Eventing](../). You don't need to be an expert, but do need to
 know roughly how things fit together.
 
 ## Prerequisites
 
-1. Setup [Knative Eventing and an Eventing-contrib resource](../README.md).
+1. Setup [Knative Eventing and an Eventing-contrib resource](../).
 
 ## Example
 

--- a/docs/eventing/flows/parallel.md
+++ b/docs/eventing/flows/parallel.md
@@ -44,4 +44,4 @@ Parallel has three parts for the Status:
 
 ## Examples
 
-Learn how to use Parallel by following the [examples](../samples/parallel/README.md)
+Learn how to use Parallel by following the [examples](../samples/parallel/)

--- a/docs/eventing/samples/_index.md
+++ b/docs/eventing/samples/_index.md
@@ -8,6 +8,6 @@ showlandingtoc: "true"
 
 Use the following code samples to help you understand the various use cases for
 Knative Eventing and Event Sources.
-[Learn more about Knative Eventing and Eventing Sources](../README.md).
+[Learn more about Knative Eventing and Eventing Sources](../).
 
 [**See all Knative code samples**](../../samples.md)

--- a/docs/eventing/samples/gitlab-source/index.md
+++ b/docs/eventing/samples/gitlab-source/index.md
@@ -15,7 +15,7 @@ Knative Service.
 You will need:
 
 1. An internet-accessible Kubernetes cluster with Knative Serving installed.
-   Follow the [installation instructions](../../../install/README.md) if you
+   Follow the [installation instructions](../../../install/) if you
    need to create one.
 1. Ensure Knative Serving is
    [configured with a domain name](../../../serving/using-a-custom-domain.md)

--- a/docs/eventing/samples/helloworld/_index.md
+++ b/docs/eventing/samples/helloworld/_index.md
@@ -13,13 +13,13 @@ We will deploy the app as a
 [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 along with a
 [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
-However, you can also deploy the app as a [Knative Serving Service](../../../serving/README.md)
+However, you can also deploy the app as a [Knative Serving Service](../../../serving/)
 
 ## Prerequisites
 
 - A Kubernetes cluster with [Knative Eventing](../../getting-started.md#installing-knative-eventing)
   installed.
   - If you decide to deploy the app as a Knative Serving Service then you will have to install
-    [Knative Serving](../../../install/README.md).
+    [Knative Serving](../../../install/).
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/eventing/samples/helloworld/helloworld-go/_index.md
+++ b/docs/eventing/samples/helloworld/helloworld-go/_index.md
@@ -16,7 +16,7 @@ We will deploy the app as a
 along with a
 [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
 However, you can also deploy the app as a
-[Knative Serving Service](../../../../serving/README.md).
+[Knative Serving Service](../../../../serving/).
 
 Follow the steps below to create the sample code and then deploy the app to your
 cluster. You can also download a working copy of the sample, by running the
@@ -280,7 +280,7 @@ application and trigger are ready, let's send a CloudEvent.
 
 ### Send CloudEvent to the Broker
 
-We can send an http request directly to the [Broker](../../../broker/README.md)
+We can send an http request directly to the [Broker](../../../broker/)
 with correct CloudEvent headers set.
 
 1. Deploy a curl pod and SSH into it

--- a/docs/eventing/samples/helloworld/helloworld-python/_index.md
+++ b/docs/eventing/samples/helloworld/helloworld-python/_index.md
@@ -8,7 +8,7 @@ type: "docs"
 A simple web app written in Python that you can use to test knative eventing. It shows how to consume a [CloudEvent](https://cloudevents.io/) in Knative eventing, and optionally how to respond back with another CloudEvent in the http response, by adding the Cloud Eventing headers outlined in the Cloud Events standard definition.
 
 We will deploy the app as a [Kubernetes Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) along with a [Kubernetes Service](https://kubernetes.io/docs/concepts/services-networking/service/).
-However, you can also deploy the app as a [Knative Serving Service](../../../../serving/README.md).
+However, you can also deploy the app as a [Knative Serving Service](../../../../serving/).
 
 Follow the steps below to create the sample code and then deploy the app to your
 cluster. You can also download a working copy of the sample, by running the

--- a/docs/eventing/samples/kafka/_index.md
+++ b/docs/eventing/samples/kafka/_index.md
@@ -97,6 +97,6 @@ $ ./kafka_setup.sh
 A number of different examples, showing the `KafkaSource`, `KafkaChannel` and
 `KafkaBinding` can be found here:
 
-- [`KafkaSource` to `Service`](./source/README.md)
-- [`KafkaChannel` and Broker](./channel/README.md)
-- [`KafkaBinding`](./binding/README.md)
+- [`KafkaSource` to `Service`](./source/)
+- [`KafkaChannel` and Broker](./channel/)
+- [`KafkaBinding`](./binding/)

--- a/docs/eventing/samples/kafka/binding/index.md
+++ b/docs/eventing/samples/kafka/binding/index.md
@@ -18,7 +18,7 @@ via Kafka Source
 ### Prerequisites
 
 1. You must ensure that you meet the
-   [prerequisites listed in the Apache Kafka overview](../README.md).
+   [prerequisites listed in the Apache Kafka overview](../).
 2. This feature is available from Knative Eventing 0.15+
 
 ### Creating a `KafkaSource` source CRD

--- a/docs/eventing/samples/kafka/channel/index.md
+++ b/docs/eventing/samples/kafka/channel/index.md
@@ -11,9 +11,9 @@ default channel configuration in Knative Eventing.
 ## Prerequisites
 
 - Ensure that you meet the
-  [prerequisites listed in the Apache Kafka overview](../README.md).
+  [prerequisites listed in the Apache Kafka overview](../).
 - A Kubernetes cluster with
-  [Knative Kafka Channel installed](../../../../install/README.md).
+  [Knative Kafka Channel installed](../../../../install/).
 
 ## Creating a `KafkaChannel` channel CRD
 

--- a/docs/eventing/samples/kafka/source/index.md
+++ b/docs/eventing/samples/kafka/source/index.md
@@ -9,8 +9,8 @@ Tutorial on how to build and deploy a `KafkaSource` [Eventing source](../../../s
 
 ## Prerequisites
 
-- Ensure that you meet the [prerequisites listed in the Apache Kafka overview](../README.md).
-- A Kubernetes cluster with [Knative Kafka Source installed](../../../../install/README.md).
+- Ensure that you meet the [prerequisites listed in the Apache Kafka overview](../).
+- A Kubernetes cluster with [Knative Kafka Source installed](../../../../install/).
 
 ## Apache Kafka Topic (Optional)
 

--- a/docs/eventing/samples/parallel/_index.md
+++ b/docs/eventing/samples/parallel/_index.md
@@ -17,7 +17,7 @@ All examples require:
   - Knative Serving
 
 All examples are using the
-[default channel template](../../channels/default-channels.md).
+[default channel template](../../channels/create-default-channel.md).
 
 ## Examples
 
@@ -30,5 +30,5 @@ trivial filtering, transformation and routing of the incoming events.
 
 The examples are:
 
-- [Parallel with multiple branches and global reply](./multiple-branches/README.md)
-- [Parallel with mutually exclusive cases](./mutual-exclusivity/README.md)
+- [Parallel with multiple branches and global reply](./multiple-branches/)
+- [Parallel with mutually exclusive cases](./mutual-exclusivity/)

--- a/docs/eventing/samples/parallel/multiple-branches/_index.md
+++ b/docs/eventing/samples/parallel/multiple-branches/_index.md
@@ -14,7 +14,7 @@ The events produced by each branch are then sent to the `event-display` service.
 
 ## Prerequisites
 
-Please refer to the sample overview for the [prerequisites](../README.md).
+Please refer to the sample overview for the [prerequisites](../).
 
 ### Create the Knative Services
 

--- a/docs/eventing/samples/parallel/mutual-exclusivity/_index.md
+++ b/docs/eventing/samples/parallel/mutual-exclusivity/_index.md
@@ -9,7 +9,7 @@ In this example, we are going to see how we can create a Parallel with mutually
 exclusive branches.
 
 This example is the same as the
-[multiple branches example](../multiple-branches/README.md) except that we are
+[multiple branches example](../multiple-branches/) except that we are
 now going to rely on the Knative
 [switch](https://github.com/lionelvillard/knative-functions#switch) function to
 provide a soft mutual exclusivity guarantee.
@@ -18,7 +18,7 @@ NOTE: this example must be deployed in the default namespace.
 
 ## Prerequisites
 
-Please refer to the sample overview for the [prerequisites](../README.md).
+Please refer to the sample overview for the [prerequisites](../).
 
 ### Create the Knative Services
 

--- a/docs/serving/samples/blue-green-deployment.md
+++ b/docs/serving/samples/blue-green-deployment.md
@@ -14,7 +14,7 @@ configuration.
 
 You need:
 
-- A Kubernetes cluster with [Knative installed](../../install/README.md).
+- A Kubernetes cluster with [Knative installed](../../install/).
 - (Optional) [A custom domain configured](../using-a-custom-domain.md) for use
   with Knative.
 

--- a/docs/serving/samples/gitwebhook-go/index.md
+++ b/docs/serving/samples/gitwebhook-go/index.md
@@ -16,7 +16,7 @@ You must meet the following requirements to run this sample:
   [Google Domains](https://domains.google/).
 - A Kubernetes cluster running with the following:
   - Knative Serving must be installed. For details about setting up a Knative
-    cluster, see the [installation guides](../../../install/README.md).
+    cluster, see the [installation guides](../../../install/).
   - Your Knative cluster must be
     [configured to use your custom domain](../../using-a-custom-domain.md).
   - You must ensure that your Knative cluster uses a static IP address:

--- a/docs/serving/samples/grpc-ping-go/index.md
+++ b/docs/serving/samples/grpc-ping-go/index.md
@@ -16,7 +16,7 @@ for production containers.
 
 ## Prerequisites
 
-- [Install the latest version of Knative Serving](../../../install/README.md).
+- [Install the latest version of Knative Serving](../../../install/).
 
 - Install [docker](https://www.docker.com/).
 

--- a/docs/serving/samples/hello-world/helloworld-java-spring/README.md
+++ b/docs/serving/samples/hello-world/helloworld-java-spring/README.md
@@ -14,7 +14,7 @@ cd knative-docs/docs/serving/samples/hello-world/helloworld-java-spring
 ## Before you begin
 
 - A Kubernetes cluster with Knative installed and DNS configured. Follow the
-  [installation instructions](../../../../install/README.md) if you need to
+  [installation instructions](../../../../install/) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/knative-routing-go/index.md
+++ b/docs/serving/samples/knative-routing-go/index.md
@@ -20,7 +20,7 @@ the Login service.
 
 ## Prerequisites
 
-1. A Kubernetes cluster with [Knative Serving](../../../install/README.md)
+1. A Kubernetes cluster with [Knative Serving](../../../install/)
    installed.
 2. Install
    [Docker](https://docs.docker.com/get-started/#prepare-your-docker-environment).

--- a/docs/serving/samples/multi-container/index.md
+++ b/docs/serving/samples/multi-container/index.md
@@ -10,7 +10,7 @@ A simple web app written in Go that you can use for multi container testing.
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed and DNS configured. Follow the
-  [installation instructions](../../../install/README.md) if you need to
+  [installation instructions](../../../install/) if you need to
   create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).

--- a/docs/serving/samples/rest-api-go/index.md
+++ b/docs/serving/samples/rest-api-go/index.md
@@ -12,7 +12,7 @@ like `AAPL`,`AMZN`, `GOOG`, `MSFT`, etc.
 
 ## Prerequisites
 
-1. A Kubernetes cluster with [Knative Serving](../../../install/README.md) installed
+1. A Kubernetes cluster with [Knative Serving](../../../install/) installed
    and DNS configured.
 1. [Docker](https://docs.docker.com/get-started/#prepare-your-docker-environment)
    installed locally.
@@ -202,7 +202,7 @@ and then you run `curl` commands to send request with your stock symbol.
 
 ## Next Steps
 
-The [traffic splitting example](../traffic-splitting/README.md) continues from
+The [traffic splitting example](../traffic-splitting/) continues from
 here to walk you through how to create new Revisions and then use traffic
 splitting between those Revisions.
 

--- a/docs/serving/samples/secrets-go/index.md
+++ b/docs/serving/samples/secrets-go/index.md
@@ -22,7 +22,7 @@ cd knative-docs/docs/serving/samples/secrets-go
 ## Before you begin
 
 - A Kubernetes cluster with Knative installed. Follow the
-  [installation instructions](../../../install/README.md) if you need to create
+  [installation instructions](../../../install/) if you need to create
   one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Fixes #3568 #3577

I use the following command to scan in multiple threads
```shell
find . -type f -print0  | xargs -0 -P 6 grep -rni "/README.md)"|grep -v https
```

```shell
./docs/serving/samples/rest-api-go/index.md:15:1. A Kubernetes cluster with [Knative Serving](../../../install/README.md) installed
./docs/serving/samples/rest-api-go/index.md:205:The [traffic splitting example](../traffic-splitting/README.md) continues from
./docs/serving/samples/knative-routing-go/index.md:23:1. A Kubernetes cluster with [Knative Serving](../../../install/README.md)
./docs/serving/samples/multi-container/index.md:13:  [installation instructions](../../../install/README.md) if you need to
./docs/serving/samples/hello-world/helloworld-java-spring/README.md:17:  [installation instructions](../../../../install/README.md) if you need to
./docs/serving/samples/grpc-ping-go/index.md:19:- [Install the latest version of Knative Serving](../../../install/README.md).
./docs/serving/samples/blue-green-deployment.md:17:- A Kubernetes cluster with [Knative installed](../../install/README.md).
./docs/serving/samples/secrets-go/index.md:25:  [installation instructions](../../../install/README.md) if you need to create
./docs/serving/samples/gitwebhook-go/index.md:19:    cluster, see the [installation guides](../../../install/README.md).
./docs/eventing/accessing-traces.md:14:You must have a Knative cluster running with the Eventing component installed. [Learn more](../install/README.md)
./docs/eventing/debugging/index.md:14:[Knative Eventing](../README.md). You don't need to be an expert, but do need to
./docs/eventing/debugging/index.md:19:1. Setup [Knative Eventing and an Eventing-contrib resource](../README.md).
./docs/eventing/samples/helloworld/helloworld-python/_index.md:11:However, you can also deploy the app as a [Knative Serving Service](../../../../serving/README.md).
./docs/eventing/samples/helloworld/helloworld-go/_index.md:19:[Knative Serving Service](../../../../serving/README.md).
./docs/eventing/samples/helloworld/helloworld-go/_index.md:283:We can send an http request directly to the [Broker](../../../broker/README.md)
./docs/eventing/samples/helloworld/_index.md:16:However, you can also deploy the app as a [Knative Serving Service](../../../serving/README.md)
./docs/eventing/samples/helloworld/_index.md:23:    [Knative Serving](../../../install/README.md).
./docs/eventing/samples/parallel/multiple-branches/_index.md:17:Please refer to the sample overview for the [prerequisites](../README.md).
./docs/eventing/samples/parallel/mutual-exclusivity/_index.md:12:[multiple branches example](../multiple-branches/README.md) except that we are
./docs/eventing/samples/parallel/mutual-exclusivity/_index.md:21:Please refer to the sample overview for the [prerequisites](../README.md).
./docs/eventing/samples/parallel/_index.md:25:[`PingSource`](../ping-source/README.md) as the source of events.
./docs/eventing/samples/parallel/_index.md:33:- [Parallel with multiple branches and global reply](./multiple-branches/README.md)
./docs/eventing/samples/parallel/_index.md:34:- [Parallel with mutually exclusive cases](./mutual-exclusivity/README.md)
./docs/eventing/samples/kafka/source/index.md:8:Tutorial on how to build and deploy a `KafkaSource` [Eventing source](../../../sources/README.md) using a Knative Serving `Service`.
./docs/eventing/samples/kafka/source/index.md:12:- Ensure that you meet the [prerequisites listed in the Apache Kafka overview](../README.md).
./docs/eventing/samples/kafka/source/index.md:13:- A Kubernetes cluster with [Knative Kafka Source installed](../../../../install/README.md).
./docs/eventing/samples/kafka/binding/index.md:21:   [prerequisites listed in the Apache Kafka overview](../README.md).
./docs/eventing/samples/kafka/channel/index.md:14:  [prerequisites listed in the Apache Kafka overview](../README.md).
./docs/eventing/samples/kafka/channel/index.md:16:  [Knative Kafka Channel installed](../../../../install/README.md).
./docs/eventing/samples/kafka/_index.md:100:- [`KafkaSource` to `Service`](./source/README.md)
./docs/eventing/samples/kafka/_index.md:101:- [`KafkaChannel` and Broker](./channel/README.md)
./docs/eventing/samples/kafka/_index.md:102:- [`KafkaBinding`](./binding/README.md)
./docs/eventing/samples/gitlab-source/index.md:18:   Follow the [installation instructions](../../../install/README.md) if you
./docs/eventing/samples/_index.md:11:[Learn more about Knative Eventing and Eventing Sources](../README.md).
./docs/eventing/flows/parallel.md:47:Learn how to use Parallel by following the [examples](../samples/parallel/README.md)
./vendor/knative.dev/hack/README.md:114:   [here](../kntest/pkg/kubetest2/gke/README.md) to the `initialize` function

```
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix broken links
