### PR TITLE
Temporarily remove kong from install guide

### DIFF
--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -333,37 +333,6 @@ kubectl logs -f deploy/knative-operator
 
           Save this for configuring DNS below.
 
-    === "Kong"
-
-        The following commands install Kong and enable its Knative integration.
-
-        1. Install Kong Ingress Controller:
-          ```bash
-          kubectl apply --filename https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/0.9.x/deploy/single/all-in-one-dbless.yaml
-          ```
-
-        1. To configure Knative Serving to use Kong, apply the content of the Serving CR as below:
-          ```bash
-          cat <<-EOF | kubectl apply -f -
-          apiVersion: operator.knative.dev/v1alpha1
-          kind: KnativeServing
-          metadata:
-            name: knative-serving
-            namespace: knative-serving
-          spec:
-            config:
-              network:
-                ingress.class: "kong"
-          EOF
-          ```
-
-        1. Fetch the External IP or CNAME:
-          ```bash
-          kubectl --namespace kong get service kong-proxy
-          ```
-
-          Save this for configuring DNS below.
-
     === "Kourier"
 
         The following commands install Kourier and enable its Knative integration.

--- a/docs/admin/install/serving/install-serving-with-yaml.md
+++ b/docs/admin/install/serving/install-serving-with-yaml.md
@@ -205,34 +205,6 @@ Follow the procedure for the networking layer of your choice:
         !!! tip
             Save this to use in the `Configure DNS` section.
 
-=== "Kong"
-
-    The following commands install Kong and enable its Knative integration.
-
-    1. Install Kong Ingress Controller:
-
-        ```bash
-        kubectl apply -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/0.9.x/deploy/single/all-in-one-dbless.yaml
-        ```
-
-    1. To configure Knative Serving to use Kong by default:
-
-        ```bash
-        kubectl patch configmap/config-network \
-          --namespace knative-serving \
-          --type merge \
-          --patch '{"data":{"ingress.class":"kong"}}'
-        ```
-
-    1. Fetch the External IP or CNAME:
-
-        ```bash
-        kubectl --namespace kong get service kong-proxy
-        ```
-
-        !!! tip
-            Save this to use in the `Configure DNS` section.
-
 ## Verify the installation
 
 !!! success "Monitor the Knative components until all of the components show a `STATUS` of `Running` or `Completed`:"

--- a/docs/admin/install/uninstall.md
+++ b/docs/admin/install/uninstall.md
@@ -154,14 +154,6 @@ Follow the relevant procedure to uninstall the networking layer you installed:
 
 
 
-=== "Kong"
-
-    Uninstall Kong Ingress Controller by running:
-
-       ```bash
-       kubectl delete -f https://raw.githubusercontent.com/Kong/kubernetes-ingress-controller/0.9.x/deploy/single/all-in-one-dbless.yaml
-       ```
-
 
 
 === "Kourier"

--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -15,7 +15,7 @@ The Knative Serving project provides middleware components that enable:
 
 - Rapid deployment of serverless containers.
 - Autoscaling including scaling pods down to zero.
-- Support for multiple networking layers such as Ambassador, Contour, Kourier, Gloo, Istio, and Kong, for integration into existing environments.
+- Support for multiple networking layers such as Ambassador, Contour, Kourier, Gloo, and Istio for integration into existing environments.
 - Point-in-time snapshots of deployed code and configurations.
 
 ## Serving resources


### PR DESCRIPTION
What the subject says, and as discussed at the recent TOC meeting -- the e2e tests haven't been passing for a little while and we want to ensure users will have a good time using the Ingresses that we list in the install guide with Knative.

Note: there are [plans to get this passing again](https://knative.slack.com/archives/C9CV04DNJ/p1623098357393000?thread_ts=1623092993.391700&cid=C9CV04DNJ) so this should hopefully be reverted sometime soonish.

/assign @dprotaso @ZhiminXiang 
cc @hbagdi 