### PR TITLE
Code snippet tweaks

### DIFF
--- a/docs/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/eventing/sources/sinkbinding/getting-started.md
@@ -1,4 +1,4 @@
-# Create a SinkBinding object
+# Creating a SinkBinding object
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-red?style=flat-square)
 
@@ -88,7 +88,7 @@ create a Knative service.
     For example:
 
     ```bash
-    $ kn service create hello --image gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
+    $ kn service create event-display --image gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display
     ```
 
 === "YAML"
@@ -224,11 +224,11 @@ Create a `SinkBinding` object that directs events from your subject to the sink.
         selector:
           matchLabels:
             <label-key>: <label-value>
-        sink:
-          ref:
-            apiVersion: serving.knative.dev/v1
-            kind: Service
-            name: <sink>
+      sink:
+        ref:
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          name: <sink>
     EOF
     ```
     Where:

--- a/docs/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/eventing/sources/sinkbinding/getting-started.md
@@ -1,7 +1,5 @@
 # Creating a SinkBinding object
 
-![API version v1](https://img.shields.io/badge/API_Version-v1-red?style=flat-square)
-
 This topic describes how to create a SinkBinding object.
 SinkBinding resolves a sink as a URI, sets the URI in the environment
 variable `K_SINK`, and adds the URI to a subject using `K_SINK`.

--- a/docs/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/eventing/sources/sinkbinding/getting-started.md
@@ -1,5 +1,7 @@
 # Creating a SinkBinding object
 
+![API version v1](https://img.shields.io/badge/API_Version-v1-red?style=flat-square)
+
 This topic describes how to create a SinkBinding object.
 SinkBinding resolves a sink as a URI, sets the URI in the environment
 variable `K_SINK`, and adds the URI to a subject using `K_SINK`.

--- a/docs/eventing/sources/sinkbinding/reference.md
+++ b/docs/eventing/sources/sinkbinding/reference.md
@@ -173,19 +173,24 @@ A `ceOverrides` definition supports the following fields:
 #### Example: CloudEvent Overrides
 
 ```yaml
-ceOverrides:
-  extensions:
-    extra: this is an extra attribute
-    additional: 42
+apiVersion: sources.knative.dev/v1
+kind: SinkBinding
+metadata:
+  name: bind-heartbeat
+spec:
+  ...
+  ceOverrides:
+    extensions:
+      extra: this is an extra attribute
+      additional: 42
 ```
 
 !!! contract
     This results in the `K_CE_OVERRIDES` environment variable being set on the
     `subject` as follows:
-
-```json
-{ "extensions": { "extra": "this is an extra attribute", "additional": "42" } }
-```
+    ```{ .json .no-copy }
+    { "extensions": { "extra": "this is an extra attribute", "additional": "42" } }
+    ```
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields

--- a/docs/eventing/sources/sinkbinding/reference.md
+++ b/docs/eventing/sources/sinkbinding/reference.md
@@ -47,13 +47,19 @@ resulting in `"http://mysink.default.svc.cluster.local/extra/path"`.
 <!-- TODO we should have a page to point to describing the ref+uri destinations and the rules we use to resolve those and reuse the page. -->
 
 ```yaml
-sink:
-  ref:
-    apiVersion: v1
-    kind: Service
-    namespace: default
-    name: mysink
-  uri: /extra/path
+apiVersion: sources.knative.dev/v1
+kind: SinkBinding
+metadata:
+  name: bind-heartbeat
+spec:
+  ...
+  sink:
+    ref:
+      apiVersion: v1
+      kind: Service
+      namespace: default
+      name: mysink
+    uri: /extra/path
 ```
 
 !!! contract
@@ -86,20 +92,31 @@ A `subject` definition supports the following fields:
 Given the following YAML, the `Deployment` named `mysubject` in the `default`
 namespace is selected:
 
-  ```yaml
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: SinkBinding
+metadata:
+  name: bind-heartbeat
+spec:
   subject:
     apiVersion: apps/v1
     kind: Deployment
     namespace: default
     name: mysubject
-  ```
+  ...
+```
 
 #### Example: Subject parameter using matchLabels
 
 Given the following YAML, any `Job` with the label `working=example` in the
 `default` namespace is selected:
 
-  ```yaml
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: SinkBinding
+metadata:
+  name: bind-heartbeat
+spec:
   subject:
     apiVersion: batch/v1beta1
     kind: Job
@@ -107,14 +124,20 @@ Given the following YAML, any `Job` with the label `working=example` in the
     selector:
       matchLabels:
         working: example
-  ```
+  ...
+```
 
 #### Example: Subject parameter using matchExpression
 
 Given the following YAML, any `Pod` with the label `working=example` OR
 `working=sample` in the ` default` namespace is selected:
 
-  ```yaml
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: SinkBinding
+metadata:
+  name: bind-heartbeat
+spec:
   subject:
     apiVersion: v1
     kind: Pod
@@ -126,7 +149,8 @@ Given the following YAML, any `Pod` with the label `working=example` OR
         values:
           - example
           - sample
-  ```
+  ...
+```
 
 
 ### CloudEvent Overrides

--- a/docs/eventing/sources/sinkbinding/reference.md
+++ b/docs/eventing/sources/sinkbinding/reference.md
@@ -1,5 +1,7 @@
 # SinkBinding reference
 
+![API version v1](https://img.shields.io/badge/API_Version-v1-red?style=flat-square)
+
 This topic provides reference information about the configurable fields for the
 SinkBinding object.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,7 +155,7 @@ nav:
         - PingSource: eventing/sources/ping-source/README.md
         - SinkBinding:
           - Overview: eventing/sources/sinkbinding/README.md
-          - Create a SinkBinding object: eventing/sources/sinkbinding/getting-started.md
+          - Creating a SinkBinding object: eventing/sources/sinkbinding/getting-started.md
           - SinkBinding reference: eventing/sources/sinkbinding/reference.md
         - Camel source: eventing/sources/apache-camel-source/README.md
         - Kafka source: eventing/sources/kafka-source/README.md


### PR DESCRIPTION
Fixes #3791
- Added context to code snippets on reference page
- Adjusted indentation in code snippet in Create a SinkBinding object section

Other tweaks
- Made the topic title a gerund
- Adjusted the app name in the kn command for creating a Knative Service to match the YAML
- Fixed the note at the end of the reference topic
- Removed API label from Creating a SinkBinding page because it is already on the README page


