### PR TITLE
Fix wrapping behavior of code in tables

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -68,3 +68,8 @@
 .md-typeset .admonition {
   font-size: 100%;
 }
+
+/* fix wrapping behavior of code in tables */
+.md-typeset table code {
+  word-break: normal;
+}


### PR DESCRIPTION
Ref #3837 

This is supposed to fix code sections breaking in the middle of the word rather than enlarging the table.
