### PR TITLE
Update otel-collector-config configmap

### DIFF
--- a/docs/admin/collecting-metrics/collector.yaml
+++ b/docs/admin/collecting-metrics/collector.yaml
@@ -13,12 +13,12 @@ data:
       logging:
       prometheus:
         endpoint: "0.0.0.0:8889"
-
-    service:
-      extensions:
+    extensions:
         health_check:
         pprof:
-        zpages:
+        zpages
+    service:
+      extensions: [health_check, pprof, zpages]
       pipelines:
         metrics:
           receivers: [opencensus]


### PR DESCRIPTION
The otel-collector-config configmap referenced in
https://knative.dev/docs/admin/collecting-metrics/#set-up-the-collector
has incorrect configuration which leads to a config loading issue causing
the otel-collector to go into a crashloop. This PR updates the config map
as per https://opentelemetry.io/docs/collector/configuration/

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->