### PR TITLE
Update knative-offerings.md

### DIFF
--- a/docs/admin/install/knative-offerings.md
+++ b/docs/admin/install/knative-offerings.md
@@ -8,6 +8,7 @@ vendors for what is or is not supported.
 
 Here is a list of commercial Knative products (alphabetically):
 
+- [Cloud Native Runtimes for VMware Tanzu](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/0.2/tanzu-cloud-native-runtimes-02/GUID-serverless-overview.html): A serverless application runtime for Kubernetes that is based on Knative, and runs on a single Kubernetes cluster
 - [Gardener](https://gardener.cloud/documentation/tutorials/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
 - [Google Cloud Run for Anthos](https://cloud.google.com/run/docs/gke/setup): Extend Google Kubernetes Engine with a flexible serverless development platform. With Cloud Run for Anthos, you get the operational flexibility of Kubernetes with the developer experience of serverless, allowing you to deploy and manage Knative-based services on your own cluster, and trigger them with events from Google, 3rd-party sources, and your own applications.
 - [Google Cloud Run](https://cloud.google.com/run/docs/setup): A fully-managed Knative-based serverless platform. With no Kubernetes cluster to manage, Cloud Run lets you go from container to production in seconds.


### PR DESCRIPTION
Add entry for VMware's Knative offering.
This was added previously in https://github.com/knative/docs/pull/3468/ and might have gotten lost due to the website migration.