### PR TITLE
Widen center content area per slack discussion

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -73,3 +73,10 @@
 .md-typeset table code {
   word-break: normal;
 }
+
+/* Widen the main column a bit to help with wide tables.
+   Note that extra-wide columns can make it hard to read prose,
+   so there is a tradeoff here. */
+.md-grid {
+  max-width: 68rem;
+}


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Widen the center body content of pages from 61rem (620px) to 68rem (about 700px) per this thread: https://knative.slack.com/archives/C9CV04DNJ/p1624553384104500?thread_ts=1624464518.093800&cid=C9CV04DNJ
