### PR TITLE
Fix inaccurate description of `default-br-config`

### DIFF
--- a/docs/admin/eventing/broker-configuration.md
+++ b/docs/admin/eventing/broker-configuration.md
@@ -13,7 +13,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Channels that do not specify CRD implementations.
+  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -56,7 +56,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Channels that do not specify CRD implementations.
+  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -85,7 +85,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Channels that do not specify CRD implementations.
+  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -169,7 +169,7 @@ the backing Channel for the Broker class:
     ```
 
 ### Configuring the default BrokerClass for the cluster
-​
+
 You can configure the `clusterDefault` Broker class so that any Broker created in the cluster that does not have a `BrokerClass` annotation uses this default class.
 
 #### Example
@@ -183,18 +183,18 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Channels that do not specify CRD implementations.
+  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
 ```
-​
+
 ### Configuring the default BrokerClass for namespaces
-​
+
 You can modify the default Broker class for one or more namespaces.
 
 For example, if you want to use a `KafkaBroker` class for all other Brokers created on the cluster, but you want to use the `MTChannelBasedBroker` class for Brokers created in `namespace-1` and `namespace-2`, you would use the following ConfigMap settings:
-​
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -204,7 +204,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Channels that do not specify CRD implementations.
+  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: KafkaBroker

--- a/docs/admin/eventing/broker-configuration.md
+++ b/docs/admin/eventing/broker-configuration.md
@@ -13,7 +13,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
+  # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -56,7 +56,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
+  # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -85,7 +85,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
+  # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -183,7 +183,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
+  # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: MTChannelBasedBroker
@@ -204,7 +204,7 @@ metadata:
   labels:
     eventing.knative.dev/release: devel
 data:
-  # Configuration for defaulting Brokers that do not specify a spec.config or Broker class.
+  # Configures the default for any Broker that does not specify a spec.config or Broker class.
   default-br-config: |
     clusterDefault:
       brokerClass: KafkaBroker


### PR DESCRIPTION
## Proposed Changes

- Reflect the changes from https://github.com/knative/eventing/pull/5703 and https://github.com/knative/eventing/pull/5713 to the documentation examples.
    (Context: it appears that this comment was copied from somewhere else, and the docs happily copied it although it didn't make sense)

This is a second take on #4179, but this time I refrained from trying to clarify the sentences I found confusing and only focused on copying the changes from https://github.com/knative/eventing/pull/5703.

/assign snneji
/assign abrennan89