### PR TITLE
fix for issue-4252: fixing content for serving metrics under activato…

### DIFF
--- a/docs/admin/collecting-metrics/serving-metrics/metrics.md
+++ b/docs/admin/collecting-metrics/serving-metrics/metrics.md
@@ -5,7 +5,7 @@ Metrics are listed next.
 
 ## Activator
 
-The following metrics allow the user to understand how application responds when traffic goes through the activator, for example, when scaling from zero. For example, high request latency means that the requests are taking too much time to be fulfilled.
+The following metrics can help you to understand how an application responds when traffic passes through the activator. For example, when scaling from zero, high request latency might mean that requests are taking too much time to be fulfilled.
 
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|

--- a/docs/admin/collecting-metrics/serving-metrics/metrics.md
+++ b/docs/admin/collecting-metrics/serving-metrics/metrics.md
@@ -5,7 +5,7 @@ Metrics are listed next.
 
 ## Activator
 
-The following metrics allow the user to understand how application responds when traffic goes through the activator, for example, when scaling from zero. For example high request latency means that requests are taken too much time be fulfilled.
+The following metrics allow the user to understand how application responds when traffic goes through the activator, for example, when scaling from zero. For example, high request latency means that the requests are taking too much time to be fulfilled.
 
 | Metric Name | Description | Type | Tags | Unit | Status |
 |:-|:-|:-|:-|:-|:-|


### PR DESCRIPTION
Fixes #4252

Proposed Changes

Under section https://knative.dev/docs/admin/collecting-metrics/serving-metrics/metrics/#activator,
the line with a typographical mistake is restructured to "For example, high request latency means that the requests are taking too much time to be fulfilled."