### PR TITLE
improve ApiServerSource doc

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -96,7 +96,7 @@ nav:
                 - Moving to knative-sandbox: developer/eventing/sources/creating-event-sources/writing-event-source/07-knative-sandbox.md
             - ApiServerSource:
               - Overview: developer/eventing/sources/apiserversource/README.md
-              - Creating an ApiServerSource object: developer/eventing/sources/apiserversource/getting-started/README.md
+              - Creating an ApiServerSource object: developer/eventing/sources/apiserversource/getting-started.md
               - ApiServerSource reference: developer/eventing/sources/apiserversource/reference.md
             - Camel source: developer/eventing/sources/apache-camel-source/README.md
             - ContainerSource:

--- a/docs/developer/eventing/sources/apiserversource/README.md
+++ b/docs/developer/eventing/sources/apiserversource/README.md
@@ -2,6 +2,7 @@
 
 ![version](https://img.shields.io/badge/API_Version-v1-red?style=flat-square)
 
-The API server source is a Knative Eventing Kubernetes custom resource that listens for Kubernetes events and forwards received events to a sink.
+The API server source is a Knative Eventing Kubernetes custom resource that listens for events emitted by the
+Kubernetes API server (eg. pod creation, deployment updates, etc...) and forwards them as CloudEvents to a sink.
 
 The API server source is part of the core Knative Eventing component, and is provided by default when Knative Eventing is installed. Multiple instances of an ApiServerSource object can be created by users.

--- a/docs/developer/eventing/sources/apiserversource/reference.md
+++ b/docs/developer/eventing/sources/apiserversource/reference.md
@@ -1,6 +1,6 @@
 # ApiServerSource reference
 
-![version](https://img.shields.io/badge/API_Version-v1-red?style=flat-square)
+![version](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)
 
 This topic provides reference information about the configurable fields for the
 ApiServerSource object.
@@ -16,13 +16,162 @@ An ApiServerSource definition supports the following fields:
 | [`kind`][kubernetes-overview] | Identifies this resource object as an ApiServerSource object. | Required |
 | [`metadata`][kubernetes-overview] | Specifies metadata that uniquely identifies the ApiServerSource object. For example, a `name`. | Required |
 | [`spec`][kubernetes-overview] | Specifies the configuration information for this ApiServerSource object. | Required |
+| [`spec.resources`](#resources-parameter) | The resources that the source tracks so it can send related lifecycle events from the Kubernetes ApiServer. Includes an optional label selector to help filter. | Required |
 | `spec.mode` | EventMode controls the format of the event. Set to `Reference` to send a `dataref` event type for the resource being watched. Only a reference to the resource is included in the event payload. Set to `Resource` to have the full resource lifecycle event in the payload. Defaults to `Reference`. | Optional |
 | [`spec.owner`](#owner-parameter) | ResourceOwner is an additional filter to only track resources that are owned by a specific resource type. If ResourceOwner matches Resources[n] then Resources[n] is allowed to pass the ResourceOwner filter. | Optional |
-| [`spec.resources`](#resources-parameter) | The resources that the source tracks so it can send related lifecycle events from the Kubernetes ApiServer. Includes an optional label selector to help filter. | Required |
-| `spec.serviceAccountName` | The name of the ServiceAccount to use to run this source. Defaults to `default` if not set. | Optional |
+| [`spec.serviceAccountName`](#serviceaccountname-parameter) | The name of the ServiceAccount to use to run this source. Defaults to `default` if not set. | Optional |
 | [`spec.sink`](#sink-parameter) | A reference to an object that resolves to a URI to use as the sink. | Required |
 | [`spec.ceOverrides`](#cloudevent-overrides) | Defines overrides to control the output format and modifications to the event sent to the sink. | Optional |
 
+
+### Resources parameter
+
+The `resources` parameter specifies the resources that the source tracks so that
+it can send related lifecycle events from the Kubernetes ApiServer.
+The parameter includes an optional label selector to help filter.
+
+A `resources` definition supports the following fields:
+
+| Field | Description | Required or optional |
+|-------|-------------|----------------------|
+| `apiVersion` | API version of the resource to watch. | Required |
+| [`kind`][kubernetes-kinds] | Kind of the resource to watch. | Required |
+| [`selector`][label-selectors] | LabelSelector filters this source to objects to those resources pass the label selector. <!-- unsure what this means --> | Optional |
+| `selector.matchExpressions` | A list of label selector requirements. The requirements are ANDed. | Use one of `matchExpressions` or `matchLabels` |
+| `selector.matchExpressions.key` | The label key that the selector applies to. | Required if using `matchExpressions` |
+| `selector.matchExpressions.operator` | Represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists` and `DoesNotExist`. | Required if using `matchExpressions` |
+| `selector.matchExpressions.values` | An array of string values. If `operator` is `In` or `NotIn`, the values array must be non-empty. If `operator` is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch. | Required if using `matchExpressions` |
+| `selector.matchLabels` | A map of key-value pairs. Each key-value pair in the `matchLabels` map is equivalent to an element of `matchExpressions`, where the key field is `matchLabels.<key>`, the `operator` is `In`, and the `values` array contains only "matchLabels.<value>". The requirements are ANDed. | Use one of `matchExpressions` or `matchLabels` |
+
+#### Example: Resources parameter
+
+Given the following YAML, the ApiServerSource object receives events for all Pods
+and Deployments in the namespace:
+
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: ApiServerSource
+metadata:
+  name: <apiserversource>
+  namespace: <namespace>
+spec:
+  # ...
+  resources:
+    - apiVersion: v1
+      kind: Pod
+    - apiVersion: apps/v1
+      kind: Deployment
+```
+
+#### Example: Resources parameter using matchExpressions
+
+Given the following YAML, ApiServerSource object receives events for all Pods in
+the namespace that have a label `app=myapp` or `app=yourapp`:
+
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: ApiServerSource
+metadata:
+  name: <apiserversource>
+  namespace: <namespace>
+spec:
+  # ...
+  resources:
+    - apiVersion: v1
+      kind: Pod
+      selector:
+        matchExpressions:
+          - key: app
+            operator: In
+            values:
+              - myapp
+              - yourapp
+```
+
+#### Example: Resources parameter using matchLabels
+
+Given the following YAML, the ApiServerSource object receives events for all Pods
+in the namespace that have a label `app=myapp`:
+
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: ApiServerSource
+metadata:
+  name: <apiserversource>
+  namespace: <namespace>
+spec:
+  # ...
+  resources:
+    - apiVersion: v1
+      kind: Pod
+      selector:
+        matchLabels:
+          app: myapp
+```
+
+### ServiceAccountName parameter
+
+ServiceAccountName is a reference to a Kubernetes service account.
+
+The proper permissions need to be assigned to the ApiServerSource object in order
+to track the lifecycle events of the specified [`resources`](#resources-parameter).
+
+#### Example: tracking pods
+
+The following 4 YAMLs create a ServiceAccount, Role and RoleBinding
+and grant the permission to get, list and watch Pod resources in `<namespace>` for the
+ApiServerSource.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: <service-account>
+  namespace: <namespace>
+```
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: <role>
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+```
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: <role-binding>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: <role>
+subjects:
+  - kind: ServiceAccount
+    name: <service-account>
+    namespace: <namespace>
+```
+
+```yaml
+apiVersion: sources.knative.dev/v1
+kind: ApiServerSource
+metadata:
+ name: <apiserversource>
+ namespace: <namespace>
+spec:
+  # ...
+  serviceAccountName: <service-account>
+  ...
+```
 
 ### Owner parameter
 
@@ -52,93 +201,6 @@ spec:
     kind: Deployment
   ...
 ```
-
-
-### Resources parameter
-
-The `resources` parameter specifies the resources that the source tracks so that
-it can send related lifecycle events from the Kubernetes ApiServer.
-The parameter includes an optional label selector to help filter.
-
-A `resources` definition supports the following fields:
-
-| Field | Description | Required or optional |
-|-------|-------------|----------------------|
-| `apiVersion` | API version of the resource to watch. | Required |
-| [`kind`][kubernetes-kinds] | Kind of the resource to watch. | Required |
-| [`selector`][label-selectors] | LabelSelector filters this source to objects to those resources pass the label selector. <!-- unsure what this means --> | Optional |
-| `selector.matchExpressions` | A list of label selector requirements. The requirements are ANDed. | Use one of `matchExpressions` or `matchLabels` |
-| `selector.matchExpressions.key` | The label key that the selector applies to. | Required if using `matchExpressions` |
-| `selector.matchExpressions.operator` | Represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists` and `DoesNotExist`. | Required if using `matchExpressions` |
-| `selector.matchExpressions.values` | An array of string values. If `operator` is `In` or `NotIn`, the values array must be non-empty. If `operator` is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch. | Required if using `matchExpressions` |
-| `selector.matchLabels` | A map of key-value pairs. Each key-value pair in the `matchLabels` map is equivalent to an element of `matchExpressions`, where the key field is `matchLabels.<key>`, the `operator` is `In`, and the `values` array contains only "matchLabels.<value>". The requirements are ANDed. | Use one of `matchExpressions` or `matchLabels` |
-
-#### Example: Resources parameter
-
-Given the following YAML, the ApiServerSource object receives events for all Pods
-and Deployments in the namespace: <!-- is this correct? -->
-
-```yaml
-apiVersion: sources.knative.dev/v1
-kind: ApiServerSource
-metadata:
-  name: <apiserversource>
-  namespace: <namespace>
-spec:
-  # ...
-  resources:
-    - apiVersion: v1
-      kind: Pod
-    - apiVersion: apps/v1
-      kind: Deployment
-```
-
-#### Example: Resources parameter using matchExpressions
-
-Given the following YAML, ApiServerSource object receives events for all Pods in
-the namespace that have a label `app=myapp` or `app=yourapp`: <!-- is this correct? -->
-
-```yaml
-apiVersion: sources.knative.dev/v1
-kind: ApiServerSource
-metadata:
-  name: <apiserversource>
-  namespace: <namespace>
-spec:
-  # ...
-  resources:
-    - apiVersion: v1
-      kind: Pod
-      selector:
-        matchExpressions:
-          - key: app
-            operator: In
-            values:
-              - myapp
-              - yourapp
-```
-
-#### Example: Resources parameter using matchLabels
-
-Given the following YAML, the ApiServerSource object receives events for all Pods
-in the namespace that have a label `app=myapp`: <!-- is this correct? -->
-
-```yaml
-apiVersion: sources.knative.dev/v1
-kind: ApiServerSource
-metadata:
-  name: <apiserversource>
-  namespace: <namespace>
-spec:
-  # ...
-  resources:
-    - apiVersion: v1
-      kind: Pod
-      selector:
-        matchLabels:
-          app: myapp
-```
-
 
 ### Sink parameter
 

--- a/docs/developer/eventing/sources/ping-source/README.md
+++ b/docs/developer/eventing/sources/ping-source/README.md
@@ -40,7 +40,7 @@ during the verification step in this procedure.
         It also makes removing the source easier, because you can delete the
         namespace to remove all of the resources.
 
-1. Create a sink. If you do not have your own sink, you can use the following example Knative Service that dumps incoming messages to a log:
+1. Create a sink. If you do not have your own sink, you can use the following example Service that dumps incoming messages to a log:
 
     1. Copy the YAML below into a file:
 
@@ -49,6 +49,7 @@ during the verification step in this procedure.
         kind: Deployment
         metadata:
           name: event-display
+          namespace: <namespace>
         spec:
           replicas: 1
           selector:
@@ -68,6 +69,7 @@ during the verification step in this procedure.
         apiVersion: v1
         metadata:
           name: event-display
+          namespace: <namespace>
         spec:
           selector:
             app: event-display
@@ -76,6 +78,8 @@ during the verification step in this procedure.
             port: 80
             targetPort: 8080
         ```
+
+        Where `<namespace>` is the name of the namespace that you created in step 1 above.
 
     1. Apply the YAML file by running the command:
 
@@ -128,6 +132,7 @@ during the verification step in this procedure.
                 kind: PingSource
                 metadata:
                   name: <pingsource-name>
+                  namespace: <namespace>
                 spec:
                   schedule: "<cron-schedule>"
                   contentType: "<content-type>"
@@ -141,10 +146,11 @@ during the verification step in this procedure.
                 Where:
 
                 - `<pingsource-name>` is the name of the PingSource that you want to create, for example, `test-ping-source`.
+                - `<namespace>` is the name of the namespace that you created in step 1 above.
                 - `<cron-schedule>` is a cron expression for the schedule for the PingSource to send events, for example, `*/1 * * * *` sends an event every minute.
                 - `<content-type>` is the media type of the data you want to send, for example, `application/json`.
                 - `<data>` is the data you want to send. This data must be represented as text, not binary. For example, a JSON object such as `{"message": "Hello world!"}`.
-                - `<sink-kind>` is any supported PodSpecable object that you want to use as a sink, for example, `Service` or `Deployment`. A PodSpecable is an object that describes a PodSpec.
+                - `<sink-kind>` is any supported [Addressable](https://knative.dev/docs/developer/concepts/duck-typing/#addressable) object that you want to use as a sink, for example, `Service` or `Deployment`.
                 - `<sink-name>` is the name of your sink, for example, `event-display`.
 
                 For more information about the fields you can configure for the PingSource object, see [PingSource reference](reference.md).
@@ -167,6 +173,7 @@ during the verification step in this procedure.
                 kind: PingSource
                 metadata:
                   name: <pingsource-name>
+                  namespace: <namespace>
                 spec:
                   schedule: "<cron-schedule>"
                   contentType: "<content-type>"
@@ -180,10 +187,11 @@ during the verification step in this procedure.
                 Where:
 
                 - `<pingsource-name>` is the name of the PingSource that you want to create, for example, `test-ping-source-binary`.
+                - `<namespace>` is the name of the namespace that you created in step 1 above.
                 - `<cron-schedule>` is a cron expression for the schedule for the PingSource to send events, for example, `*/1 * * * *` sends an event every minute.
                 - `<content-type>` is the media type of the data you want to send, for example, `application/json`.
                 - `<base64-data>` is the base64 encoded binary data that you want to send, for example, `ZGF0YQ==`.
-                - `<sink-kind>` is any supported PodSpecable object that you want to use as a sink, for example, `Service` or `Deployment`. A PodSpecable is an object that describes a PodSpec.
+                - `<sink-kind>` is any supported [Addressable](https://knative.dev/docs/developer/concepts/duck-typing/#addressable) object that you want to use as a sink, for example, `Service` or `Deployment`.
                 - `<sink-name>` is the name of your sink, for example, `event-display`.
 
                 For more information about the fields you can configure for the PingSource object, see [PingSource reference](reference.md).


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Fixes https://github.com/knative/docs/issues/4287

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix `getting-started` page missing in the nabber
- Add event-display as an example for sink
- Document ServiceAccountName in the reference doc
- Various fixes
