### PR TITLE
Update version dropdown in old docs

### DIFF
--- a/archived/v0.21-docs/client/connecting-kn-to-your-cluster/index.html
+++ b/archived/v0.21-docs/client/connecting-kn-to-your-cluster/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/accessing-traces/index.html
+++ b/archived/v0.21-docs/eventing/accessing-traces/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/broker/alternate/index.html
+++ b/archived/v0.21-docs/eventing/broker/alternate/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/broker/config-br-defaults/index.html
+++ b/archived/v0.21-docs/eventing/broker/config-br-defaults/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/broker/index.html
+++ b/archived/v0.21-docs/eventing/broker/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/broker/kafka-broker/index.html
+++ b/archived/v0.21-docs/eventing/broker/kafka-broker/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/broker/kafka-configmap/index.html
+++ b/archived/v0.21-docs/eventing/broker/kafka-configmap/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/channels/channel-types-defaults/index.html
+++ b/archived/v0.21-docs/eventing/channels/channel-types-defaults/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/channels/channels-crds/index.html
+++ b/archived/v0.21-docs/eventing/channels/channels-crds/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/channels/create-default-channel/index.html
+++ b/archived/v0.21-docs/eventing/channels/create-default-channel/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/channels/index.html
+++ b/archived/v0.21-docs/eventing/channels/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/debugging/index.html
+++ b/archived/v0.21-docs/eventing/debugging/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/event-delivery/index.html
+++ b/archived/v0.21-docs/eventing/event-delivery/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/event-registry/index.html
+++ b/archived/v0.21-docs/eventing/event-registry/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/flows/index.html
+++ b/archived/v0.21-docs/eventing/flows/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/flows/parallel/index.html
+++ b/archived/v0.21-docs/eventing/flows/parallel/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/flows/sequence/index.html
+++ b/archived/v0.21-docs/eventing/flows/sequence/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/getting-started/index.html
+++ b/archived/v0.21-docs/eventing/getting-started/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/index.html
+++ b/archived/v0.21-docs/eventing/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/cloud-audit-logs-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/cloud-audit-logs-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/cloud-pubsub-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/cloud-pubsub-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/cloud-scheduler-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/cloud-scheduler-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/cloud-storage-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/cloud-storage-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/container-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/container-source/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/github-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/github-source/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/gitlab-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/gitlab-source/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/helloworld/helloworld-go/index.html
+++ b/archived/v0.21-docs/eventing/samples/helloworld/helloworld-go/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/helloworld/helloworld-python/index.html
+++ b/archived/v0.21-docs/eventing/samples/helloworld/helloworld-python/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/helloworld/index.html
+++ b/archived/v0.21-docs/eventing/samples/helloworld/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/index.html
+++ b/archived/v0.21-docs/eventing/samples/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/iot-core/index.html
+++ b/archived/v0.21-docs/eventing/samples/iot-core/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/kafka/binding/index.html
+++ b/archived/v0.21-docs/eventing/samples/kafka/binding/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/kafka/channel/index.html
+++ b/archived/v0.21-docs/eventing/samples/kafka/channel/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/kafka/index.html
+++ b/archived/v0.21-docs/eventing/samples/kafka/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/kafka/source/index.html
+++ b/archived/v0.21-docs/eventing/samples/kafka/source/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/kubernetes-event-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/kubernetes-event-source/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/parallel/index.html
+++ b/archived/v0.21-docs/eventing/samples/parallel/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/parallel/multiple-branches/index.html
+++ b/archived/v0.21-docs/eventing/samples/parallel/multiple-branches/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/parallel/mutual-exclusivity/index.html
+++ b/archived/v0.21-docs/eventing/samples/parallel/mutual-exclusivity/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/ping-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/ping-source/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/sequence/index.html
+++ b/archived/v0.21-docs/eventing/samples/sequence/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/sequence/sequence-reply-to-event-display/index.html
+++ b/archived/v0.21-docs/eventing/samples/sequence/sequence-reply-to-event-display/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/sequence/sequence-reply-to-sequence/index.html
+++ b/archived/v0.21-docs/eventing/samples/sequence/sequence-reply-to-sequence/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/sequence/sequence-terminal/index.html
+++ b/archived/v0.21-docs/eventing/samples/sequence/sequence-terminal/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/sequence/sequence-with-broker-trigger/index.html
+++ b/archived/v0.21-docs/eventing/samples/sequence/sequence-with-broker-trigger/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source-easy-way/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source-easy-way/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/01-theory/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/01-theory/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/02-lifecycle-and-types/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/02-lifecycle-and-types/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/03-controller/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/03-controller/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/04-reconciler/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/04-reconciler/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/05-receive-adapter/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/05-receive-adapter/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/06-yaml/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/06-yaml/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/07-knative-sandbox/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/07-knative-sandbox/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/samples/writing-event-source/index.html
+++ b/archived/v0.21-docs/eventing/samples/writing-event-source/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sink/index.html
+++ b/archived/v0.21-docs/eventing/sink/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sink/kafka-sink/index.html
+++ b/archived/v0.21-docs/eventing/sink/kafka-sink/index.html
@@ -156,27 +156,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -299,27 +280,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sources/apache-camel-source/index.html
+++ b/archived/v0.21-docs/eventing/sources/apache-camel-source/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sources/apiserversource/index.html
+++ b/archived/v0.21-docs/eventing/sources/apiserversource/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sources/containersource/index.html
+++ b/archived/v0.21-docs/eventing/sources/containersource/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sources/index.html
+++ b/archived/v0.21-docs/eventing/sources/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sources/pingsource/index.html
+++ b/archived/v0.21-docs/eventing/sources/pingsource/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sources/sinkbinding/index.html
+++ b/archived/v0.21-docs/eventing/sources/sinkbinding/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/sugar/index.html
+++ b/archived/v0.21-docs/eventing/sugar/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/eventing/triggers/index.html
+++ b/archived/v0.21-docs/eventing/triggers/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/index.html
+++ b/archived/v0.21-docs/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/any-kubernetes-cluster/index.html
+++ b/archived/v0.21-docs/install/any-kubernetes-cluster/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/check-install-version/index.html
+++ b/archived/v0.21-docs/install/check-install-version/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/collecting-logs/index.html
+++ b/archived/v0.21-docs/install/collecting-logs/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/index.html
+++ b/archived/v0.21-docs/install/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/install-kn/index.html
+++ b/archived/v0.21-docs/install/install-kn/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/installing-istio/index.html
+++ b/archived/v0.21-docs/install/installing-istio/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/knative-with-operators/index.html
+++ b/archived/v0.21-docs/install/knative-with-operators/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/operator/configuring-eventing-cr/index.html
+++ b/archived/v0.21-docs/install/operator/configuring-eventing-cr/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/operator/configuring-serving-cr/index.html
+++ b/archived/v0.21-docs/install/operator/configuring-serving-cr/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/upgrade-installation-with-operator/index.html
+++ b/archived/v0.21-docs/install/upgrade-installation-with-operator/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/install/upgrade-installation/index.html
+++ b/archived/v0.21-docs/install/upgrade-installation/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/knative-offerings/index.html
+++ b/archived/v0.21-docs/knative-offerings/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/reference/api/eventing/index.html
+++ b/archived/v0.21-docs/reference/api/eventing/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/reference/api/index.html
+++ b/archived/v0.21-docs/reference/api/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/reference/api/serving-api/index.html
+++ b/archived/v0.21-docs/reference/api/serving-api/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/reference/index.html
+++ b/archived/v0.21-docs/reference/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/reference/relnotes/index.html
+++ b/archived/v0.21-docs/reference/relnotes/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/reference/resources/index.html
+++ b/archived/v0.21-docs/reference/resources/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/samples/index.html
+++ b/archived/v0.21-docs/samples/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/accessing-traces/index.html
+++ b/archived/v0.21-docs/serving/accessing-traces/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/autoscale-go/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/autoscale-go/index.html
@@ -153,27 +153,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -296,27 +277,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/autoscaling-concepts/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/autoscaling-concepts/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/autoscaling-metrics/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/autoscaling-metrics/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/autoscaling-targets/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/autoscaling-targets/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/concurrency/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/concurrency/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/kpa-specific/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/kpa-specific/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/rps-target/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/rps-target/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/scale-bounds/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/scale-bounds/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/autoscaling/scale-to-zero/index.html
+++ b/archived/v0.21-docs/serving/autoscaling/scale-to-zero/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/cluster-local-route/index.html
+++ b/archived/v0.21-docs/serving/cluster-local-route/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/config-ha/index.html
+++ b/archived/v0.21-docs/serving/config-ha/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/creating-domain-mappings/index.html
+++ b/archived/v0.21-docs/serving/creating-domain-mappings/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/custom-metrics-api/index.html
+++ b/archived/v0.21-docs/serving/custom-metrics-api/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/debugging-application-issues/index.html
+++ b/archived/v0.21-docs/serving/debugging-application-issues/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/deploying/private-registry/index.html
+++ b/archived/v0.21-docs/serving/deploying/private-registry/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/feature-flags/index.html
+++ b/archived/v0.21-docs/serving/feature-flags/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/getting-started-knative-app/index.html
+++ b/archived/v0.21-docs/serving/getting-started-knative-app/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/gke-assigning-static-ip-address/index.html
+++ b/archived/v0.21-docs/serving/gke-assigning-static-ip-address/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/index.html
+++ b/archived/v0.21-docs/serving/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/installing-cert-manager/index.html
+++ b/archived/v0.21-docs/serving/installing-cert-manager/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/istio-authorization/index.html
+++ b/archived/v0.21-docs/serving/istio-authorization/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/knative-kubernetes-services/index.html
+++ b/archived/v0.21-docs/serving/knative-kubernetes-services/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/load-balancing/index.html
+++ b/archived/v0.21-docs/serving/load-balancing/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/load-balancing/target-burst-capacity/index.html
+++ b/archived/v0.21-docs/serving/load-balancing/target-burst-capacity/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/rolling-out-latest-revision/index.html
+++ b/archived/v0.21-docs/serving/rolling-out-latest-revision/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/blue-green-deployment/index.html
+++ b/archived/v0.21-docs/serving/samples/blue-green-deployment/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-dotnet/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-dotnet/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-go/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-go/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-nodejs/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-nodejs/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-rust/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-rust/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-spring/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-spring/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-vertx/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/cloudevents-vertx/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/cloudevents/index.html
+++ b/archived/v0.21-docs/serving/samples/cloudevents/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/gitwebhook-go/index.html
+++ b/archived/v0.21-docs/serving/samples/gitwebhook-go/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/grpc-ping-go/index.html
+++ b/archived/v0.21-docs/serving/samples/grpc-ping-go/index.html
@@ -153,27 +153,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -296,27 +277,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-csharp/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-csharp/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-go/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-go/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-java-spark/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-java-spark/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-java-spring/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-java-spring/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-kotlin/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-kotlin/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-nodejs/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-nodejs/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-php/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-php/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-python/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-python/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-ruby/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-ruby/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-scala/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-scala/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/helloworld-shell/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/helloworld-shell/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/hello-world/index.html
+++ b/archived/v0.21-docs/serving/samples/hello-world/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/index.html
+++ b/archived/v0.21-docs/serving/samples/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/knative-routing-go/index.html
+++ b/archived/v0.21-docs/serving/samples/knative-routing-go/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/multi-container/index.html
+++ b/archived/v0.21-docs/serving/samples/multi-container/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/rest-api-go/index.html
+++ b/archived/v0.21-docs/serving/samples/rest-api-go/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/secrets-go/index.html
+++ b/archived/v0.21-docs/serving/samples/secrets-go/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/tag-header-based-routing/index.html
+++ b/archived/v0.21-docs/serving/samples/tag-header-based-routing/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/samples/traffic-splitting/index.html
+++ b/archived/v0.21-docs/serving/samples/traffic-splitting/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/services/creating-services/index.html
+++ b/archived/v0.21-docs/serving/services/creating-services/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/services/deployment/index.html
+++ b/archived/v0.21-docs/serving/services/deployment/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/services/index.html
+++ b/archived/v0.21-docs/serving/services/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/setting-up-custom-ingress-gateway/index.html
+++ b/archived/v0.21-docs/serving/setting-up-custom-ingress-gateway/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/spec/knative-api-specification-1.0/index.html
+++ b/archived/v0.21-docs/serving/spec/knative-api-specification-1.0/index.html
@@ -158,27 +158,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>

