### PR TITLE
Remove navigation.indexes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,6 @@ theme:
     - navigation.tracking
     - navigation.tabs.sticky
     - navigation.top
-    - navigation.indexes
 
 markdown_extensions:
   # - mdx_include:


### PR DESCRIPTION
Removes `navigation.indexes` to fix `README.md` navigation issue.

See Slack thread: https://knative.slack.com/archives/C9CV04DNJ/p1637161269112900