### PR TITLE
set namespace to default before the installation verification

### DIFF
--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -26,7 +26,7 @@ kubectl apply -f {{artifact(org="knative",repo="operator",file="operator.yaml" )
     kubectl config set-context --current --namespace=default
     ```
 
-1. Check the operator deployment by running the command:
+1. Check the operator deployment status by running the command:
 
     ```
     kubectl get deployment knative-operator

--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -23,7 +23,7 @@ kubectl apply -f {{artifact(org="knative",repo="operator",file="operator.yaml" )
 1. Because the operator is installed to the `default` namespace, ensure you set the current namespace to `default` by running the command:
 
     ```
-    kubectl config set-context --current --namespace=default 
+    kubectl config set-context --current --namespace=default
     ```
 
 1. Check the operator deployment by running the command:

--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -26,10 +26,11 @@ kubectl apply -f {{artifact(org="knative",repo="operator",file="operator.yaml" )
     kubectl config set-context --current --namespace=default 
     ```
 
-Check the operator deployment:
-```
-kubectl get deployment knative-operator
-```
+1. Check the operator deployment by running the command:
+
+    ```
+    kubectl get deployment knative-operator
+    ```
 
 If the operator is installed correctly, the deployment shows a `Ready` status:
 

--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -21,10 +21,11 @@ kubectl apply -f {{artifact(org="knative",repo="operator",file="operator.yaml" )
 
 Verify your installation:
 
-Be sure to set the current namespace to the `default` as the operator is installed to `default` namespace:
-```
-kubectl config set-context --current --namespace=default 
-```
+1. Because the operator is installed to the `default` namespace, ensure you set the current namespace to `default` by running the command:
+
+    ```
+    kubectl config set-context --current --namespace=default 
+    ```
 
 Check the operator deployment:
 ```

--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -21,6 +21,12 @@ kubectl apply -f {{artifact(org="knative",repo="operator",file="operator.yaml" )
 
 Verify your installation:
 
+Be sure to set the current namespace to the `default` as the operator is installed to `default` namespace:
+```
+kubectl config set-context --current --namespace=default 
+```
+
+Check the operator deployment:
 ```
 kubectl get deployment knative-operator
 ```

--- a/docs/admin/install/knative-with-operators.md
+++ b/docs/admin/install/knative-with-operators.md
@@ -19,7 +19,6 @@ kubectl apply -f {{artifact(org="knative",repo="operator",file="operator.yaml" )
 
 ## Verify your installation
 
-Verify your installation:
 
 1. Because the operator is installed to the `default` namespace, ensure you set the current namespace to `default` by running the command:
 


### PR DESCRIPTION
## Description of the problem this PR solves

In the  "knative-with-operators" installation documents,  the knative operator is installed to the default namespace.
but this was not mentioned in the "verifiy the installation" section.
 
## Proposed Changes <!-- Describe the changes the PR makes. -->
 
- add a step to make sure the user switches to the default namespace before the installation check.

