### PR TITLE
[#3917] add instructions to upgrade kn

### DIFF
--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -48,3 +48,15 @@
 
         !!! note
             Running `kn` from a container image does not place the binary on a permanent path. This procedure must be repeated each time you want to use `kn`.
+
+??? bug "Having issues upgrading `kn`?"
+
+    If you are having issues upgrading using Homebrew, it may be due to a change to a `CLI` repository, where `master` branch was renamed to `main`. If so, run
+
+    ```
+    brew tap --repair
+    brew update
+    brew upgrade kn
+    ```
+
+    to resolve the issue.


### PR DESCRIPTION
For Homebrew users, they may run into issues upgrading due to a branch
rename from `master` to `main`.

Fixes #3917 

## Proposed Changes 
Add section with instructions for Homebrew users that have issues updating kn cli due to a git branch re-name.
