### PR TITLE
fix for issue-4269: fixing deadlink in knative operator page

### DIFF
--- a/docs/snippets/prerequisites.md
+++ b/docs/snippets/prerequisites.md
@@ -5,7 +5,7 @@ Before installing Knative, you must meet the following prerequisites:
 - **For prototyping purposes**, Knative works on most local deployments of Kubernetes. For example, you can use a local, one-node cluster that has 2&nbsp;CPUs and 4&nbsp;GB of memory.
 
     !!! tip
-        You can install a local distribution of Knative for development use by following the [Getting started guide](../../../../getting-started/){_blank}.
+        You can install a local distribution of Knative for development use by following the [Getting started guide](/docs/getting-started/){_blank}.
 
 - **For production purposes**, it is recommended that:
 
@@ -13,7 +13,7 @@ Before installing Knative, you must meet the following prerequisites:
     - If you have multiple nodes in your cluster, for each node you need at least 2&nbsp;CPUs, 4&nbsp;GB of memory, and 20&nbsp;GB of disk storage.
 - You have a cluster that uses Kubernetes v1.19 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
-- Your Kubernetes cluster must have access to the internet, because Kubernetes needs to be able to fetch images. To pull from a private registry, see [Deploying images from a private container registry](../../../../serving/deploying-from-private-registry).
+- Your Kubernetes cluster must have access to the internet, because Kubernetes needs to be able to fetch images. To pull from a private registry, see [Deploying images from a private container registry](/docs/developer/serving/deploying-from-private-registry/).
 
 !!! caution
     The system requirements provided are recommendations only. The requirements for your installation might vary, depending on whether you use optional components, such as a networking layer.


### PR DESCRIPTION
Fixes https://github.com/knative/docs/issues/4269

Proposed Changes

The Getting started hyperlink should point to https://knative.dev/docs/getting-started/ and the Deploying images from a private container registry hyperlink to https://knative.dev/docs/developer/serving/deploying-from-private-registry/

Under the ```prerequisites.md``` the aforementioned links were being used relatively with respect to the path of ```docs/admin/install/eventing/install-eventing-with-yaml.md``` & ```docs/admin/install/serving/install-serving-with-yaml.md``` 
This was causing issues in the documentation when used from ```docs/admin/install/knative-with-operators.md``` leading it to miss out on the ```/doc``` path from the page's path. This PR should the problematic behavior.