### PR TITLE
Enhance DLQ CloudEvents with destination

### DIFF
--- a/docs/developer/eventing/event-delivery.md
+++ b/docs/developer/eventing/event-delivery.md
@@ -82,6 +82,17 @@ Failed events may, depending on the specific Channel implementation in use, be
 enhanced with extension attributes prior to forwarding to the`deadLetterSink`.
 These extension attributes are as follows:
 
+- **knativeerrordest**
+    - **Type:** String
+    - **Description:** The original destination URL to which the failed event
+      was sent.  This could be either a `delivery` or `reply` URL based on
+      which operation encountered the failed event.
+    - **Constraints:** Always present because every HTTP Request has a
+      destination URL.
+    - **Examples:**
+        - "http://myservice.mynamespace.svc.cluster.local:3000/mypath"
+        - ...any `deadLetterSink` URL...
+
 - **knativeerrorcode**
     - **Type:** Int
     - **Description:** The HTTP Response **StatusCode** from the final event


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

These changes are related to Eventing [Issue #5726](https://github.com/knative/eventing/issues/5726) ([PR #5727](https://github.com/knative/eventing/pull/5727)).

Simply attempting to add a new CloudEvent extension attribute to Dead Letter Sink events capturing the original destination URL.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Enhancing the current documentation by describing the new `knativeerrordest` extension attribute in the same manner as existing attributes.


Holding until the actual Eventing PR is merged ; )
/hold