### PR TITLE
Example Updates in `/developer/eventing/sources/sinkbinding/getting-started.md`

### DIFF
--- a/docs/developer/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/developer/eventing/sources/sinkbinding/getting-started.md
@@ -154,7 +154,7 @@ any extra overrides given by `CE_OVERRIDES`.
               restartPolicy: Never
               containers:
                 - name: single-heartbeat
-                  image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/heartbeats
+                  image: gcr.io/knative-nightly/knative.dev/eventing/cmd/heartbeats:latest
                   args:
                   - --period=1
                   env:

--- a/docs/developer/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/developer/eventing/sources/sinkbinding/getting-started.md
@@ -186,11 +186,10 @@ Create a `SinkBinding` object that directs events from your subject to the sink.
     Create a `SinkBinding` object by running:
 
     ```bash
-    kn source binding create <name> \
-      --namespace <namespace> \
-      --subject "<subject>" \
-      --sink <sink> \
-      --ce-override "<cloudevent-overrides>"
+    kn source binding create bind-heartbeat \
+     --subject "Job:batch/v1:app=heartbeat-cron" \
+     --sink event-display \
+     --ce-override "sink=bound"
     ```
     Where:
 

--- a/docs/developer/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/developer/eventing/sources/sinkbinding/getting-started.md
@@ -208,11 +208,11 @@ Create a `SinkBinding` object that directs events from your subject to the sink.
 
     For example:
     ```bash
-    $ kn source binding create bind-heartbeat \
-      --namespace sinkbinding-example \
-      --subject "Job:batch/v1:app=heartbeat-cron" \
-      --sink http://event-display.svc.cluster.local \
-      --ce-override "sink=bound"
+    $ kn source binding create <name> \
+      --namespace <namespace> \
+      --subject "<subject>" \
+      --sink <sink> \
+      --ce-override "<cloudevent-overrides>"
     ```
 
 === "YAML"

--- a/docs/developer/eventing/sources/sinkbinding/getting-started.md
+++ b/docs/developer/eventing/sources/sinkbinding/getting-started.md
@@ -137,7 +137,7 @@ any extra overrides given by `CE_OVERRIDES`.
 1. Create a YAML file for the CronJob using the following example:
 
     ```yaml
-    apiVersion: batch/v1beta1
+    apiVersion: batch/v1
     kind: CronJob
     metadata:
       name: heartbeat-cron


### PR DESCRIPTION
Closes part of issue https://github.com/knative/docs/issues/4178

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updates the example YAML API version in `/developer/eventing/sources/sinkbinding/getting-started.md` moving the batch API from `v1beta1` to `v1`
