### PR TITLE
Update version warning banner for new release

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -70,6 +70,11 @@
 }
 .md-announce {
   background: #fff5b5;
+  background: repeating-linear-gradient(-50deg, #ffe8b5, #ffe8b5 80px, #fff5b5 80px, #fff5b5 160px);
+  border-bottom: 2px solid #f93;
+}
+.md-announce .versionwarning h1 {
+  font-weight: bold;
 }
 .md-announce .versionwarning p {
   color: black;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -71,7 +71,6 @@
 .md-announce {
   background: #fff5b5;
   background: repeating-linear-gradient(-50deg, #ffe8b5, #ffe8b5 80px, #fff5b5 80px, #fff5b5 160px);
-  border-bottom: 2px solid #f93;
 }
 .md-announce .versionwarning h1 {
   font-weight: bold;

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -7,15 +7,12 @@
 {% block announce %}
 {% if config.extra.version_warning %}
 <div class="versionwarning" style="margin: .6rem auto; padding: 0 .8rem">
-  <h1 style="color: #ffcc00">You are viewing documentation for Knative version: {{ config.extra.knative_version }}</h1>
+  <h1>⚠ You are viewing an archived snapshot of the documentation for Knative version: {{ config.extra.knative_version }}</h1>
   <p>
-  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The version you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="{{ base_url }}/../docs/">the latest version</a>.
+  Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The documentation you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="{{ base_url }}/../docs/">the latest version</a>.
   </p>
 </div>
 {% endif %}
-<div class="versionwarning" style="display: flex; justify-content: center;">
-  <p>👋 Welcome to the new Knative.dev! Pardon our progress, if you find any issues with this site, please submit them <a target="_blank" href="https://github.com/knative/docs/issues/new/choose">here</a>!</p>
-</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
We've been live for a full release now with the new site. Time to take the warnings about being new away!

Also fixed up the colours and text for the warning shown on old docs versions, and added an emoji because emojis are cool.

(Do let me know if you hate the diagonal stripes, I think they look good and emphasise the warning, but this is the sort of things where opinions differ in which case I'll happily drop them!)

Fixes #4150.

/assign @omerbensaadon @csantanapr 