### PR TITLE
Clarify Magic DNS Caveat

### DIFF
--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -328,9 +328,14 @@ kubectl logs -f deploy/knative-operator
     kubectl apply --filename {{artifact(repo="serving",file="serving-default-domain.yaml")}}
     ```
 
-    **Caveat**: This will only work if the cluster LoadBalancer service exposes an
-    IPv4 address or hostname, so it will not work with IPv6 clusters or local setups
-    like Minikube. For these, see "Real DNS" or "Temporary DNS".
+    !!! info "Caveat"
+        This will only work if the cluster `LoadBalancer` service exposes an
+        IPv4 address or hostname, so it will not work with IPv6 clusters or local setups
+        like Minikube unless [`minikube tunnel`](https://minikube.sigs.k8s.io/docs/commands/tunnel/)
+        is running.
+
+        For these, see the "Real DNS" or "Temporary DNS" tabs.
+
 
 === "Real DNS"
     To configure DNS for Knative, take the External IP

--- a/docs/admin/install/serving/install-serving-with-yaml.md
+++ b/docs/admin/install/serving/install-serving-with-yaml.md
@@ -194,10 +194,13 @@ Follow the procedure for the DNS of your choice:
     kubectl apply -f {{ artifact(repo="serving",file="serving-default-domain.yaml")}}
     ```
 
-    !!! info "CAVEAT"
-        This will only work if the cluster LoadBalancer service exposes an
+    !!! info "Caveat"
+        This will only work if the cluster `LoadBalancer` service exposes an
         IPv4 address or hostname, so it will not work with IPv6 clusters or local setups
-        like Minikube. For these, see "Real DNS" or "Temporary DNS".
+        like Minikube unless [`minikube tunnel`](https://minikube.sigs.k8s.io/docs/commands/tunnel/)
+        is running.
+
+        For these, see the "Real DNS" or "Temporary DNS" tabs.
 
 === "Real DNS"
 


### PR DESCRIPTION
Magic DNS does work locally on minikube, so long as `minikube tunnel` is
running. This caused confusion for a user in slack.