### PR TITLE
Update kafka channel samples with configmap changes

### DIFF
--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -307,11 +307,11 @@ data:
 namespace, be sure your roles and bindings are configured so that the
 knative-eventing pods can access it.
 
-## Channel Configuration
+## Channel configuration
 
 The `config-kafka` ConfigMap allows for a variety of channel options such as:
 - CPU and Memory requests and limits for the dispatcher (and receiver for
-   the distributed channel type) deployments created by the controller
+  the distributed channel type) deployments created by the controller
 - Kafka topic default values (number of partitions, replication factor, and
   retention time)
 - Maximum idle connections/connections per host for Knative cloudevents

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -36,7 +36,7 @@ EOF
 
 ## Specifying the default channel configuration
 
-To configure the usage of the `KafkaChannel` CRD as the
+1. To configure the usage of the `KafkaChannel` CRD as the
 [default channel configuration](../../../channels/channel-types-defaults), edit the
 `default-ch-webhook` ConfigMap as follows:
 
@@ -62,10 +62,9 @@ EOF
 
 ## Creating an Apache Kafka channel using the default channel configuration
 
-1. Now that `KafkaChannel` is set as the default channel configuration, you can
+1. Now that `KafkaChannel` is set as the default channel configuration,
 use the `channels.messaging.knative.dev` CRD to create a new Apache Kafka
 channel, using the generic `Channel`:
-
 ```
 cat <<-EOF | kubectl apply -f -
 ---
@@ -75,10 +74,8 @@ metadata:
   name: testchannel-one
 EOF
 ```
-
 2. Check Kafka for a `testchannel` topic. With Strimzi this can be done by
 using the command:
-
 ```
 kubectl -n kafka exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
 ```
@@ -168,7 +165,7 @@ your configuration with the following options.
 kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c user-container
 ```
 
-## Authentication against an Apache Kafka
+## Authentication against an Apache Kafka cluster
 
 In production environments it is common that the Apache Kafka cluster is
 secured using [TLS](http://kafka.apache.org/documentation/#security_ssl)
@@ -309,7 +306,7 @@ data:
       authSecretName: <kafka-auth-secret>
       authSecretNamespace: <namespace>
 ...
- ```
+```
 
 !!! note
     The default secret name and namespace are `kafka-cluster` and
@@ -320,15 +317,23 @@ data:
 ## Channel configuration
 
 The `config-kafka` ConfigMap allows for a variety of channel options such as:
+
 - CPU and Memory requests and limits for the dispatcher (and receiver for
   the distributed channel type) deployments created by the controller
+
 - Kafka topic default values (number of partitions, replication factor, and
   retention time)
+
 - Maximum idle connections/connections per host for Knative cloudevents
+
 - The brokers string for your Kafka connection
+
 - The name and namespace of your TLS/SASL authentication secret
+
 - The Kafka admin type (distributed channel only)
+
 - Nearly all the settings exposed in a [Sarama Config Struct](https://github.com/Shopify/sarama/blob/master/config.go)
+
 - Sarama debugging assistance (via sarama.enableLogging)
 
 For detailed information (particularly for the distributed channel), see the

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -174,10 +174,8 @@ Follow the section corresponding to the channel type that you used
 
 #### TLS authentication
 
-To use TLS authentication you must create:
-
-* A CA certificate
-* A client certificate and key
+To use TLS authentication you must have a CA root certificate as well as
+a client certificate and key.
 
 1. Create the certificate files as secret fields in your chosen namespace:
    ```shell
@@ -194,8 +192,8 @@ To use TLS authentication you must create:
 
 To use SASL authentication, you will need the following information:
 
-* A username and password.
-* The type of SASL mechanism you wish to use. For example; `PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512`.
+- A username and password.
+- The type of SASL mechanism you wish to use. For example; `PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512`.
 
 !!! note
     It is recommended to also enable TLS. If you enable this, you will also

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -99,7 +99,8 @@ name of the channel.  In the consolidated channel implementation, it is also
 prefixed with `knative-messaging-kafka` to indicate that it is an Apache Kafka
 channel from Knative.
 
-**NOTE:** The topic of a Kafka channel is an implementation detail and records from it should not be consumed from different applications.
+!!! note
+    The topic of a Kafka channel is an implementation detail and records from it should not be consumed from different applications.
 
 ## Configuring the Knative broker for Apache Kafka channels
 
