### PR TITLE
Update binary name to match the binary downloads

### DIFF
--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -6,9 +6,9 @@
             ```
 
     === "Using a binary"
-         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it on your `PATH` (for example, in `/usr/local/bin`).
+         You can install the `kn-quickstart` plugin by downloading the executable binary for your system and placing it on your `PATH` (for example, in `/usr/local/bin`).
 
-         A link to the latest stable binary release is available on the [`quickstart` release page](https://github.com/knative-sandbox/kn-plugin-quickstart/releases){target=_blank}.
+         A link to the latest stable binary release is available on the [`kn-quickstart` release page](https://github.com/knative-sandbox/kn-plugin-quickstart/releases){target=_blank}.
 
     === "Using Go"
         1. Check out the `kn-plugin-quickstart` repository:
@@ -36,15 +36,15 @@
              kn quickstart --help
              ```
 
-The `quickstart` plugin completes the following functions:
+The `kn-quickstart` plugin completes the following functions:
 
 1. **Checks if you have [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} installed,** and creates a cluster called `knative`.
 1. **Installs Knative Serving with Kourier** as the default networking layer, and nip.io as the DNS.
 1. **Installs Knative Eventing** and creates an in-memory Broker and Channel implementation.
 
-!!! todo "Install Knative and Kubernetes on a local Docker Daemon using `kn quickstart`"
+!!! todo "Install Knative and Kubernetes on a local Docker Daemon using `kn-quickstart`"
     ```bash
-    kn quickstart kind
+    kn-quickstart kind
     ```
 
 ??? bug "Having issues with Kind?"


### PR DESCRIPTION
I don't have a mac so am unsure if doing the brew install would make it so one could invoke `kn quickstart X`. However, when I download the binary labeled `kn-quickstart` I can invoke that directly and `kn` is unaware of any command `quickstart`.

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update the binary call to include a `-` instead of a space.
