### PR TITLE
fixing icon displaying issue in safari  (#3665)

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -173,3 +173,8 @@ body {
     flex-wrap: wrap;
   }
 }
+
+/*fixing issue in safari css */
+.md-typeset .task-list-item {
+  margin-left: 25px !important;
+}


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-Added margin for the list tag which solves issue #3665 
-Checked on Safari Version 14.1 (16611.1.21.161.6)
![WhatsApp Image 2021-06-05 at 1 55 29 PM](https://user-images.githubusercontent.com/65550720/120901279-d7a64180-c607-11eb-9deb-bf29a9aaf7a3.jpeg)


