### PR TITLE
Rename net-ingressv2 to net-gateway-api

### DIFF
--- a/golang/_redirects
+++ b/golang/_redirects
@@ -4,7 +4,7 @@
 # DO NOT EDIT!
 #
 # To regenerate, run:
-#   redir-gen
+#   ./tools/redir-gen/redir-gen
 /actions-downstream-test/* go-get=1 /golang/actions-downstream-test.html 200
 /actions-kind/* go-get=1 /golang/actions-kind.html 200
 /async-component/* go-get=1 /golang/async-component.html 200
@@ -52,8 +52,8 @@
 /monitoring/* go-get=1 /golang/monitoring.html 200
 /net-certmanager/* go-get=1 /golang/net-certmanager.html 200
 /net-contour/* go-get=1 /golang/net-contour.html 200
+/net-gateway-api/* go-get=1 /golang/net-gateway-api.html 200
 /net-http01/* go-get=1 /golang/net-http01.html 200
-/net-ingressv2/* go-get=1 /golang/net-ingressv2.html 200
 /net-istio/* go-get=1 /golang/net-istio.html 200
 /net-kourier/* go-get=1 /golang/net-kourier.html 200
 /networking/* go-get=1 /golang/networking.html 200

--- a/golang/container-freezer.html
+++ b/golang/container-freezer.html
@@ -1,4 +1,4 @@
 <html><head>
     <meta name="go-import" content="knative.dev/container-freezer git https://github.com/knative-sandbox/container-freezer">
-    <meta name="go-source" content="knative.dev/container-freezer https://github.com/knative-sandbox/container-freezer https://github.com/knative-sandbox/container-freezer/tree/main{/dir} https://github.com/knative-sandbox/container-freezer/blob/main{/dir}/{file}#L{line}">
+    <meta name="go-source" content="knative.dev/container-freezer     https://github.com/knative-sandbox/container-freezer https://github.com/knative-sandbox/container-freezer/tree/main{/dir} https://github.com/knative-sandbox/container-freezer/blob/main{/dir}/{file}#L{line}">
 </head></html>


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

See https://github.com/knative/community/pull/797

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Re-run `./tools/redir-gen`. (This should be automated at some point, but not today)
