### PR TITLE
adding documentation for hpa custom metrics

### DIFF
--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -15,52 +15,89 @@ The possible metric types that can be configured per revision depend on the type
 For more information about KPA and HPA, see the documentation on [Supported Autoscaler types](autoscaler-types.md).
 
 * **Per-revision annotation key:** `autoscaling.knative.dev/metric`
-* **Possible values:** `"concurrency"`, `"rps"` or `"cpu"`, depending on your Autoscaler type. The `cpu` metric is only supported on revisions with the HPA class.
+* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `cpu`/`memory`/custom metrics are only supported on revisions with the HPA class.
 * **Default:** `"concurrency"`
 
 
-=== "Per-revision concurrency configuration"
-    ```yaml
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    metadata:
-      name: helloworld-go
-      namespace: default
-    spec:
-      template:
-        metadata:
-          annotations:
-            autoscaling.knative.dev/metric: "concurrency"
-    ```
+=== Per-revision concurrency configuration
 
-=== "Per-revision rps configuration"
-    ```yaml
-    apiVersion: serving.knative.dev/v1
-    kind: Service
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: default
+spec:
+  template:
     metadata:
-      name: helloworld-go
-      namespace: default
-    spec:
-      template:
-        metadata:
-          annotations:
-            autoscaling.knative.dev/metric: "rps"
-    ```
+      annotations:
+        autoscaling.knative.dev/metric: "concurrency"
+```
 
-=== "Per-revision cpu configuration"
-    ```yaml
-    apiVersion: serving.knative.dev/v1
-    kind: Service
+=== Per-revision rps configuration
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: default
+spec:
+  template:
     metadata:
-      name: helloworld-go
-      namespace: default
-    spec:
-      template:
-        metadata:
-          annotations:
-            autoscaling.knative.dev/metric: "cpu"
-    ```
+      annotations:
+        autoscaling.knative.dev/metric: "rps"
+```
 
+=== Per-revision cpu configuration
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
+        autoscaling.knative.dev/metric: "cpu"
+```
+
+=== Per-revision memory configuration
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
+        autoscaling.knative.dev/metric: "memory"
+```
+
+=== Per-revision custom metric configuration
+Assuming that you have a custom metric named `metricName` you can create an HPA to autoscale the revision by that metric.
+The HPA will be configured to use the average value of that metric over all the pods of the revision.
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-go
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
+        autoscaling.knative.dev/metric: "metricName"
+```
 
 
 

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -67,19 +67,19 @@ spec:
 
 === Per-revision memory configuration
 
-```yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: helloworld-go
-  namespace: default
-spec:
-  template:
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
     metadata:
-      annotations:
-        autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
-        autoscaling.knative.dev/metric: "memory"
-```
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        metadata:
+          annotations:
+            autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
+            autoscaling.knative.dev/metric: "memory"
+    ```
 
 === Per-revision custom metric configuration
 Assuming that you have a custom metric named `metricName` you can create an HPA to autoscale the revision by that metric.

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -36,18 +36,18 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
 
 === Per-revision rps configuration
 
-```yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: helloworld-go
-  namespace: default
-spec:
-  template:
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
     metadata:
-      annotations:
-        autoscaling.knative.dev/metric: "rps"
-```
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        metadata:
+          annotations:
+            autoscaling.knative.dev/metric: "rps"
+    ```
 
 === Per-revision cpu configuration
 

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -82,22 +82,25 @@ spec:
     ```
 
 === Per-revision custom metric configuration
-Assuming that you have a custom metric named `metricName` you can create an HPA to autoscale the revision by that metric.
-The HPA will be configured to use the **average value** of that metric over all the pods of the revision.
 
