### PR TITLE
Ignore venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ hack/__pycache__
 /site/
 /temp/
 /node_modules/
+venv/
 
 
 .settings/


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updates `.gitignore` file to ignore `venv/` directory (python virtual environment, used for building mkdocs locally)
