### PR TITLE
Document missing activator-capacity

### DIFF
--- a/docs/serving/load-balancing/README.md
+++ b/docs/serving/load-balancing/README.md
@@ -15,7 +15,7 @@ You can turn on Knative load balancing, by placing the _Activator service_ in th
 Activator pods are scaled horizontally, so there may be multiple Activators in a deployment. In general, the system will perform best if the number of revision pods is larger than the number of Activator pods, and those numbers divide equally.
 <!--TODO(#2472): Add better documentation about what the activator is; explain the components of load balancing; maybe add a diagram-->
 
-Knative assigns a subset of Activators for each revision, depending on the revision size. More revision pods will mean a greater number of Activators for that revision.
+Knative assigns a subset of Activators for each revision, depending on the revision size and the configured capacity per Activator. More revision pods will mean a greater number of Activators for that revision.
 
 The Activator load balancing algorithm works as follows:
 
@@ -24,12 +24,13 @@ The Activator load balancing algorithm works as follows:
 
 For more information, see the documentation on [concurrency](../../serving/autoscaling/concurrency).
 
-## Configuring target burst capacity
+## Configuring target burst capacity behavior
 
 Target burst capacity is mainly responsible for determining whether the Activator is in the request path outside of scale-from-zero scenarios.
 
-Target burst capacity can be configured using a combination of the following parameters:
+Target burst capacity and it's effect of the system can be configured using a combination of the following parameters:
 
 - Setting the targeted concurrency limits for the revision. See [concurrency](../../serving/autoscaling/concurrency).
 - Setting the target utilization parameters. See [target utilization](../../serving/autoscaling/concurrency#target-utilization).
 - Setting the target burst capacity. You can configure target burst capacity using the `autoscaling.knative.dev/targetBurstCapacity` annotation key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](./target-burst-capacity#setting-the-target-burst-capacity).
+- Setting the Activator capacity via the `config-autoscaler` ConfigMap. See [Setting the Activator capacity](./target-burst-capacity#setting-the-activator-capacity)

--- a/docs/serving/load-balancing/README.md
+++ b/docs/serving/load-balancing/README.md
@@ -24,13 +24,13 @@ The Activator load balancing algorithm works as follows:
 
 For more information, see the documentation on [concurrency](../../serving/autoscaling/concurrency).
 
-## Configuring target burst capacity behavior
+## Configuring target burst capacity
 
 Target burst capacity is mainly responsible for determining whether the Activator is in the request path outside of scale-from-zero scenarios.
 
-Target burst capacity and its effect of the system can be configured using a combination of the following parameters:
+Target burst capacity can be configured using a combination of the following parameters:
 
 - Setting the targeted concurrency limits for the revision. See [concurrency](../../serving/autoscaling/concurrency).
 - Setting the target utilization parameters. See [target utilization](../../serving/autoscaling/concurrency#target-utilization).
 - Setting the target burst capacity. You can configure target burst capacity using the `autoscaling.knative.dev/targetBurstCapacity` annotation key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](./target-burst-capacity#setting-the-target-burst-capacity).
-- Setting the Activator capacity via the `config-autoscaler` ConfigMap. See [Setting the Activator capacity](./activator-capacity#setting-the-activator-capacity)
+- Setting the Activator capacity by using the `config-autoscaler` ConfigMap. See [Setting the Activator capacity](./activator-capacity#setting-the-activator-capacity)

--- a/docs/serving/load-balancing/README.md
+++ b/docs/serving/load-balancing/README.md
@@ -15,7 +15,7 @@ You can turn on Knative load balancing, by placing the _Activator service_ in th
 Activator pods are scaled horizontally, so there may be multiple Activators in a deployment. In general, the system will perform best if the number of revision pods is larger than the number of Activator pods, and those numbers divide equally.
 <!--TODO(#2472): Add better documentation about what the activator is; explain the components of load balancing; maybe add a diagram-->
 
-Knative assigns a subset of Activators for each revision, depending on the revision size and the configured capacity per Activator. More revision pods will mean a greater number of Activators for that revision.
+Knative assigns a subset of Activators for each revision, depending on the revision size. More revision pods will mean a greater number of Activators for that revision.
 
 The Activator load balancing algorithm works as follows:
 
@@ -28,7 +28,7 @@ For more information, see the documentation on [concurrency](../../serving/autos
 
 Target burst capacity is mainly responsible for determining whether the Activator is in the request path outside of scale-from-zero scenarios.
 
-Target burst capacity and it's effect of the system can be configured using a combination of the following parameters:
+Target burst capacity and its effect of the system can be configured using a combination of the following parameters:
 
 - Setting the targeted concurrency limits for the revision. See [concurrency](../../serving/autoscaling/concurrency).
 - Setting the target utilization parameters. See [target utilization](../../serving/autoscaling/concurrency#target-utilization).

--- a/docs/serving/load-balancing/README.md
+++ b/docs/serving/load-balancing/README.md
@@ -33,4 +33,4 @@ Target burst capacity and it's effect of the system can be configured using a co
 - Setting the targeted concurrency limits for the revision. See [concurrency](../../serving/autoscaling/concurrency).
 - Setting the target utilization parameters. See [target utilization](../../serving/autoscaling/concurrency#target-utilization).
 - Setting the target burst capacity. You can configure target burst capacity using the `autoscaling.knative.dev/targetBurstCapacity` annotation key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](./target-burst-capacity#setting-the-target-burst-capacity).
-- Setting the Activator capacity via the `config-autoscaler` ConfigMap. See [Setting the Activator capacity](./target-burst-capacity#setting-the-activator-capacity)
+- Setting the Activator capacity via the `config-autoscaler` ConfigMap. See [Setting the Activator capacity](./activator-capacity#setting-the-activator-capacity)

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -7,9 +7,9 @@ type: "docs"
 
 # Configuring Activator capacity
 
-If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the into the request path if the Revision is scaled to zero.
+If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.
 
-If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
+If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like using the formula: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
 
 ## Setting the Activator capacity
 

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -7,7 +7,9 @@ type: "docs"
 
 # Configuring Activator capacity
 
-If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary (if target burst capacity is not set to 0). If available, it'll pick at least two for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
+If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the into the request path if the Revision is scaled to zero. 
+
+If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
 
 ## Setting the Activator capacity
 

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -7,9 +7,9 @@ type: "docs"
 
 # Configuring Activator capacity
 
-If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.
+If there is more than one Activator in the system, Knative puts as many Activators on the request path as required to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.
 
-If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ using the formula: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretical capacity of the existing application, including any additional target burst capacity.
+Knative uses at least two Activators to enable high availability if possible. The actual number of Activators is calculated taking the _Activator capacity_ into account, by using the formula `(replicas * target + targetBurstCapacity)/activatorCapacity`. This means that there are enough Activators in the routing path to handle the theoretical capacity of the existing application, including any additional target burst capacity.
 
 ## Setting the Activator capacity
 

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -1,0 +1,41 @@
+---
+title: "Configuring Activator capacity"
+linkTitle: "Configuring Activator capacity"
+weight: 50
+type: "docs"
+---
+
+# Configuring Activator capacity
+
+If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary (if target burst capacity is not set to 0). If available, it'll pick at least two for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
+
+## Setting the Activator capacity
+
+- **Global key:** `activator-capacity`
+- **Possible values:** int (at least 1)
+- **Default:** `100`
+
+**Example:**
+
+=== "Global (ConfigMap)"
+    ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-autoscaler
+      namespace: knative-serving
+    data:
+      activator-capacity: "200"
+    ```
+
+=== "Global (Operator)"
+    ```yaml
+    apiVersion: operator.knative.dev/v1alpha1
+    kind: KnativeServing
+    metadata:
+      name: knative-serving
+    spec:
+      config:
+        autoscaler:
+          activator-capacity: "200"
+    ```

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -7,7 +7,7 @@ type: "docs"
 
 # Configuring Activator capacity
 
-If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the into the request path if the Revision is scaled to zero. 
+If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the into the request path if the Revision is scaled to zero.
 
 If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
 

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -1,10 +1,3 @@
----
-title: "Configuring Activator capacity"
-linkTitle: "Configuring Activator capacity"
-weight: 50
-type: "docs"
----
-
 # Configuring Activator capacity
 
 If there is more than one Activator in the system, Knative puts as many Activators on the request path as required to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -9,7 +9,7 @@ type: "docs"
 
 If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.
 
-If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like using the formula: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
+If available, Knative will pick at least two Activators for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ using the formula: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretical capacity of the existing application, including any additional target burst capacity.
 
 ## Setting the Activator capacity
 

--- a/docs/serving/load-balancing/target-burst-capacity.md
+++ b/docs/serving/load-balancing/target-burst-capacity.md
@@ -1,13 +1,13 @@
 ---
-title: "Configuring target burst capacity"
-linkTitle: "Configuring target burst capacity"
+title: "Configuring target burst capacity behavior"
+linkTitle: "Configuring target burst capacity behavior"
 weight: 50
 type: "docs"
 aliases:
     - /docs/serving/autoscaling/target-burst-capacity
 ---
 
-# Configuring target burst capacity
+# Configuring target burst capacity behavior
 
 _Target burst capacity_ is a [global and per-revision](../../serving/autoscaling/autoscaling-concepts.md) integer setting that determines the size of traffic burst a Knative application can handle without buffering.
 If a traffic burst is too large for the application to handle, the _Activator_ service will be placed in the request path to protect the revision and optimize request load balancing.

--- a/docs/serving/load-balancing/target-burst-capacity.md
+++ b/docs/serving/load-balancing/target-burst-capacity.md
@@ -78,3 +78,36 @@ Target burst capacity can be configured using a combination of the following par
 - If `autoscaling.knative.dev/targetBurstCapacity` is set to `-1`, the Activator is always in the request path, regardless of the revision size.
 
 - If `autoscaling.knative.dev/targetBurstCapacity` is set to another integer, the Activator may be in the path, depending on the revision scale and load.
+
+## Setting the Activator capacity
+
+If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary. If available, it'll pick at least two for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
+
+- **Global key:** `activator-capacity`
+- **Possible values:** int (at least 1)
+- **Default:** `100`
+
+**Example:**
+
+=== "Global (ConfigMap)"
+    ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: config-autoscaler
+      namespace: knative-serving
+    data:
+      activator-capacity: "200"
+    ```
+
+=== "Global (Operator)"
+    ```yaml
+    apiVersion: operator.knative.dev/v1alpha1
+    kind: KnativeServing
+    metadata:
+      name: knative-serving
+    spec:
+      config:
+        autoscaler:
+          activator-capacity: "200"
+    ```

--- a/docs/serving/load-balancing/target-burst-capacity.md
+++ b/docs/serving/load-balancing/target-burst-capacity.md
@@ -1,13 +1,13 @@
 ---
-title: "Configuring target burst capacity behavior"
-linkTitle: "Configuring target burst capacity behavior"
+title: "Configuring target burst capacity"
+linkTitle: "Configuring target burst capacity"
 weight: 50
 type: "docs"
 aliases:
     - /docs/serving/autoscaling/target-burst-capacity
 ---
 
-# Configuring target burst capacity behavior
+# Configuring target burst capacity
 
 _Target burst capacity_ is a [global and per-revision](../../serving/autoscaling/autoscaling-concepts.md) integer setting that determines the size of traffic burst a Knative application can handle without buffering.
 If a traffic burst is too large for the application to handle, the _Activator_ service will be placed in the request path to protect the revision and optimize request load balancing.
@@ -78,36 +78,3 @@ Target burst capacity can be configured using a combination of the following par
 - If `autoscaling.knative.dev/targetBurstCapacity` is set to `-1`, the Activator is always in the request path, regardless of the revision size.
 
 - If `autoscaling.knative.dev/targetBurstCapacity` is set to another integer, the Activator may be in the path, depending on the revision scale and load.
-
-## Setting the Activator capacity
-
-If there's more than one Activator in the system, Knative will put as many of them on the request path as it thinks is necessary. If available, it'll pick at least two for high availability reasons. The actual number of Activators is calculated via a given _Activator capacity_ like such: `(replicas * target + targetBurstCapacity)/activatorCapacity`. That means, there are enough Activators in the routing path to handle the theoretic capacity of the existing application, including any additional target burst capacity.
-
-- **Global key:** `activator-capacity`
-- **Possible values:** int (at least 1)
-- **Default:** `100`
-
-**Example:**
-
-=== "Global (ConfigMap)"
-    ```yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: config-autoscaler
-      namespace: knative-serving
-    data:
-      activator-capacity: "200"
-    ```
-
-=== "Global (Operator)"
-    ```yaml
-    apiVersion: operator.knative.dev/v1alpha1
-    kind: KnativeServing
-    metadata:
-      name: knative-serving
-    spec:
-      config:
-        autoscaler:
-          activator-capacity: "200"
-    ```


### PR DESCRIPTION
 As per title, this setting was missing in our documentation and completes the autoscaling docs again.

/assign @julz 