### PR TITLE
Typo in quickstart markdown link

### DIFF
--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -1,7 +1,7 @@
 !!! todo "Installing the `kn` CLI"
 
     === "Using Homebrew"
-        For macOS, you can install `kn` by using [Homebrew](https://brew.sh"){target=_blank}.
+        For macOS, you can install `kn` by using [Homebrew](https://brew.sh){target=_blank}.
 
         ```
         brew install knative/client/kn


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fixes typo in homebrew link in install-kn.md snippet 
