### PR TITLE
Add docs about the new priority class name feature flag

### DIFF
--- a/docs/serving/feature-flags.md
+++ b/docs/serving/feature-flags.md
@@ -238,6 +238,23 @@ spec:
                   fieldPath: spec.nodeName
 ```
 
+## Kubernetes Priority Class Name
+
+- **Type**: extension
+- **ConfigMap key:** `kubernetes.podspec-priorityclassname`
+
+This flag controls whether [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#pod-priority) can be specified.
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+...
+spec:
+  template:
+    spec:
+      priorityClassName: high-priority
+```
+
 ## Kubernetes Dry Run
 
 * **Type**: extension


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps to perform a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting 
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

Consult [Knative contributor's guide](help/contributing) for all resources for contributing to
Knative documentation.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

This adds the doc for https://github.com/knative/serving/issues/3587 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add docs about the new kubernetes.podspec-priorityclassname feature flag for enabling priorityClassName in podSpec

