### PR TITLE
Update strimzi-kafka-operator version

### DIFF
--- a/docs/eventing/samples/kafka/README.md
+++ b/docs/eventing/samples/kafka/README.md
@@ -30,9 +30,7 @@ is to install it by using [Strimzi](https://strimzi.io).
    ```
 1. Install the Strimzi operator, like:
    ```bash
-   curl -L "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-cluster-operator-0.16.2.yaml" \
-     | sed 's/namespace: .*/namespace: kafka/' \
-     | kubectl -n kafka apply -f -
+   kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
    ```
 1. Describe the size of your Apache Kafka installation in `kafka.yaml`, like:
    ```yaml
@@ -42,16 +40,23 @@ is to install it by using [Strimzi](https://strimzi.io).
      name: my-cluster
    spec:
      kafka:
-       version: 2.4.0
+       version: 2.8.0
        replicas: 1
        listeners:
-         plain: {}
-         tls: {}
+         - name: plain
+           port: 9092
+           type: internal
+           tls: false
+         - name: tls
+           port: 9093
+           type: internal
+           tls: true
        config:
          offsets.topic.replication.factor: 1
          transaction.state.log.replication.factor: 1
          transaction.state.log.min.isr: 1
-         log.message.format.version: "2.4"
+         log.message.format.version: "2.8"
+         inter.broker.protocol.version: "2.8"
        storage:
          type: ephemeral
      zookeeper:

--- a/docs/eventing/samples/kafka/kafka.yaml
+++ b/docs/eventing/samples/kafka/kafka.yaml
@@ -4,16 +4,23 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 2.4.0
+    version: 2.8.0
     replicas: 1
     listeners:
-      plain: {}
-      tls: {}
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
       transaction.state.log.min.isr: 1
-      log.message.format.version: "2.4"
+      log.message.format.version: "2.8"
+      inter.broker.protocol.version: "2.8"
     storage:
       type: ephemeral
   zookeeper:


### PR DESCRIPTION

<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps to perform a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting 
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

Consult [Knative contributor's guide](help/contributing) for all resources for contributing to
Knative documentation.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Fixes: https://github.com/knative/docs/issues/4058 

 Update kafka version to `2.8.0`, because strimzi(0.24.0) only suport kafka version >=2.7.0 ,see https://strimzi.io/downloads/

## Proposed Changes <!-- Describe the changes the PR makes. -->

- 
-
-
