### PR TITLE
Drop install instructions for Gloo until we have better CI coverage

### DIFF
--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -286,53 +286,6 @@ kubectl logs -f deploy/knative-operator
 
           Save this for configuring DNS below.
 
-    === "Gloo"
-
-        _For a detailed guide on Gloo integration, see
-        [Installing Gloo for Knative](https://docs.solo.io/gloo/latest/installation/knative/)
-        in the Gloo documentation._
-
-        The following commands install Gloo and enable its Knative integration.
-
-        1. Make sure `glooctl` is installed (version 1.3.x and higher recommended):
-          ```bash
-          glooctl version
-          ```
-
-          If it is not installed, you can install the latest version using:
-          ```bash
-          curl -sL https://run.solo.io/gloo/install | sh
-          export PATH=$HOME/.gloo/bin:$PATH
-          ```
-
-          Or following the
-          [Gloo CLI install instructions](https://docs.solo.io/gloo/latest/installation/knative/#install-command-line-tool-cli).
-
-        1. Install Gloo and the Knative integration:
-          ```bash
-          glooctl install knative --install-knative=false
-          ```
-
-        1. To configure Knative Serving to use Gloo, apply the content of the Serving CR as below:
-          ```bash
-          cat <<-EOF | kubectl apply -f -
-          apiVersion: operator.knative.dev/v1alpha1
-          kind: KnativeServing
-          metadata:
-            name: knative-serving
-            namespace: knative-serving
-          EOF
-          ```
-
-          There is no need to configure the ingress class to use the gloo.
-
-        1. Fetch the External IP or CNAME:
-          ```bash
-          glooctl proxy url --name knative-external-proxy
-          ```
-
-          Save this for configuring DNS below.
-
     === "Kourier"
 
         The following commands install Kourier and enable its Knative integration.

--- a/docs/admin/install/serving/install-serving-with-yaml.md
+++ b/docs/admin/install/serving/install-serving-with-yaml.md
@@ -142,44 +142,6 @@ Follow the procedure for the networking layer of your choice:
             Save this to use in the `Configure DNS` section.
 
 
-=== "Gloo"
-
-    _For a detailed guide on Gloo integration, see
-    [Installing Gloo for Knative](https://docs.solo.io/gloo/latest/installation/knative/)
-    in the Gloo documentation._
-
-    The following commands install Gloo and enable its Knative integration.
-
-    1. Make sure `glooctl` is installed (version 1.3.x and higher recommended):
-
-        ```bash
-        glooctl version
-        ```
-
-        If it is not installed, you can install the latest version using:
-        ```bash
-        curl -sL https://run.solo.io/gloo/install | sh
-        export PATH=$HOME/.gloo/bin:$PATH
-        ```
-
-        Or following the
-        [Gloo CLI install instructions](https://docs.solo.io/gloo/latest/installation/knative/#install-command-line-tool-cli).
-
-    1. Install Gloo and the Knative integration:
-      ```bash
-      glooctl install knative --install-knative=false
-      ```
-
-    1. Fetch the External IP or CNAME:
-
-        ```bash
-        glooctl proxy url --name knative-external-proxy
-        ```
-
-        !!! tip
-            Save this to use in the `Configure DNS` section.
-
-
 === "Istio"
 
     The following commands install Istio and enable its Knative integration.

--- a/docs/admin/install/uninstall.md
+++ b/docs/admin/install/uninstall.md
@@ -126,16 +126,6 @@ Follow the relevant procedure to uninstall the networking layer you installed:
 
 
 
-=== "Gloo"
-
-    Uninstall Gloo and the Knative integration by running:
-
-       ```bash
-       glooctl uninstall knative
-       ```
-
-
-
 === "Istio"
 
     The following commands uninstall Istio and enable its Knative integration.


### PR DESCRIPTION
As discussed in the recent TOC meeting, we want to be sure the Ingresses
we list in the install instructions are ones we're confident will work
well with Knative, to avoid folks having a bad first experience.

Currently we don't have good (any) CI coverage for Gloo, so removing it
from the list for the moment until we do.

/assign @dprotaso @nak3 @ZhiminXiang 
