### PR TITLE
Fix operator link on Knative release notes page

### DIFF
--- a/docs/reference/relnotes/README.md
+++ b/docs/reference/relnotes/README.md
@@ -2,7 +2,7 @@
 
 For details about the Knative releases, see the following pages:
 
-- [Knative Serving releases](https://github.com/knative/serving/releases)
-- [Knative Serving Operator releases](https://github.com/knative/serving-operator/releases)
 - [Knative CLI releases](https://github.com/knative/client/releases)
 - [Knative Eventing releases](https://github.com/knative/eventing/releases)
+- [Knative Serving releases](https://github.com/knative/serving/releases)
+- [Knative Operator releases](https://github.com/knative/operator/releases)


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix operator link on https://knative.dev/docs/reference/relnotes/: just changed link from archived knative/serving-operator to latest knative/operator release page.
