### PR TITLE
Fix exposed links

### DIFF
--- a/docs/developer/eventing/sinks/README.md
+++ b/docs/developer/eventing/sinks/README.md
@@ -136,3 +136,11 @@ The `svc` in `http://event-display.svc.cluster.local` determines that the sink i
 | -- | -- | -- |
 | [KafkaSink](kafka-sink.md)  | Knative  | Send events to a Kafka topic |
 | [RedisSink](https://github.com/knative-sandbox/eventing-redis/tree/main/sink)  | Knative  | Send events to a Redis Stream |
+
+
+[kubernetes-kinds]:
+  https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+[kubernetes-names]:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+[kubernetes-namespaces]:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/


### PR DESCRIPTION
Fixes the following exposed links in the table: 
<img width="257" alt="Screen Shot 2021-09-06 at 16 04 24" src="https://user-images.githubusercontent.com/33425661/132236508-2ef78df9-1d42-4c9d-b8f4-964506c237b5.png">
