### PR TITLE
Propose new site nav

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -190,7 +190,7 @@ nav:
           - Broker configuration example: eventing/broker/example-mtbroker.md
           - Apache Kafka Broker: eventing/broker/kafka-broker/README.md
           - RabbitMQ Broker: eventing/broker/rabbitmq-broker/README.md
-        - Accessing CloudEvent traces: eventing/accessing-traces.md 
+        - Accessing CloudEvent traces: eventing/accessing-traces.md
       # Eventing - admin docs
       - Administrator topics:
         # Eventing config


### PR DESCRIPTION
Fixes #4296

Submitting this PR to propose a new nav structure as indicated by the [card sort](https://miro.com/app/board/o9J_l1Iv2e4=/) results. Thank you to all the card sort participants! 

I would really appreciate to hear any opinions/feedback on this new site nav.

Once this is merged I will unblock the issues in [this epic](https://github.com/knative/docs/issues/4230) to move items in the directory structure, fix links, and add redirects. 

I've done the following:
- Created an Install section 
- Created a Code samples section
- Removed Developer and Admin guides from top-nav
- Moved all Serving + Eventing Content under Serving + Eventing sections  
- Removed Client from top level and put it in install section

I've left a few comments for topics I was unsure about where they should go:
- L187 - Event registry: eventing/event-registry.md # does this make sense here since it mentions being used with brokers and triggers?
- L200 - Accessing CloudEvent traces: eventing/accessing-traces.md # not sure whether this is admin or dev (or neither)
