### PR TITLE
Updating links to blog docs to mkdocs branch

### DIFF
--- a/docs/help/contributor/creating-blog-posts.md
+++ b/docs/help/contributor/creating-blog-posts.md
@@ -21,10 +21,10 @@ Anyone can write a blog post and submit it for review. Commercial content is not
 To submit a blog post:
 
 1. [Sign the Contributor License Agreements](https://github.com/knative/community/blob/main/CONTRIBUTING.md#contributor-license-agreements) if you have not yet done so.
-1. Familiarize yourself with the Markdown format for existing blog posts in the [docs repository](https://github.com/knative/docs/tree/main/blog). Blog posts are categorized into different directories. You can explore the directories to find examples.
+1. Familiarize yourself with the Markdown format for existing blog posts in the [docs repository](https://github.com/knative/docs/tree/mkdocs/blog). Blog posts are categorized into different directories. You can explore the directories to find examples.
 1. Write your blog post in a text editor of your choice.
 1. (Optional) If you need help with markdown, check out [StakEdit](https://stackedit.io/app#) or read [GitHub's formatting syntax](https://help.github.com/en/github/writing-on-github/basic-writing-and-formatting-syntax) for more information.
-1. Choose a directory in the [docs repository](https://github.com/knative/docs/tree/main/blog), and click **Create new file**.
+1. Choose a directory in the [docs repository](https://github.com/knative/docs/tree/mkdocs/blog), and click **Create new file**.
 1. Paste your content into the editor and save it. Name the file in the following way: *[BLOG] Your proposed title* , but don’t put the date in the file name. The blog reviewers will work with you on the final file name, and the date on which the blog will be published.
 1. When you save the file, GitHub will walk you through the pull request (PR) process.
 1. A reviewer is assigned to all pull requests automatically. The reviewer checks your submission, and works with you on feedback and final details. When the pull request is approved, the blog will be scheduled for publication.


### PR DESCRIPTION
There's a couple of links on the "Creating Blog Posts" doc that still point to the `main` branch. This PR updates those links to point to the `mkdocs` branch.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updating links to blog docs to mkdocs branch
-
-
