### PR TITLE
We haven't required Istio for 2 1/2 years

### DIFF
--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -1,6 +1,6 @@
 # Knative Serving
 
-Knative Serving builds on Kubernetes and Istio to support deploying and serving
+Knative Serving builds on Kubernetes to support deploying and serving
 of serverless applications and functions. Serving is easy to get started with
 and scales to support advanced scenarios.
 


### PR DESCRIPTION
Updates #63

## Proposed Changes <!-- Describe the changes the PR makes. -->

- For the last two and half years, we haven't required Istio, but the opening serving sentence still suggests that Istio is a hard dependency.

  Brought up by a prospective customer this week.
