### PR TITLE
Lock mkdocs version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material>=7.1
+mkdocs-material==7.3.1
 mkdocs-exclude>=1.0
 mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5


### PR DESCRIPTION
Locks the mkdocs version to 7.3.1 so that we don't get inadvertent bugs. We'll manually bump mkdocs in future so that we can see a preview before upgrading.

This should (🤞) fix the margin rendering bug if we cherry pick it back, and prevent future bugs.

/assign @omerbensaadon @csantanapr 