### PR TITLE
Enable sticky tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
     - navigation.tabs.sticky
     - navigation.indexes
     - navigation.top
+    - navigation.tabs.sticky
 
 markdown_extensions:
   # - mdx_include:


### PR DESCRIPTION
Trying out the new [sticky tabs feature](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/?h=sticky#sticky-navigation-tabs) in mkdocs. Wdyt @omerbensaadon @csantanapr?