### PR TITLE
Updating knative client connection doc

### DIFF
--- a/docs/client/README.md
+++ b/docs/client/README.md
@@ -32,6 +32,10 @@ After you have installed `kubectl` or `kn`, these tools will search for the `kub
 
 A `kubeconfig` file is usually automatically created when you create a Kubernetes cluster.
 
+You can also specify the configuration by setting the environment variable `$KUBECONFIG` that points to the config file.
+
+`kn` has the `--config` option which can also be used for specifying a config file like `--config path/to/config`.
+
 For more information about `kubeconfig` files, see <a href="https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/" target="_blank">Organizing Cluster Access Using kubeconfig Files</a>.
 
 ### Using kubeconfig files with your platform

--- a/docs/client/README.md
+++ b/docs/client/README.md
@@ -32,9 +32,11 @@ After you have installed `kubectl` or `kn`, these tools will search for the `kub
 
 A `kubeconfig` file is usually automatically created when you create a Kubernetes cluster.
 
-You can also specify the configuration by setting the environment variable `$KUBECONFIG` that points to the config file.
+You can also specify a config file in the following ways:
 
-`kn` has the `--config` option which can also be used for specifying a config file like `--config path/to/config`.
+- Setting the environment variable `$KUBECONFIG`, and point it to the kubeconfig file.
+
+- Using the `kn` CLI `--config` option, for example, `kn --config path/to/config service list`. The default config is at `~/.config/kn/config.yaml`.
 
 For more information about `kubeconfig` files, see <a href="https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/" target="_blank">Organizing Cluster Access Using kubeconfig Files</a>.
 

--- a/docs/client/README.md
+++ b/docs/client/README.md
@@ -36,7 +36,7 @@ You can also specify a config file in the following ways:
 
 - Setting the environment variable `$KUBECONFIG`, and point it to the kubeconfig file.
 
-- Using the `kn` CLI `--config` option, for example, `kn --config path/to/config service list`. The default config is at `~/.config/kn/config.yaml`.
+- Using the `kn` CLI `--config` option, for example, `kn service list --config path/to/config.yaml`. The default config is at `~/.config/kn/config.yaml`.
 
 For more information about `kubeconfig` files, see <a href="https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/" target="_blank">Organizing Cluster Access Using kubeconfig Files</a>.
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps to perform a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting 
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

Consult [Knative contributor's guide](help/contributing) for all resources for contributing to
Knative documentation.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Fixes: [#1251](https://github.com/knative/client/issues/1251)

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adding information about `KUBECONFIG` env variable
- Adding information about `--config` option in `kn`
