### PR TITLE
docs about usage of internal services in an "api-gateway" access model

### DIFF
--- a/docs/serving/samples/knative-routing-go/index.md
+++ b/docs/serving/samples/knative-routing-go/index.md
@@ -260,6 +260,41 @@ The Gateway proxy checks the updated host, and forwards it to `Search` or
 
 ![Object model](./images/knative-routing-sample-flow.png)
 
+## Using internal services and `"httpProtocol": "Redirected"`
+
+Using the above approach, services will be available using two entrypoints into the cluster:
+The original ones provided by Knative Serving (`search-service.default.example.com` and `login-service.default.example.com`),
+as well as the additional entrypoints `example.com/search` and `example.com/login`
+provided by the manually added VirtualService (`entry-route`).
+
+To make sure your service can only be reached via the manually created
+VirtualService, you can add the label `networking.knative.dev/visibility: cluster-local`
+to the Knative Service definitions, and route traffic over
+`knative-local-gateway.istio-system.svc.cluster.local` with a destination address of an internal service,
+instead of the public ingress one at `istio-ingressgateway.istio-system.svc.cluster.local`
+with a destination address of an externally available service.
+
+Using
+
+```
+kubectl label kservice search-service login-service networking.knative.dev/visibility=cluster-local
+```
+
+you label the services as an cluster-local services, removing access via `search-service.default.example.com`
+and `login-service.default.example.com`. After doing so, your previous routing rule will not be routable anymore.
+Running
+
+```
+kubectl apply --filename docs/serving/samples/knative-routing-go/routing-internal.yaml
+```
+
+will replace the custom routing rule with one that uses the `knative-local-gateway`, enabling access
+via `example.com/search` and `example.com/login` again.
+
+With these changes, you can also use [the `autoTLS` feature](../../using-auto-tls.md) in combination with the global setting
+`"httpProtocol": "Redirected"`, which would otherwise try to redirect the `entry-route`
+VirtualService requests from HTTP to HTTPS, failing the request.
+
 ## Clean Up
 
 To clean up the sample resources:

--- a/docs/serving/samples/knative-routing-go/routing-internal.yaml
+++ b/docs/serving/samples/knative-routing-go/routing-internal.yaml
@@ -31,13 +31,13 @@ spec:
     rewrite:
       # Rewrite the original host header to the host header of Search service
       # in order to redirect requests to Search service.
-      authority: search-service.default.example.com
+      authority: search-service.default.svc.cluster.local
     route:
-      # Basically here we redirect the request to the cluster entry again with
-      # updated header "search-service.default.example.com" so the request will
+      # Basically here we redirect the request to the internal gateway with
+      # updated header "search-service.default.svc.cluster.local" so the request will
       # eventually be directed to Search service.
       - destination:
-          host: istio-ingressgateway.istio-system.svc.cluster.local
+          host: knative-local-gateway.istio-system.svc.cluster.local
           port:
             number: 80
         weight: 100
@@ -47,13 +47,13 @@ spec:
     rewrite:
       # Rewrite the original host header to the host header of Search service
       # in order to redirect requests to Search service.
-      authority: login-service.default.example.com
+      authority: login-service.default.svc.cluster.local
     route:
-      # Basically here we redirect the request to the cluster entry again with
-      # updated header "login-service.default.example.com" so the request will
+      # Basically here we redirect the request to the internal gateway with
+      # updated header "login-service.default.svc.cluster.local" so the request will
       # eventually be directed to Login service.
       - destination:
-          host: istio-ingressgateway.istio-system.svc.cluster.local
+          host: knative-local-gateway.istio-system.svc.cluster.local
           port:
             number: 80
         weight: 100


### PR DESCRIPTION
Fixes #3562

## Proposed Changes <!-- Describe the changes the PR makes. -->

I promised to write down how to support `"httpProtocol": "Redirected"` for the documentation found at https://knative.dev/docs/serving/samples/knative-routing-go/index.html

Thanks to @nak3 I found out how to do it, and wanted to make others lives easier by documenting it.

In case you think it would be better, I can also add graphics - but I did not have the sources of the already-present image, and did not want to make a bad copy of it.
