### PR TITLE
Bumping macros plugin version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs-material>=7.1
 mkdocs-exclude>=1.0
-mkdocs-macros-plugin>=0.5
+mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5
 mkdocs-redirects>=1.0.3
 mkdocs-rss-plugin>=0.18.0


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Updating minimum version of `mkdocs-macros-plugin` plugin to 0.5.12

As discussed in #3765 , when mkdocs moved to version 1.2 the `mkdocs-macros-plugin` stopped working with `mkdocs serve`. As [a fix was introduced in version 0.5.12](https://github.com/fralau/mkdocs_macros_plugin/issues/86#issuecomment-864519215) of the plugin, that should be the minimum acceptable version of the plugin.