@@ -132,7 +133,8 @@ knative-messaging-kafka.default.default-kn2-trigger
 ...
 ```
 
-**NOTE:** The topic of a Kafka channel is an implementation detail and records from it should not be consumed from different applications.
+!!! note
+    The topic of a Kafka channel is an implementation detail and records from it should not be consumed from different applications.
 
 ## Creating a service and trigger to use the Apache Kafka broker
 
@@ -191,7 +193,8 @@ $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
   --from-file=user.key=key.pem
  ```
 
-*NOTE:* It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
+!!! note
+    It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
 
 For the distributed channel type, place the certificate into your
 `config-kafka` ConfigMap and set the TLS.Enable field to `true`, for example:

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -164,8 +164,8 @@ shows how to configure the `KafkaChannel` to work against a protected Apache
 Kafka cluster, with the two supported TLS and SASL authentication methods.
 
 !!! note
-Kafka channels require certificates to be in `.pem` format. If your files
-are in a different format, you must convert them to `.pem`.
+    Kafka channels require certificates to be in `.pem` format. If your files
+    are in a different format, you must convert them to `.pem`.
 
 Follow the section corresponding to the channel type that you used
 (consolidated or distributed) when installing eventing-kafka:
@@ -188,7 +188,7 @@ To use TLS authentication you must create:
    ```
 
    !!! note
-   It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
+       It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
 
 #### SASL authentication
 

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -187,8 +187,8 @@ To use TLS authentication you must create:
      --from-file=user.key=key.pem
    ```
 
-   !!! note
-       It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
+!!! note
+    It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
 
 #### SASL authentication
 

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -198,8 +198,8 @@ To use SASL authentication, you will need the following information:
 * The type of SASL mechanism you wish to use. For example; `PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512`.
 
 !!! note
-It is recommended to also enable TLS. If you enable this, you will also
-need the `ca.crt` certificate as described in the previous section.
+    It is recommended to also enable TLS. If you enable this, you will also
+    need the `ca.crt` certificate as described in the previous section.
 
 1. Create a secret with a `ca.crt` field if using a custom CA certificate,
    for example:
@@ -220,8 +220,8 @@ need the `ca.crt` certificate as described in the previous section.
      --from-literal=user="my-sasl-user"
    ```
 
-   !!! note
-   It is important to use the same keys; `user`, `password` and `saslType`.
+!!! note
+    It is important to use the same keys; `user`, `password` and `saslType`.
 
 ### Distributed channel authentication
 
@@ -298,7 +298,7 @@ To use SASL authentication, you will need the following information:
 
 ### All channel types and authentication methods
 
-1. After you have created the secret for your desired authentication method by
+1. If you have created a secret for your desired authentication method by
    using the previous steps, reference the secret and the namespace of the
    secret in the `config-kafka` ConfigMap:
    ```

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -72,7 +72,7 @@ default channel configuration in Knative Eventing.
      name: testchannel-one
    EOF
    ```
-2. Check Kafka for a `testchannel` topic. With Strimzi this can be done by
+2. Check Kafka for a `testchannel-one` topic. With Strimzi this can be done by
    using the command:
    ```
    kubectl -n kafka exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
@@ -99,7 +99,6 @@ channel from Knative.
 
 1. To setup a broker that will use the new default Kafka channels, you must
    create a new _default_ broker, using the command:
-
    ```shell
    kubectl create -f - <<EOF
    apiVersion: eventing.knative.dev/v1
@@ -108,18 +107,19 @@ channel from Knative.
     name: default
    EOF
    ```
-   This will give you two pods, such as:
-   ```
-   default-broker-filter-64658fc79f-nf596                            1/1     Running     0          15m
-   default-broker-ingress-ff79755b6-vj9jt                            1/1     Running     0          15
-   ```
-   Inside the Apache Kafka cluster you should see two new topics, such as:
-   ```
-   ...
-   knative-messaging-kafka.default.default-kn2-ingress
-   knative-messaging-kafka.default.default-kn2-trigger
-   ...
-   ```
+
+This will give you two pods, such as:
+```
+default-broker-filter-64658fc79f-nf596                            1/1     Running     0          15m
+default-broker-ingress-ff79755b6-vj9jt                            1/1     Running     0          15
+```
+Inside the Apache Kafka cluster you should see two new topics, such as:
+```
+...
+knative-messaging-kafka.default.default-kn2-ingress
+knative-messaging-kafka.default.default-kn2-trigger
+...
+```
 
 !!! note
     The topic of a Kafka channel is an implementation detail and records from it should not be consumed from different applications.
