### PR TITLE
Adding command-line instructions for using cloudevents player 

### DIFF
--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -76,7 +76,10 @@ Create the CloudEvents Player Service:
 
 ![CloudEvents Player Send](images/event_sent.png)
 
-??? tip "Want to send events via the command line instead?"
+??? tip "Clicking the :fontawesome-solid-envelope: shows you the CloudEvent as the Broker sees it."
+    ![Event_Details](images/event_details.
+
+??? question "Want to send events via the command line instead?"
     As an alternative to the Web form, events can also be sent/viewed via the command line.
 
     To post an event:
@@ -92,12 +95,8 @@ Create the CloudEvents Player Service:
 
     And to view events:
     ```bash
-    curl http://cloudevents-player.default.127.0.0.1.nip.io/messages \
-        -H "Content-Type: application/json"
+    curl http://cloudevents-player.default.127.0.0.1.nip.io/messages
     ```
-
-??? tip "Clicking the :fontawesome-solid-envelope: shows you the CloudEvent as the Broker sees it."
-    ![Event_Details](images/event_details.png)
 
 The :material-send: icon in the "Status" column implies that the event has been sent to our Broker... but where has the event gone? **Well, right now, nowhere!**
 

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -76,6 +76,25 @@ Create the CloudEvents Player Service:
 
 ![CloudEvents Player Send](images/event_sent.png)
 
+??? tip "Want to send events via the command line instead?"
+    As an alternative to the Web form, events can also be sent/viewed via the command line.
+    
+    To post an event:
+    ```bash
+    curl -v http://cloudevents-player.default.127.0.0.1.nip.io \
+        -H "Content-Type: application/json" \
+        -H "Ce-Id: 123456789" \
+        -H "Ce-Specversion: 1.0" \
+        -H "Ce-Type: some-type" \
+        -H "Ce-Source: command-line" \
+        -d '{"msg":"Hello CloudEvents!"}'
+    ```
+    
+    And to view events:
+    ```bash
+    curl -v http://cloudevents-player.default.127.0.0.1.nip.io/messages \
+        -H "Content-Type: application/json"
+    ```
 
 ??? tip "Clicking the :fontawesome-solid-envelope: shows you the CloudEvent as the Broker sees it."
     ![Event_Details](images/event_details.png)

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -78,10 +78,10 @@ Create the CloudEvents Player Service:
 
 ??? tip "Want to send events via the command line instead?"
     As an alternative to the Web form, events can also be sent/viewed via the command line.
-    
+
     To post an event:
     ```bash
-    curl -v http://cloudevents-player.default.127.0.0.1.nip.io \
+    curl -i http://cloudevents-player.default.127.0.0.1.nip.io \
         -H "Content-Type: application/json" \
         -H "Ce-Id: 123456789" \
         -H "Ce-Specversion: 1.0" \
@@ -89,10 +89,10 @@ Create the CloudEvents Player Service:
         -H "Ce-Source: command-line" \
         -d '{"msg":"Hello CloudEvents!"}'
     ```
-    
+
     And to view events:
     ```bash
-    curl -v http://cloudevents-player.default.127.0.0.1.nip.io/messages \
+    curl http://cloudevents-player.default.127.0.0.1.nip.io/messages \
         -H "Content-Type: application/json"
     ```
 


### PR DESCRIPTION
Fixes #4390 

## Proposed Changes 

Adds a tip box with instructions for using `curl` to send/receive cloud events to the Getting Started guide. 

retry from #4391 since that one seems to be borked