### PR TITLE
#3935: Move private container registry docs to developer guide

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -68,6 +68,7 @@ nav:
             - Configuring custom domains: developer/serving/services/custom-domains.md
             - Configure resource requests and limits: developer/serving/services/configure-requests-limits-services.md
           - Traffic management: developer/serving/traffic-management.md
+          - Deploying from private registries: developer/serving/deploying-from-private-registry.md
           - Troubleshooting:
             - Debugging application issues: developer/serving/troubleshooting/debugging-application-issues.md
         - Knative Eventing:
@@ -110,7 +111,6 @@ nav:
     - Knative Serving:
       - Overview: serving/README.md
       - Developer Topics:
-        - Deploying from private registries: serving/deploying-from-private-registry.md
         - Tag resolution: serving/tag-resolution.md
         - Gradually rolling out latest Revisions: serving/rolling-out-latest-revision.md
         - Creating and using Subroutes: serving/using-subroutes.md

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -1,6 +1,7 @@
 plugins:
   redirects:
     redirect_maps:
+      serving/deploying-from-private-registry.md: developer/serving/deploying-from-private-registry.md
       serving/samples/blue-green-deployment.md: developer/serving/traffic-management.md
       serving/samples/traffic-splitting/README.md: developer/serving/traffic-management.md
       admin/install/install-eventing-with-yaml.md: admin/install/eventing/install-eventing-with-yaml.md

--- a/docs/developer/serving/deploying-from-private-registry.md
+++ b/docs/developer/serving/deploying-from-private-registry.md
@@ -44,7 +44,7 @@ To configure using a private container registry, you must:
     Example:
 
     ```bash
-    kubectl create secret `container-registry` \
+    kubectl create secret container-registry \
       --docker-server=https://gcr.io/ \
       --docker-email=my-account-email@address.com \
       --docker-username=my-grc-username \

--- a/docs/developer/serving/deploying-from-private-registry.md
+++ b/docs/developer/serving/deploying-from-private-registry.md
@@ -63,7 +63,7 @@ To configure using a private container registry, you must:
     !!! note
         By default, the `default` service account in each of the [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) of your Knative cluster are used by your Revisions, unless the [`serviceAccountName`](https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md#revision-2) is specified.
 
-    For example, if have you named your secrets `container-registry`, you can run the following command to modify the `default` service account, :
+    For example, if have you named your secrets `container-registry`, you can run the following command to modify the `default` service account:
 
     ```bash
     kubectl patch serviceaccount default -p "{\"imagePullSecrets\": [{\"name\": \"container-registry\"}]}"

--- a/docs/developer/serving/deploying-from-private-registry.md
+++ b/docs/developer/serving/deploying-from-private-registry.md
@@ -11,51 +11,51 @@ To configure using a private container registry, you must:
 
 ## Prerequisites
 
-- You must have a Kubernetes cluster with [Knative Serving installed](../../install/).
+- You must have a Kubernetes cluster with Knative Serving installed.
 - You must have access to credentials for the private container registry where your container images are stored.
 
 ## Procedure
 
-1. Create a `imagePullSecrets` that contains your credentials as a list of secrets:
+1. Create a `imagePullSecrets` object that contains your credentials as a list of secrets:
 
     ```bash
-    kubectl create secret docker-registry [REGISTRY-CRED-SECRETS] \
-      --docker-server=[PRIVATE_REGISTRY_SERVER_URL] \
-      --docker-email=[PRIVATE_REGISTRY_EMAIL] \
-      --docker-username=[PRIVATE_REGISTRY_USER] \
-      --docker-password=[PRIVATE_REGISTRY_PASSWORD]
+    kubectl create secret docker-registry <registry-credential-secrets> \
+      --docker-server=<private-registry-url>] \
+      --docker-email=<private-registry-email> \
+      --docker-username=<private-registry-user> \
+      --docker-password=<private-registry-password>
     ```
 
     Where:
 
-    - `[REGISTRY-CRED-SECRETS]` is the name that you want to use for your secrets (the `imagePullSecrets` object). For example, `container-registry`.
+    - `<registry-credential-secrets>` is the name that you want to use for your secrets (the `imagePullSecrets` object). For example, `container-registry`.
 
