### PR TITLE
fixing broken links

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,5 +18,3 @@ into a single location:
          * [Procedure](docs/contributor/templates/template-procedure.md)
          * [Troubleshooting](docs/contributor/templates/template-troubleshooting.md)
          * [Blog](docs/contributor/templates/template-blog-entry.md)
-   * [Website help](https://knative.dev/docs/help/contributor/publishing)
-   * [Maintainer help](https://knative.dev/docs/help/maintainer/)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,5 +18,5 @@ into a single location:
          * [Procedure](docs/contributor/templates/template-procedure.md)
          * [Troubleshooting](docs/contributor/templates/template-troubleshooting.md)
          * [Blog](docs/contributor/templates/template-blog-entry.md)
-   * [Website help](https://knative.dev/help/contributor/publishing)
-   * [Maintainer help](https://knative.dev/help/maintainer/)
+   * [Website help](https://knative.dev/docs/help/contributor/publishing)
+   * [Maintainer help](https://knative.dev/docs/help/maintainer/)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,10 +9,10 @@ _build:
 All information about contributing to the Knative documentation has been moved
 into a single location:
 
-#### [Go to the How-to guides for Knative docs contributors](https://knative.dev/help/)
+#### [Go to the How-to guides for Knative docs contributors](https://knative.dev/docs/help/)
 
 **Quick links**:
-   * [Docs help](https://knative.dev/help/contributor/)
+   * [Docs help](https://knative.dev/docs/help/contributor/)
       * New content templates:
          * [Concept](docs/contributor/templates/template-concept.md)
          * [Procedure](docs/contributor/templates/template-procedure.md)

--- a/blog/README.md
+++ b/blog/README.md
@@ -1,4 +1,4 @@
 # README
 
 All information about contributing to the Knative documentation has been moved
-into a single location: [Knative contributor's guide](../docs/help/contributor/readme.md)
+into a single location: [Knative contributor's guide](../docs/help/contributor/README.md)

--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -85,6 +85,6 @@ The net-istio-controller deployment reconciles a cluster's ingress into an
 - For a deeper look at the services and deployments involved in Knative Serving,
   click
   [here](https://github.com/knative/specs/blob/main/specs/serving/overview.md).
-- For a high-level analysis of Serving, look at the [documentation here](./).
-- Check out the Knative Serving code samples [here](samples/) for more
+- For a high-level analysis of Serving, look at the [documentation here](./README.md).
+- Check out the Knative Serving code samples [here](./samples/README.md) for more
   hands-on tutorials.

--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -85,6 +85,6 @@ The net-istio-controller deployment reconciles a cluster's ingress into an
 - For a deeper look at the services and deployments involved in Knative Serving,
   click
   [here](https://github.com/knative/specs/blob/main/specs/serving/overview.md).
-- For a high-level analysis of Serving, look at the [documentation here](README.md).
-- Check out the Knative Serving code samples [here](samples/README.md) for more
+- For a high-level analysis of Serving, look at the [documentation here](./).
+- Check out the Knative Serving code samples [here](samples/) for more
   hands-on tutorials.

--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -85,6 +85,6 @@ The net-istio-controller deployment reconciles a cluster's ingress into an
 - For a deeper look at the services and deployments involved in Knative Serving,
   click
   [here](https://github.com/knative/specs/blob/main/specs/serving/overview.md).
-- For a high-level analysis of Serving, look at the [documentation here](./README.md).
-- Check out the Knative Serving code samples [here](./samples/README.md) for more
+- For a high-level analysis of Serving, look at the [documentation here](README.md).
+- Check out the Knative Serving code samples [here](samples/README.md) for more
   hands-on tutorials.


### PR DESCRIPTION
Fixes #4013 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fixes broken links on docs/serving/knative-kubernetes-services.md page
(note that the first link here was circular... I assume it was meant to point to the readme)
- Fixes broken links in `DEVELOPMENT.md`