### PR TITLE
Fix broken Gardener links

### DIFF
--- a/docs/admin/install/knative-offerings.md
+++ b/docs/admin/install/knative-offerings.md
@@ -9,7 +9,7 @@ vendors for what is or is not supported.
 Here is a list of commercial Knative products (alphabetically):
 
 - [Cloud Native Runtimes for VMware Tanzu](https://docs.vmware.com/en/Cloud-Native-Runtimes-for-VMware-Tanzu/0.2/tanzu-cloud-native-runtimes-02/GUID-serverless-overview.html): A serverless application runtime for Kubernetes that is based on Knative, and runs on a single Kubernetes cluster
-- [Gardener](https://gardener.cloud/documentation/tutorials/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
+- [Gardener](https://gardener.cloud/docs/tutorials/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
 - [Google Cloud Run for Anthos](https://cloud.google.com/run/docs/gke/setup): Extend Google Kubernetes Engine with a flexible serverless development platform. With Cloud Run for Anthos, you get the operational flexibility of Kubernetes with the developer experience of serverless, allowing you to deploy and manage Knative-based services on your own cluster, and trigger them with events from Google, 3rd-party sources, and your own applications.
 - [Google Cloud Run](https://cloud.google.com/run/docs/setup): A fully-managed Knative-based serverless platform. With no Kubernetes cluster to manage, Cloud Run lets you go from container to production in seconds.
 - [IBM Cloud Code Engine](https://cloud.ibm.com/codeengine): A fully-managed serverless platform that runs all your containerized workloads, including http-driven application, batch jobs or event-driven functions.

--- a/docs/knative-offerings.md
+++ b/docs/knative-offerings.md
@@ -15,7 +15,7 @@ vendors for what is or is not supported.
 
 Here is a list of commercial Knative products (alphabetically):
 
-- [Gardener](https://gardener.cloud/documentation/tutorials/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
+- [Gardener](https://gardener.cloud/docs/tutorials/knative-install/): Install Knative in Gardener's vanilla Kubernetes clusters to add an extra layer of serverless runtime.
 - [Google Cloud Run for Anthos](https://cloud.google.com/run/docs/gke/setup): Extend Google Kubernetes Engine with a flexible serverless development platform. With Cloud Run for Anthos, you get the operational flexibility of Kubernetes with the developer experience of serverless, allowing you to deploy and manage Knative-based services on your own cluster, and trigger them with events from Google, 3rd-party sources, and your own applications.
 - [Google Cloud Run](https://cloud.google.com/run/docs/setup): A fully-managed Knative-based serverless platform. With no Kubernetes cluster to manage, Cloud Run lets you go from container to production in seconds.
 - [IBM Cloud Code Engine](https://cloud.ibm.com/codeengine): A fully-managed serverless platform that runs all your containerized workloads, including http-driven application, batch jobs or event-driven functions.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
- [Concept](./docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](./docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps to perform a task as well as some context about the task.
- [Troubleshooting](./docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting 
topics list common errors and solutions.
- [Blog](./docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

Consult [Knative contributor's guide](./help/contributing) for all resources for contributing to
Knative documentation.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix two broken links which are pointing Gardener documentation.