### PR TITLE
Adding docs for pod capabilities feature flat (see serving PR #11410)

### DIFF
--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -275,6 +275,34 @@ spec:
         ...
 ```
 
+## Kubernetes Security Context Capabilities
+
+* **Type**: extension
+* **ConfigMap key**: `kubernetes.containerspec-addcapabilities`
+
+This flag controls whether users can add capabilities on the `securityContext` of the container.
+
+When set to `enabled` or `allowed` it allows [Linux capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) to be added to the container.
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+spec:
+ template:
+  spec:
+   containers:
+     - image: gcr.io/knative-samples/helloworld-go
+       env:
+         - name: TARGET
+           value: "Go Sample v1"
+       securityContext:
+         capabilities:
+           add:
+             - NET_BIND_SERVICE
+```
+
 ## Tag Header Based Routing
 * **Type**: extension
 * **ConfigMap key:** `tag-header-based-routing`


### PR DESCRIPTION
Documentation in support of [Serving PR #11410](https://github.com/knative/serving/pull/11410)

## Proposed Changes 

- Adds documentation for a feature gate that allows users to add Linux capabilities to a container
