### PR TITLE
Fix Kafka Channel yaml

### DIFF
--- a/docs/eventing/samples/kafka/channel/README.md
+++ b/docs/eventing/samples/kafka/channel/README.md
@@ -17,9 +17,9 @@ default Channel configuration for Knative Eventing.
     kind: KafkaChannel
     metadata:
       name: my-kafka-channel
-      spec:
-        numPartitions: 3
-        replicationFactor: 1
+    spec:
+      numPartitions: 3
+      replicationFactor: 1
     ```
 
 1. Apply the YAML file by running the command:


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

The proposed yaml to create a Kafka Channel leads to an error, because of the wrong indentation of the spec tag.


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Move the `spec` block one indentation to the left.

See the error here:
```
$ k apply -f harald                 
error: error validating "harald": error validating data: ValidationError(KafkaChannel.metadata): unknown field "spec" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2; if you choose to ignore these errors, turn validation off with --validate=false

$ cat harald                                 
apiVersion: messaging.knative.dev/v1beta1
kind: KafkaChannel
metadata:
  name: my-kafka-channel
  spec:
    numPartitions: 3
    replicationFactor: 1

$ vi harald                                                                                                                                                                                                                   $ k apply -f harald                                                                                                                                                                                                             kafkachannel.messaging.knative.dev/my-kafka-channel created

$ cat harald                                                                                                                                                                                                                    
apiVersion: messaging.knative.dev/v1beta1
kind: KafkaChannel
metadata:
  name: my-kafka-channel
spec:
  numPartitions: 3
  replicationFactor: 1

$ k apply -f harald                                                                                                                                                                                                            
kafkachannel.messaging.knative.dev/my-kafka-channel created
```
