### PR TITLE
Fix a mismatch in 'a' vs. plural

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -36,7 +36,7 @@
         <li class="task-list-item">
           <input type="checkbox" checked disabled />
           <span class="task-list-indicator"></span>
-          <b>Stand up a scalable, secure, stateless services in seconds.</b>
+          <b>Stand up scalable, secure, stateless services in seconds.</b>
         </li>
         <li class="task-list-item">
           <input type="checkbox" checked disabled /><span class="task-list-indicator"></span><b>Focused API</b> with


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- drop the a since later on it uses plural for services.
-
-
