### PR TITLE
Make blog distinct again

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -15,7 +15,7 @@ nav:
     - Reference: /docs/reference/
     - "Join the Community ➠": /community/
     # Blog
-    - Blog:
+    - "Blog ➠":
       - index.md
       - Releases:
           - releases/announcing-knative-v0-26-release.md

--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -15,7 +15,7 @@ nav:
     - Reference: /docs/reference/
     - "Join the Community ➠": /community/
     # Blog
-    - "Blog ➠":
+    - Blog:
       - index.md
       - Releases:
           - releases/announcing-knative-v0-26-release.md

--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -11,6 +11,9 @@ nav:
     - Knative Eventing: /docs/eventing/
     # Client
     - Client: /docs/client/
+    # Reference docs
+    - Reference: /docs/reference/
+    - "Join the Community ➠": /community/
     # Blog
     - Blog:
       - index.md
@@ -51,6 +54,3 @@ nav:
       - Events:
           - events/knative-at-kubecon-eu-2019.md
           - events/knative-at-kubecon-seattle.md
-    # Reference docs
-    - Reference: /docs/reference/
-    - "Join the Community ➠": /community/

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -264,6 +264,7 @@ nav:
           - CloudStorageSource: eventing/samples/cloud-storage-source/README.md
           - GitHub source: eventing/samples/github-source/README.md
           - GitLab source: eventing/samples/gitlab-source/README.md
+    - Blog: /blog/
     # Reference docs
     - Reference:
       - Overview: reference/README.md
@@ -273,4 +274,4 @@ nav:
       - Concepts:
         - Duck types: reference/concepts/duck-typing.md
     - "Join the Community ➠": /community/
-    - "Blog ➠": /blog/
+    - Blog: /blog/

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -264,7 +264,6 @@ nav:
           - CloudStorageSource: eventing/samples/cloud-storage-source/README.md
           - GitHub source: eventing/samples/github-source/README.md
           - GitLab source: eventing/samples/gitlab-source/README.md
-    - Blog: /blog/
     # Reference docs
     - Reference:
       - Overview: reference/README.md
@@ -274,3 +273,4 @@ nav:
       - Concepts:
         - Duck types: reference/concepts/duck-typing.md
     - "Join the Community ➠": /community/
+    - Blog: /blog/

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -273,4 +273,4 @@ nav:
       - Concepts:
         - Duck types: reference/concepts/duck-typing.md
     - "Join the Community ➠": /community/
-    - Blog: /blog/
+    - "Blog ➠": /blog/

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -39,8 +39,8 @@
   border-bottom: 1px solid var(--home-color);
 }
 
-/* Make community tab distinct until it moves to mkdocs */
-.md-tabs__list li:nth-last-child(1) {
+.md-tabs__list li:nth-last-child(1),
+.md-tabs__list li:nth-last-child(2) {
   background: var(--home-color);
   float: right;
 }


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

Per [discussion on Slack](https://knative.slack.com/archives/C01JBD1LSF3/p1635796691053300), we want to make the link to the blog distinct again, by reverting it to the right of the header / putting it in the dark blue box. That's what this PR does.

