### PR TITLE
Add a bit of padding around the logo in the header

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -50,6 +50,7 @@
   background-size: 300% 100%;
   opacity: 0.4;
   z-index: -1;
+  padding: 20px;
 }
 
 .md-typeset img,


### PR DESCRIPTION
Just a liiiiittle bit of padding to make the logo not hug the browser's (and header's) edges as much.
