### PR TITLE
Set v1.20 as minimum k8s version

### DIFF
--- a/docs/snippets/prerequisites.md
+++ b/docs/snippets/prerequisites.md
@@ -11,7 +11,7 @@ Before installing Knative, you must meet the following prerequisites:
 
     - If you have only one node in your cluster, you need at least 6&nbsp;CPUs, 6&nbsp;GB of memory, and 30&nbsp;GB of disk storage.
     - If you have multiple nodes in your cluster, for each node you need at least 2&nbsp;CPUs, 4&nbsp;GB of memory, and 20&nbsp;GB of disk storage.
-- You have a cluster that uses Kubernetes v1.19 or newer.
+- You have a cluster that uses Kubernetes v1.20 or newer.
 - You have installed the [`kubectl` CLI](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 - Your Kubernetes cluster must have access to the internet, because Kubernetes needs to be able to fetch images. To pull from a private registry, see [Deploying images from a private container registry](/docs/developer/serving/deploying-from-private-registry/).
 


### PR DESCRIPTION
v1.20 is the minimum k8s version since knative v0.26.0 as per https://github.com/knative/serving/releases/tag/v0.26.0