### PR TITLE
Updates Broken Link in Event Registry Documentation

### DIFF
--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -283,7 +283,8 @@ the next topic: How do we actually populate the registry in the first place?
 
 ## Next steps
 
-1. [Installing Knative](../../getting-started/install-knative-quickstart/).
+1. [Installing Knative](../../docs/admin/install/README.md).
+
 1. [Knative code samples](../samples/) is a useful resource to better understand
    some of the Event Sources (remember to point them to a Broker if you want
    automatic registration of EventTypes in the registry).

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -283,7 +283,7 @@ the next topic: How do we actually populate the registry in the first place?
 
 ## Next steps
 
-1. [Installing Knative](../../docs/admin/install/README.md).
+1. [Installing Knative](../../admin/install/).
 
 1. [Knative code samples](../samples/) is a useful resource to better understand
    some of the Event Sources (remember to point them to a Broker if you want


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch.

If the change should also be in the most recent release, add the
corresponding "cherrypick-0.X" label; for example, "cherrypick-0.12", to the
original PR. Best practice is to open a PR for the cherry-pick yourself after
your original PR has been merged into the main branch. Once the cherry-pick PR
has merged, remove the cherry-pick label from the original PR.

Use one of the new content templates:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps to perform a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting 
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

Consult [Knative contributor's guide](help/contributing) for all resources for contributing to
Knative documentation.

Learn more about contributing to the Knative Docs:
https://github.com/knative/docs
 -->

Fixes #4092 

## Proposed Changes <!-- Describe the changes the PR makes. -->
- Fixes a broken link in the Event Registry documentation pointing to the installation of Knative. 