--- a/archived/v0.21-docs/serving/tag-resolution/index.html
+++ b/archived/v0.21-docs/serving/tag-resolution/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-a-custom-domain-per-service/index.html
+++ b/archived/v0.21-docs/serving/using-a-custom-domain-per-service/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-a-custom-domain/index.html
+++ b/archived/v0.21-docs/serving/using-a-custom-domain/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-a-tls-cert/index.html
+++ b/archived/v0.21-docs/serving/using-a-tls-cert/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-auto-tls/index.html
+++ b/archived/v0.21-docs/serving/using-auto-tls/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-cert-manager-on-gcp/index.html
+++ b/archived/v0.21-docs/serving/using-cert-manager-on-gcp/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-external-dns-on-gcp/index.html
+++ b/archived/v0.21-docs/serving/using-external-dns-on-gcp/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/using-subroutes/index.html
+++ b/archived/v0.21-docs/serving/using-subroutes/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/serving/webhook-customizations/index.html
+++ b/archived/v0.21-docs/serving/webhook-customizations/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.21-docs/smoketest/index.html
+++ b/archived/v0.21-docs/smoketest/index.html
@@ -143,27 +143,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>

--- a/archived/v0.22-docs/client/configure-kn/index.html
+++ b/archived/v0.22-docs/client/configure-kn/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/client/index.html
+++ b/archived/v0.22-docs/client/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/client/install-kn/index.html
+++ b/archived/v0.22-docs/client/install-kn/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/client/kn-plugins/index.html
+++ b/archived/v0.22-docs/client/kn-plugins/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/accessing-traces/index.html
+++ b/archived/v0.22-docs/eventing/accessing-traces/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/broker/alternate/index.html
+++ b/archived/v0.22-docs/eventing/broker/alternate/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/broker/config-br-defaults/index.html
+++ b/archived/v0.22-docs/eventing/broker/config-br-defaults/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/broker/index.html
+++ b/archived/v0.22-docs/eventing/broker/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/broker/kafka-broker/index.html
+++ b/archived/v0.22-docs/eventing/broker/kafka-broker/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/broker/kafka-configmap/index.html
+++ b/archived/v0.22-docs/eventing/broker/kafka-configmap/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/channels/channel-types-defaults/index.html
+++ b/archived/v0.22-docs/eventing/channels/channel-types-defaults/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/channels/channels-crds/index.html
+++ b/archived/v0.22-docs/eventing/channels/channels-crds/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/channels/create-default-channel/index.html
+++ b/archived/v0.22-docs/eventing/channels/create-default-channel/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/channels/index.html
+++ b/archived/v0.22-docs/eventing/channels/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/channels/subscriptions/index.html
+++ b/archived/v0.22-docs/eventing/channels/subscriptions/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/debugging/index.html
+++ b/archived/v0.22-docs/eventing/debugging/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/event-delivery/index.html
+++ b/archived/v0.22-docs/eventing/event-delivery/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/event-registry/index.html
+++ b/archived/v0.22-docs/eventing/event-registry/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/flows/index.html
+++ b/archived/v0.22-docs/eventing/flows/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/flows/parallel/index.html
+++ b/archived/v0.22-docs/eventing/flows/parallel/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/flows/sequence/index.html
+++ b/archived/v0.22-docs/eventing/flows/sequence/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/getting-started/index.html
+++ b/archived/v0.22-docs/eventing/getting-started/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/index.html
+++ b/archived/v0.22-docs/eventing/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/cloud-audit-logs-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/cloud-audit-logs-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/cloud-pubsub-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/cloud-pubsub-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/cloud-scheduler-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/cloud-scheduler-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/cloud-storage-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/cloud-storage-source/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/container-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/container-source/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/github-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/github-source/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/gitlab-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/gitlab-source/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/helloworld/helloworld-go/index.html
+++ b/archived/v0.22-docs/eventing/samples/helloworld/helloworld-go/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/helloworld/helloworld-python/index.html
+++ b/archived/v0.22-docs/eventing/samples/helloworld/helloworld-python/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/helloworld/index.html
+++ b/archived/v0.22-docs/eventing/samples/helloworld/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/index.html
+++ b/archived/v0.22-docs/eventing/samples/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/iot-core/index.html
+++ b/archived/v0.22-docs/eventing/samples/iot-core/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/kafka/binding/index.html
+++ b/archived/v0.22-docs/eventing/samples/kafka/binding/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/kafka/channel/index.html
+++ b/archived/v0.22-docs/eventing/samples/kafka/channel/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/kafka/index.html
+++ b/archived/v0.22-docs/eventing/samples/kafka/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/kafka/source/index.html
+++ b/archived/v0.22-docs/eventing/samples/kafka/source/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/kubernetes-event-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/kubernetes-event-source/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/parallel/index.html
+++ b/archived/v0.22-docs/eventing/samples/parallel/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/parallel/multiple-branches/index.html
+++ b/archived/v0.22-docs/eventing/samples/parallel/multiple-branches/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/parallel/mutual-exclusivity/index.html
+++ b/archived/v0.22-docs/eventing/samples/parallel/mutual-exclusivity/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/ping-source/index.html
+++ b/archived/v0.22-docs/eventing/samples/ping-source/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/sequence/index.html
+++ b/archived/v0.22-docs/eventing/samples/sequence/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/sequence/sequence-reply-to-event-display/index.html
+++ b/archived/v0.22-docs/eventing/samples/sequence/sequence-reply-to-event-display/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/sequence/sequence-reply-to-sequence/index.html
+++ b/archived/v0.22-docs/eventing/samples/sequence/sequence-reply-to-sequence/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/sequence/sequence-terminal/index.html
+++ b/archived/v0.22-docs/eventing/samples/sequence/sequence-terminal/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/samples/sequence/sequence-with-broker-trigger/index.html
+++ b/archived/v0.22-docs/eventing/samples/sequence/sequence-with-broker-trigger/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sink/index.html
+++ b/archived/v0.22-docs/eventing/sink/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sink/kafka-sink/index.html
+++ b/archived/v0.22-docs/eventing/sink/kafka-sink/index.html
@@ -156,27 +156,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -299,27 +280,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/apache-camel-source/index.html
+++ b/archived/v0.22-docs/eventing/sources/apache-camel-source/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/apiserversource/index.html
+++ b/archived/v0.22-docs/eventing/sources/apiserversource/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/containersource/index.html
+++ b/archived/v0.22-docs/eventing/sources/containersource/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source-easy-way/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source-easy-way/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/01-theory/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/01-theory/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/02-lifecycle-and-types/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/02-lifecycle-and-types/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/03-controller/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/03-controller/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/04-reconciler/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/04-reconciler/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/05-receive-adapter/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/05-receive-adapter/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/06-yaml/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/06-yaml/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/07-knative-sandbox/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/07-knative-sandbox/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/index.html
+++ b/archived/v0.22-docs/eventing/sources/creating-event-sources/writing-event-source/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/index.html
+++ b/archived/v0.22-docs/eventing/sources/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/pingsource/index.html
+++ b/archived/v0.22-docs/eventing/sources/pingsource/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sources/sinkbinding/index.html
+++ b/archived/v0.22-docs/eventing/sources/sinkbinding/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/sugar/index.html
+++ b/archived/v0.22-docs/eventing/sugar/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/eventing/triggers/index.html
+++ b/archived/v0.22-docs/eventing/triggers/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/index.html
+++ b/archived/v0.22-docs/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/check-install-version/index.html
+++ b/archived/v0.22-docs/install/check-install-version/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/collecting-logs/index.html
+++ b/archived/v0.22-docs/install/collecting-logs/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/collecting-metrics/index.html
+++ b/archived/v0.22-docs/install/collecting-metrics/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/index.html
+++ b/archived/v0.22-docs/install/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/install-eventing-with-yaml/index.html
+++ b/archived/v0.22-docs/install/install-eventing-with-yaml/index.html
@@ -153,27 +153,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -296,27 +277,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/install-extensions/index.html
+++ b/archived/v0.22-docs/install/install-extensions/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/install-serving-with-yaml/index.html
+++ b/archived/v0.22-docs/install/install-serving-with-yaml/index.html
@@ -153,27 +153,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -296,27 +277,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/installation-files/index.html
+++ b/archived/v0.22-docs/install/installation-files/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/installing-istio/index.html
+++ b/archived/v0.22-docs/install/installing-istio/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/knative-with-operators/index.html
+++ b/archived/v0.22-docs/install/knative-with-operators/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/operator/configuring-eventing-cr/index.html
+++ b/archived/v0.22-docs/install/operator/configuring-eventing-cr/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/operator/configuring-serving-cr/index.html
+++ b/archived/v0.22-docs/install/operator/configuring-serving-cr/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/install/prerequisites/index.html
+++ b/archived/v0.22-docs/install/prerequisites/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/knative-offerings/index.html
+++ b/archived/v0.22-docs/knative-offerings/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/reference/api/eventing/index.html
+++ b/archived/v0.22-docs/reference/api/eventing/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/reference/api/index.html
+++ b/archived/v0.22-docs/reference/api/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/reference/api/serving-api/index.html
+++ b/archived/v0.22-docs/reference/api/serving-api/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/reference/index.html
+++ b/archived/v0.22-docs/reference/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/reference/relnotes/index.html
+++ b/archived/v0.22-docs/reference/relnotes/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/samples/index.html
+++ b/archived/v0.22-docs/samples/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/accessing-traces/index.html
+++ b/archived/v0.22-docs/serving/accessing-traces/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/autoscale-go/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/autoscale-go/index.html
@@ -153,27 +153,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -296,27 +277,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/autoscaling-concepts/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/autoscaling-concepts/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/autoscaling-metrics/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/autoscaling-metrics/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/autoscaling-targets/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/autoscaling-targets/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/concurrency/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/concurrency/index.html
@@ -150,27 +150,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -293,27 +274,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/kpa-specific/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/kpa-specific/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/rps-target/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/rps-target/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/scale-bounds/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/scale-bounds/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/autoscaling/scale-to-zero/index.html
+++ b/archived/v0.22-docs/serving/autoscaling/scale-to-zero/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/cluster-local-route/index.html
+++ b/archived/v0.22-docs/serving/cluster-local-route/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/config-ha/index.html
+++ b/archived/v0.22-docs/serving/config-ha/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/creating-domain-mappings/index.html
+++ b/archived/v0.22-docs/serving/creating-domain-mappings/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/debugging-application-issues/index.html
+++ b/archived/v0.22-docs/serving/debugging-application-issues/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/deploying/private-registry/index.html
+++ b/archived/v0.22-docs/serving/deploying/private-registry/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/feature-flags/index.html
+++ b/archived/v0.22-docs/serving/feature-flags/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/getting-started-knative-app/index.html
+++ b/archived/v0.22-docs/serving/getting-started-knative-app/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/gke-assigning-static-ip-address/index.html
+++ b/archived/v0.22-docs/serving/gke-assigning-static-ip-address/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/index.html
+++ b/archived/v0.22-docs/serving/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/installing-cert-manager/index.html
+++ b/archived/v0.22-docs/serving/installing-cert-manager/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/istio-authorization/index.html
+++ b/archived/v0.22-docs/serving/istio-authorization/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/knative-kubernetes-services/index.html
+++ b/archived/v0.22-docs/serving/knative-kubernetes-services/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/load-balancing/index.html
+++ b/archived/v0.22-docs/serving/load-balancing/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/load-balancing/target-burst-capacity/index.html
+++ b/archived/v0.22-docs/serving/load-balancing/target-burst-capacity/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/rolling-out-latest-revision/index.html
+++ b/archived/v0.22-docs/serving/rolling-out-latest-revision/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/blue-green-deployment/index.html
+++ b/archived/v0.22-docs/serving/samples/blue-green-deployment/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-dotnet/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-dotnet/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-go/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-go/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-nodejs/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-nodejs/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-rust/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-rust/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-spring/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-spring/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-vertx/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/cloudevents-vertx/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/cloudevents/index.html
+++ b/archived/v0.22-docs/serving/samples/cloudevents/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/gitwebhook-go/index.html
+++ b/archived/v0.22-docs/serving/samples/gitwebhook-go/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/grpc-ping-go/index.html
+++ b/archived/v0.22-docs/serving/samples/grpc-ping-go/index.html
@@ -153,27 +153,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -296,27 +277,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-csharp/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-csharp/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-go/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-go/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-java-spark/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-java-spark/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-java-spring/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-java-spring/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-kotlin/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-kotlin/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-nodejs/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-nodejs/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-php/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-php/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-python/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-python/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-ruby/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-ruby/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-scala/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-scala/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/helloworld-shell/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/helloworld-shell/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/hello-world/index.html
+++ b/archived/v0.22-docs/serving/samples/hello-world/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/index.html
+++ b/archived/v0.22-docs/serving/samples/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/knative-routing-go/index.html
+++ b/archived/v0.22-docs/serving/samples/knative-routing-go/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/multi-container/index.html
+++ b/archived/v0.22-docs/serving/samples/multi-container/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/rest-api-go/index.html
+++ b/archived/v0.22-docs/serving/samples/rest-api-go/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/secrets-go/index.html
+++ b/archived/v0.22-docs/serving/samples/secrets-go/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/tag-header-based-routing/index.html
+++ b/archived/v0.22-docs/serving/samples/tag-header-based-routing/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/samples/traffic-splitting/index.html
+++ b/archived/v0.22-docs/serving/samples/traffic-splitting/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/services/creating-services/index.html
+++ b/archived/v0.22-docs/serving/services/creating-services/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/services/deployment/index.html
+++ b/archived/v0.22-docs/serving/services/deployment/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/services/index.html
+++ b/archived/v0.22-docs/serving/services/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/setting-up-custom-ingress-gateway/index.html
+++ b/archived/v0.22-docs/serving/setting-up-custom-ingress-gateway/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/spec/knative-api-specification-1.0/index.html
+++ b/archived/v0.22-docs/serving/spec/knative-api-specification-1.0/index.html
@@ -137,27 +137,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../../development/">(Development)</a>
 </div>
 
       </li>

