### PR TITLE
Fix sample output

### DIFF
--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -183,7 +183,7 @@ autoscaler             1/1     1            1           18s
 autoscaler-hpa         1/1     1            1           14s
 controller             1/1     1            1           18s
 domain-mapping         1/1     1            1           12s
-domainmapping-webhoop  1/1     1            1           12s
+domainmapping-webhook  1/1     1            1           12s
 webhook                1/1     1            1           17s
 ```
 

--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -182,8 +182,8 @@ activator              1/1     1            1           18s
 autoscaler             1/1     1            1           18s
 autoscaler-hpa         1/1     1            1           14s
 controller             1/1     1            1           18s
-net-istio-webhook      1/1     1            1           12s
-net-istio-controller   1/1     1            1           12s
+domain-mapping         1/1     1            1           12s
+domainmapping-webhoop  1/1     1            1           12s
 webhook                1/1     1            1           17s
 ```
 

--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -509,15 +509,16 @@ If Knative Eventing has been successfully deployed, all deployments of the Knati
 is a sample output:
 
 ```
-NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
-broker-controller      1/1     1            1           63s
-broker-filter          1/1     1            1           62s
-broker-ingress         1/1     1            1           62s
-eventing-controller    1/1     1            1           67s
-eventing-webhook       1/1     1            1           67s
-imc-controller         1/1     1            1           59s
-imc-dispatcher         1/1     1            1           59s
-mt-broker-controller   1/1     1            1           62s
+NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
+eventing-controller     1/1     1            1           43s
+eventing-webhook        1/1     1            1           42s
+imc-controller          1/1     1            1           39s
+imc-dispatcher          1/1     1            1           38s
+mt-broker-controller    1/1     1            1           36s
+mt-broker-filter        1/1     1            1           37s
+mt-broker-ingress       1/1     1            1           37s
+pingsource-mt-adapter   0/0     0            0           43s
+sugar-controller        1/1     1            1           36s
 ```
 
 ### Check the status of Knative Eventing Custom Resource:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->
Fix deprecated sample output documentation

## Proposed Changes <!-- Describe the changes the PR makes. -->


- Use domain-mapping and domainmapping-webhook insted of the net-istio in sample output
- Use new sample output for knative eventing installation
-
