### PR TITLE
Changes all references of `kn quickstart` to `kn-quickstart`

### DIFF
--- a/blog/releases/announcing-knative-v0-25-release.md
+++ b/blog/releases/announcing-knative-v0-25-release.md
@@ -126,7 +126,7 @@ Follow the instructions in the documentation
 
 #### 💫 New Features & Changes
 
-- The new plugin `kn-quickstart` is now part of the home-brew plugins suite. Install the plugin using `brew install knative-sandbox/kn-plugins/quickstart` then use it with `kn quickstart kind` this will create a kind cluster with knative installed. Make sure to update `kn` to `v0.25` for example using `brew upgrade kn`
+- The new plugin `kn-quickstart` is now part of the home-brew plugins suite. Install the plugin using `brew install knative-sandbox/kn-plugins/quickstart` then use it with `kn-quickstart kind` this will create a kind cluster with knative installed. Make sure to update `kn` to `v0.25` for example using `brew upgrade kn`
 
 - Deprecate `lookup-path` as path lookup will always be enabled in the future ([#1422](https://github.com/knative/client/pull/1422))
 - Add `--tls` option to domain create command ([#1419](https://github.com/knative/client/pull/1419))

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -44,7 +44,7 @@ The `quickstart` plugin completes the following functions:
 
 !!! todo "Install Knative and Kubernetes on a local Docker Daemon using `kn quickstart`"
     ```bash
-    kn quickstart kind
+    kn-quickstart kind
     ```
 
 ??? bug "Having issues with Kind?"


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Fixes #4261 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Changes references of `kn quickstart` to `kn-quickstart` in both `blog/releases/announcing-knative-v0-25-release.md ` and `docs/snippets/quickstart-install.md`
