### PR TITLE
Blog: fix code-samples nav link

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -4,7 +4,7 @@ nav:
     - Installing: /docs/install/
     - Serving: /docs/serving/
     - Eventing: /docs/eventing/
-    - Code samples: /docs/samples.md
+    - Code samples: /docs/samples/
     - Reference: /docs/reference/
     - "Join the Community ➠": /community/
     - Case studies: /docs/about/case-studies/deepc


### PR DESCRIPTION
Fix issue on current blog page where the code-samples nav page goes to code-samples.md instead of code-samples.

ref: https://knative.dev/blog/articles/knative-1.0/
ref: https://twitter.com/cra/status/1458593293458198528