### PR TITLE
Change Api version to sources.knative.dev/v1

### DIFF
--- a/docs/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/eventing/sources/sinkbinding/getting-started.md
@@ -213,7 +213,7 @@ Create a `SinkBinding` object that directs events from your subject to the sink.
 
     ```yaml
     kubectl apply -f - <<EOF
-    apiVersion: sources.knative.dev/v1alpha1
+    apiVersion: sources.knative.dev/v1
     kind: SinkBinding
     metadata:
       name: <name>


### PR DESCRIPTION
Simply change API version for SinkBinding from _v1alpha1_ to _v1_ to align with the latest version of knative (v0.23)