### PR TITLE
Use correct branch for samples

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -22,7 +22,7 @@ set -x
 VERSIONS=("0.23" "0.22" "0.21")
 # 3) For now, set branches too. (This will go away when all branches are release-NN).
 DOCS_BRANCHES=("mkrelease-0.23" "mkrelease-0.22" "mkrelease-0.22")
-RELEASE_BRANCHES=("v0.23.0" "v0.22.0" "v0.21.0")
+RELEASE_BRANCHES=("release-0.23" "release-0.22" "release-0.21")
 REPOS=("julz" "julz" "julz")
 # 4) PR the result to main.
 # 5) Party.
@@ -52,7 +52,7 @@ else
   # TODO: Uncomment this when 0.24 is cut.
   # curl -f --show-error https://raw.githubusercontent.com/knative/serving/${RELEASE_BRANCHES[0]}/docs/serving-api.md -s > "$TEMP/docs-$latest/docs/reference/api/serving-api.md"
   # curl -f --show-error https://raw.githubusercontent.com/knative/eventing/${RELEASE_BRANCHES[0]}/docs/eventing-api.md -s > "$TEMP/docs-$latest/docs/reference/api/eventing-api.md"
-  pushd "$TEMP/docs-$latest"; KNATIVE_VERSION=$latest mkdocs build -d $SITE/docs; popd
+  pushd "$TEMP/docs-$latest"; KNATIVE_VERSION=$latest SAMPLES_BRANCH="${RELEASE_BRANCHES[0]}" mkdocs build -d $SITE/docs; popd
 
   # Previous release branches release-$version to /v$version-docs
   versionjson=""
@@ -64,7 +64,7 @@ else
     # git clone --depth 1 -b ${DOCS_BRANCHES[$i+1]} https://github.com/${REPOS[i+1]}/docs "$TEMP/docs-$version"
     # curl -f --show-error https://raw.githubusercontent.com/knative/serving/${RELEASE_BRANCHES[i+1]}/docs/serving-api.md -s > "$TEMP/docs-$version/docs/reference/api/serving-api.md"
     # curl -f --show-error https://raw.githubusercontent.com/knative/eventing/${RELEASE_BRANCHES[i+1]}/docs/eventing-api.md -s > "$TEMP/docs-$version/docs/reference/api/eventing-api.md"
-    # pushd "$TEMP/docs-$version"; KNATIVE_VERSION=$version VERSION_WARNING=true mkdocs build -d "$SITE/v$version-docs"; popd
+    # pushd "$TEMP/docs-$version"; KNATIVE_VERSION=$version SAMPLES_BRANCH="${RELEASE_BRANCHES[i+1]}" VERSION_WARNING=true mkdocs build -d "$SITE/v$version-docs"; popd
   done
 
   # Set up the version file to point to the built docs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -338,7 +338,6 @@ plugins:
 copyright: "Copyright © 2021 The Knative Authors"
 
 extra:
-  branch: v0.23.0 # Branch to use for examples
   social:
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/KnativeProject
@@ -351,5 +350,6 @@ extra:
   # TODO: Replace with https://github.com/mkdocs/mkdocs/pull/2267 once mkdocs 1.2 is out.
   version_warning: !!python/object/apply:os.getenv ["VERSION_WARNING"]
   knative_version: !!python/object/apply:os.getenv ["KNATIVE_VERSION"]
+  branch: !!python/object/apply:os.getenv ["SAMPLES_BRANCH", "mkdocs"]
   version:
     provider: mike


### PR DESCRIPTION
Sets the branch for code samples (i.e. the `{{ branch }}` variable) to either `mkdocs` (when building the dev docs), or to the version of docs being built (e.g. release-0.23 etc). This makes sure we create the correct links for the `git clones` in the samples.

Fixes https://github.com/knative/docs/issues/3715.

/assign @omerbensaadon @csantanapr 