### PR TITLE
Add entry for flag documentation

### DIFF
--- a/docs/help/contributor/style-guide/documenting-code.md
+++ b/docs/help/contributor/style-guide/documenting-code.md
@@ -258,3 +258,16 @@ Apply code formatting only to special-purpose text:
     <some-code>
     ```
     ````
+
+
+## Documentation of flags
+> Always use the short version of flags used in a command than the extended version, i.e., use ```-n``` rather than ```--namespace```
+=== ":white_check_mark: Correct"
+     ```bash
+     kubectl apply -f <filename>.yaml -n <namespace>
+     ```
+
+=== ":no_entry: Incorrect"
+      ```bash
+      kubectl apply --filename <filename>.yaml --namespace <namespace>
+      ```

--- a/docs/help/contributor/style-guide/documenting-code.md
+++ b/docs/help/contributor/style-guide/documenting-code.md
@@ -261,7 +261,7 @@ Apply code formatting only to special-purpose text:
 
 
 ## Documentation of flags
-> Always use the short version of flags used in a command than the extended version, i.e., use ```-n``` rather than ```--namespace```
+> Always use the short version of flags used in a command rather than the extended version. For example, use `-n` rather than `--namespace`.
 === ":white_check_mark: Correct"
      ```bash
      kubectl apply -f <filename>.yaml -n <namespace>


### PR DESCRIPTION
fixes #4077

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Fixes #4077

## Proposed Changes 
- Add entry that describes the documentation style of flags that mentions using short flags rather than the extended version
