### PR TITLE
fix out of date link to Gardener

### DIFF
--- a/docs/knative-offerings.md
+++ b/docs/knative-offerings.md
@@ -15,7 +15,7 @@ vendors for what is or is not supported.
 
 Here is a list of commercial Knative products (alphabetically):
 
-- [Gardener](https://gardener.cloud/documentation/050-tutorials/content/howto/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
+- [Gardener](https://gardener.cloud/documentation/tutorials/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
 - [Google Cloud Run for Anthos](https://cloud.google.com/run/docs/gke/setup): Extend Google Kubernetes Engine with a flexible serverless development platform. With Cloud Run for Anthos, you get the operational flexibility of Kubernetes with the developer experience of serverless, allowing you to deploy and manage Knative-based services on your own cluster, and trigger them with events from Google, 3rd-party sources, and your own applications.
 - [Google Cloud Run](https://cloud.google.com/run/docs/setup): A fully-managed Knative-based serverless platform. With no Kubernetes cluster to manage, Cloud Run lets you go from container to production in seconds.
 - [IBM Cloud Code Engine](https://cloud.ibm.com/codeengine): A fully-managed serverless platform that runs all your containerized workloads, including http-driven application, batch jobs or event-driven functions.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

The [original link to Gardener](https://gardener.cloud/documentation/050-tutorials/content/howto/knative-install/) is out of date. The PR updates it to the [correct one](https://gardener.cloud/documentation/tutorials/knative-install/).
