### PR TITLE
Bump cert manager API verson

### DIFF
--- a/docs/admin/install/install-extensions.md
+++ b/docs/admin/install/install-extensions.md
@@ -47,7 +47,7 @@ The tabs below expand to show instructions for installing each Serving extension
     via cert-manager.
 
     1. First, install
-      [cert-manager version `0.12.0` or higher](../serving/installing-cert-manager.md)
+      [cert-manager version `v1.0.0` or higher](../serving/installing-cert-manager.md)
 
     2. Next, install the component that integrates Knative with cert-manager:
 

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -81,7 +81,7 @@ and which DNS provider validates those requests.
       [Configuring HTTPS with cert-manager and Google Cloud DNS](./using-cert-manager-on-gcp.md).
 
       ```shell
-      apiVersion: cert-manager.io/v1alpha2
+      apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
         name: letsencrypt-dns-issuer
@@ -112,7 +112,7 @@ and which DNS provider validates those requests.
 
     ```shell
     kubectl apply -f - <<EOF
-    apiVersion: cert-manager.io/v1alpha2
+    apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
       name: letsencrypt-http01-issuer

--- a/docs/serving/using-cert-manager-on-gcp.md
+++ b/docs/serving/using-cert-manager-on-gcp.md
@@ -108,7 +108,7 @@ TLS certificates and how the requests are validated with Cloud DNS.
 
    ```shell
    kubectl apply --filename - <<EOF
-   apiVersion: cert-manager.io/v1alpha2
+   apiVersion: cert-manager.io/v1
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-issuer
@@ -171,7 +171,7 @@ exists.
    export DOMAIN=<your-domain.com>
 
    kubectl apply --filename - <<EOF
-   apiVersion: cert-manager.io/v1alpha2
+   apiVersion: cert-manager.io/v1
    kind: Certificate
    metadata:
      name: my-certificate

--- a/docs/serving/using-cert-manager-on-gcp.md
+++ b/docs/serving/using-cert-manager-on-gcp.md
@@ -38,7 +38,7 @@ and Cloud DNS:
     [Knative installation guides](../install/).
   - Your Knative cluster must be configured to use a
     [custom domain](./using-a-custom-domain.md).
-  - [cert-manager v0.6.1 or higher installed](./installing-cert-manager.md)
+  - [cert-manager v1.0.0 or higher installed](./installing-cert-manager.md)
 - Your DNS provider must be setup and configured to your domain.
 
 ## Creating a service account and using a Kubernetes secret


### PR DESCRIPTION
`cert-manager` is deprecating all alpha and beta API versions in the next release (see [cert-manager#4021](https://github.com/jetstack/cert-manager/pull/4021)).

This PR changes `cert-manager` examples in docs to use `v1` API instead of `v1alpha2`.

It also bumps the minimum required version of `cert-manager` to be `v1.0.0`- this is the first stable version and also the first with `v1` API.

Please let me know if this is the wrong branch to PR against- I saw that most PRs were made against this branch rather than `main` so did the same.

Potentially related https://github.com/knative-sandbox/net-certmanager/issues/219