### PR TITLE
Add footer to homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 ---
 template: home.html
 title: Knative
+hide_next: true
 ---

--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -235,3 +235,11 @@ body {
 .md-typeset .task-list-item {
   margin-left: 25px;
 }
+
+/* No next/prev links on home page so make sure next/prev area of footer collapses nicely */
+footer nav.md-footer__inner {
+  padding: 0;
+}
+footer .md-footer-meta .md-footer-meta__inner {
+  padding: 1em 0;
+}

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -181,34 +181,5 @@
 
 <!-- Application footer -->
 {% block footer %}
-  <!-- Cookie Bannier -->
-  <div id="cookieModal" class="md-typeset modal custom fade" role="dialog" data-backdrop="false">
-    <div class="modal-dialog modal-xl">
-      <div class="modal-content">
-        <div class="modal-body">
-          <p>We use cookies. <a href="https://developers.google.com/analytics/devguides/collection/analyticsjs/cookie-usage" target="_blank">Google Analytics</a> is used to improve your experience and help us understand site traffic and page usage.</p>
-          <div class="consent-buttons">
-            <button type="button" class="md-button" onclick="learnaboutcookies()">Learn more</button>
-            <button type="button" class="md-button md-button--primary" onclick="acceptcookie()">Accept</button>
-            <div class="opt-out">
-              <hr>
-              <p><a href="/about-analytics-cookies/">Learn about analytics cookies and how you can take steps to opt-out from sharing your usage data.</a></p>
-              <button type="button" class="md-button" onclick="optout()">I understand how to opt-out, hide this notice.</button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="cookienotice md-typeset">
-    <div class="text">
-      <p>We use analytics and cookies to understand site traffic. Information about your use of
-        our site is shared with Google for that purpose. <a href="/about-analytics-cookies/">Learn more.</a>
-      </p>
-    </div>
-    <div class="buttons">
-      <a class="close" onclick="closenotice()">&times;</a>
-      <a class="ok" onclick="acceptcookie()">OK</a>
-    </div>
-  </div>
+  {% include "partials/footer.html" %}
 {% endblock %}


### PR DESCRIPTION
This has two advantages:
1. We get the privacy policy (etc) linked on the homepage, which seems Right (also more consistent).
2. We can drop the duplicated cookie popup code in home.html, since it's included via the footer on all non-homepage pages.

/assign @csantanapr @omerbensaadon 