### PR TITLE
fix for issue-4233: correctly sourced collector with a fix

### DIFF
--- a/docs/admin/collecting-metrics/README.md
+++ b/docs/admin/collecting-metrics/README.md
@@ -43,7 +43,7 @@ In the following example, you can configure a single collector instance using a 
 1. Create a Deployment, Service, and ConfigMap for the collector by entering the following command:
 
        ```bash
-       kubectl apply -f https://raw.githubusercontent.com/knative/docs/master/docs/install/collecting-metrics/collector.yaml
+       kubectl apply -f https://raw.githubusercontent.com/knative/docs/main/docs/admin/collecting-metrics/collector.yaml
        ```
 
 1. Update the `config-observability` ConfigMaps in the Knative Serving and

--- a/docs/admin/collecting-metrics/collector.yaml
+++ b/docs/admin/collecting-metrics/collector.yaml
@@ -16,7 +16,7 @@ data:
     extensions:
         health_check:
         pprof:
-        zpages
+        zpages:
     service:
       extensions: [health_check, pprof, zpages]
       pipelines:


### PR DESCRIPTION
Fixes #4233

Proposed Changes
Point the collector.yaml referenced in https://github.com/knative/docs/blob/main/docs/admin/collecting-metrics/README.md to the appropriate path. As the current one on the published documentation at step (2) of set up the collector section in https://knative.dev/docs/admin/collecting-metrics/ is still sourced from the master branch.

As a fix I am pointing ```collector.yaml``` to https://raw.githubusercontent.com/knative/docs/main/docs/admin/collecting-metrics/collector.yaml which also has a minor issue on the ```line 19``` where we have a missing : afer the key zpages.