### PR TITLE
Little fixes for the experimental features page

### DIFF
--- a/docs/eventing/experimental-features.md
+++ b/docs/eventing/experimental-features.md
@@ -61,7 +61,7 @@ data:
 
 **Stage**: Alpha, disabled by default
 
-**Tracking issue**: https://github.com/knative/eventing/issues/5086
+**Tracking issue**: [#5086](https://github.com/knative/eventing/issues/5086)
 
 When using the `KReference` type to refer to another Knative resource, you can just specify the API `group` of the resource, instead of the full `APIVersion`.
 
@@ -84,7 +84,7 @@ name: my-channel
 With this feature you can allow Knative to resolve the full `APIVersion` and further upgrades, deprecations and removals of the referred CRD without affecting existing resources.
 
 !!! note
-    At the moment this feature is implemented only for `Subscription.Spec.Subscriber.Ref`.
+    At the moment this feature is implemented only for `Subscription.Spec.Subscriber.Ref` and `Subscription.Spec.Channel`.
 
 ### DeliverySpec.Timeout field
 
@@ -92,7 +92,7 @@ With this feature you can allow Knative to resolve the full `APIVersion` and fur
 
 **Stage**: Alpha, disabled by default
 
-**Tracking issue**: https://github.com/knative/eventing/issues/5148
+**Tracking issue**: [#5148](https://github.com/knative/eventing/issues/5148)
 
 When using the `delivery` spec to configure event delivery parameters, you can use `timeout` field to specify the timeout for each sent HTTP request. The duration of the `timeout` parameter is specified using the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601#Times) format.
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- :bug: Fixed links
- :bug: Added new supported field for kreference-group

