### PR TITLE
Use correct ClusterIssue name

### DIFF
--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -198,12 +198,10 @@ in the `knative-serving` namespace to reference your new `ClusterIssuer`.
 1.  Add the `issuerRef` within the `data` section:
 
     ```shell
-    ...
     data:
-    ...
       issuerRef: |
         kind: ClusterIssuer
-        name: letsencrypt-issuer
+        name: letsencrypt-http01-issuer
     ```
 
     Example:
@@ -247,11 +245,8 @@ requests are handled:
 1.  Add the `autoTLS: Enabled` attribute under the `data` section:
 
     ```shell
-    ...
     data:
-    ...
       autoTLS: Enabled
-    ...
     ```
 
     Example:
@@ -285,11 +280,8 @@ requests are handled:
       clients to use HTTPS.
 
      ```shell
-     ...
      data:
-     ...
-       autoTLS: Enabled
-     ...
+       httpProtocol: Redirected
      ```
 
      Example:
@@ -303,7 +295,6 @@ requests are handled:
      data:
        ...
        autoTLS: Enabled
-       ...
        httpProtocol: Redirected
        ...
      ```


### PR DESCRIPTION
The doc uses ClusterIssuer `letsencrypt-http01-issuer` but the configuration uses
`letsencrypt-issuer` so it is confusable. Actual report is https://github.com/knative/docs/issues/3560.

So this patch changes the ClusterIssuer name to
`letsencrypt-http01-issuer` which is used in this doc section.

Fix https://github.com/knative/docs/issues/3560