### PR TITLE
Updating quickstart to use the plugin

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -3,7 +3,7 @@
 !!! warning
     Knative Quickstart Environments are for experimentation use only. For production installation, see our [Administrator's Guide](../admin/README.md)
 
-Before you can get started with a Knative Quickstart deployment you must install kind and the Kubernetes CLI.
+Before you can get started with a Knative Quickstart deployment you must install kind, the Kubernetes CLI, and the Knative CLI.
 
 ### Install Kind (Kubernetes in Docker)
 
@@ -13,17 +13,17 @@ You can use [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_bla
 
 The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank}, allows you to run commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.
 
-
-## Install the Knative "Quickstart" environment
-
-You can get started with a local deployment of Knative by using _Knative on Kind_ (`konk`):
-
---8<-- "quickstart-install.md"
-
-## Install the Knative CLI
+### Install the Knative CLI
 
 The Knative CLI (`kn`) provides a quick and easy interface for creating Knative resources, such as Knative Services and Event Sources, without the need to create or modify YAML files directly.
 
 `kn` also simplifies completion of otherwise complex procedures such as autoscaling and traffic splitting.
 
 --8<-- "install-kn.md"
+
+## Install the Knative "Quickstart" environment
+
+You can get started with a local deployment of Knative by using the Knative `quickstart` plugin.
+
+--8<-- "quickstart-install.md"
+

--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -7,9 +7,11 @@
         brew install knative/client/kn
         ```
 
+        Note: Quickstart requires `kn` version 0.25 or later. To upgrade an existing install to the latest version, run `brew upgrade kn`.
+
     === "Using a binary"
 
-        You can install `kn` by downloading the executable binary for your system and placing it in the system path.
+        You can install `kn` by downloading the executable binary for your system and placing it in the system path. Note that you will need `kn` version 0.25 or later.
 
         1. Download the binary for your system from the [`kn` release page](https://github.com/knative/client/releases){target=_blank}.
 

--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -1,7 +1,7 @@
 !!! todo "Installing the `kn` CLI"
 
     === "Using Homebrew"
-        For macOS, you can install `kn` by using [Homebrew](https://github.com/knative/homebrew-client){target=_blank}.
+        For macOS, you can install `kn` by using [Homebrew](https://brew.sh"){target=_blank}.
 
         ```
         brew install knative/client/kn

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -1,6 +1,6 @@
 !!! todo "Installing the `quickstart` plugin"
     === "Using Homebrew"
-        For macOS, you can install the `quickstart` plugin by using <a href="https://brew.sh" target="_blank">Homebrew</a>.
+        For macOS, you can install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}.
             ```
             brew install knative-sandbox/kn-plugins/quickstart
             ```
@@ -8,7 +8,7 @@
     === "Using a binary"
          You can install the `quickstart` plugin by downloading the executable binary for your system and placing it on your `PATH` (for example, in `/usr/local/bin`).
 
