### PR TITLE
update fork and knative/docs repo url

### DIFF
--- a/help/contributor/how-to/github.md
+++ b/help/contributor/how-to/github.md
@@ -20,7 +20,7 @@ At a high-level, you must setup and know the following to get started:
 To check out your fork of the `knative/docs` repository:
 
 1. Create your own
-   [fork of the `knative/docs` repo](https://help.github.com/articles/fork-a-repo/)
+   [fork](https://help.github.com/articles/fork-a-repo/) of the [`knative/docs` repo](https://github.com/knative/docs).
 1. Configure
    [GitHub access through SSH](https://help.github.com/articles/connecting-to-github-with-ssh/).
 1. Clone your fork to your machine and set the `upstream` remote to the


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"
- While going through the GitHub workflow for Knative documentation, The very first section is ["Set up your local machine "](https://knative.dev/help/contributor/how-to/github/#clone), which contains the first point to create your fork of the knative/docs repo. 
## Proposed Changes <!-- Describe the changes the PR makes. -->

- So for easy access, we can update the fork URL with the ["fork"](https://help.github.com/articles/fork-a-repo/) word and then can attach the knative/docs URL to the word ["knative/docs repo"](https://github.com/knative/docs) which can be easy for the new contributors to easily access the repo.