@@ -151,7 +151,6 @@ your configuration with the following options.
 ### Receive events via Knative
 
 1. Observe the events in the log of the `ksvc` using the command:
-
    ```
    kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c user-container
    ```

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -62,9 +62,9 @@ EOF
 
 ## Creating an Apache Kafka channel using the default channel configuration
 
-Now that `KafkaChannel` is set as the default channel configuration, you can use
-the `channels.messaging.knative.dev` CRD to create a new Apache Kafka channel,
-using the generic `Channel`:
+1. Now that `KafkaChannel` is set as the default channel configuration, you can
+use the `channels.messaging.knative.dev` CRD to create a new Apache Kafka
+channel, using the generic `Channel`:
 
 ```
 cat <<-EOF | kubectl apply -f -
@@ -76,8 +76,8 @@ metadata:
 EOF
 ```
 
-Check Kafka for a `testchannel` topic. With Strimzi this can be done by using
-the command:
+2. Check Kafka for a `testchannel` topic. With Strimzi this can be done by
+using the command:
 
 ```
 kubectl -n kafka exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
@@ -104,8 +104,8 @@ channel from Knative.
 
 ## Configuring the Knative broker for Apache Kafka channels
 
-To setup a broker that will use the new default Kafka channels, you must create
-a new _default_ broker, using the command:
+1. To setup a broker that will use the new default Kafka channels, you must
+create a new _default_ broker, using the command:
 
 ```shell
 kubectl create -f - <<EOF
@@ -147,11 +147,9 @@ API, which then routes events to a Knative `Service`.
    kubectl apply -f 000-ksvc.yaml
    ```
 2. Install a source that publishes to the default broker
-
    ```
    kubectl apply -f 020-k8s-events.yaml
    ```
-
 3. Create a trigger that routes the events to the `ksvc`:
    ```
    kubectl apply -f 030-trigger.yaml
@@ -164,7 +162,7 @@ your configuration with the following options.
 
 ### Receive events via Knative
 
-Now you can see the events in the log of the `ksvc` using the command:
+1. Observe the events in the log of the `ksvc` using the command:
 
 ```
 kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c user-container
@@ -172,7 +170,11 @@ kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c us
 
 ## Authentication against an Apache Kafka
 
-In production environments it is common that the Apache Kafka cluster is secured using [TLS](http://kafka.apache.org/documentation/#security_ssl) or [SASL](http://kafka.apache.org/documentation/#security_sasl). This section shows how to configure the `KafkaChannel` to work against a protected Apache Kafka cluster, with the two supported TLS and SASL authentication methods.
+In production environments it is common that the Apache Kafka cluster is
+secured using [TLS](http://kafka.apache.org/documentation/#security_ssl)
+or [SASL](http://kafka.apache.org/documentation/#security_sasl). This section
+shows how to configure the `KafkaChannel` to work against a protected Apache
+Kafka cluster, with the two supported TLS and SASL authentication methods.
 
 ### TLS authentication
 
@@ -182,7 +184,8 @@ To use TLS authentication you must create:
 * A client certificate and key
 
 !!! note
-    Kafka channels require these files to be in `.pem` format. If your files are in a different format, you must convert them to `.pem`.
+    Kafka channels require these files to be in `.pem` format. If your files
+    are in a different format, you must convert them to `.pem`.
 
 1. For the consolidated channel type, create the certificate files as secret
 fields in your chosen namespace:
@@ -196,7 +199,7 @@ $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
 !!! note
     It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
 
-For the distributed channel type, place the certificate into your
+1. For the distributed channel type, place the certificate into your
 `config-kafka` ConfigMap and set the TLS.Enable field to `true`, for example:
 
 ```
@@ -227,15 +230,16 @@ To use SASL authentication, you will need the following information:
 * The type of SASL mechanism you wish to use. For example; `PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512`.
 
 !!! note
-    It is recommended to also enable TLS. If you enable this, you will also need the `ca.crt` certificate as described in the previous section.
+    It is recommended to also enable TLS. If you enable this, you will also
+    need the `ca.crt` certificate as described in the previous section.
 
 #### SASL secret
 
 The SASL secret is different depending on whether you are using the
-consolidated or distributed channel implementation. For the
-consolidated channel, create a secret with a `ca.crt` field if using
-a custom CA certificate, for example:
+consolidated or distributed channel implementation.
 