-         A link to the latest stable binary release is available on the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
+         A link to the latest stable binary release is available on the [`quickstart` release page](https://github.com/knative-sandbox/kn-plugin-quickstart/releases){target=_blank}.
 
     === "Using Go"
         1. Check out the `kn-plugin-quickstart` repository:

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -3,7 +3,6 @@
         For macOS, you can install the `quickstart` plugin by using <a href="https://brew.sh" target="_blank">Homebrew</a>.
             ```
             brew install knative-sandbox/kn-plugins/quickstart
-            mkdir -p ~/.config/kn/plugins && cp /usr/local/bin/kn-quickstart ~/.config/kn/plugins
             ```
 
     === "Using a binary"

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -5,10 +5,10 @@
             brew install knative-sandbox/kn-plugins/quickstart
             mkdir -p ~/.config/kn/plugins && cp /usr/local/bin/kn-quickstart ~/.config/kn/plugins
             ```
-        
+
     === "Using a binary"
-         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it in the `~/.config/kn/plugins` directory. 
-         
+         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it in the `~/.config/kn/plugins` directory.
+
          A link to the latest stable binary release is available on the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
 
     === "Using Go"

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -1,6 +1,6 @@
 !!! todo "Installing the `quickstart` plugin"
     === "Using Homebrew"
-        For macOS, you can install the `quickstart` plugin by using <a href="https://github.com/knative/homebrew-client">Homebrew</a>.
+        For macOS, you can install the `quickstart` plugin by using <a href="https://brew.sh" target="_blank">Homebrew</a>.
             ```
             brew install knative-sandbox/kn-plugins/quickstart
             mkdir -p ~/.config/kn/plugins && cp /usr/local/bin/kn-quickstart ~/.config/kn/plugins

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -24,11 +24,10 @@
               hack/build.sh
               ```
 
-        1. Move the executable binary file to the `kn` plugins directory:
+        1. Move the executable binary file to a directory on your `PATH`:
 
              ```
-             mkdir -p ~/.config/kn/plugins
-             mv kn-quickstart ~/.config/kn/plugins
+             mv kn-quickstart /usr/local/bin
              ```
 
          1. Verify that the plugin is working, for example:

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -1,22 +1,74 @@
+!!! todo "Installing the `quickstart` plugin"
+    === "Using a binary"
+         You can install the `quickstart` plugin by:
+    
+         1. Download the binary for your system from the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
+    
+         1. Rename the binary, make it executable, and rename it to `kn-quickstart`:
+    
+             ```
+             mv kn-quickstart-darwin-amd64 kn-quickstart
+             chmod +x kn-quickstart
+             ```
+    
+            (the original name will depend on your system architecture, i.e. `kn-quickstart-darwin-amd64`, `kn-quickstart-linux-amd64`, etc.)
+    
+         1. Move the executable binary file to the `kn` plugins directory:
+    
+             ```
+             mkdir -p ~/.config/kn/plugins
+             mv kn-quickstart ~/.config/kn/plugins
+             ```
+       
+         1. Verify that the plugin is working, for example:
+    
+             ```
+             kn quickstart --help
+             ```
+        
+    === "Using Go"
+        1. Check out the `kn-plugin-quickstart` repository:
 
+              ```
+              git clone https://github.com/knative-sandbox/kn-plugin-quickstart.git
+              cd kn-plugin-quickstart/
+              ```
 
-`konk` is a shell script that completes the following functions:
+        1. Build an executable binary:
+
+              ```
+              hack/build.sh
+              ```
+        1. Move the executable binary file to the `kn` plugins directory:
+    
+             ```
+             mkdir -p ~/.config/kn/plugins
+             mv kn-quickstart ~/.config/kn/plugins
+             ```
+       
+         1. Verify that the plugin is working, for example:
+    
+             ```
+             kn quickstart --help
+             ```
+      
+The `quickstart` plugin completes the following functions:
 
 1. **Checks if you have [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} installed,** and creates a cluster called `knative`.
 1. **Installs Knative Serving with Kourier** as the default networking layer, and nip.io as the DNS.
 1. **Installs Knative Eventing** and creates an in-memory Broker and Channel implementation.
 
-!!! todo "Install Knative and Kubernetes on a local Docker Daemon using `konk`"
+!!! todo "Install Knative and Kubernetes on a local Docker Daemon using `kn quickstart`"
     ```bash
-    curl -sL install.konk.dev | bash
+    kn quickstart kind
     ```
 
 ??? bug "Having issues with Kind?"
-    We've found that some users (specifically Linux) may have trouble with Docker and, subsequently, Kind. Though this tutorial assumes you have KonK installed, you can easily follow along with a different installation.
+    We've found that some users (specifically Linux) may have trouble with Docker and, subsequently, Kind. Though this tutorial assumes you have Kind installed, you can easily follow along with a different installation.
 
     We have provide an alternative Quickstart on `minikube` here: [https://github.com/csantanapr/knative-minikube](https://github.com/csantanapr/knative-minikube){_target="_blank"}
 
-Installing `konk` may take a few minutes. After the script is finished, check to make sure you have a Cluster called `knative`
+Installing may take a few minutes. After the plugin is finished, check to make sure you have a Cluster called `knative`
 !!! success "Verify Installation"
     ```bash
     kind get clusters

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -6,7 +6,7 @@
             ```
 
     === "Using a binary"
-         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it in the `~/.config/kn/plugins` directory.
+         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it on your `PATH` (for example, in `/usr/local/bin`).
 
          A link to the latest stable binary release is available on the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
 

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -1,31 +1,31 @@
 !!! todo "Installing the `quickstart` plugin"
     === "Using a binary"
          You can install the `quickstart` plugin by:
-    
+
          1. Download the binary for your system from the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
-    
+
          1. Rename the binary, make it executable, and rename it to `kn-quickstart`:
-    
+
              ```
              mv kn-quickstart-darwin-amd64 kn-quickstart
              chmod +x kn-quickstart
              ```
-    
+
             (the original name will depend on your system architecture, i.e. `kn-quickstart-darwin-amd64`, `kn-quickstart-linux-amd64`, etc.)
-    
+
          1. Move the executable binary file to the `kn` plugins directory:
-    
+
              ```
              mkdir -p ~/.config/kn/plugins
              mv kn-quickstart ~/.config/kn/plugins
              ```
-       
+
          1. Verify that the plugin is working, for example:
-    
+
              ```
              kn quickstart --help
              ```
-        
+
     === "Using Go"
         1. Check out the `kn-plugin-quickstart` repository:
 
@@ -39,19 +39,20 @@
               ```
               hack/build.sh
               ```
+
         1. Move the executable binary file to the `kn` plugins directory:
-    
+
              ```
              mkdir -p ~/.config/kn/plugins
              mv kn-quickstart ~/.config/kn/plugins
              ```
-       
+
          1. Verify that the plugin is working, for example:
-    
+
              ```
              kn quickstart --help
              ```
-      
+
 The `quickstart` plugin completes the following functions:
 
 1. **Checks if you have [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} installed,** and creates a cluster called `knative`.

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -1,30 +1,15 @@
 !!! todo "Installing the `quickstart` plugin"
+    === "Using Homebrew"
+        For macOS, you can install the `quickstart` plugin by using <a href="https://github.com/knative/homebrew-client">Homebrew</a>.
+            ```
+            brew install knative-sandbox/kn-plugins/quickstart
+            mkdir -p ~/.config/kn/plugins && cp /usr/local/bin/kn-quickstart ~/.config/kn/plugins
+            ```
+        
     === "Using a binary"
-         You can install the `quickstart` plugin by:
-
-         1. Download the binary for your system from the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
-
-         1. Rename the binary, make it executable, and rename it to `kn-quickstart`:
-
-             ```
-             mv kn-quickstart-darwin-amd64 kn-quickstart
-             chmod +x kn-quickstart
-             ```
-
-            (the original name will depend on your system architecture, i.e. `kn-quickstart-darwin-amd64`, `kn-quickstart-linux-amd64`, etc.)
-
-         1. Move the executable binary file to the `kn` plugins directory:
-
-             ```
-             mkdir -p ~/.config/kn/plugins
-             mv kn-quickstart ~/.config/kn/plugins
-             ```
-
-         1. Verify that the plugin is working, for example:
-
-             ```
-             kn quickstart --help
-             ```
+         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it in the `~/.config/kn/plugins` directory. 
+         
+         A link to the latest stable binary release is available on the <a href="https://github.com/knative-sandbox/kn-plugin-quickstart/releases"> `quickstart` release page</a>.
 
     === "Using Go"
         1. Check out the `kn-plugin-quickstart` repository:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
- [Concept](./docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](./docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps to perform a task as well as some context about the task.
- [Troubleshooting](./docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting 
topics list common errors and solutions.
- [Blog](./docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

Consult [Knative contributor's guide](./help/contributing) for all resources for contributing to
Knative documentation.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Fixes #4040 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updates the quickstart guide to make use of the `kn-quickstart` plugin instead of the KonK script.

/assign @csantanapr @omerbensaadon 
