### PR TITLE
Adding `strict-subscriber` docs

### DIFF
--- a/docs/eventing/experimental-features.md
+++ b/docs/eventing/experimental-features.md
@@ -118,3 +118,31 @@ spec:
 ```
 
 You can specify a `delivery` spec for Channels, Subscriptions, Brokers, Triggers, and any other resource spec that accepts the `delivery` field.
+
+### Strict Subscriber
+
+**Flag name**: `strict-subscriber`
+
+**Stage**: Alpha, disabled by default
+
+**Tracking issue**: [#5762](https://github.com/knative/eventing/pull/5762)
+
+When defining a Subscription, if this flag is enabled, validation will fail if the field `spec.subscriber` is not defined. This flag was implemented to follow the latest version of the [Knative Eventing Spec that can be found here](https://github.com/knative/specs/tree/main/specs/eventing)
+
+A Subscription like the following example will fail validation if the previous flag is enabled: 
+```
+```yaml
+apiVersion: messaging.knative.dev/v1
+kind: Subscription
+metadata:
+  name: example-subscription
+  namespace: example-namespace
+spec:
+  reply: 
+    ref:
+     apiVersion: serving.knative.dev/v1
+     kind: Service
+     name: example-reply
+```
+
+With the flag disabled (default behavior) the Subscription can define a subscriber or a reply field and validation will succeed, this is the behavior default behavior in version 0.26 and before.


### PR DESCRIPTION
Adding `strict-subscriber` flag to experimental features page

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

Adds documentation for: https://github.com/knative/eventing/pull/5762

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adding experimental feature flag docs for `strict-subscriber`

