### PR TITLE
Add `nodeSelector` to override system deployments by operator

### DIFF
--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -457,7 +457,7 @@ spec:
 
 ### Override nodeSelector
 
-The following KnativeServing resource overrides the `webhook` deployment to have `disktype: hdd` nodeSelector.
+The following KnativeServing resource overrides the `webhook` deployment to use the `disktype: hdd` nodeSelector:
 
 ```
 apiVersion: operator.knative.dev/v1alpha1

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -432,7 +432,7 @@ Currently `replicas`, `labels`, `annotations` and `nodeSelector` are supported.
 ### Override replicas, labels and annotations
 
 The following KnativeServing resource overrides the `webhook` deployment to have `3` Replicas, the label `mylabel: foo`, and the annotation `myannotataions: bar`,
-while other system deployments have `2` replicas by `spec.high-availability`.
+while other system deployments have `2` Replicas by using `spec.high-availability`.
 
 ```
 apiVersion: operator.knative.dev/v1alpha1

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -427,9 +427,15 @@ spec:
 ## Override system deployments
 
 If you would like to override some configurations for a specific deployment, you can override the configuration by using `spec.deployments` in CR.
-Currently `replicas`, `labels` and `annotations` are supported.
+Currently the following configurations are supported.
+- `replicas`
+- `labels`
+- `annotations`
+- `nodeSelector`
 
-For example, the following KnativeServing resource overrides the `webhook` to have `3` replicass, `mylabel: foo` labels and `myannotataions: bar` annotations,
+### Override replicas, labels and annotations
+
+The following KnativeServing resource overrides the `webhook` deployment to have `3` replicass, `mylabel: foo` labels and `myannotataions: bar` annotations,
 while other system deployments have `2` replicas by `spec.high-availability`.
 
 ```
@@ -451,3 +457,20 @@ spec:
 ```
 
 **NOTE:** The labels and annotations settings override webhook's labels and annotations in deployment and pod both.
+
+### Override nodeSelector
+
+The following KnativeServing resource overrides the `webhook` deployment to have `disktype: hdd` nodeSelector.
+
+```
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: ks
+  namespace: knative-serving
+spec:
+  deployments:
+  - name: webhook
+    nodeSelector:
+      disktype: hdd
+```

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -431,7 +431,7 @@ Currently `replicas`, `labels`, `annotations` and `nodeSelector` are supported.
 
 ### Override replicas, labels and annotations
 
-The following KnativeServing resource overrides the `webhook` deployment to have `3` replicass, `mylabel: foo` labels and `myannotataions: bar` annotations,
+The following KnativeServing resource overrides the `webhook` deployment to have `3` Replicas, the label `mylabel: foo`, and the annotation `myannotataions: bar`,
 while other system deployments have `2` replicas by `spec.high-availability`.
 
 ```

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -452,7 +452,8 @@ spec:
       myannotataions: bar
 ```
 
-**NOTE:** The labels and annotations settings override webhook's labels and annotations in deployment and pod both.
+!!! note
+    The KnativeServing resource `label` and `annotation` settings override the webhook's labels and annotations for both Deployments and Pods.
 
 ### Override nodeSelector
 

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -427,11 +427,7 @@ spec:
 ## Override system deployments
 
 If you would like to override some configurations for a specific deployment, you can override the configuration by using `spec.deployments` in CR.
-Currently the following configurations are supported.
-- `replicas`
-- `labels`
-- `annotations`
-- `nodeSelector`
+Currently `replicas`, `labels`, `annotations` and `nodeSelector` are supported.
 
 ### Override replicas, labels and annotations
 


### PR DESCRIPTION
This patch adds docs for https://github.com/knative/operator/pull/658.
It adds `nodeSelector` to override system deployments by operator.

/cc @houshengbo 
