### PR TITLE
Disable section index feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,6 @@ theme:
     - navigation.tabs
     - navigation.tracking
     - navigation.tabs.sticky
-    - navigation.indexes
     - navigation.top
 
 markdown_extensions:


### PR DESCRIPTION
We were opting in to this without it actually being available outside Insiders before, now it's available to all so got silently enabled by the new version coming out and.. I think we need to change our nav a bit to properly use it, so the result is a regression right now.

/assign @omerbensaadon @csantanapr 