+1. For the consolidated channel, create a secret with a `ca.crt` field if
+using a custom CA certificate, for example:
 ```
 $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
   --from-file=ca.crt=caroot.pem \
@@ -243,10 +247,8 @@ $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
   --from-literal=saslType="SCRAM-SHA-512" \
   --from-literal=user="my-sasl-user"
 ```
-
-or, if you want to use public CA certificates, you must use the
+2. Optional. If you want to use public CA certificates, you must use the
 `tls.enabled=true` flag, rather than the `ca.crt` argument, for example:
-
 ```
 $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
   --from-literal=tls.enabled=true \
@@ -258,10 +260,10 @@ $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
 !!! note
     It is important to use the same keys; `user`, `password` and `saslType`.
 
-For the distributed channel type, do not place the certificate into the secret;
-instead place the root certificate data (if using a custom CA cert) directly
-into your `config-kafka` ConfigMap and set SASL.Enable to `true`. For example:
-
+1. For the distributed channel type, do not place the certificate into the
+secret; instead place the root certificate data (if using a custom CA cert)
+directly into your `config-kafka` ConfigMap and set the SASL.Enable field
+to `true`. For example:
 ```
 $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
     --from-literal=password="SecretPassword" \
@@ -295,8 +297,9 @@ data:
 
 ### All authentication methods
 
-After you have created the secret for your desired authentication type by using the previous
-steps, reference the secret and the namespace of the secret in the `config-kafka` ConfigMap:
+1. After you have created the secret for your desired authentication type by
+using the previous steps, reference the secret and the namespace of the secret
+in the `config-kafka` ConfigMap:
 
 ```
 ...

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -191,7 +191,7 @@ $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
   --from-file=ca.crt=caroot.pem \
   --from-file=user.crt=certificate.pem \
   --from-file=user.key=key.pem
- ```
+```
 
 !!! note
     It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -21,7 +21,7 @@ default channel configuration in Knative Eventing.
 
 1. Create a new object by configuring the YAML file as follows:
    ```
-   cat <<-EOF | kubectl apply -f -
+   kubectl apply -f - <<EOF
    ---
    apiVersion: messaging.knative.dev/v1beta1
    kind: KafkaChannel
@@ -39,7 +39,7 @@ default channel configuration in Knative Eventing.
    [default channel configuration](../../../channels/channel-types-defaults), 
    edit the `default-ch-webhook` ConfigMap as follows:
    ```
-   cat <<-EOF | kubectl apply -f -
+   kubectl apply -f - <<EOF
    ---
    apiVersion: v1
    kind: ConfigMap
@@ -64,7 +64,7 @@ default channel configuration in Knative Eventing.
    use the `channels.messaging.knative.dev` CRD to create a new Apache Kafka
    channel, using the generic `Channel`:
    ```
-   cat <<-EOF | kubectl apply -f -
+   kubectl apply -f - <<EOF
    ---
    apiVersion: messaging.knative.dev/v1
    kind: Channel

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -20,7 +20,7 @@ default channel configuration in Knative Eventing.
 ## Creating a `KafkaChannel` channel CRD
 
 1. Create a new object by configuring the YAML file as follows:
-   ```
+   ```shell
    kubectl apply -f - <<EOF
    ---
    apiVersion: messaging.knative.dev/v1beta1
@@ -38,7 +38,7 @@ default channel configuration in Knative Eventing.
 1. To configure the usage of the `KafkaChannel` CRD as the
    [default channel configuration](../../../channels/channel-types-defaults), 
    edit the `default-ch-webhook` ConfigMap as follows:
-   ```
+   ```shell
    kubectl apply -f - <<EOF
    ---
    apiVersion: v1
@@ -63,7 +63,7 @@ default channel configuration in Knative Eventing.
 1. Now that `KafkaChannel` is set as the default channel configuration,
    use the `channels.messaging.knative.dev` CRD to create a new Apache Kafka
    channel, using the generic `Channel`:
-   ```
+   ```shell
    kubectl apply -f - <<EOF
    ---
    apiVersion: messaging.knative.dev/v1
@@ -74,7 +74,7 @@ default channel configuration in Knative Eventing.
    ```
 2. Check Kafka for a `testchannel-one` topic. With Strimzi this can be done by
    using the command:
-   ```
+   ```shell
    kubectl -n kafka exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
    ```
    The result is:
@@ -131,15 +131,15 @@ the`ApiServerSource` to publish events to the broker as well as the `Trigger`
 API, which then routes events to a Knative `Service`.
 
 1. Install `ksvc`, using the command:
-   ```
+   ```shell
    kubectl apply -f 000-ksvc.yaml
    ```
 2. Install a source that publishes to the default broker
-   ```
+   ```shell
    kubectl apply -f 020-k8s-events.yaml
    ```
 3. Create a trigger that routes the events to the `ksvc`:
-   ```
+   ```shell
    kubectl apply -f 030-trigger.yaml
    ```
 
@@ -151,7 +151,7 @@ your configuration with the following options.
 ### Receive events via Knative
 
 1. Observe the events in the log of the `ksvc` using the command:
-   ```
+   ```shell
    kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c user-container
    ```
 
@@ -176,8 +176,8 @@ To use TLS authentication you must create:
 
 1. For the consolidated channel type, create the certificate files as secret
    fields in your chosen namespace:
-   ```
-   $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
+   ```shell
+   kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
      --from-file=ca.crt=caroot.pem \
      --from-file=user.crt=certificate.pem \
      --from-file=user.key=key.pem
@@ -226,7 +226,7 @@ consolidated or distributed channel implementation.
 
 1. For the consolidated channel, create a secret with a `ca.crt` field if
    using a custom CA certificate, for example:
-   ```
+   ```shell
    kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
      --from-file=ca.crt=caroot.pem \
      --from-literal=password="SecretPassword" \
