### PR TITLE
make netlify beta site return to home page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Knative
-site_url: https://knative.dev/docs
+site_url: https://beta-knative.netlify.app/docs
 site_description: Knative Documentation
 extra_css:
   - stylesheets/extra.css

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,7 +5,7 @@
 <div class="versionwarning" style="margin: .6rem auto; padding: 0 .8rem">
   <h1 style="color: #ffcc00">You are viewing documentation for Knative version: {{ config.extra.knative_version }}</h1>
   <p>
-  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="{{ base_url }}/../docs/">the latest version</a>.
+  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="https://beta-knative.netlify.app/docs/">the latest version</a>.
   </p>
 </div>
 {% endif %}


### PR DESCRIPTION
make netlify hostname default to make it usable on netlify for now
This to fix when clicking on latest version
![image](https://user-images.githubusercontent.com/1094878/118571101-5f0c3d80-b74b-11eb-98af-001765f28310.png)
