### PR TITLE
Adjust breakpoint for new max-width

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -151,7 +151,7 @@ body {
   margin: 1.2em;
 }
 
-@media only screen and (max-width: 1240px) {
+@media only screen and (max-width: 1440px) {
   .components-container,
   .calltoaction-container,
   .usedby-container,
@@ -160,17 +160,17 @@ body {
   .intro-container {
     padding: 40px;
   }
-
-  .intro-container img {
-    display: block;
-    margin:0 auto;
-    float: none;
-  }
 }
 
 @media only screen and (max-width: 800px) {
   .component-flex {
     flex-wrap: wrap;
+  }
+
+  .intro-container img {
+    display: block;
+    margin:0 auto;
+    float: none;
   }
 }
 


### PR DESCRIPTION
As per title, this fixes the breakpoints (and lacking paddings) on the main page. Also moves the rocket image breaking to even smaller screens as there's no point breaking that this early.

/assign @julz 