@@ -235,7 +235,7 @@ consolidated or distributed channel implementation.
    ```
 2. Optional. If you want to use public CA certificates, you must use the
    `tls.enabled=true` flag, rather than the `ca.crt` argument, for example:
-   ```
+   ```shell
    kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
      --from-literal=tls.enabled=true \
      --from-literal=password="SecretPassword" \
@@ -250,7 +250,7 @@ consolidated or distributed channel implementation.
    secret; instead place the root certificate data (if using a custom CA cert)
    directly into your `config-kafka` ConfigMap and set the SASL.Enable field
    to `true`. For example:
-   ```
+   ```shell
    kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
        --from-literal=password="SecretPassword" \
        --from-literal=saslType="PLAIN" \

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -19,76 +19,72 @@ default channel configuration in Knative Eventing.
 
 ## Creating a `KafkaChannel` channel CRD
 
-Create a new object by configuring the YAML file as follows:
-
-```
-cat <<-EOF | kubectl apply -f -
----
-apiVersion: messaging.knative.dev/v1beta1
-kind: KafkaChannel
-metadata:
-  name: my-kafka-channel
-spec:
-  numPartitions: 3
-  replicationFactor: 1
-EOF
-```
+1. Create a new object by configuring the YAML file as follows:
+   ```
+   cat <<-EOF | kubectl apply -f -
+   ---
+   apiVersion: messaging.knative.dev/v1beta1
+   kind: KafkaChannel
+   metadata:
+     name: my-kafka-channel
+   spec:
+     numPartitions: 3
+     replicationFactor: 1
+   EOF
+   ```
 
 ## Specifying the default channel configuration
 
 1. To configure the usage of the `KafkaChannel` CRD as the
-[default channel configuration](../../../channels/channel-types-defaults), edit the
-`default-ch-webhook` ConfigMap as follows:
-
-```
-cat <<-EOF | kubectl apply -f -
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: default-ch-webhook
-  namespace: knative-eventing
-data:
-  # Configuration for defaulting channels that do not specify CRD implementations.
-  default-ch-config: |
-    clusterDefault:
-      apiVersion: messaging.knative.dev/v1beta1
-      kind: KafkaChannel
-      spec:
-        numPartitions: 3
-        replicationFactor: 1
-EOF
-```
+   [default channel configuration](../../../channels/channel-types-defaults), 
+   edit the `default-ch-webhook` ConfigMap as follows:
+   ```
+   cat <<-EOF | kubectl apply -f -
+   ---
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: default-ch-webhook
+     namespace: knative-eventing
+   data:
+     # Configuration for defaulting channels that do not specify CRD implementations.
+     default-ch-config: |
+       clusterDefault:
+         apiVersion: messaging.knative.dev/v1beta1
+         kind: KafkaChannel
+         spec:
+           numPartitions: 3
+           replicationFactor: 1
+   EOF
+   ```
 
 ## Creating an Apache Kafka channel using the default channel configuration
 
 1. Now that `KafkaChannel` is set as the default channel configuration,
-use the `channels.messaging.knative.dev` CRD to create a new Apache Kafka
-channel, using the generic `Channel`:
-```
-cat <<-EOF | kubectl apply -f -
----
-apiVersion: messaging.knative.dev/v1
-kind: Channel
-metadata:
-  name: testchannel-one
-EOF
-```
+   use the `channels.messaging.knative.dev` CRD to create a new Apache Kafka
+   channel, using the generic `Channel`:
+   ```
+   cat <<-EOF | kubectl apply -f -
+   ---
+   apiVersion: messaging.knative.dev/v1
+   kind: Channel
+   metadata:
+     name: testchannel-one
+   EOF
+   ```
 2. Check Kafka for a `testchannel` topic. With Strimzi this can be done by
-using the command:
-```
-kubectl -n kafka exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
-```
-
-The result is:
-
-```
-...
-__consumer_offsets
-knative-messaging-kafka.default.my-kafka-channel
-knative-messaging-kafka.default.testchannel-one
-...
-```
+   using the command:
+   ```
+   kubectl -n kafka exec -it my-cluster-kafka-0 -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
+   ```
+   The result is:
+   ```
+   ...
+   __consumer_offsets
+   knative-messaging-kafka.default.my-kafka-channel
+   knative-messaging-kafka.default.testchannel-one
+   ...
+   ```
 
 The Apache Kafka topic that is created by the channel implementation contains
 the name of the namespace, `default` in this example, followed by the actual
@@ -102,33 +98,28 @@ channel from Knative.
 ## Configuring the Knative broker for Apache Kafka channels
 
 1. To setup a broker that will use the new default Kafka channels, you must
-create a new _default_ broker, using the command:
+   create a new _default_ broker, using the command:
 
-```shell
-kubectl create -f - <<EOF
-apiVersion: eventing.knative.dev/v1
-kind: Broker
-metadata:
- name: default
-EOF
-```
-
-This will give you two pods, such as:
-
-```
-default-broker-filter-64658fc79f-nf596                            1/1     Running     0          15m
-default-broker-ingress-ff79755b6-vj9jt                            1/1     Running     0          15m
-
-```
-
-Inside the Apache Kafka cluster you should see two new topics, such as:
-
-```
-...
-knative-messaging-kafka.default.default-kn2-ingress
-knative-messaging-kafka.default.default-kn2-trigger
-...
-```
+   ```shell
+   kubectl create -f - <<EOF
+   apiVersion: eventing.knative.dev/v1
+   kind: Broker
+   metadata:
+    name: default
+   EOF
+   ```
+   This will give you two pods, such as:
+   ```
+   default-broker-filter-64658fc79f-nf596                            1/1     Running     0          15m
+   default-broker-ingress-ff79755b6-vj9jt                            1/1     Running     0          15
+   ```
+   Inside the Apache Kafka cluster you should see two new topics, such as:
+   ```
+   ...
+   knative-messaging-kafka.default.default-kn2-ingress
+   knative-messaging-kafka.default.default-kn2-trigger
+   ...
+   ```
 
 !!! note
     The topic of a Kafka channel is an implementation detail and records from it should not be consumed from different applications.
@@ -161,9 +152,9 @@ your configuration with the following options.
 
 1. Observe the events in the log of the `ksvc` using the command:
 
-```
-kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c user-container
-```
+   ```
+   kubectl logs --selector='serving.knative.dev/service=broker-kafka-display' -c user-container
+   ```
 
 ## Authentication against an Apache Kafka cluster
 
@@ -185,39 +176,38 @@ To use TLS authentication you must create:
     are in a different format, you must convert them to `.pem`.
 
 1. For the consolidated channel type, create the certificate files as secret
-fields in your chosen namespace:
-```
-$ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
-  --from-file=ca.crt=caroot.pem \
-  --from-file=user.crt=certificate.pem \
-  --from-file=user.key=key.pem
-```
+   fields in your chosen namespace:
+   ```
+   $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
+     --from-file=ca.crt=caroot.pem \
+     --from-file=user.crt=certificate.pem \
+     --from-file=user.key=key.pem
+   ```
 
 !!! note
     It is important to use the same keys (`ca.crt`, `user.crt` and `user.key`).
 
 1. For the distributed channel type, place the certificate into your
-`config-kafka` ConfigMap and set the TLS.Enable field to `true`, for example:
-
-```
-...
-data:
-  sarama: |
-    config: |
-      Net:
-        TLS:
-          Enable: true
-          Config:
-            RootPEMs: # Array of Root Certificate PEM Files (Use '|-' Syntax To Preserve Linefeeds & Avoiding Terminating \n)
-            - |-
-              -----BEGIN CERTIFICATE-----
-              MIIGDzCCA/egAwIBAgIUWq6j7u/25wPQiNMPZqL6Vy0rkvQwDQYJKoZIhvcNAQEL
-              ...
-              771uezZAFqd1GLLL8ZYRmCsAMg==
-              -----END CERTIFICATE-----
-...
-```
-
+   `config-kafka` ConfigMap and set the TLS.Enable field to `true`,
+   for example:
+   ```
+   ...
+   data:
+     sarama: |
+       config: |
+         Net:
+           TLS:
+             Enable: true
+             Config:
+               RootPEMs: # Array of Root Certificate PEM Files (Use '|-' Syntax To Preserve Linefeeds & Avoiding Terminating \n)
+               - |-
+                 -----BEGIN CERTIFICATE-----
+                 MIIGDzCCA/egAwIBAgIUWq6j7u/25wPQiNMPZqL6Vy0rkvQwDQYJKoZIhvcNAQEL
+                 ...
+                 771uezZAFqd1GLLL8ZYRmCsAMg==
+                 -----END CERTIFICATE-----
+   ...
+   ```
 
 ### SASL authentication
 
@@ -236,77 +226,74 @@ The SASL secret is different depending on whether you are using the
 consolidated or distributed channel implementation.
 
 1. For the consolidated channel, create a secret with a `ca.crt` field if
-using a custom CA certificate, for example:
-```
-$ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
-  --from-file=ca.crt=caroot.pem \
-  --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
-  --from-literal=user="my-sasl-user"
-```
+   using a custom CA certificate, for example:
+   ```
+   kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
+     --from-file=ca.crt=caroot.pem \
+     --from-literal=password="SecretPassword" \
+     --from-literal=saslType="SCRAM-SHA-512" \
+     --from-literal=user="my-sasl-user"
+   ```
 2. Optional. If you want to use public CA certificates, you must use the
-`tls.enabled=true` flag, rather than the `ca.crt` argument, for example:
-```
-$ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
-  --from-literal=tls.enabled=true \
-  --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
-  --from-literal=user="my-sasl-user"
-```
+   `tls.enabled=true` flag, rather than the `ca.crt` argument, for example:
+   ```
+   kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
+     --from-literal=tls.enabled=true \
+     --from-literal=password="SecretPassword" \
+     --from-literal=saslType="SCRAM-SHA-512" \
+     --from-literal=user="my-sasl-user"
+   ```
 
 !!! note
     It is important to use the same keys; `user`, `password` and `saslType`.
 
 1. For the distributed channel type, do not place the certificate into the
-secret; instead place the root certificate data (if using a custom CA cert)
-directly into your `config-kafka` ConfigMap and set the SASL.Enable field
-to `true`. For example:
-```
-$ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
-    --from-literal=password="SecretPassword" \
-    --from-literal=saslType="PLAIN" \
-    --from-literal=username="my-sasl-user"
-```
-
-Example of adding a certificate to the `config-kafka` ConfigMap and enabling
-TLS and SASL:
-
-```
-...
-data:
-  sarama: |
-    config: |
-      Net:
-        TLS:
-          Enable: true
-          Config:
-            RootPEMs: # Array of Root Certificate PEM Files (Use '|-' Syntax To Preserve Linefeeds & Avoiding Terminating \n)
-            - |-
-              -----BEGIN CERTIFICATE-----
-              MIIGDzCCA/egAwIBAgIUWq6j7u/25wPQiNMPZqL6Vy0rkvQwDQYJKoZIhvcNAQEL
-              ...
-              771uezZAFqd1GLLL8ZYRmCsAMg==
-              -----END CERTIFICATE-----
-        SASL:
-          Enable: true
-...
-```
+   secret; instead place the root certificate data (if using a custom CA cert)
+   directly into your `config-kafka` ConfigMap and set the SASL.Enable field
+   to `true`. For example:
+   ```
+   kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
+       --from-literal=password="SecretPassword" \
+       --from-literal=saslType="PLAIN" \
+       --from-literal=username="my-sasl-user"
+   ```
+   Example of adding a certificate to the `config-kafka` ConfigMap and enabling
+   TLS and SASL:
+   ```
+   ...
+   data:
+     sarama: |
+       config: |
+         Net:
+           TLS:
+             Enable: true
+             Config:
+               RootPEMs: # Array of Root Certificate PEM Files (Use '|-' Syntax To Preserve Linefeeds & Avoiding Terminating \n)
+               - |-
+                 -----BEGIN CERTIFICATE-----
+                 MIIGDzCCA/egAwIBAgIUWq6j7u/25wPQiNMPZqL6Vy0rkvQwDQYJKoZIhvcNAQEL
+                 ...
+                 771uezZAFqd1GLLL8ZYRmCsAMg==
+                 -----END CERTIFICATE-----
+           SASL:
+             Enable: true
+   ...
+   ```
 
 ### All authentication methods
 
 1. After you have created the secret for your desired authentication type by
-using the previous steps, reference the secret and the namespace of the secret
-in the `config-kafka` ConfigMap:
-
-```
-...
-data:
-  eventing-kafka: |
-    kafka:
-      authSecretName: <kafka-auth-secret>
-      authSecretNamespace: <namespace>
-...
-```
+   using the previous steps, reference the secret and the namespace of the
+   secret in the `config-kafka` ConfigMap:
+   ```
+   ...
+   data:
+     eventing-kafka: |
+       kafka:
+         authSecretName: <kafka-auth-secret>
+         authSecretNamespace: <namespace>
+   ...
+   ```
 
 !!! note
     The default secret name and namespace are `kafka-cluster` and

--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -37,7 +37,7 @@ EOF
 ## Specifying the default channel configuration
 
 To configure the usage of the `KafkaChannel` CRD as the
-[default channel configuration](../../../channels/channel-types-defaults.md), edit the
+[default channel configuration](../../../channels/channel-types-defaults), edit the
 `default-ch-webhook` ConfigMap as follows:
 
 ```
