### PR TITLE
add gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: |
+      pip install mkdocs-material 
+      pip install mkdocs-material-extensions mkdocs-macros-plugin mkdocs-exclude mkdocs-awesome-pages-plugin mkdocs-redirects # runs during prebuild
+    command: mkdocs serve
+
+
+# List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 8000
+    onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,8 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
   - init: |
-      pip install mkdocs-material 
-      pip install mkdocs-material-extensions mkdocs-macros-plugin mkdocs-exclude mkdocs-awesome-pages-plugin mkdocs-redirects # runs during prebuild
-    command: mkdocs serve
+      pip install -r requirements.txt
+    command: mkdocs serve --dirtyreload
 
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->
Hi! I'm Pauline from [Gitpod](https://gitpod.io/). 👋🏼 

I came across your project during one of my evenings of GitHub browsing and thought that I'd raise a PR to help future contributors get started easily. Gitpod allows this by creating a workspace that lets contributors get started with coding almost immediately, without having to worry about dependencies and other tools that they need to install to get themselves onboarded onto the project. Instant dev environments all from the browser!

This PR is for docs initially, but I'd love to see Gitpod support in other Knative repos as well 🧡 I'll raise them if this docs PR goes well! I'm more than happy to answer any questions, but if you want to see this magic in action, try it here:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/knative/docs/pull/4507)
