### PR TITLE
Fix compile error for Dockerfile

### DIFF
--- a/docs/serving/samples/grpc-ping-go/Dockerfile
+++ b/docs/serving/samples/grpc-ping-go/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.12 as builder
+FROM golang:1.13 as builder
 
 # Retrieve the dependencies.
 RUN go get google.golang.org/grpc


### PR DESCRIPTION
Fix compile error on golang 1.12 .  It doesn't define the method "errors.Is" yet. The error message is  as follows. 
#golang.org/x/net/http2  
src/golang.org/x/net/http2/client_conn_pool.go:305:6: undefined: errors.Is
golang 1.13+ defined the method "errors.Is", It will pass the compile when using golang 1.13+ instead.

<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
