### PR TITLE
Fixed case of cloudDNS

### DIFF
--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -76,7 +76,7 @@ and which DNS provider validates those requests.
               name: letsencrypt-dns-issuer
             solvers:
             - dns01:
-                clouddns:
+                cloudDNS:
                   # Set this to your GCP project-id
                   project: $PROJECT_ID
                   # Set this to the secret that we publish our service account key


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->
- Fixes case of cloudDNS.  Refer this example yaml from cert-manager documentation: https://cert-manager.io/docs/configuration/acme/dns01/google/#create-an-issuer-that-uses-clouddns