### PR TITLE
One plugin section to rule them all (fixes search)

### DIFF
--- a/docs/check-install-version.md
+++ b/docs/check-install-version.md
@@ -12,11 +12,16 @@ To obtain the version of the Knative component that you have running on your clu
 
 === "Knative Serving"
 
-      ```
-      kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels "serving.knative.dev/release"}}'
-      ```
+    ```
+    {% raw %}
+    kubectl get namespace knative-serving -o 'go-template={{index .metadata.labels "serving.knative.dev/release"}}'
+    {% endraw %}
+    ```
+
 === "Knative Eventing"
 
-      ```
-      kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels "eventing.knative.dev/release"}}'
-      ```
+    ```
+    {% raw %}
+    kubectl get namespace knative-eventing -o 'go-template={{index .metadata.labels "eventing.knative.dev/release"}}'
+    {% endraw %}
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -231,18 +231,6 @@ theme:
     - navigation.indexes
     - navigation.top
 
-plugins:
-  - search
-  - macros:
-      module_name: hack/macros
-  - exclude:
-      glob:
-        # Exclude files that contain hugo specific shortcodes
-        # (either the include shortcode or not-converted-yet tabs).
-        - smoketest.md
-        - "*/serving-api.md" # shortcode to serving.md
-        - "*/_index.md" # pretty much all shortcodes
-
 markdown_extensions:
   # - mdx_include:
   #     base_path: docs
@@ -267,30 +255,40 @@ markdown_extensions:
       permalink: true
 
 plugins:
-    - awesome-pages:
-        filename: .index
-        collapse_single_pages: true
-        strict: false
-    - redirects:
-        redirect_maps:
-            'install/collecting-logs/index.md': 'admin/collecting-logs/README.md'
-            'install/README.md': 'admin/install/README.md'
-            'install/collecting-metrics/index.md': 'admin/collecting-metrics/README.md'
-            'install/install-eventing-with-yaml.md': 'admin/install/install-eventing-with-yaml.md'
-            'install/install-extensions.md': 'admin/install/install-extensions.md'
-            'install/install-serving-with-yaml.md': 'admin/install/install-serving-with-yaml.md'
-            'install/installation-files.md': 'admin/install/installation-files.md'
-            'install/installing-istio.md': 'admin/install/installing-istio.md'
-            'install/knative-offerings.md': 'admin/install/knative-offerings.md'
-            'install/knative-with-operators.md': 'admin/install/knative-with-operators.md'
-            'install/operator/configuring-eventing-cr.md': 'admin/install/operator/configuring-eventing-cr.md'
-            'install/operator/configuring-serving-cr.md': 'admin/install/operator/configuring-serving-cr.md'
-            'install/prerequisites.md': 'admin/install/prerequisites.md'
-            'uninstall.md': 'admin/install/uninstall.md'
-            'upgrade/index.md': 'admin/upgrade/README.md'
-            'upgrade/upgrade-installation-with-operator.md': 'admin/upgrade/upgrade-installation-with-operator.md'
-            'upgrade/upgrade-installation.md': 'admin/upgrade/upgrade-installation.md'
-            'install/check-install-version.md': 'check-install-version.md'
+  - search
+  - macros:
+      module_name: hack/macros
+  - exclude:
+      glob:
+        # Exclude files that contain hugo specific shortcodes
+        # (either the include shortcode or not-converted-yet tabs).
+        - smoketest.md
+        - "*/serving-api.md" # shortcode to serving.md
+        - "*/_index.md" # pretty much all shortcodes
+  - awesome-pages:
+      filename: ".index"
+      collapse_single_pages: true
+      strict: false
+  - redirects:
+      redirect_maps:
+        'install/collecting-logs/index.md': 'admin/collecting-logs/README.md'
+        'install/README.md': 'admin/install/README.md'
+        'install/collecting-metrics/index.md': 'admin/collecting-metrics/README.md'
+        'install/install-eventing-with-yaml.md': 'admin/install/install-eventing-with-yaml.md'
+        'install/install-extensions.md': 'admin/install/install-extensions.md'
+        'install/install-serving-with-yaml.md': 'admin/install/install-serving-with-yaml.md'
+        'install/installation-files.md': 'admin/install/installation-files.md'
+        'install/installing-istio.md': 'admin/install/installing-istio.md'
+        'install/knative-offerings.md': 'admin/install/knative-offerings.md'
+        'install/knative-with-operators.md': 'admin/install/knative-with-operators.md'
+        'install/operator/configuring-eventing-cr.md': 'admin/install/operator/configuring-eventing-cr.md'
+        'install/operator/configuring-serving-cr.md': 'admin/install/operator/configuring-serving-cr.md'
+        'install/prerequisites.md': 'admin/install/prerequisites.md'
+        'uninstall.md': 'admin/install/uninstall.md'
+        'upgrade/index.md': 'admin/upgrade/README.md'
+        'upgrade/upgrade-installation-with-operator.md': 'admin/upgrade/upgrade-installation-with-operator.md'
+        'upgrade/upgrade-installation.md': 'admin/upgrade/upgrade-installation.md'
+        'install/check-install-version.md': 'check-install-version.md'
 
 copyright: "Copyright © 2021 The Knative Authors"
 


### PR DESCRIPTION
Fixes the search not showing up. We'd accidentally ended up with two `plugins` section in the yaml, which meant the search plugin wasn't in the list of plugins any more

/assign @csantanapr @omerbensaadon 