### PR TITLE
redirect latest release from mkdocs to knative.dev

### DIFF
--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -64,7 +64,7 @@ else
   # Set up the version file to point to the built docs.
   cat << EOF > site/versions.json
   [
-    {"version": "v$version-docs", "title": "v$latest", "aliases": [""]},
+    {"version": "v$latest-docs", "title": "v$latest", "aliases": [""]},
     $versionjson
     {"version": "development", "title": "(Pre-release)", "aliases": [""]}
   ]

--- a/hack/build-with-blog.sh
+++ b/hack/build-with-blog.sh
@@ -64,7 +64,7 @@ else
   # Set up the version file to point to the built docs.
   cat << EOF > site/versions.json
   [
-    {"version": "docs", "title": "v$latest", "aliases": [""]},
+    {"version": "v$version-docs", "title": "v$latest", "aliases": [""]},
     $versionjson
     {"version": "development", "title": "(Pre-release)", "aliases": [""]}
   ]


### PR DESCRIPTION
latest release today is v0.23 the content we want users to see today is on knative.dev not in dev-kantive.netlify.app 
Today dev-kantive.netlify.app should only expose to users the development branch which is the mkdocs branch in this repository

/assign @omerbensaadon @julz 