-    - `[PRIVATE_REGISTRY_SERVER_URL]` is the URL of the private registry where your container images are stored. Examples include [Google Container Registry](https://gcr.io/) or [DockerHub](https://docker.io/).
+    - `<private-registry-url>` is the URL of the private registry where your container images are stored. Examples include [Google Container Registry](https://gcr.io/) or [DockerHub](https://docker.io/).
 
-    * `[PRIVATE_REGISTRY_EMAIL]` is the email address that is associated with
+    * `<private-registry-email>` is the email address that is associated with
       the private registry.
 
-    * `[PRIVATE_REGISTRY_USER]` is the username that you use to access the
+    * `<private-registry-user>` is the username that you use to access the
       private container registry.
 
-    * `[PRIVATE_REGISTRY_PASSWORD]` is the password that you use to access
+    * `<private-registry-password>` is the password that you use to access
       the private container registry.
 
-      Example:
+    Example:
 
-        ```bash
-        kubectl create secret `container-registry` \
-          --docker-server=https://gcr.io/ \
-          --docker-email=my-account-email@address.com \
-          --docker-username=my-grc-username \
-          --docker-password=my-gcr-password
-        ```
+    ```bash
+    kubectl create secret `container-registry` \
+      --docker-server=https://gcr.io/ \
+      --docker-email=my-account-email@address.com \
+      --docker-username=my-grc-username \
+      --docker-password=my-gcr-password
+    ```
 
     !!! tip
         After you have created the `imagePullSecrets` object, you can view the secrets by running:
 
         ```bash
-        kubectl get secret [REGISTRY-CRED-SECRETS] --output=yaml
+        kubectl get secret <registry-credential-secrets> -o=yaml
         ```
 
 1. Add the `imagePullSecrets` to the `default` service account in the `default` namespace.

--- a/docs/developer/serving/deploying-from-private-registry.md
+++ b/docs/developer/serving/deploying-from-private-registry.md
@@ -1,0 +1,72 @@
+# Deploying images from a private container registry
+
+You can share access to private container images across multiple Services and Revisions by configuring your Knative cluster to deploy images from a private
+container registry.
+
+To configure using a private container registry, you must:
+
+1. Create a list of Kubernetes secrets ([`imagePullSecrets`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core)) by using your registry credentials.
+1. Add those `imagePullSecrets` to the default [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
+1. Deploy those configurations to your Knative cluster.
+
+## Prerequisites
+
+- You must have a Kubernetes cluster with [Knative Serving installed](../../install/).
+- You must have access to credentials for the private container registry where your container images are stored.
+
+## Procedure
+
+1. Create a `imagePullSecrets` that contains your credentials as a list of secrets:
+
+    ```bash
+    kubectl create secret docker-registry [REGISTRY-CRED-SECRETS] \
+      --docker-server=[PRIVATE_REGISTRY_SERVER_URL] \
+      --docker-email=[PRIVATE_REGISTRY_EMAIL] \
+      --docker-username=[PRIVATE_REGISTRY_USER] \
+      --docker-password=[PRIVATE_REGISTRY_PASSWORD]
+    ```
+
+    Where:
+
+    - `[REGISTRY-CRED-SECRETS]` is the name that you want to use for your secrets (the `imagePullSecrets` object). For example, `container-registry`.
+
+    - `[PRIVATE_REGISTRY_SERVER_URL]` is the URL of the private registry where your container images are stored. Examples include [Google Container Registry](https://gcr.io/) or [DockerHub](https://docker.io/).
+
+    * `[PRIVATE_REGISTRY_EMAIL]` is the email address that is associated with
+      the private registry.
+
+    * `[PRIVATE_REGISTRY_USER]` is the username that you use to access the
+      private container registry.
+
+    * `[PRIVATE_REGISTRY_PASSWORD]` is the password that you use to access
+      the private container registry.
+
+      Example:
+
+        ```bash
+        kubectl create secret `container-registry` \
+          --docker-server=https://gcr.io/ \
+          --docker-email=my-account-email@address.com \
+          --docker-username=my-grc-username \
+          --docker-password=my-gcr-password
+        ```
+
+    !!! tip
+        After you have created the `imagePullSecrets` object, you can view the secrets by running:
+
+        ```bash
+        kubectl get secret [REGISTRY-CRED-SECRETS] --output=yaml
+        ```
+
+1. Add the `imagePullSecrets` to the `default` service account in the `default` namespace.
+
+    !!! note
+        By default, the `default` service account in each of the [namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) of your Knative cluster are used by your Revisions, unless the [`serviceAccountName`](https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md#revision-2) is specified.
+
+    For example, if have you named your secrets `container-registry`, you can run the following command to modify the `default` service account, :
+
+    ```bash
+    kubectl patch serviceaccount default -p "{\"imagePullSecrets\": [{\"name\": \"container-registry\"}]}"
+    ```
+
+    New pods that are created in the `default` namespace now include your credentials and have access to your container images in the private registry.


### PR DESCRIPTION
Partial fix for https://github.com/knative/docs/issues/3935, related to https://github.com/knative/docs/issues/3710

## Proposed Changes

- Move and clean up private container registry docs
- Direct preview link: https://deploy-preview-3965--dev-knative.netlify.app/development/developer/serving/deploying-from-private-registry/