### PR TITLE
Tame the footer and make the prev/next stand out

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -199,12 +199,16 @@
 }
 
 /* Tame the footer and make the prev/next stand out */
-.md-footer__inner {
+.md-footer {
     color: var(--md-typeset-a-color);
     background-color: var(--md-default-bg-color);
 }
 
 .md-footer__link {
     width: unset;
+}
+
+.md-footer-meta {
+    background-color: var(--md-footer-bg-color);
 }
 /* ------------------------------------------------- */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -204,10 +204,6 @@
     background-color: var(--md-default-bg-color);
 }
 
-.md-footer__link {
-    width: unset;
-}
-
 .md-footer-meta {
     background-color: var(--md-footer-bg-color);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -197,3 +197,14 @@
   border: 1px solid rgba(0,0,0,.2);
   outline: 0;
 }
+
+/* Tame the footer and make the prev/next stand out */
+.md-footer__inner {
+    color: var(--md-typeset-a-color);
+    background-color: var(--md-default-bg-color);
+}
+
+.md-footer__link {
+    width: unset;
+}
+/* ------------------------------------------------- */


### PR DESCRIPTION
Originally the prev/next links looked like they were part of the header and were easy to miss. This makes it more obvious while at the same time making the header look more sleek.

<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
  - [Documentation](./template-docs-page.md) -- Instructions and a template that
    you can use to help you add new documentation.
  - [Blog](./template-blog-entry.md) -- Instructions and a template that
    you can use to help you post to the Knative blog.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

-
-
-
