### PR TITLE
Add forward slash to search separators

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -284,7 +284,9 @@ markdown_extensions:
   - def_list
 
 plugins:
-  - search
+  - search:
+      # Spaces, dashes, periods and forward-slash (so serving.knative.dev/blibble can be searched as blibble).
+      separator: '[\/\s\-\.]+'
   - macros:
       module_name: hack/macros
       include_dir: docs/snippets


### PR DESCRIPTION
Fixes #3843 

Before:

<img width="731" alt="image" src="https://user-images.githubusercontent.com/354013/124102064-ed1c5900-da57-11eb-943f-70fb0e52c917.png">


After:

<img width="769" alt="image" src="https://user-images.githubusercontent.com/354013/124101737-90b93980-da57-11eb-9dfa-75ee157f93a1.png">

/assign @dprotaso @omerbensaadon 