### PR TITLE
Drop unneccesary important specifiers

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -47,14 +47,15 @@
 }
 
 /* text sizing of tables, Alert, Warnings, Notes*/
-.md-typeset table {
-  font-size: 100% !important;
+.md-typeset table, .md-typeset table:not([class]) {
+  font-size: 100%;
+
 }
 
 .md-typeset code {
-  font-size: 100% !important;
+  font-size: 100%;
 }
 
 .md-typeset .admonition {
-  font-size: 100% !important;
+  font-size: 100%;
 }

--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -176,5 +176,5 @@ body {
 
 /*fixing issue in safari css */
 .md-typeset .task-list-item {
-  margin-left: 25px !important;
+  margin-left: 25px;
 }


### PR DESCRIPTION
The `!important` specifier should [generally be avoided because it makes css hard to maintain](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity#the_!important_exception). Luckily, it doesn't look like we actually need it in any of these cases :).

/assign @omerbensaadon @csantanapr 