### PR TITLE
Revert changes to community

### DIFF
--- a/community/_index.md
+++ b/community/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Join the Knative community"
+linkTitle: "Community"
+type: "docs"
+showlandingtoc: "false"
+---
+
+Knative is an open source project that anyone in the community can use, improve, and enjoy. We'd love ❣ you to join us!
+
+Here are a few ways to find out what's happening and get involved.
+
+{{< showpartial "community_links.html" >}}

--- a/community/annual_reports/_index.md
+++ b/community/annual_reports/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Knative Annual Reports"
+linkTitle: "Annual reports"
+weight: 40
+type: "docs"
+---
+
+Welcome to the Knative Annual Reports page. Feedback and comments are welcome at [knative-steering@googlegroups.com](mailto:knative-steering@googlegroups.com).
+
+| Annual Reports |
+| -------------- |
+| [2019](https://github.com/knative/community/tree/main/annual_reports/Knative%202019%20Annual%20Report.pdf) |
+| [2020](https://github.com/knative/community/tree/main/annual_reports/Knative%202020%20Annual%20Report.pdf) |
+

--- a/community/calendar/_index.md
+++ b/community/calendar/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Knative Community Calendar"
+linkTitle: "Community Calendar"
+weight: 29
+showlandingtoc: "false"
+type: "docs"
+---
+
+The [Knative Community Calendar](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com) contain events that provides the opportunity to learn more about Knative and meet other Knative users and contributors.
+
+Events don't have to be organized by the Knative project to be added to the calendar. If you want to add an event to the calendar please send an email to [knative-steering@googlegroups.com](mailto:knative-steering@googlegroups.com) or post to the #community channel in the Knative [Slack](https://slack.knative.dev) workspace.
+
+<iframe src="https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/community/contributing/_index.md
+++ b/community/contributing/_index.md
@@ -1,0 +1,56 @@
+---
+title: "Knative contribution guidelines"
+linkTitle: "Contribution guidelines"
+weight: 20
+type: "docs"
+showlandingtoc: "true"
+aliases:
+  - /docs/contribution-guidelines/
+  - /contributing/
+---
+
+Learn how to join the community of Knative contributors.
+
+## Audience
+
+Knative is designed for different personas:
+
+![Diagram that displays different Audiences for Knative](./images/knative-audience.svg)
+
+### Developers
+
+Knative components offer developers Kubernetes-native APIs for deploying
+serverless-style functions, applications, and containers to an auto-scaling
+runtime.
+
+To join the conversation, head over to the
+[Knative users](https://groups.google.com/d/forum/knative-users) Google group.
+
+### Operators
+
+Knative components are intended to be integrated into more polished products
+that cloud service providers or in-house teams in large enterprises can then
+operate.
+
+Any enterprise or cloud provider can adopt Knative components into their own
+systems and pass the benefits along to their customers.
+
+### Contributors
+
+With a clear project scope, lightweight governance model, and clean lines of
+separation between pluggable components, the Knative project establishes an
+efficient contributor workflow.
+
+Knative is a diverse, open, and inclusive community.
+Your own path to becoming a Knative contributor can begin in any of the
+following components:
+
+- [serving](https://github.com/knative/serving/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Akind%2Fgood-first-issue)
+- [eventing](https://github.com/knative/eventing/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Akind%2Fgood-first-issue)
+- [client](https://github.com/knative/client/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Akind%2Fgood-first-issue)
+- [documentation](https://github.com/knative/docs/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Akind%2Fgood-first-issue)
+
+[Bug reports](https://github.com/knative/serving/issues/new) and friction logs
+from new developers are especially welcome.
+
+{{% readfile file="README.md" %}}

--- a/community/meetup/_index.md
+++ b/community/meetup/_index.md
@@ -1,0 +1,82 @@
+---
+title: "Knative Community Meetup"
+linkTitle: "Community Meetup"
+weight: 30
+type: "docs"
+---
+
+Welcome to the Knative Community Meetup page!
+
+The virtual event is designed for end users, a space for our community to meet, get to know each other, and learn about uses and applications of Knative.
+
+Catch up with past community meetups on our [YouTube channel](https://www.youtube.com/playlist?list=PLQjzPfIiEQLLyCyLBKLlwDLfE_A-P7nyg).
+
+Here we will list all the information related to past and future events.
+
+Stay tuned for new events by subscribing to our [calendar](https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com&ctz=America%2FLos_Angeles) ([iCal export file](https://calendar.google.com/calendar/ical/knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com/public/basic.ics)) and following us on [Twitter](https://twitter.com/KnativeProject).
+
+---
+
+### 2020-05-14 – Knative Community Meetup #2
+
+Video: https://youtu.be/24owwOKj86E
+
+## Agenda
+- Welcome! (5’)
+  - Announce recording of meeting.
+- Update from the Steering Committee (15’)
+  - TOC election results (Tomas Isdal)
+- Working groups updates (5’)
+- Demo - "Automating service delivery with bindings" by Evan Anderson, software engineer at VMware (30’)
+- Demo discussion / conversation (15’-20’)
+- Close (5’)
+- Take the [survey](https://docs.google.com/forms/d/e/1FAIpQLSebw2IOjmnStiUhPpnndpjyuBUoziZOw9PK9fnJeFBQX0QxWw/viewform)! (it’s good karma)
+
+## TOC Election results
+- Nghia Tran (Google) - new member
+- Markus Thömmes (Red Hat) - new member
+- Grant Rodgers (Google) - new member
+- Matt Moore (VMWare) - existing member
+- Evan Anderson (VMWare) - existing member
+Congratulations to the newly elected members! ✨
+
+## Working group updates
+- Autoscaling WG
+  - Big improvements to the autoscaling documentation, both internally and user-facing. Go check them out!
+  - User facing docs: https://knative.dev/docs/serving/configuring-autoscaling/
+  - Technical docs: https://github.com/knative/serving/blob/main/docs/scaling/SYSTEM.md
+- A lot of improvements to the loadbalancing in Knative has landed, vastly improving latency for concurrency-limited revisions. Give HEAD a whirl if you’re seeing issues there.
+- Speaking of issues: We need your input!
+  - We’re preparing a questionnaire to gather structured feedback regarding the types of workloads you’re running and which settings you find yourself tweaking to make autoscaling work in your favor.
+  - While we’re preparing that (will likely be sent out via the knative-users list), please feel free to give us free-form feedback on anything autoscaling. That can either be Github issues if you’re having issues, a thread on knative-users or send it to me privately if you can’t share publicly.
+
+## Eventing
+- Update on Brokers
+  - https://github.com/knative/eventing/issues/3139
+
+---
+
+### 2020-04-16 – Knative Community Meetup #1
+Video: https://www.youtube.com/watch?v=k0QJEyV4U-4
+
+Agenda:
+- Welcome! (5’)
+  - Announce recording of meeting.
+- Update from the Steering Committee (5’)
+  - TOC election announcement (Brenda Chan)
+- Working groups updates (15’-20’)
+  - Eventing (Aleksander Slominski and Davy Odom)
+  - Networking (Nghia Tran)
+  - Operation (Vincent Hou)
+  - Client (Roland Huss)
+- [Demo - "Tracking the Bitcoin ledger" - by Johana Saladas (IBM) (30’)](https://www.youtube.com/watch?v=sGi_LuAaaT0)
+- Demo discussion / conversation (15’-20’)
+- Close (5’)
+  - Take the [survey](https://docs.google.com/forms/d/e/1FAIpQLSebw2IOjmnStiUhPpnndpjyuBUoziZOw9PK9fnJeFBQX0QxWw/viewform)! (it’s good karma)
+
+The demo for this first community meetup is "Tracking the Bitcoin ledger", designed and carried out by @josiemundi, software engineer at IBM. Thank you for volunteering, Johana!
+
+Here are the resources from the demo:
+- https://github.com/josiemundi/knative-eventing-blockchain-demo
+- https://github.com/josiemundi/knative-bitcoin-websocket-eventsource
+

--- a/community/samples/_index.md
+++ b/community/samples/_index.md
@@ -1,0 +1,47 @@
+---
+title: "Community code samples"
+linkTitle: "Code samples"
+weight: 40
+type: "docs"
+---
+
+Get up and running with one of the community code samples. These samples are
+contributed and maintained by members of the Knative community.
+
+Note: It is possible that one or more samples might become outdated or the
+original author is unable to maintain their contribution. If you find that
+something isn't working, lend a helping hand and fix it in a PR.
+
+[Learn more about the lifespan of samples](https://github.com/knative/docs/tree/main/CONTRIBUTING.md#user-focused-content)
+
+[**See all Knative code samples**](../../docs/samples)
+
+### Interactive serving sample
+
+Check out [this Katacoda
+tutorial](https://www.katacoda.com/swapb/scenarios/knative-intro) which will
+walk you through installing Knative and the `kn` command line tool, deploying a
+sample container, updating your deployment, and performing a traffic split
+between the two versions.
+
+### Serving samples
+
+Knative Serving sample apps.
+
+| Sample Name | Description | Language(s) |
+| ----------- | ----------- | ----------- |
+| Hello World | A quick introduction to Knative Serving that highlights how to deploy an app. | [Clojure](./serving/helloworld-clojure/), [Dart](./serving/helloworld-dart/), [Elixir](./serving/helloworld-elixir/), [Haskell](./serving/helloworld-haskell/), [Java - Micronaut](./serving/helloworld-java-micronaut/), [Java - Quarkus](./serving/helloworld-java-quarkus/), [R - Go Server](./serving/helloworld-r/), [Rust](./serving/helloworld-rust/), [Swift](./serving/helloworld-swift/), [Vertx](./serving/helloworld-vertx/) |
+| Machine Learning | A quick introduction to using Knative Serving to serve machine learning models | [Python - BentoML](./serving/machinelearning-python-bentoml)
+
+#### Eventing and Eventing Resources samples
+
+- _Be the first to contribute an Eventing or Eventing Sources code sample to the
+  community collection._
+
+### Client samples
+
+Knative `kn` Client sample workflows and apps.
+
+| Sample Name | Description |
+| ----------- | ----------- |
+| [knfun](https://github.com/maximilien/knfun) | Knative micro-functions (Twitter and Watson APIs) demo using the `kn` client. |

--- a/community/samples/serving/_index.md
+++ b/community/samples/serving/_index.md
@@ -1,0 +1,8 @@
+---
+title: "Knative Serving code samples"
+linkTitle: "Serving Samples"
+weight: 4
+type: "docs"
+---
+
+Community contributed and maintained code samples for Knative Serving.

--- a/community/samples/serving/helloworld-clojure/index.md
+++ b/community/samples/serving/helloworld-clojure/index.md
@@ -113,7 +113,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-clojure .
 
@@ -126,7 +126,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -148,7 +148,7 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-clojure.default.1.2.3.4.sslip.io
    Hello World!
    ```
@@ -157,6 +157,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-dart/index.md
+++ b/community/samples/serving/helloworld-dart/index.md
@@ -42,7 +42,7 @@ be created using the following instructions.
 2. If you want to run locally, install dependencies. If you only want to run in
    Docker or Knative, you can skip this step.
 
-   ```bash
+   ```shell
    > pub get
    ```
 
@@ -111,7 +111,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-dart .
 
@@ -124,7 +124,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -146,7 +146,7 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-dart.default.1.2.3.4.sslip.io
    Hello Dart Sample v1
    ```
@@ -155,6 +155,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-deno/index.md
+++ b/community/samples/serving/helloworld-deno/index.md
@@ -11,7 +11,7 @@ Follow the steps below to create the sample code and then deploy the app to your
 cluster. You can also download a working copy of the sample, by running the
 following commands:
 
-```bash
+```shell
 git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-deno
 ```
@@ -87,7 +87,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-deno .
 
@@ -100,7 +100,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -113,13 +113,13 @@ folder) you're ready to build and deploy the sample app.
 
 1. Run the following command to find the domain URL for your service:
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-deno  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example:
 
-   ```bash
+   ```shell
    NAME                URL
    helloworld-deno        http://helloworld-deno.default.1.2.3.4.sslip.io
    ```
@@ -127,13 +127,13 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-deno.default.1.2.3.4.sslip.io
    ```
 
    Example:
 
-   ```bash
+   ```shell
    curl http://helloworld-deno.default.1.2.3.4.sslip.io
    [1] "Hello R Sample v1!"
    ```
@@ -144,6 +144,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-elixir/index.md
+++ b/community/samples/serving/helloworld-elixir/index.md
@@ -30,7 +30,7 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 1. Generate a new project.
 
-```bash
+```shell
 mix phoenix.new helloelixir
 ```
 
@@ -127,7 +127,7 @@ above.
     shell of an example on `config/prod.secret.exs.sample` and you can use the
     following command to generate a new prod secrets file.
 
-    ```bash
+    ```shell
     SECRET_KEY_BASE=$(elixir -e ":crypto.strong_rand_bytes(48) |> Base.encode64 |> IO.puts")
     sed "s|SECRET+KEY+BASE|$SECRET_KEY_BASE|" config/prod.secret.exs.sample >config/prod.secret.exs
     ```
@@ -136,7 +136,7 @@ above.
     Docker Hub, run these commands replacing `{username}` with your Docker Hub
     username:
 
-    ```bash
+    ```shell
      # Build the container on your local machine
      docker build -t {username}/helloworld-elixir .
 
@@ -149,7 +149,7 @@ above.
     in `service.yaml` matches the container you built in the previous step.
     Apply the configuration using `kubectl`:
 
-    ```bash
+    ```shell
     kubectl apply --filename service.yaml
     ```
 
@@ -172,7 +172,7 @@ above.
 1.  Now you can make a request to your app to see the results. Replace
     `{IP_ADDRESS}` with the address you see returned in the previous step.
 
-        ```bash
+        ```shell
         curl http://helloworld-elixir.default.1.2.3.4.sslip.io
 
         ...
@@ -294,6 +294,6 @@ above.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-haskell/index.md
+++ b/community/samples/serving/helloworld-haskell/index.md
@@ -139,7 +139,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, enter these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-haskell .
 
@@ -152,7 +152,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -174,7 +174,7 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-haskell.default.1.2.3.4.sslip.io
    Hello world: Haskell Sample v1
    ```
@@ -183,6 +183,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-java-micronaut/index.md
+++ b/community/samples/serving/helloworld-java-micronaut/index.md
@@ -219,7 +219,7 @@ your sample app to your cluster:
    Docker Hub registry. You must replace the `{username}` variables in the
    following commands with your Docker Hub username.
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-java-micronaut .
 
@@ -230,7 +230,7 @@ your sample app to your cluster:
 1. Now that your container image is in the registry, you can deploy it to your
    Knative cluster by running the `kubectl apply` command:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -253,13 +253,13 @@ To verify that your sample app has been successfully deployed:
 1. Retrieve the URL for your service, by running the following `kubectl get`
    command:
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-java-micronaut  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example result:
 
-   ```bash
+   ```shell
    NAME                          URL
    helloworld-java-micronaut     http://helloworld-java-micronaut.default.1.2.3.4.sslip.io
    ```
@@ -267,13 +267,13 @@ To verify that your sample app has been successfully deployed:
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-java-micronaut.default.1.2.3.4.sslip.io
    ```
 
    Example result:
 
-   ```bash
+   ```shell
     Hello World: Micronaut Sample v1
    ```
 
@@ -284,6 +284,6 @@ Congratulations on deploying your sample Java app to Knative!
 To remove the sample app from your cluster, run the following `kubectl delete`
 command:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-java-quarkus/index.md
+++ b/community/samples/serving/helloworld-java-quarkus/index.md
@@ -53,7 +53,7 @@ which you update and create the necessary build and configuration files:
 1. From the console, create a new empty web project using the Maven archetype
    commands:
 
-   ```bash
+   ```shell
    mvn io.quarkus:quarkus-maven-plugin:0.13.3:create \
     -DprojectGroupId=com.redhat.developer.demos \
     -DprojectArtifactId=helloworld-java-quarkus \
@@ -129,13 +129,13 @@ which you update and create the necessary build and configuration files:
 1. Remove `src/main/resources/META-INF/resources/index.html` file since it's
    unncessary for this example.
 
-   ```bash
+   ```shell
    rm src/main/resources/META-INF/resources/index.html
    ```
 
 1. Remove `.dockerignore` file since it's unncessary for this example.
 
-   ```bash
+   ```shell
    rm .dockerignore
    ```
 
@@ -206,7 +206,7 @@ which you update and create the necessary build and configuration files:
 
 1. Run the application locally:
 
-   ```bash
+   ```shell
    ./mvnw compile quarkus:dev
    ```
 
@@ -221,7 +221,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-java-quarkus .
 
@@ -238,7 +238,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -251,7 +251,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, use
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-java-quarkus
 
    NAME                     URL
@@ -261,7 +261,7 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-java-quarkus.default.1.2.3.4.sslip.io
 
    Namaste Knative World!
@@ -271,6 +271,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-r/index.md
+++ b/community/samples/serving/helloworld-r/index.md
@@ -13,7 +13,7 @@ Follow the steps below to create the sample code and then deploy the app to your
 cluster. You can also download a working copy of the sample, by running the
 following commands:
 
-```bash
+```shell
 git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-r
 ```
@@ -135,7 +135,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-r .
 
@@ -148,7 +148,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -161,13 +161,13 @@ folder) you're ready to build and deploy the sample app.
 
 1. Run the following command to find the domain URL for your service:
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-r  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example:
 
-   ```bash
+   ```shell
    NAME                URL
    helloworld-r        http://helloworld-r.default.1.2.3.4.sslip.io
    ```
@@ -175,13 +175,13 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-r.default.1.2.3.4.sslip.io
    ```
 
    Example:
 
-   ```bash
+   ```shell
    curl http://helloworld-r.default.1.2.3.4.sslip.io
    [1] "Hello R Sample v1!"
    ```
@@ -192,6 +192,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-rserver/index.md
+++ b/community/samples/serving/helloworld-rserver/index.md
@@ -14,7 +14,7 @@ Follow the steps below to create the sample code and then deploy the app to your
 cluster. You can also download a working copy of the sample, by running the
 following commands:
 
-```bash
+```shell
 git clone -b "{{< branch >}}" https://github.com/knative/docs knative-docs
 cd knative-docs/docs/serving/samples/hello-world/helloworld-r
 ```
@@ -106,7 +106,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-rserver .
 
@@ -119,7 +119,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -132,13 +132,13 @@ folder) you're ready to build and deploy the sample app.
 
 1. Run the following command to find the domain URL for your service:
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-r  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example:
 
-   ```bash
+   ```shell
    NAME                URL
    helloworld-r    http://helloworld-r.default.1.2.3.4.sslip.io
    ```
@@ -146,13 +146,13 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-rserver.default.1.2.3.4.sslip.io
    ```
 
    Example:
 
-   ```bash
+   ```shell
    curl http://helloworld-rserver.default.1.2.3.4.sslip.io
    [1] "Hello R Sample v1!"
    ```
@@ -163,6 +163,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-rust/index.md
+++ b/community/samples/serving/helloworld-rust/index.md
@@ -140,7 +140,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, enter these commands replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-rust .
 
@@ -153,7 +153,7 @@ folder) you're ready to build and deploy the sample app.
    in `service.yaml` matches the container you built in the previous step. Apply
    the configuration using `kubectl`:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -166,7 +166,7 @@ folder) you're ready to build and deploy the sample app.
 
 1. To find the URL for your service, enter:
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-rust  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    NAME                URL
    helloworld-rust     http://helloworld-rust.default.1.2.3.4.sslip.io
@@ -175,7 +175,7 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-rust.default.1.2.3.4.sslip.io
    Hello World!
    ```
@@ -184,6 +184,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-swift/index.md
+++ b/community/samples/serving/helloworld-swift/index.md
@@ -120,7 +120,7 @@ folder) you're ready to build and deploy the sample app.
    Docker Hub, run these commands, replacing `{username}` with your Docker Hub
    username:
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-swift .
 
@@ -133,7 +133,7 @@ folder) you're ready to build and deploy the sample app.
    in the `service.yaml` file matches the container you built in the previous
    step. Apply the configuration using the `kubectl` command:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -155,7 +155,7 @@ folder) you're ready to build and deploy the sample app.
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-swift.default.1.2.3.4.sslip.io
    Hello Swift
    ```
@@ -164,6 +164,6 @@ folder) you're ready to build and deploy the sample app.
 
 To remove the sample app from your cluster, delete the service record:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/helloworld-vertx/index.md
+++ b/community/samples/serving/helloworld-vertx/index.md
@@ -187,7 +187,7 @@ your sample app to your cluster:
    Docker Hub registry. You must replace the `{username}` variables in the
    following commands with your Docker Hub username.
 
-   ```bash
+   ```shell
    # Build the container on your local machine
    docker build -t {username}/helloworld-vertx .
 
@@ -198,7 +198,7 @@ your sample app to your cluster:
 1. Now that your container image is in the registry, you can deploy it to your
    Knative cluster by running the `kubectl apply` command:
 
-   ```bash
+   ```shell
    kubectl apply --filename service.yaml
    ```
 
@@ -221,13 +221,13 @@ To verify that your sample app has been successfully deployed:
 1. Retrieve the URL for your service, by running the following `kubectl get`
    command:
 
-   ```bash
+   ```shell
    kubectl get ksvc helloworld-vertx  --output=custom-columns=NAME:.metadata.name,URL:.status.url
    ```
 
    Example result:
 
-   ```bash
+   ```shell
    NAME                URL
    helloworld-vertx    http://helloworld-vertx.default.1.2.3.4.sslip.io
    ```
@@ -235,13 +235,13 @@ To verify that your sample app has been successfully deployed:
 1. Now you can make a request to your app and see the result. Replace
    the URL below with the URL returned in the previous command.
 
-   ```bash
+   ```shell
    curl http://helloworld-vertx.default.1.2.3.4.sslip.io
    ```
 
    Example result:
 
-   ```bash
+   ```shell
     Hello World: Eclipse Vert.x Sample v1
    ```
 
@@ -252,6 +252,6 @@ Congratulations on deploying your sample Java app to Knative!
 To remove the sample app from your cluster, run the following `kubectl delete`
 command:
 
-```bash
+```shell
 kubectl delete --filename service.yaml
 ```

--- a/community/samples/serving/machinelearning-python-bentoml/index.md
+++ b/community/samples/serving/machinelearning-python-bentoml/index.md
@@ -28,7 +28,7 @@ Knative deployment guide with BentoML is also available in the
 - Python 3.6 or above installed and running on your local machine.
   - Install `scikit-learn` and `bentoml` packages:
 
-    ```bash
+    ```shell
     pip install scikit-learn
     pip install bentoml
     ```
@@ -54,19 +54,19 @@ as API endpoint with KNative Serving.
 
     Run the `main.py` file to train and save the model:
 
-    ```bash
+    ```shell
     python main.py
     ```
 
 3. Use BentoML CLI to check saved model's information.
 
-    ```bash
+    ```shell
     bentoml get IrisClassifier:latest
     ```
 
     Example:
 
-    ```bash
+    ```shell
     > bentoml get IrisClassifier:latest
     {
       "name": "IrisClassifier",
@@ -110,14 +110,14 @@ as API endpoint with KNative Serving.
 4. Test run API server. BentoML can start an API server from the saved model. Use
   BentoML CLI command to start an API server locally and test it with the `curl` command.
 
-    ```bash
+    ```shell
     bentoml serve IrisClassifier:latest
     ```
 
     In another terminal window, make `curl` request with sample data to the API server
     and get prediction result:
 
-    ```bash
+    ```shell
     curl -v -i \
     --header "Content-Type: application/json" \
     --request POST \
@@ -133,7 +133,7 @@ a Dockerfile is automatically generated when saving the model.
 1. To build an API model server docker image, replace `{username}` with your Docker Hub
   username and run the following commands.
 
-    ```bash
+    ```shell
     # jq might not be installed on your local system, please follow jq install
     # instruction at https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
@@ -150,7 +150,7 @@ a Dockerfile is automatically generated when saving the model.
 
     {{% readfile file="service.yaml" %}}
 
-    ```bash
+    ```shell
     kubectl apply --filename service.yaml
     ```
 
@@ -164,7 +164,7 @@ a Dockerfile is automatically generated when saving the model.
 
 4. Run the following command to find the domain URL for your service:
 
-    ```bash
+    ```shell
     kubectl get ksvc iris-classifier --output=custom-columns=NAME:.metadata.name,URL:.status.url
 
     NAME              URL
@@ -174,7 +174,7 @@ a Dockerfile is automatically generated when saving the model.
 5. Replace the request URL with the URL return in the previous command, and execute the
   command to get prediction result from the deployed model API endpoint.
 
-    ```bash
+    ```shell
     curl -v -i \
       --header "Content-Type: application/json" \
       --request POST \
@@ -188,6 +188,6 @@ a Dockerfile is automatically generated when saving the model.
 
 To remove the application from your cluster, delete the service record:
 
-  ```bash
+  ```shell
   kubectl delete --filename service.yaml
   ```


### PR DESCRIPTION
This commit reverts changes made to community which assumed it was being built by mkdocs (since it's still built with hugo) and caused formatting to break in the community tab.

/assign @omerbensaadon I did a straight `git checkout HEAD~10 community/` so please check I didn't revert something we actually wanted here, but it looks right to me