### PR TITLE
Add branch-based versioning

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -36,3 +36,9 @@
 .md-version__list li:nth-last-child(1) a {
   color: gray;
 }
+
+/* bit of a hack to stop the banner taking space when empty */
+.md-announce .md-announce__inner {
+  margin: 0;
+  padding: 0;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -32,3 +32,7 @@
 .md-nav__title .md-nav__button.md-logo svg {
   width: auto;
 }
+
+.md-version__list li:nth-last-child(1) a {
+  color: gray;
+}

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -105,7 +105,7 @@ if [ -z "$SKIP_BLOG" ]; then
       -exec sed -i '/](/ { /http/ !{s#\.md##g} }' {} +
 
   # Run the hugo build as normal!
-  npx hugo
+  PATH=${PATH}:${PWD}/node_modules/.bin hugo
   popd
 
   # Hugo builds to public/, just copy over to site/ to match up with mkdocs

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -15,12 +15,12 @@ set -x
 VERSIONS=("0.23" "0.22" "0.21")
 # 3) For now, set branches too. (This will go away when all branches are release-NN).
 BRANCHES=("mkrelease-0.23" "mkrelease-0.22" "mkrelease-0.22")
+REPOS=("julz" "julz" "julz")
 # 4) PR the result to main.
 # 5) Party.
 
 community_branch=${COMMUNITY_BRANCH:-main}
 community_repo=${COMMUNITY_REPO:-knative}
-repo=${DOCS_REPO:-knative}
 latest=${VERSIONS[0]}
 previous=("${VERSIONS[@]:1}")
 
@@ -36,7 +36,7 @@ else
   mkdocs build -f mkdocs.yml -d site/development
 
   # Latest release branch to /docs
-  git clone --depth 1 -b ${BRANCHES[0]} https://github.com/$repo/docs "temp/docs-$latest"
+  git clone --depth 1 -b ${BRANCHES[0]} https://github.com/${REPOS[0]}/docs "temp/docs-$latest"
   pushd "temp/docs-$latest"
   KNATIVE_VERSION=$latest mkdocs build -d ../../site/docs
   popd
@@ -46,7 +46,7 @@ else
   for i in "${!previous[@]}"; do
     version=${previous[$i]}
     versionjson+="{\"version\": \"v$version-docs\", \"title\": \"v$version\", \"aliases\": [\"\"]},"
-    git clone --depth 1 -b ${BRANCHES[$i+1]} https://github.com/$repo/docs "temp/docs-$version"
+    git clone --depth 1 -b ${BRANCHES[$i+1]} https://github.com/${REPOS[i+1]}/docs "temp/docs-$version"
     pushd "temp/docs-$version"
     KNATIVE_VERSION=$version VERSION_WARNING=true mkdocs build -d "../../site/v$version-docs"
     popd

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -90,10 +90,24 @@ if [ -z "$SKIP_BLOG" ]; then
   cp -r temp/community/* temp/website/content/en/community/contributing/
   rm -r temp/website/content/en/community/contributing/elections/2021-TOC # Temp fix for markdown that confuses hugo.
 
-  # Run the hugo build as normal!
-
-  # need postcss cli in PATH
+  # See https://github.com/knative/website/blob/main/scripts/processsourcefiles.sh#L125
+  # For the reasoning behind all this.
+  echo 'Converting all links in GitHub source files to Hugo supported relative links...'
   pushd temp/website
+  # Convert relative links to support Hugo
+  find . -type f -path '*/content/*.md' ! -name '*_index.md' ! -name '*index.md' ! -name '*README.md' \
+    ! -name '*serving-api.md' ! -name '*eventing-contrib-api.md' ! -name '*eventing-api.md' \
+    ! -name '*build-api.md' ! -name '*.git*' ! -path '*/.github/*' ! -path '*/hack/*' \
+    ! -path '*/node_modules/*' ! -path '*/test/*' ! -path '*/themes/*' ! -path '*/vendor/*' \
+    -exec sed -i '/](/ { s#(\.\.\/#(../../#g; s#(\.\/#(../#g; }' {} +
+  # Convert all relative links from README.md to index.html
+  find . -type f -path '*/content/*.md' ! -name '_index.md' \
+      -exec sed -i '/](/ { /http/ !{s#README\.md#index.html#g} }' {} +
+  # Convert all Markdown links to HTML
+  find . -type f -path '*/content/*.md' \
+      -exec sed -i '/](/ { /http/ !{s#\.md##g} }' {} +
+
+  # Run the hugo build as normal!
   npx hugo
   popd
 

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -75,7 +75,8 @@ fi
 if [ -z "$SKIP_BLOG" ]; then
   # Clone out the website and community repos for the hugo bits.
   # TODO(jz) Cache this and just do a pull/update/use siblings for local dev flow.
-  git clone --depth 1 --recurse-submodules https://github.com/knative/website temp/website
+  git clone --depth 1 https://github.com/knative/website temp/website
+  pushd temp/website; git submodule update --init --recursive --depth 1; popd
   git clone --depth 1 https://github.com/knative/community temp/community
 
   # Move blog files into position
@@ -97,13 +98,9 @@ if [ -z "$SKIP_BLOG" ]; then
   popd
 
   # Hugo builds to public/, just copy over to site/ to match up with mkdocs
-  mv temp/website/public/blog site/
-  mv temp/website/public/community site/
-  mv temp/website/public/css site/
-  mv temp/website/public/scss site/
-  mv temp/website/public/webfonts site/
-  mv temp/website/public/images site/
-  mv temp/website/public/js site/
+  for d in blog community css scss webfonts images js; do
+    mv temp/website/public/$d site/
+  done
 fi
 
 # Home page is served from docs, so add a redirect.

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -11,16 +11,16 @@ set -x
 # Releasing a new version:
 # 1) Make a release-NN branch as normal.
 # 2) Update VERSIONS (on main) to include the new version.
-VERSIONS=("0.23" "0.22" "0.21")
+VERSIONS=("0.23" "0.22")
 
 # 3) For now, update the function below to map version to branch.
 # This is temporary so we can use non release-N branches while we transition
 # (since we'll want mkdocs versions of the last 2 releases). TODO: Drop this
 # when all the versions are in release-$version branches (in mkdocs format).
 function branch_for_version() {
-  if [ "$1" == "0.23" ]; then echo "mkdocs"
-  elif [ "$1" == "0.22" ]; then echo "mkdocs"
-  elif [ "$1" == "0.21" ]; then echo "mkdocs"
+  if [ "$1" == "0.23" ]; then echo "mkrelease-0.23"
+  elif [ "$1" == "0.22" ]; then echo "mkrelease-0.22"
+  elif [ "$1" == "0.21" ]; then echo "mkversion2"
   else
     echo "No branch for version $1. Update branch_for_version function"
     exit 1

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -18,6 +18,8 @@ BRANCHES=("mkrelease-0.23" "mkrelease-0.22" "mkrelease-0.22")
 # 4) PR the result to main.
 # 5) Party.
 
+community_branch=${COMMUNITY_BRANCH:-main}
+community_repo=${COMMUNITY_REPO:-knative}
 repo=${DOCS_REPO:-knative}
 latest=${VERSIONS[0]}
 previous=("${VERSIONS[@]:1}")
@@ -65,7 +67,7 @@ if [ -z "$SKIP_BLOG" ]; then
   # TODO(jz) Cache this and just do a pull/update/use siblings for local dev flow.
   git clone --depth 1 https://github.com/knative/website temp/website
   pushd temp/website; git submodule update --init --recursive --depth 1; popd
-  git clone --depth 1 https://github.com/knative/community temp/community
+  git clone -b ${community_branch} --depth 1 https://github.com/${community_repo}/community temp/community
 
   # Move blog files into position
   mkdir -p temp/website/content/en

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -7,6 +7,13 @@ set -x
 # Also builds previous versions unless BUILD_VERSIONS=no.
 # - Results are written to site/ as normal.
 # - Run as "./hack/build-with-blog.sh serve" to run a local preview server on site/ afterwards (requires `npm install -g http-server`).
+#
+# PREREQS (Unless BUILD_BLOG=no is set):
+# 1. Install Hugo: https://www.docsy.dev/docs/getting-started/#install-hugo
+# 2. For Mac OSX: The script uses the `gnu` version of `sed`. To install `gnu-sed`, you use brew:
+#    1. Run `brew install gnu-sed`
+#    2. Add it to your `PATH`. For example, add the following line to your `~/.bash_profile`:
+#      `PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"`
 
 # Releasing a new version:
 # 1) Make a release-NN branch as normal.

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -92,9 +92,8 @@ if [ -z "$SKIP_BLOG" ]; then
   # Run the hugo build as normal!
 
   # need postcss cli in PATH
-  PATH=${PATH}:${PWD}/node_modules/.bin
   pushd temp/website
-  hugo
+  npx hugo
   popd
 
   # Hugo builds to public/, just copy over to site/ to match up with mkdocs

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 
+set -e
+set -x
+
 # Builds blog and community into the site by cloning the website repo, copying blog/community dirs in, running hugo.
-# Also builds previous versions if BUILD_VERSIONS=yes (see below).
+# Also builds previous versions unless BUILD_VERSIONS=no.
 # - Results are written to site/ as normal.
 # - Run as "./hack/build-with-blog.sh serve" to run a local preview server on site/ afterwards (requires `npm install -g http-server`).
 
+# Releasing a new version:
+# 1) Make a release-NN branch as normal.
+# 2) Update VERSIONS (on main) to include the new version.
+VERSIONS=("0.23" "0.22" "0.21")
 
-# Versioning:
-# To release (1) make a release branch as normal (2) change the
-# `knative_version` and `branch` variables in the release branch version
-# of mkdocs.yml so {{ artifact }} and {{ branch }} links point to the
-# right versions of things (3) Update variables below.
-BUILD_VERSIONS="yes"         # TODO(jz) - detect if this is a pr preview/local and turn this off?
-LATEST="0.23"                # release-$latest to /docs (HEAD builds to /development)
-PREVIOUS=("0.22" "0.21")     # each release-$previous to /$previous-docs
-
-# TODO: drop this when all the versions are in release-$version branches (in mkdocs format).
+# 3) For now, update the function below to map version to branch.
+# This is temporary so we can use non release-N branches while we transition
+# (since we'll want mkdocs versions of the last 2 releases). TODO: Drop this
+# when all the versions are in release-$version branches (in mkdocs format).
 function branch_for_version() {
   if [ "$1" == "0.23" ]; then echo "mkdocs"
   elif [ "$1" == "0.22" ]; then echo "mkdocs"
@@ -26,16 +27,17 @@ function branch_for_version() {
   fi
 }
 
-# Quit on error
-set -e
-# Echo each line
-set -x
+# 4) PR the result to main.
+# 5) Party.
 
 rm -rf temp
 mkdir temp
 rm -rf site/
 
-if [ "$BUILD_VERSIONS" != "yes" ]; then
+LATEST=${VERSIONS[0]}
+PREVIOUS=("${VERSIONS[@]:1}") 
+
+if [ "$BUILD_VERSIONS" == "no" ]; then
   # HEAD to /docs if we're not doing versioning.
   mkdocs build -f mkdocs.yml -d site/docs
 else
@@ -45,15 +47,17 @@ else
   # Latest release branch to /docs
   git clone -b $(branch_for_version $LATEST) https://github.com/knative/docs "temp/docs-$LATEST" # TODO this should use the actual branch but there isnt one yet!
   pushd "temp/docs-$LATEST"
-  mkdocs build -d ../../site/docs     # latest version: docs => docs/
+  KNATIVE_VERSION=$LATEST mkdocs build -d ../../site/docs     # latest release-N: docs => docs/
   popd
 
   # Previous release branches release-$version to /$version-docs
+  versionjson=""
   for version in "${PREVIOUS[@]}"
   do
     pushd "temp/docs-$LATEST"
     git checkout $(branch_for_version $version)
-    mkdocs build -d "../../site/v$version-docs"   # old releases: docs => vN-docs/
+    versionjson+="{\"version\": \"v$version-docs\", \"title\": \"v$version\", \"aliases\": [\"\"]},"
+    KNATIVE_VERSION=$version VERSION_WARNING=true mkdocs build -d "../../site/v$version-docs"   # previous releases-N: docs => vN-docs/
     popd
   done
 
@@ -61,51 +65,46 @@ else
   cat << EOF > site/versions.json
   [
     {"version": "docs", "title": "v$LATEST", "aliases": [""]},
-EOF
-  for version in "${PREVIOUS[@]}"
-  do
-  cat << EOF >> site/versions.json
-    {"version": "v$version-docs", "title": "v$version", "aliases": [""]},
-EOF
-  done
-  cat << EOF >> site/versions.json
+    $versionjson
     {"version": "development", "title": "(Pre-release)", "aliases": [""]}
   ]
 EOF
 fi
 
-# Clone out the website and community repos for the hugo bits.
-# TODO(jz) Cache this and just do a pull/update/use siblings for local dev flow.
-git clone --recurse-submodules https://github.com/knative/website temp/website
-git clone https://github.com/knative/community temp/community
+if [ ! -z "SKIP_BLOG" ]; then
+  # Clone out the website and community repos for the hugo bits.
+  # TODO(jz) Cache this and just do a pull/update/use siblings for local dev flow.
+  git clone --recurse-submodules https://github.com/knative/website temp/website
+  git clone https://github.com/knative/community temp/community
 
-# Move blog files into position
-mkdir -p temp/website/content/en
-cp -r blog temp/website/content/en/
+  # Move blog files into position
+  mkdir -p temp/website/content/en
+  cp -r blog temp/website/content/en/
 
-# Clone community/ in to position too
-# This is pretty weird: the base community is in docs, but then the
-# community repo is overlayed into the community/contributing subdir.
-cp -r community temp/website/content/en/
-cp -r temp/community/* temp/website/content/en/community/contributing/
-rm -r temp/website/content/en/community/contributing/elections/2021-TOC # Temp fix for markdown that confuses hugo.
+  # Clone community/ in to position too
+  # This is pretty weird: the base community is in docs, but then the
+  # community repo is overlayed into the community/contributing subdir.
+  cp -r community temp/website/content/en/
+  cp -r temp/community/* temp/website/content/en/community/contributing/
+  rm -r temp/website/content/en/community/contributing/elections/2021-TOC # Temp fix for markdown that confuses hugo.
 
-# Run the hugo build as normal!
+  # Run the hugo build as normal!
 
-# need postcss cli in PATH
-PATH=${PATH}:${PWD}/node_modules/.bin
-pushd temp/website
-hugo
-popd
+  # need postcss cli in PATH
+  PATH=${PATH}:${PWD}/node_modules/.bin
+  pushd temp/website
+  hugo
+  popd
 
-# Hugo builds to public/, just copy over to site/ to match up with mkdocs
-mv temp/website/public/blog site/
-mv temp/website/public/community site/
-mv temp/website/public/css site/
-mv temp/website/public/scss site/
-mv temp/website/public/webfonts site/
-mv temp/website/public/images site/
-mv temp/website/public/js site/
+  # Hugo builds to public/, just copy over to site/ to match up with mkdocs
+  mv temp/website/public/blog site/
+  mv temp/website/public/community site/
+  mv temp/website/public/css site/
+  mv temp/website/public/scss site/
+  mv temp/website/public/webfonts site/
+  mv temp/website/public/images site/
+  mv temp/website/public/js site/
+fi
 
 # Home page is served from docs, so add a redirect.
 # TODO(jz) in production this should be done with a netlify 301 (or maybe just copy docs/index up with a base set).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -231,6 +231,7 @@ markdown_extensions:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - attr_list
+  - meta
   - pymdownx.superfences
   - pymdownx.tabbed
   - pymdownx.details

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -250,8 +250,6 @@ copyright: "Copyright © 2021 The Knative Authors"
 
 extra:
   branch: v0.23.0 # Branch to use for examples
-  # version for download links, empty or "dev" to use googlestorage nightlies.
-  # version: v0.23.0
   social:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/KnativeProject
@@ -261,5 +259,8 @@ extra:
     - icon: fontawesome/brands/slack
       link: https://slack.knative.dev
       name: Slack
+  # TODO: Replace with https://github.com/mkdocs/mkdocs/pull/2267 once mkdocs 1.2 is out.
+  version_warning: !!python/object/apply:os.getenv ["VERSION_WARNING"]
+  knative_version: !!python/object/apply:os.getenv ["KNATIVE_VERSION"]
   version:
     provider: mike

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block announce %}
+{% if config.extra.version_warning %}
+<div class="versionwarning" style="margin: .6rem auto; padding: 0 .8rem">
+  <h1 style="color: #ffcc00">You are viewing documentation for Knative version: {{ config.extra.knative_version }}</h1>
+  <p>
+  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="http://knative.dev/docs">the latest version</a>.
+  </p>
+</div>
+{% endif %}
+{% endblock %}
+

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,7 +5,7 @@
 <div class="versionwarning" style="margin: .6rem auto; padding: 0 .8rem">
   <h1 style="color: #ffcc00">You are viewing documentation for Knative version: {{ config.extra.knative_version }}</h1>
   <p>
-  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="http://knative.dev/docs">the latest version</a>.
+  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="{{ base_url }}/../docs/">the latest version</a>.
   </p>
 </div>
 {% endif %}


### PR DESCRIPTION
https://user-images.githubusercontent.com/354013/118398771-073ddb80-b652-11eb-90d9-24dcca25f255.mov

Builds previous versions of docs in to the site based on release branches.

**TL;dr:** `mkdocs serve` in any branch for live preview of just that version of docs, `./hack/build-with-blog.sh [serve]` to build/preview the whole thing, release by creating release branch as normal and updating RELEASES at top of build-with-blog.sh.

Fixes #3573.

/assign @omerbensaadon @csantanapr 

# Preview docs with live reload

- `mkdocs serve --dirtyreload` - this will preview just the current version, very fast (immediate) update of changes to pages
- Run on a release branch (or on main, or wherever) to view docs for just that release.

# Preview versioned docs, blog posts and `main` of community

- `./hack/build-with-blog.sh serve`
- We'll set netlify PR previews (and builds) up to run this, too.

# Preview community repo PRs

- `COMMUNITY_BRANCH=${pr branch here} COMMUNITY_REPO=${pr author username} ./hack/build-with-blog.sh serve`. This will build community tab from the given branch of the given repo instead of main of knative/docs, good for previewing PRs to community before merging.

# Build full versioned docs with blog and community included

- `./hack/build-with-blog.sh` - builds the whole shebang. HEAD -> /development, latest release -> /docs etc. This is what actions/netlify builds will run.
- Automatically adds version warning banners to old pages, sets correct version for artifact links etc
- Note: this is currently using my julz/docs repo's mkrelease-0.23 and mkrelease-0.22 branches until we have past version branches created on the main repo. This can be changed via the BRANCHES array at the top of the script.

# Releasing

- Create release branch, just like today
- Update RELEASES array at top of hack/build-with-blog.sh (on main/mkdocs) to tell us what releases to build. PR the result.
- That's it.