### PR TITLE
Add short notes to explain about customizing domain and customizing domain template

### DIFF
--- a/docs/developer/serving/services/custom-domains.md
+++ b/docs/developer/serving/services/custom-domains.md
@@ -13,6 +13,11 @@ serve a Knative Service at this domain.
     If you create a domain mapping to map to a [private Knative Service](private-services.md),
     the private Knative Service is accessible from public internet with the custom domain of the domain mapping.
 
+!!! tip
+    This section instructs how to customize the domain of each service regardless of the default domain.
+    If you want to customize the domain template to assign the default domain name,
+    please refer to [setting up a custom domain template](../../../serving/using-a-custom-domain.md).
+
 ## Prerequisites
 
 - You must have access to a Kubernetes cluster, with Knative Serving and an Ingress implementation installed. For more information, see the [Installation documentation](../../../admin/install/README.md).

--- a/docs/serving/using-a-custom-domain.md
+++ b/docs/serving/using-a-custom-domain.md
@@ -1,10 +1,15 @@
-# Setting up a custom domain
+# Setting up a custom domain template
 
 By default, Knative Serving routes use `example.com` as the default domain. The
 fully qualified domain name for a route by default is
 `{route}.{namespace}.{default-domain}`.
 
 To change the {default-domain} value there are a few steps involved:
+
+!!! tip
+    Customizing domain template effects on your cluster globally.
+    If you want to constomize the domain of each service, use `DomainMapping` instead.
+    For more details, please refer to [configuring custom domains](../developer/serving/services/custom-domains.md).
 
 ## Edit using kubectl
 


### PR DESCRIPTION
The following two sections have the same title and instruct how to customize domain:

https://knative.dev/docs/serving/using-a-custom-domain/
https://knative.dev/docs/developer/serving/services/custom-domains/

It should have different titles and a note about the difference.

So this patch changes to:
- Add a short explanation and the link for each section.
- Change the title for domain template to "Customizing domain template".

Fix https://github.com/knative/docs/issues/4256