### PR TITLE
Adding quickstart instructions for minikube

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -5,6 +5,8 @@ Before you can get started with a Knative Quickstart deployment you must set up 
 
 You can use [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} (Kubernetes in Docker) to run a local Kubernetes cluster with Docker container nodes.
 
+Alternatively, you can also use [`minikube`](https://minikube.sigs.k8s.io/docs/start/){target=_blank} to run a local Kubernetes cluster that can be deployed as a VM, a container, or bare-metal.
+
 ## Install the Kubernetes CLI
 
 The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank}, allows you to run commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.

--- a/docs/getting-started/install-knative-quickstart.md
+++ b/docs/getting-started/install-knative-quickstart.md
@@ -17,6 +17,21 @@ You can get started with a local deployment of Knative by using _Knative on Kind
     ```
     curl -sL install.konk.dev | bash
     ```
+ 
+## Install Knative on Minikube
+
+As an alternative to Kind, you can also install Knative on Minikube:
+
+[`knative-on-minikube.sh`](https://raw.githubusercontent.com/psschwei/knative-on-minikube/main/knative-on-minikube.sh) is a shell script that completes the following fuctions:
+
+1. Creates a cluster called `minikube`.
+1. Installs Knative Serving with Kourier as the default networking layer, and sslip.io as the DNS.
+1. Installs Knative Eventing and creates a default broker and channel implementation.
+
+Prerequisites:
+
+* [Minikube](https://minikube.sigs.k8s.io/docs/start/) is installed on your machine
+* The appropriate [driver](https://minikube.sigs.k8s.io/docs/drivers/) is configured for your machine. The script defaults to using `kvm2`, an alternative driver can be used by setting `VM_DRIVER` variable, i.e. `VM_DRIVER=docker ./knative-on-minikube.sh`
 
 ## Install the Knative CLI
 


### PR DESCRIPTION
Currently, the "Getting Started" section has instructions for getting set up using Kind. However, some developers prefer to use Minikube instead or have issues getting Kind working on their systems. To support those users, this PR adds instructions for getting started with Knative using Minikube.

The [script](https://github.com/psschwei/knative-on-minikube/blob/main/knative-on-minikube.sh) used for setting up Minikube is currently housed in my personal repo, but it should probably be moved into the docs repo somewhere.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds quickstart instructions to the docs for setting up a local cluster using minikube