@@ -179,9 +179,10 @@ To use TLS authentication you must create:
 * A CA certificate
 * A client certificate and key
 
-**NOTE:** Kafka channels require these files to be in `.pem` format. If your files are in a different format, you must convert them to `.pem`.
+!!! note
+    Kafka channels require these files to be in `.pem` format. If your files are in a different format, you must convert them to `.pem`.
 
-For the consolidated channel type, create the certificate files as secret
+1. For the consolidated channel type, create the certificate files as secret
 fields in your chosen namespace:
 ```
 $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
@@ -222,7 +223,8 @@ To use SASL authentication, you will need the following information:
 * A username and password.
 * The type of SASL mechanism you wish to use. For example; `PLAIN`, `SCRAM-SHA-256` or `SCRAM-SHA-512`.
 
-**NOTE:** It is recommended to also enable TLS. If you enable this, you will also need the `ca.crt` certificate as described in the previous section.
+!!! note
+    It is recommended to also enable TLS. If you enable this, you will also need the `ca.crt` certificate as described in the previous section.
 
 #### SASL secret
 
@@ -250,7 +252,8 @@ $ kubectl create secret --namespace <namespace> generic <kafka-auth-secret> \
   --from-literal=user="my-sasl-user"
 ```
 
-*NOTE:* It is important to use the same keys; `user`, `password` and `saslType`.
+!!! note
+    It is important to use the same keys; `user`, `password` and `saslType`.
 
 For the distributed channel type, do not place the certificate into the secret;
 instead place the root certificate data (if using a custom CA cert) directly
