### PR TITLE
Use absolute links for blog and community

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -233,8 +233,8 @@ nav:
       - Installing kn: client/install-kn.md
       - Customizing kn: client/configure-kn.md
       - kn plugins: client/kn-plugins.md
-    - "Join the Community ➠": ../community/
-    - "Read the Blog ➠": ../blog/
+    - "Join the Community ➠": /community/
+    - "Read the Blog ➠": /blog/
 
 theme:
   name: material


### PR DESCRIPTION
Looks like the upgrade to mkdocs 1.2 breaks relative links that escape the base dir. Absolute links is a trivial fix (although it does break the blog and community links for github pages, but Im not sure we should care now we have PR previews, tbh).