-```yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: helloworld-go
-  namespace: default
-spec:
-  template:
+    You can create an HPA to scale the revision by a metric that you specify.
+    The HPA will be configured to use the **average value** of your metric over all the Pods of the revision.
+
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
     metadata:
-      annotations:
-        autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
-        autoscaling.knative.dev/metric: "metricName"
-```
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        metadata:
+          annotations:
+            autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
+            autoscaling.knative.dev/metric: "<metric-name>"
+    ```
+
+    Where `<metric-name>` is your custom metric.
 
 
 

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -19,7 +19,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
 * **Default:** `"concurrency"`
 
 
-=== Per-revision concurrency configuration
+=== "Per-revision concurrency configuration"
 
     ```yaml
     apiVersion: serving.knative.dev/v1

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -65,7 +65,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "cpu"
     ```
 
-=== Per-revision memory configuration
+=== "Per-revision memory configuration"
 
     ```yaml
     apiVersion: serving.knative.dev/v1

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -34,7 +34,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "concurrency"
     ```
 
-=== Per-revision rps configuration
+=== "Per-revision rps configuration"
 
     ```yaml
     apiVersion: serving.knative.dev/v1

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -15,7 +15,7 @@ The possible metric types that can be configured per revision depend on the type
 For more information about KPA and HPA, see the documentation on [Supported Autoscaler types](autoscaler-types.md).
 
 * **Per-revision annotation key:** `autoscaling.knative.dev/metric`
-* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `cpu`/`memory`/custom metrics are only supported on revisions with the HPA class.
+* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `cpu`/`memory`/`custom` metrics are only supported on revisions with the HPA class.
 * **Default:** `"concurrency"`
 
 

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -49,7 +49,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "rps"
     ```
 
-=== Per-revision cpu configuration
+=== "Per-revision cpu configuration"
 
     ```yaml
     apiVersion: serving.knative.dev/v1

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -81,7 +81,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "memory"
     ```
 
-=== Per-revision custom metric configuration
+=== "Per-revision custom metric configuration"
 
     You can create an HPA to scale the revision by a metric that you specify.
     The HPA will be configured to use the **average value** of your metric over all the Pods of the revision.

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -83,7 +83,7 @@ spec:
 
 === Per-revision custom metric configuration
 Assuming that you have a custom metric named `metricName` you can create an HPA to autoscale the revision by that metric.
-The HPA will be configured to use the average value of that metric over all the pods of the revision.
+The HPA will be configured to use the **average value** of that metric over all the pods of the revision.
 
 ```yaml
 apiVersion: serving.knative.dev/v1

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -21,15 +21,15 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
 
 === Per-revision concurrency configuration
 
-```yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: helloworld-go
-  namespace: default
-spec:
-  template:
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
     metadata:
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        metadata:
       annotations:
         autoscaling.knative.dev/metric: "concurrency"
 ```

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -30,9 +30,9 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
     spec:
       template:
         metadata:
-      annotations:
-        autoscaling.knative.dev/metric: "concurrency"
-```
+          annotations:
+            autoscaling.knative.dev/metric: "concurrency"
+    ```
 
 === Per-revision rps configuration
 

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -15,7 +15,7 @@ The possible metric types that can be configured per revision depend on the type
 For more information about KPA and HPA, see the documentation on [Supported Autoscaler types](autoscaler-types.md).
 
 * **Per-revision annotation key:** `autoscaling.knative.dev/metric`
-* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `cpu`/`memory`/`custom` metrics are only supported on revisions with the HPA class.
+* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `"cpu"`, `"memory"`, and `"custom"` metrics are only supported on revisions that use the HPA class.
 * **Default:** `"concurrency"`
 
 

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -51,19 +51,19 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
 
 === Per-revision cpu configuration
 
-```yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: helloworld-go
-  namespace: default
-spec:
-  template:
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
     metadata:
-      annotations:
-        autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
-        autoscaling.knative.dev/metric: "cpu"
-```
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        metadata:
+          annotations:
+            autoscaling.knative.dev/class: "hpa.autoscaling.knative.dev"
+            autoscaling.knative.dev/metric: "cpu"
+    ```
 
 === Per-revision memory configuration
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

This documents changes made in : https://github.com/knative/serving/pull/12277


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add documentation for HPA autoscaling by custom metrics
