### PR TITLE
Bump k8s min version to 1.19

### DIFF
--- a/docs/snippets/prerequisites.md
+++ b/docs/snippets/prerequisites.md
@@ -10,7 +10,7 @@ Before installing Knative, you must meet the following prerequisites:
 - **For production purposes**, it is recommended that:
     - If you have only one node in your cluster, you will need at least 6 CPUs, 6 GB of memory, and 30 GB of disk storage.
     - If you have multiple nodes in your cluster, for each node you will need at least 2 CPUs, 4 GB of memory, and 20 GB of disk storage.
-- You have a cluster that uses Kubernetes v1.18 or newer.
+- You have a cluster that uses Kubernetes v1.19 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Your Kubernetes cluster must have access to the internet, since Kubernetes needs to be able to fetch images. To pull from a private registry, see [Deploying images from a private container registry](../../../../serving/deploying-from-private-registry).
 


### PR DESCRIPTION
This patch bumps k8s min version to 1.19.

Please also refer to https://github.com/knative/pkg/pull/2157.

/cc @dprotaso 