### PR TITLE
Add Activator capacity to navigation

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -85,6 +85,7 @@ nav:
         - Load balancing:
           - Overview: serving/load-balancing/README.md
           - Configuring target burst capacity: serving/load-balancing/target-burst-capacity.md
+          - Configuring Activator capacity: serving/load-balancing/activator-capacity.md
         - Revision garbage collection: serving/revision-gc.md
         - Autoscaling:
           - Overview: serving/autoscaling/README.md


### PR DESCRIPTION
Noticed that this file was on the site but could not be found in the navigation