@@ -289,9 +292,9 @@ data:
 
 ### All authentication methods
 
-After creating the secret for your desired authentication type using the above
-steps, reference that secret and the namespace of the secret in the
-`config-kafka` ConfigMap:
+After you have created the secret for your desired authentication type by using the previous
+steps, reference the secret and the namespace of the secret in the `config-kafka` ConfigMap:
+
 ```
 ...
 data:
@@ -302,10 +305,11 @@ data:
 ...
  ```
 
-*NOTE:* The default secret name and namespace are `kafka-cluster` and
-`knative-eventing` respectively. If you reference a secret in a different
-namespace, be sure your roles and bindings are configured so that the
-knative-eventing pods can access it.
+!!! note
+    The default secret name and namespace are `kafka-cluster` and
+    `knative-eventing` respectively. If you reference a secret in a different
+    namespace, be sure your roles and bindings are configured so that the
+    knative-eventing pods can access it.
 
 ## Channel configuration
 


### PR DESCRIPTION
This updates the samples/kafka/channel README with information related to the configmap consolidation 

## Proposed Changes

- Describe configmap updates (mainly SASL options and miscellaneous channel configuration) from https://github.com/knative-sandbox/eventing-kafka/pull/622
- Update links and call out areas where the difference between consolidated vs. distributed channel is important
