### PR TITLE
Add net-istio webhook to spec.registry.override

### DIFF
--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -203,8 +203,8 @@ spec:
 ```
 
 !!! note
-    If the container name is not unique across all of the deployments, daemonsets and jobs,
-    you can prefix the container name with the "parent's" name and a slash, e.g. `net-istio/webhook`.
+    If the container name is not unique across all Deployments, DaemonSets and Jobs,
+    you can prefix the container name with the parent container name and a slash. For example, `net-istio/webhook`.
 
 ### Download images with secrets:
 

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -203,7 +203,7 @@ spec:
 ```
 
 !!! note
-    If the container name is not unique across all of the deployments, daemonsets and jobs, 
+    If the container name is not unique across all of the deployments, daemonsets and jobs,
     you can prefix the container name with the "parent's" name and a slash, e.g. `net-istio/webhook`.
 
 ### Download images with secrets:

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -198,13 +198,13 @@ spec:
       webhook: docker.io/knative-images-repo4/webhook:v0.13.0
       autoscaler-hpa: docker.io/knative-images-repo5/autoscaler-hpa:v0.13.0
       networking-istio: docker.io/knative-images-repo6/prefix-networking-istio:v0.13.0
-      net-istio/webhook: docker.io/knative-images-repo6/networking-istio-webhook:v0.13.0
+      istio-webhook/webhook: docker.io/knative-images-repo6/networking-istio-webhook:v0.13.0
       queue-proxy: docker.io/knative-images-repo7/queue-proxy-suffix:v0.13.0
 ```
 
 !!! note
     If the container name is not unique across all Deployments, DaemonSets and Jobs,
-    you can prefix the container name with the parent container name and a slash. For example, `net-istio/webhook`.
+    you can prefix the container name with the parent container name and a slash. For example, `istio-webhook/webhook`.
 
 ### Download images with secrets:
 

--- a/docs/admin/install/operator/configuring-serving-cr.md
+++ b/docs/admin/install/operator/configuring-serving-cr.md
@@ -178,6 +178,7 @@ For example, to given the following images:
 | `webhook` | `docker.io/knative-images-repo4/webhook:v0.13.0` |
 | `autoscaler-hpa` | `docker.io/knative-images-repo5/autoscaler-hpa:v0.13.0` |
 | `networking-istio` | `docker.io/knative-images-repo6/prefix-networking-istio:v0.13.0` |
+| `(net-istio) webhook` | `docker.io/knative-images-repo6/networking-istio-webhook:v0.13.0` |
 | `queue-proxy` | `docker.io/knative-images-repo7/queue-proxy-suffix:v0.13.0` |
 
 The operator CR should be modified to include the full list:
@@ -197,8 +198,13 @@ spec:
       webhook: docker.io/knative-images-repo4/webhook:v0.13.0
       autoscaler-hpa: docker.io/knative-images-repo5/autoscaler-hpa:v0.13.0
       networking-istio: docker.io/knative-images-repo6/prefix-networking-istio:v0.13.0
+      net-istio/webhook: docker.io/knative-images-repo6/networking-istio-webhook:v0.13.0
       queue-proxy: docker.io/knative-images-repo7/queue-proxy-suffix:v0.13.0
 ```
+
+!!! note
+    If the container name is not unique across all of the deployments, daemonsets and jobs, 
+    you can prefix the container name with the "parent's" name and a slash, e.g. `net-istio/webhook`.
 
 ### Download images with secrets:
 


### PR DESCRIPTION
container name `webhook` is duplicated with serving and net-istio. But
the example does not have net-istio's webhook so users hit an issue
like https://github.com/knative/operator/issues/519 and https://github.com/knative-sandbox/net-istio/pull/560
when we followed the current doc.

This patch adds the net-istio webhook to the doc.

/cc @houshengbo 