### PR TITLE
Add "Third-Party Ingress Implementations" page

### DIFF
--- a/docs/admin/install/serving/ingress-implementations.md
+++ b/docs/admin/install/serving/ingress-implementations.md
@@ -1,7 +1,6 @@
 # Unofficial ingress implementations
 
-In addition to the Knative Ingress implementations in the ([install a networking layer](../install-serving-with-yaml/#install-a-networking-layer)) section,
-there are other Knative Ingress implementations.
+In addition to the Knative ingress implementations in the ([install a networking layer](../install-serving-with-yaml/#install-a-networking-layer)) section, there are other Knative ingress implementations.
 
 Here is the list of the ingress implementations (alphabetically):
 

--- a/docs/admin/install/serving/ingress-implementations.md
+++ b/docs/admin/install/serving/ingress-implementations.md
@@ -1,0 +1,11 @@
+# Unofficial Ingress Implementations
+
+In addition to the Knative Ingress implementations in the ([install a networking layer](../install-serving-with-yaml/#install-a-networking-layer)) section,
+there are other Knative Ingress implementations.
+
+Here is the list of the ingress implementations (alphabetically):
+
+- [Emissary-Ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary-Ingress is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on Envoy Proxy.
+- [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-kong-with-knative/): Kong is an open source API Gateway built for hybrid and multi-cloud environments.
+
+These implementations are not officially supported by Knative community at this moment, but the implementation will be added to the main guide once it is ready for general use.

--- a/docs/admin/install/serving/ingress-implementations.md
+++ b/docs/admin/install/serving/ingress-implementations.md
@@ -1,4 +1,4 @@
-# Unofficial Ingress Implementations
+# Unofficial ingress implementations
 
 In addition to the Knative Ingress implementations in the ([install a networking layer](../install-serving-with-yaml/#install-a-networking-layer)) section,
 there are other Knative Ingress implementations.

--- a/docs/admin/install/serving/ingress-implementations.md
+++ b/docs/admin/install/serving/ingress-implementations.md
@@ -4,7 +4,7 @@ In addition to the Knative ingress implementations in the ([install a networking
 
 Here is the list of the ingress implementations (alphabetically):
 
-- [Emissary-Ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary-Ingress is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on Envoy Proxy.
+- [Emissary ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary ingress is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes ingress built on Envoy Proxy.
 - [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-kong-with-knative/): Kong is an open source API Gateway built for hybrid and multi-cloud environments.
 
 These implementations are not officially supported by Knative community at this moment, but the implementation will be added to the main guide once it is ready for general use.

--- a/docs/admin/install/serving/knative-third-party-ingress.md
+++ b/docs/admin/install/serving/knative-third-party-ingress.md
@@ -1,0 +1,8 @@
+# Third-Party Ingress Implementations
+
+Knative Ingress ([a networking layer](install-serving-with-yaml/#install-a-networking-layer)) is also implemented by third-party projects.
+
+Here is a list of the third-Party ingress implementations (alphabetically):
+
+- [Emissary-Ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary-Ingress (formerly known as Ambassador API Gateway) is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on Envoy Proxy.
+- [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-kong-with-knative/): Kong is an open source API Gateway built for hybrid and multi-cloud environments.

--- a/docs/admin/install/serving/knative-third-party-ingress.md
+++ b/docs/admin/install/serving/knative-third-party-ingress.md
@@ -1,8 +1,0 @@
-# Third-Party Ingress Implementations
-
-Knative Ingress ([a networking layer](../install-serving-with-yaml/#install-a-networking-layer)) is also implemented by third-party projects.
-
-Here is a list of the third-Party ingress implementations (alphabetically):
-
-- [Emissary-Ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary-Ingress is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on Envoy Proxy.
-- [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-kong-with-knative/): Kong is an open source API Gateway built for hybrid and multi-cloud environments.

--- a/docs/admin/install/serving/knative-third-party-ingress.md
+++ b/docs/admin/install/serving/knative-third-party-ingress.md
@@ -1,8 +1,8 @@
 # Third-Party Ingress Implementations
 
-Knative Ingress ([a networking layer](install-serving-with-yaml/#install-a-networking-layer)) is also implemented by third-party projects.
+Knative Ingress ([a networking layer](../install-serving-with-yaml/#install-a-networking-layer)) is also implemented by third-party projects.
 
 Here is a list of the third-Party ingress implementations (alphabetically):
 
-- [Emissary-Ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary-Ingress (formerly known as Ambassador API Gateway) is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on Envoy Proxy.
+- [Emissary-Ingress (Ambassador API Gateway)](https://www.getambassador.io/docs/edge-stack/latest/howtos/knative/): Emissary-Ingress is an open-source Kubernetes-native API Gateway + Layer 7 load balancer + Kubernetes Ingress built on Envoy Proxy.
 - [Kong](https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/using-kong-with-knative/): Kong is an open source API Gateway built for hybrid and multi-cloud environments.

--- a/docs/install/serving/install-serving-with-yaml.md
+++ b/docs/install/serving/install-serving-with-yaml.md
@@ -168,6 +168,8 @@ Follow the procedure for the networking layer of your choice:
         !!! tip
             Save this to use in the following [Configure DNS](#configure-dns) section.
 
+You can also use other ingress implementations provdied by a third-party. See [Third-Party Ingress Implementations](./knative-third-party-ingress).
+
 ## Verify the installation
 
 !!! success

--- a/docs/install/serving/install-serving-with-yaml.md
+++ b/docs/install/serving/install-serving-with-yaml.md
@@ -169,7 +169,7 @@ Follow the procedure for the networking layer of your choice:
             Save this to use in the following [Configure DNS](#configure-dns) section.
 
 !!! info
-    You can also use other ingress implementations provdied by a third-party. See [Third-Party Ingress Implementations](../knative-third-party-ingress).
+    You can also use other ingress implementations provdied. See [Unofficial Ingress Implementations](../ingress-implementations).
 
 ## Verify the installation
 

--- a/docs/install/serving/install-serving-with-yaml.md
+++ b/docs/install/serving/install-serving-with-yaml.md
@@ -169,7 +169,7 @@ Follow the procedure for the networking layer of your choice:
             Save this to use in the following [Configure DNS](#configure-dns) section.
 
 !!! info
-    You can also use other ingress implementations provdied by a third-party. See [Third-Party Ingress Implementations](./knative-third-party-ingress).
+    You can also use other ingress implementations provdied by a third-party. See [Third-Party Ingress Implementations](../knative-third-party-ingress).
 
 ## Verify the installation
 

--- a/docs/install/serving/install-serving-with-yaml.md
+++ b/docs/install/serving/install-serving-with-yaml.md
@@ -169,7 +169,7 @@ Follow the procedure for the networking layer of your choice:
             Save this to use in the following [Configure DNS](#configure-dns) section.
 
 !!! info
-    You can also use other ingress implementations provdied. See [Unofficial Ingress Implementations](../ingress-implementations).
+    You can also use other ingress implementations provided. See [unofficial ingress implementations](../ingress-implementations).
 
 ## Verify the installation
 

--- a/docs/install/serving/install-serving-with-yaml.md
+++ b/docs/install/serving/install-serving-with-yaml.md
@@ -168,7 +168,8 @@ Follow the procedure for the networking layer of your choice:
         !!! tip
             Save this to use in the following [Configure DNS](#configure-dns) section.
 
-You can also use other ingress implementations provdied by a third-party. See [Third-Party Ingress Implementations](./knative-third-party-ingress).
+!!! info
+    You can also use other ingress implementations provdied by a third-party. See [Third-Party Ingress Implementations](./knative-third-party-ingress).
 
 ## Verify the installation
 


### PR DESCRIPTION
Today, Ingress implementations are listed in the docs[1] with
the installation steps.

The Ingress was added in the serving repo to run CI but that
was so hard for both Knative project and Ingress providers to maintain
as fixing/updating e2e tests are not so simple work.
So some implementations were dropped from the e2e tests as
well as from the docs.

Although I still think we don't need to maintain the e2e tests, we should
host the Knative Ingress implementations list in the docs site.

Hence, this patch adds the new "Third-Party Ingress Implementations" page.

[1] https://knative.dev/docs/admin/install/serving/install-serving-with-yaml/#install-a-networking-layer