### PR TITLE
Add instruction for custom istio gateway

### DIFF
--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -136,6 +136,6 @@ For the gateway above, it should be updated to:
 gateway.custom-ns.knative-custom-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
 ```
 
-The configuration format should be `gateway.GATEWAY_NAMESPACE.GATEWAY_NAME`.
-The `GATEWAY_NAMESPACE` is optional. when it is omitted, the system will search for
+The configuration format should be `gateway.<gateway-namespace>.<gateway-name>`.
+`<gateway-namespace>` is optional. When it is omitted, the system searches for
 the gateway in the serving system namespace `knative-serving`.

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -34,7 +34,7 @@ spec:
           istio: custom-gateway
 ```
 
-### Step 2: Update Knative Gateway
+### Step 2: Update the Knative gateway
 
 Update gateway instance `knative-ingress-gateway` under `knative-serving`
 namespace:

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -114,7 +114,7 @@ EOF
 !!! note
     Replace the label selector `istio: ingressgateway` with the label of your service.
 
-### Step 2: Update Gateway Configmap
+### Step 2: Update the gateway ConfigMap
 
 Update gateway configmap `config-istio` under `knative-serving`
 namespace:

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -60,25 +60,39 @@ If there is a change in service ports (compared with that of
 
 ### Step 3: Update the gateway ConfigMap
 
-Update gateway configmap `config-istio` under `knative-serving`
+1. Update gateway configmap `config-istio` under `knative-serving`
 namespace:
 
-```bash
-kubectl edit configmap config-istio -n knative-serving
-```
+     ```bash
+     kubectl edit configmap config-istio -n knative-serving
+     ```
 
-Replace the `istio-ingressgateway.istio-system.svc.cluster.local` field with
+     This command opens your default text editor and allows you to edit the config-istio ConfigMap.
+
+     ```yaml
+     apiVersion: v1
+     data:
+       _example: |
+         ################################
+         #                              #
+         #    EXAMPLE CONFIGURATION     #
+         #                              #
+         ################################
+         # ...
+         gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+     ```
+
+1. Edit the file to replace the `istio-ingressgateway.istio-system.svc.cluster.local` field with
 the fully qualified url of your service.
-
-```
-gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
-```
-
 For the service above, it should be updated to:
 
-```
-gateway.knative-serving.knative-ingress-gateway: custom-ingressgateway.custom-ns.svc.cluster.local
-```
+     ```yaml
+     apiVersion: v1
+     data:
+       gateway.knative-serving.knative-ingress-gateway: custom-ingressgateway.custom-ns.svc.cluster.local
+     kind: ConfigMap
+     [...]
+     ```
 
 ## Replace the `knative-ingress-gateway` gateway
 
@@ -116,25 +130,39 @@ EOF
 
 ### Step 2: Update the gateway ConfigMap
 
-Update the gateway ConfigMap `config-istio` under the `knative-serving`
-namespace by running the command:
+1. Update gateway configmap `config-istio` under `knative-serving`
+namespace:
 
-```bash
-kubectl edit configmap config-istio -n knative-serving
-```
+     ```bash
+     kubectl edit configmap config-istio -n knative-serving
+     ```
 
-Replace the `gateway.knative-serving.knative-ingress-gateway` field with
+     This command opens your default text editor and allows you to edit the config-istio ConfigMap.
+
+     ```yaml
+     apiVersion: v1
+     data:
+       _example: |
+         ################################
+         #                              #
+         #    EXAMPLE CONFIGURATION     #
+         #                              #
+         ################################
+         # ...
+         gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+     ```
+
+1. Edit the file to replace the `gateway.knative-serving.knative-ingress-gateway` field with
 the customized gateway.
-
-```
-gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
-```
-
 For the gateway above, it should be updated to:
 
-```
-gateway.custom-ns.knative-custom-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
-```
+     ```yaml
+     apiVersion: v1
+     data:
+       gateway.custom-ns.knative-custom-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+     kind: ConfigMap
+     [...]
+     ```
 
 The configuration format should be `gateway.<gateway-namespace>.<gateway-name>`.
 `<gateway-namespace>` is optional. When it is omitted, the system searches for

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -13,7 +13,7 @@ the `knative-serving` namespace. By default, we use Istio gateway service
 `istio-ingressgateway` under `istio-system` namespace as its underlying service.
 You can replace the service and the gateway with that of your own as follows.
 
-## Replace the default `istio-ingressgateway` service with `custom-ingressgateway`
+## Replace the default `istio-ingressgateway` service
 
 #### Step 1: Create Gateway Service and Deployment Instance
 
@@ -80,7 +80,7 @@ For the service above, it should be updated to:
 gateway.knative-serving.knative-ingress-gateway: custom-ingressgateway.custom-ns.svc.cluster.local
 ```
 
-## Replace knative-ingress-gateway gateway with own knative-custom-gateway
+## Replace the knative-ingress-gateway gateway
 
 We customized the gateway service so far, but we may also want to use our own gateway.
 We can replace the default gateway with our own gateway with following steps.
@@ -136,6 +136,6 @@ For the gateway above, it should be updated to:
 gateway.custom-ns.knative-custom-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
 ```
 
-The configuration format should be `gateway.{{gateway_namespace}}.{{gateway_name}}`.
-The `{{gateway_namespace}}` is optional. when it is omitted, the system will search for
+The configuration format should be `gateway.GATEWAY_NAMESPACE.GATEWAY_NAME`.
+The `GATEWAY_NAMESPACE` is optional. when it is omitted, the system will search for
 the gateway in the serving system namespace `knative-serving`.

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -116,7 +116,7 @@ EOF
 
 ### Step 2: Update the gateway ConfigMap
 
-Update gateway configmap `config-istio` under `knative-serving`
+Update the gateway ConfigMap `config-istio` under the `knative-serving`
 namespace:
 
 ```bash

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -15,7 +15,7 @@ You can replace the service and the gateway with that of your own as follows.
 
 ## Replace the default `istio-ingressgateway` service
 
-#### Step 1: Create Gateway Service and Deployment Instance
+### Step 1: Create the gateway service and deployment instance
 
 You'll need to create the gateway service and deployment instance to handle
 traffic first. Let's say you customized the default `istio-ingressgateway` to

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -82,7 +82,7 @@ namespace:
          gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
      ```
 
-1. Edit the file to replace the `istio-ingressgateway.istio-system.svc.cluster.local` field with
+1. Edit the file to add the `gateway.knative-serving.knative-ingress-gateway: <ingress_name>.<ingress_namespace>.svc.cluster.local` field with
 the fully qualified url of your service.
 For the service above, it should be updated to:
 
@@ -152,7 +152,7 @@ namespace:
          gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
      ```
 
-1. Edit the file to replace the `gateway.knative-serving.knative-ingress-gateway` field with
+1. Edit the file to add the `gateway.<gateway-namespace>.<gateway-name>: istio-ingressgateway.istio-system.svc.cluster.local` field with
 the customized gateway.
 For the gateway above, it should be updated to:
 

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -58,7 +58,7 @@ istio: custom-gateway
 If there is a change in service ports (compared with that of
 `istio-ingressgateway`), update the port info in the gateway accordingly.
 
-### Step 3: Update Gateway Configmap
+### Step 3: Update the gateway ConfigMap
 
 Update gateway configmap `config-istio` under `knative-serving`
 namespace:

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -80,7 +80,7 @@ For the service above, it should be updated to:
 gateway.knative-serving.knative-ingress-gateway: custom-ingressgateway.custom-ns.svc.cluster.local
 ```
 
-## Replace the knative-ingress-gateway gateway
+## Replace the `knative-ingress-gateway` gateway
 
 We customized the gateway service so far, but we may also want to use our own gateway.
 We can replace the default gateway with our own gateway with following steps.

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -85,7 +85,7 @@ gateway.knative-serving.knative-ingress-gateway: custom-ingressgateway.custom-ns
 We customized the gateway service so far, but we may also want to use our own gateway.
 We can replace the default gateway with our own gateway with following steps.
 
-#### Step 1: Create Gateway
+### Step 1: Create the gateway
 
 Let's say you replace the default `knative-ingress-gateway` gateway with
 `knative-custom-gateway` in `custom-ns`.

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -117,7 +117,7 @@ EOF
 ### Step 2: Update the gateway ConfigMap
 
 Update the gateway ConfigMap `config-istio` under the `knative-serving`
-namespace:
+namespace by running the command:
 
 ```bash
 kubectl edit configmap config-istio -n knative-serving


### PR DESCRIPTION
This patch adds the instruction to use custom Istio Gateway.

Current doc has a similar instruction "customize Istio Gateway
Service". This doc is very similar but for "customize Istio Gateway".

Fix https://github.com/knative/docs/issues/3524