### PR TITLE
Use `redirected` instead of `enabled` in the HTTPS redirection example

### DIFF
--- a/docs/serving/services/http-option.md
+++ b/docs/serving/services/http-option.md
@@ -23,7 +23,7 @@ You can override the default behavior for each Service or global configuration.
       name: example
       namespace: default
       annotations:
-        networking.knative.dev/httpOption: "enabled"
+        networking.knative.dev/httpOption: "redirected"
     spec:
       ...
     ```
@@ -36,7 +36,7 @@ You can override the default behavior for each Service or global configuration.
       name: config-network
       namespace: knative-serving
     data:
-      http-protocol: "enabled"
+      http-protocol: "redirected"
     ```
 
 === "Global (Operator)"
@@ -48,5 +48,5 @@ You can override the default behavior for each Service or global configuration.
     spec:
       config:
         network:
-          httpProtocol: "enabled"
+          httpProtocol: "redirected"
     ```


### PR DESCRIPTION
In [HTTPS redirection](https://knative.dev/docs/serving/services/http-option/) doc, the example uses `enabled` but it is a default value and so it doe not change anything actually.

The section is talking about `HTTPS redirection` so we should use
`redirected` in the example configuration.

/cc @abrennan89 @mgencur 