--- a/archived/v0.22-docs/serving/tag-resolution/index.html
+++ b/archived/v0.22-docs/serving/tag-resolution/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-a-custom-domain-per-service/index.html
+++ b/archived/v0.22-docs/serving/using-a-custom-domain-per-service/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-a-custom-domain/index.html
+++ b/archived/v0.22-docs/serving/using-a-custom-domain/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-a-tls-cert/index.html
+++ b/archived/v0.22-docs/serving/using-a-tls-cert/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-auto-tls/index.html
+++ b/archived/v0.22-docs/serving/using-auto-tls/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-cert-manager-on-gcp/index.html
+++ b/archived/v0.22-docs/serving/using-cert-manager-on-gcp/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-external-dns-on-gcp/index.html
+++ b/archived/v0.22-docs/serving/using-external-dns-on-gcp/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/using-subroutes/index.html
+++ b/archived/v0.22-docs/serving/using-subroutes/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/serving/webhook-customizations/index.html
+++ b/archived/v0.22-docs/serving/webhook-customizations/index.html
@@ -141,27 +141,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -284,27 +265,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/smoketest/index.html
+++ b/archived/v0.22-docs/smoketest/index.html
@@ -143,27 +143,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>

--- a/archived/v0.22-docs/uninstall/index.html
+++ b/archived/v0.22-docs/uninstall/index.html
@@ -147,27 +147,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -290,27 +271,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/upgrade/index.html
+++ b/archived/v0.22-docs/upgrade/index.html
@@ -133,27 +133,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
       </li>
