### PR TITLE
Fix broken links: create-default-channel in page of channel-types-defaults.md return 404

### DIFF
--- a/docs/eventing/channels/channel-types-defaults.md
+++ b/docs/eventing/channels/channel-types-defaults.md
@@ -42,4 +42,4 @@ Default channels can be configured for the cluster, a namespace on the cluster, 
 
 ## Next steps
 
-- Create an [InMemoryChannel](/create-default-channel)
+- Create an [InMemoryChannel](../create-default-channel)


### PR DESCRIPTION
link of "Create an InMemoryChannel" in https://knative.dev/docs/eventing/channels/channel-types-defaults/#next-steps return 404

Signed-off-by: jtcheng <jtcheng@alauda.io>
