### PR TITLE
Remove reference to domainmapping yaml

### DIFF
--- a/docs/admin/install/serving/install-serving-with-yaml.md
+++ b/docs/admin/install/serving/install-serving-with-yaml.md
@@ -260,14 +260,3 @@ The tabs below expand to show instructions for installing each Serving extension
         kubectl apply -f {{ artifact(repo="serving",file="serving-nscert.yaml")}}
         ```
 
-
-=== "DomainMapping CRD"
-
-    The DomainMapping CRD allows a user to map a domain name that they own to a specific Knative Service.
-
-    * Apply the DomainMapping CRD by running the commands:
-
-        ```bash
-        kubectl apply -f {{ artifact(repo="serving",file="serving-domainmapping-crds.yaml")}}
-        kubectl apply -f {{ artifact(repo="serving",file="serving-domainmapping.yaml")}}
-        ```

--- a/docs/admin/install/serving/serving-installation-files.md
+++ b/docs/admin/install/serving/serving-installation-files.md
@@ -14,8 +14,6 @@ The table below describes the installation files included in Knative Serving:
 | serving-core.yaml | Required: Knative Serving core components. | serving-crds.yaml |
 | serving-crds.yaml | Required: Knative Serving core CRDs. | none |
 | serving-default-domain.yaml | Configures Knative Serving to use [http://sslip.io](http://sslip.io) as the default DNS suffix. | serving-core.yaml |
-| serving-domainmapping-crds.yaml | CRDs used by the Domain Mapping feature. | none |
-| serving-domainmapping.yaml | Components used by the Domain Mapping feature. | serving-domainmapping-crds.yaml |
 | serving-hpa.yaml | Components to autoscale Knative revisions through the Kubernetes Horizontal Pod Autoscaler. | serving-core.yaml |
   serving-nscert.yaml | Components to provision TLS wildcard certificates. | serving-core.yaml |
 | serving-post-install-jobs.yaml | Additional jobs after installing `serving-core.yaml`. Currently it is the same as `serving-storage-version-migration.yaml`. | serving-core.yaml |

--- a/docs/admin/install/uninstall.md
+++ b/docs/admin/install/uninstall.md
@@ -66,19 +66,6 @@ Uninstall any Serving extensions you have installed by following the relevant st
 
 
 
-=== "DomainMapping CRD"
-
-    To uninstall the `DomainMapping` components run:
-
-    ```bash
-    kubectl delete -f {{ artifact( repo="serving", file="serving-domainmapping.yaml") }}
-    kubectl delete -f {{ artifact( repo="serving", file="serving-domainmapping-crds.yaml") }}
-    ```
-
-
-
-
-
 ### Uninstalling a networking layer
 
 Follow the relevant procedure to uninstall the networking layer you installed:


### PR DESCRIPTION
The DomainMapping feature is now beta, and therefore built in to the
main yaml files. These links are therefore now 404s.

/assign @dprotaso @omerbensaadon 