### PR TITLE
Bump Istio version to 1.9.5 for supported Istio version

### DIFF
--- a/docs/admin/install/installing-istio.md
+++ b/docs/admin/install/installing-istio.md
@@ -18,13 +18,12 @@ installation.
 You need:
 
 - A Kubernetes cluster created.
-- [`istioctl`](https://istio.io/docs/setup/install/istioctl/) (v1.7 or later) installed.
+- [`istioctl`](https://istio.io/docs/setup/install/istioctl/) installed.
 
 ## Supported Istio versions
 
-The current known-to-be-stable version of Istio tested in conjunction with Knative is **v1.8.2**.
-Versions in the 1.7 line are generally fine too.
-1.8.0 and 1.8.1 have bugs that don't work with Knative.
+The current known-to-be-stable version of Istio tested in conjunction with Knative is **v1.9.5**.
+Versions in the 1.9 line are generally fine too.
 
 ## Installing Istio
 


### PR DESCRIPTION
This patch Bump istio version to 1.9.5 for supported Istio version.
https://github.com/knative-sandbox/net-istio/pull/648 started testing it as stable.

/cc @ZhiminXiang @arturenault 