### PR TITLE
update config elements for eventing channel and pingsource

### DIFF
--- a/docs/eventing/configuration/kafka-channel-configuration.md
+++ b/docs/eventing/configuration/kafka-channel-configuration.md
@@ -19,7 +19,7 @@ To use Kafka Channels, you must:
       name: kafka-channel
       namespace: knative-eventing
     data:
-      channelTemplateSpec: |
+      channel-template-spec: |
         apiVersion: messaging.knative.dev/v1beta1
         kind: KafkaChannel
         spec:

--- a/docs/eventing/configuration/sources-configuration.md
+++ b/docs/eventing/configuration/sources-configuration.md
@@ -10,7 +10,7 @@ For the available parameters, see [PingSource reference](../../eventing/sources/
 In addition to the parameters that you can configure in the PingSource resource, there is a global ConfigMap called `config-ping-defaults`.
 This ConfigMap allows you to change the maximum amount of data that the PingSource adds to the CloudEvents it produces.
 
-The `dataMaxSize` parameter allows you to set the maximum number of bytes allowed to be sent for a message excluding any base64 decoding. The default value, `-1`, sets no limit for data.
+The `data-max-size` parameter allows you to set the maximum number of bytes allowed to be sent for a message excluding any base64 decoding. The default value, `-1`, sets no limit for data.
 
 ```
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
 data:
-  dataMaxSize: -1
+  data-max-size: -1
 ```
 
 You can edit this ConfigMap by running the command:

--- a/docs/install/eventing/install-eventing-with-yaml.md
+++ b/docs/install/eventing/install-eventing-with-yaml.md
@@ -168,7 +168,7 @@ Follow the procedure for the Broker of your choice:
           name: imc-channel
           namespace: knative-eventing
         data:
-          channelTemplateSpec: |
+          channel-template-spec: |
             apiVersion: messaging.knative.dev/v1
             kind: InMemoryChannel
         ---
@@ -178,7 +178,7 @@ Follow the procedure for the Broker of your choice:
           name: kafka-channel
           namespace: knative-eventing
         data:
-          channelTemplateSpec: |
+          channel-template-spec: |
             apiVersion: messaging.knative.dev/v1alpha1
             kind: KafkaChannel
             spec:

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -48,7 +48,7 @@ The `spec.config` in the KnativeEventing CR has one `<name>` entry for each Conf
 
 ### Setting a default channel
 
-If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be the default configuration, you can change the default behavior by updating the `default-ch-webhook` ConfigMap. 
+If you are using different channel implementations, like the KafkaChannel, or you want a specific configuration of the InMemoryChannel to be the default configuration, you can change the default behavior by updating the `default-ch-webhook` ConfigMap.
 
 You can do this by modifying the KnativeEventing CR:
 
@@ -83,7 +83,7 @@ spec:
 
 ### Setting the default channel for the broker
 
-If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap. 
+If you are using a channel-based broker, you can change the default channel type for the broker from InMemoryChannel to KafkaChannel, by updating the `config-br-default-channel` ConfigMap.
 
 You can do this by modifying the KnativeEventing CR:
 
@@ -96,7 +96,7 @@ metadata:
 spec:
   config:
     config-br-default-channel:
-      channelTemplateSpec: |
+      channel-template-spec: |
         apiVersion: messaging.knative.dev/v1beta1
         kind: KafkaChannel
         spec:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update ConfigMap element names for eventing's channel and pingsource. They are [being renamed to keep consistent](https://github.com/knative/eventing/issues/5789) with other configuration elements.

Previous configuration element names are still processed the same but we want the new ones to be the only reference to users.

**MERGEABLE** since related PR at https://github.com/knative/eventing/pull/5875 got merged.