@@ -276,27 +257,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/upgrade/upgrade-installation-with-operator/index.html
+++ b/archived/v0.22-docs/upgrade/upgrade-installation-with-operator/index.html
@@ -138,27 +138,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -281,27 +262,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>

--- a/archived/v0.22-docs/upgrade/upgrade-installation/index.html
+++ b/archived/v0.22-docs/upgrade/upgrade-installation/index.html
@@ -144,27 +144,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
       </li>
@@ -287,27 +268,8 @@ if (!doNotTrack) {
 </a>
 
 <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../docs/">v0.23</a>
-  
-  <a
-  class="dropdown-item active"
-  style="" href="../../../v0.22-docs/">v0.22</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="../../../v0.21-docs/">v0.21</a>
-  
-  <a
-  class="dropdown-item"
-  style="" href="https://github.com/knative/docs/branches">Archives</a>
-  
-  <a
-  class="dropdown-item"
-  style="color:#BCBCBC" href="../../../development/">Pre-release</a>
-  
+  <a class="dropdown-item" href="../../../docs/">Latest Version</a>
+  <a class="dropdown-item" style="color:#bcbcbc" href="../../../development/">(Development)</a>
 </div>
 
     </div>


### PR DESCRIPTION
Updates the drop-down on the archived docs to only include latest and dev, so the dropdown is evergreen and
will not need regenerating for future releases.

/assign @omerbensaadon 