### PR TITLE
Remove navigation.instant feature to fix anchors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -248,7 +248,6 @@ theme:
   custom_dir: overrides
   features:
     - navigation.tabs
-    - navigation.instant
     - navigation.tracking
     - navigation.tabs.sticky
     - navigation.indexes


### PR DESCRIPTION
Looks like navigation.instant makes link anchors not work properly (disabled it on a hunch and it fixed the issue). I don't think the feature really buys us anything much, our search index isn't that big, so easiest to just disable it.

Fixes #3829.

/assign @csantanapr @omerbensaadon @dprotaso 