### PR TITLE
update examples to use kebab case

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -88,7 +88,7 @@ nav:
           - Using a custom TLS certificate for DomainMapping: serving/services/byo-certificate.md
           # TODO: Add security section to docs?
           - Configure resource requests and limits: serving/services/configure-requests-limits-services.md
-          - HTTPS redirection: serving/services/http-option.md
+          - HTTPS redirection: serving/services/http-protocol.md
         - Traffic management: serving/traffic-management.md
         - Configuring gradual rollout of traffic to Revisions: serving/rolling-out-latest-revision.md
         - Tag resolution: serving/tag-resolution.md

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -72,7 +72,7 @@ plugins:
       developer/serving/services/configure-requests-limits-services.md: serving/services/configure-requests-limits-services.md
       developer/serving/services/creating-services.md: serving/services/creating-services.md
       developer/serving/services/custom-domains.md: serving/services/custom-domains.md
-      developer/serving/services/http-option.md: serving/services/http-option.md
+      developer/serving/services/http-option.md: serving/services/http-protocol.md
       developer/serving/services/ingress-class.md: serving/services/ingress-class.md
       developer/serving/services/private-services.md: serving/services/private-services.md
       developer/serving/services/README.md: serving/services/README.md
@@ -130,3 +130,4 @@ plugins:
       serving/spec/knative-api-specification-1.0.md: https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md
       serving/using-an-ssl-cert/index.md: serving/using-a-tls-cert.md
       serving/using-subroutes.md: serving/traffic-management.md
+      serving/services/http-option.md: serving/services/http-protocol.md

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -35,7 +35,7 @@ Create the CloudEvents Player Service:
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/minScale: "1"
+            autoscaling.knative.dev/min-scale: "1"
         spec:
           containers:
             - image: ruromero/cloudevents-player:latest

--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -288,7 +288,7 @@ Knative Serving with different ingresses:
         spec:
           config:
             network:
-              ingress.class: "ambassador.ingress.networking.knative.dev"
+              ingress-class: "ambassador.ingress.networking.knative.dev"
         ```
 
     1. Apply the YAML file by running the command:
@@ -327,7 +327,7 @@ Knative Serving with different ingresses:
               enabled: true
           config:
             network:
-              ingress.class: "contour.ingress.networking.knative.dev"
+              ingress-class: "contour.ingress.networking.knative.dev"
         ```
 
     1. Apply the YAML file by running the command:
@@ -361,7 +361,7 @@ Knative Serving with different ingresses:
               enabled: true
           config:
             network:
-              ingress.class: "kourier.ingress.networking.knative.dev"
+              ingress-class: "kourier.ingress.networking.knative.dev"
         ```
 
     1. Apply the YAML file by running the command:

--- a/docs/serving/autoscaling/autoscale-go/README.md
+++ b/docs/serving/autoscaling/autoscale-go/README.md
@@ -189,10 +189,10 @@ autoscaler classes built into Knative:
            autoscaling.knative.dev/metric: concurrency
            # Target 10 requests in-flight per pod.
            autoscaling.knative.dev/target: "10"
-           # Disable scale to zero with a minScale of 1.
-           autoscaling.knative.dev/minScale: "1"
+           # Disable scale to zero with a min scale of 1.
+           autoscaling.knative.dev/min-scale: "1"
            # Limit scaling to 100 pods.
-           autoscaling.knative.dev/maxScale: "100"
+           autoscaling.knative.dev/max-scale: "100"
        spec:
          containers:
            - image: gcr.io/knative-samples/autoscale-go:0.1

--- a/docs/serving/autoscaling/concurrency.md
+++ b/docs/serving/autoscaling/concurrency.md
@@ -136,7 +136,7 @@ For example, if `containerConcurrency` is set to 10, and the target utilization 
 Requests numbered 7 to 10 will still be sent to the existing replicas, but this allows for additional replicas to be started in anticipation of being needed when the `containerConcurrency` limit is reached.
 
 * **Global key:** `container-concurrency-target-percentage`
-* **Per-revision annotation key:** `autoscaling.knative.dev/targetUtilizationPercentage`
+* **Per-revision annotation key:** `autoscaling.knative.dev/target-utilization-percentage`
 * **Possible values:** float
 * **Default:** `70`
 
@@ -153,7 +153,7 @@ Requests numbered 7 to 10 will still be sent to the existing replicas, but this 
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/targetUtilizationPercentage: "80"
+            autoscaling.knative.dev/target-utilization-percentage: "80"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go

--- a/docs/serving/autoscaling/kpa-specific.md
+++ b/docs/serving/autoscaling/kpa-specific.md
@@ -78,7 +78,7 @@ The panic window is defined as a percentage of the stable window to assure that 
 This value indicates how the window over which historical data is evaluated will shrink upon entering panic mode. For example, a value of `10.0` means that in panic mode the window will be 10% of the stable window size.
 
 * **Global key:** `panic-window-percentage`
-* **Per-revision annotation key:** `autoscaling.knative.dev/panicWindowPercentage`
+* **Per-revision annotation key:** `autoscaling.knative.dev/panic-window-percentage`
 * **Possible values:** float, `1.0` <= value <= `100.0`
 * **Default:** `10.0`
 
@@ -95,7 +95,7 @@ This value indicates how the window over which historical data is evaluated will
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/panicWindowPercentage: "20.0"
+            autoscaling.knative.dev/panic-window-percentage: "20.0"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go
@@ -156,7 +156,7 @@ The default setting of `200.0` means that panic mode will be start if traffic is
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/panicThresholdPercentage: "150.0"
+            autoscaling.knative.dev/panic-threshold-percentage: "150.0"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go

--- a/docs/serving/autoscaling/kpa-specific.md
+++ b/docs/serving/autoscaling/kpa-specific.md
@@ -139,7 +139,7 @@ This value is a percentage of the traffic that the current amount of replicas ca
 The default setting of `200.0` means that panic mode will be start if traffic is twice as high as the current replica population can handle.
 
 * **Global key:** `panic-threshold-percentage`
-* **Per-revision annotation key:** `autoscaling.knative.dev/panicThresholdPercentage`
+* **Per-revision annotation key:** `autoscaling.knative.dev/panic-threshold-percentage`
 * **Possible values:** float, `110.0` <= value <= `1000.0`
 * **Default:** `200.0`
 

--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -11,7 +11,7 @@ This value controls the minimum number of replicas that each Revision should hav
 Knative will attempt to never have less than this number of replicas at any one point in time.
 
 * **Global key:** n/a
-* **Per-revision annotation key:** `autoscaling.knative.dev/minScale`
+* **Per-revision annotation key:** `autoscaling.knative.dev/min-scale`
 * **Possible values:** integer
 * **Default:** `0` if scale-to-zero is enabled and class KPA is used, `1` otherwise
 
@@ -31,7 +31,7 @@ Knative will attempt to never have less than this number of replicas at any one 
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/minScale: "3"
+            autoscaling.knative.dev/min-scale: "3"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go
@@ -49,7 +49,7 @@ If the `max-scale-limit` global key is set, Knative ensures that neither the glo
 When `max-scale-limit` is set to a positive value, a revision with a max scale above that value (including 0, which means unlimited) is disallowed.
 
 * **Global key:** `max-scale`
-* **Per-revision annotation key:** `autoscaling.knative.dev/maxScale`
+* **Per-revision annotation key:** `autoscaling.knative.dev/max-scale`
 * **Possible values:** integer
 * **Default:** `0` which means unlimited
 
@@ -66,7 +66,7 @@ When `max-scale-limit` is set to a positive value, a revision with a max scale a
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/maxScale: "3"
+            autoscaling.knative.dev/max-scale: "3"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go
@@ -110,7 +110,7 @@ After the Revision has reached this scale one time, this value is ignored. This 
 When the Revision is created, the larger of initial scale and lower bound is automatically chosen as the initial target scale.
 
 * **Global key:** `initial-scale` in combination with `allow-zero-initial-scale`
-* **Per-revision annotation key:** `autoscaling.knative.dev/initialScale`
+* **Per-revision annotation key:** `autoscaling.knative.dev/initial-scale`
 * **Possible values:** integer
 * **Default:** `1`
 
@@ -127,7 +127,7 @@ When the Revision is created, the larger of initial scale and lower bound is aut
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/initialScale: "0"
+            autoscaling.knative.dev/initial-scale: "0"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go
@@ -172,7 +172,7 @@ will eventually be scaled down if reduced concurrency is maintained for the
 delay period.
 
 * **Global key:** `scale-down-delay`
-* **Per-revision annotation key:** `autoscaling.knative.dev/scaleDownDelay`
+* **Per-revision annotation key:** `autoscaling.knative.dev/scale-down-delay`
 * **Possible values:** Duration, `0s` <= value <= `1h`
 * **Default:** `0s` (no delay)
 
@@ -189,7 +189,7 @@ delay period.
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/scaleDownDelay: "15m"
+            autoscaling.knative.dev/scale-down-delay: "15m"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go
@@ -217,9 +217,4 @@ delay period.
         autoscaler:
           scale-down-delay: "15m"
     ```
-
-
-
-
-
 ---

--- a/docs/serving/autoscaling/scale-to-zero.md
+++ b/docs/serving/autoscaling/scale-to-zero.md
@@ -93,7 +93,7 @@ The `scale-to-zero-pod-retention-period` flag determines the minimum amount of t
 This contrasts with the `scale-to-zero-grace-period` flag, which determines the maximum amount of time that the last pod will remain active after the Autoscaler decides to scale pods to zero.
 
 * **Global key:** `scale-to-zero-pod-retention-period`
-* **Per-revision annotation key:** `autoscaling.knative.dev/scaleToZeroPodRetentionPeriod`
+* **Per-revision annotation key:** `autoscaling.knative.dev/scale-to-zero-pod-retention-period`
 * **Possible values:** Non-negative duration string
 * **Default:** `0s`
 
@@ -110,7 +110,7 @@ This contrasts with the `scale-to-zero-grace-period` flag, which determines the 
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/scaleToZeroPodRetentionPeriod: "1m5s"
+            autoscaling.knative.dev/scale-to-zero-pod-retention-period: "1m5s"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go

--- a/docs/serving/configuration/rolling-out-latest-revision-configmap.md
+++ b/docs/serving/configuration/rolling-out-latest-revision-configmap.md
@@ -24,7 +24,7 @@ You can configure the `rollout-duration` parameter by modifying the `config-netw
     spec:
       config:
         network:
-           rolloutDuration: "380s"
+           rollout-duration: "380s"
     ```
 
 {% include "route-status-updates.md" %}

--- a/docs/serving/load-balancing/README.md
+++ b/docs/serving/load-balancing/README.md
@@ -24,5 +24,5 @@ Target burst capacity can be configured using a combination of the following par
 
 - Setting the targeted concurrency limits for the revision. See [concurrency](../autoscaling/concurrency.md).
 - Setting the target utilization parameters. See [target utilization](../autoscaling/concurrency.md#target-utilization).
-- Setting the target burst capacity. You can configure target burst capacity using the `autoscaling.knative.dev/targetBurstCapacity` annotation key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](target-burst-capacity.md#setting-the-target-burst-capacity).
+- Setting the target burst capacity. You can configure target burst capacity using the `target-burst-capacity` key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](target-burst-capacity.md#setting-the-target-burst-capacity).
 - Setting the Activator capacity by using the `config-autoscaler` ConfigMap. See [Setting the Activator capacity](activator-capacity.md#setting-the-activator-capacity).

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -2,7 +2,7 @@
 
 If there is more than one Activator in the system, Knative puts as many Activators on the request path as required to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.
 
-Knative uses at least two Activators to enable high availability if possible. The actual number of Activators is calculated taking the _Activator capacity_ into account, by using the formula `(replicas * target + targetBurstCapacity)/activatorCapacity`. This means that there are enough Activators in the routing path to handle the theoretical capacity of the existing application, including any additional target burst capacity.
+Knative uses at least two Activators to enable high availability if possible. The actual number of Activators is calculated taking the _Activator capacity_ into account, by using the formula `(replicas * target + target-burst-capacity)/activator-capacity`. This means that there are enough Activators in the routing path to handle the theoretical capacity of the existing application, including any additional target burst capacity.
 
 ## Setting the Activator capacity
 

--- a/docs/serving/load-balancing/target-burst-capacity.md
+++ b/docs/serving/load-balancing/target-burst-capacity.md
@@ -9,12 +9,12 @@ Target burst capacity can be configured using a combination of the following par
 
 - Setting the targeted concurrency limits for the revision. See [concurrency](../autoscaling/concurrency.md).
 - Setting the target utilization parameters. See [target utilization](../autoscaling/concurrency.md#target-utilization).
-- Setting the target burst capacity. You can configure target burst capacity using the `autoscaling.knative.dev/targetBurstCapacity` annotation key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](#setting-the-target-burst-capacity).
+- Setting the target burst capacity. You can configure target burst capacity using the `target-burst-capacity` annotation key in the `config-autoscaler` ConfigMap. See [Setting the target burst capacity](#setting-the-target-burst-capacity).
 
 ## Setting the target burst capacity
 
 - **Global key:** `target-burst-capacity`
-- **Per-revision annotation key:** `autoscaling.knative.dev/targetBurstCapacity`
+- **Per-revision annotation key:** `autoscaling.knative.dev/target-burst-capacity`
 - **Possible values:** float (`0` means the Activator is only in path when scaled to 0, `-1` means the Activator is always in path)
 - **Default:** `200`
 
@@ -32,7 +32,7 @@ Target burst capacity can be configured using a combination of the following par
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/targetBurstCapacity: "200"
+            autoscaling.knative.dev/target-burst-capacity: "200"
     ```
 
 === "Global (ConfigMap)"
@@ -61,11 +61,11 @@ Target burst capacity can be configured using a combination of the following par
 
 
 
-- If `autoscaling.knative.dev/targetBurstCapacity` is set to `0`, the Activator is only added to the request path during scale from zero scenarios, and ingress load balancing will be applied.
+- If `autoscaling.knative.dev/target-burst-capacity` is set to `0`, the Activator is only added to the request path during scale from zero scenarios, and ingress load balancing will be applied.
 
 !!! note
     Ingress gateway load balancing requires additional configuration. For more information about load balancing using an ingress gateway, see the [Serving API](../../reference/api/serving-api.md) documentation.
 
-- If `autoscaling.knative.dev/targetBurstCapacity` is set to `-1`, the Activator is always in the request path, regardless of the revision size.
+- If `autoscaling.knative.dev/target-burst-capacity` is set to `-1`, the Activator is always in the request path, regardless of the revision size.
 
-- If `autoscaling.knative.dev/targetBurstCapacity` is set to another integer, the Activator may be in the path, depending on the revision scale and load.
+- If `autoscaling.knative.dev/target-burst-capacity` is set to another integer, the Activator may be in the path, depending on the revision scale and load.

--- a/docs/serving/rolling-out-latest-revision.md
+++ b/docs/serving/rolling-out-latest-revision.md
@@ -14,7 +14,7 @@ metadata:
   name: helloworld-go
   namespace: default
   annotations:
-    serving.knative.dev/rolloutDuration: "380s"
+    serving.knative.dev/rollout-duration: "380s"
 ```
 
 {% include "route-status-updates.md" %}

--- a/docs/serving/services/certificate-class.md
+++ b/docs/serving/services/certificate-class.md
@@ -1,18 +1,16 @@
 # Configuring a custom certificate class for a Service
 
-<!-- TODO: Update this page when new 'certificate-class' annotation is available -->
-
-When autoTLS is enabled and Knative Services are created, a certificate class (`certificate.class`) is automatically chosen based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the certificate class is not specified, this defaults to `cert-manager.certificate.networking.knative.dev`. After `certificate.class` is configured, it is used for all Knative Services unless it is overridden with a `certificate.class` annotation.
+When autoTLS is enabled and Knative Services are created, a certificate class (`certificate-class`) is automatically chosen based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the certificate class is not specified, this defaults to `cert-manager.certificate.networking.knative.dev`. After `certificate-class` is configured, it is used for all Knative Services unless it is overridden with a `certificate-class` annotation.
 
 ## Using the certificate class annotation
 
-Generally it is recommended for Knative Services to use the default `certificate.class`. However, in scenarios where there are multiple certificate providers, you might want to specify different certificate class annotations for each Service.
+Generally it is recommended for Knative Services to use the default `certificate-class`. However, in scenarios where there are multiple certificate providers, you might want to specify different certificate class annotations for each Service.
 
-You can configure each Service to use a different certificate class by specifying the `networking.knative.dev/certificate.class` annotation.
+You can configure each Service to use a different certificate class by specifying the `networking.knative.dev/certificate-class` annotation.
 
 To add a certificate class annotation to a Service, run the following command:
 ```bash
-kubectl annotate kservice <service-name> networking.knative.dev/certifcate.class=<certificate-provider>
+kubectl annotate kservice <service-name> networking.knative.dev/certifcate-class=<certificate-provider>
 ```
 Where:
 

--- a/docs/serving/services/http-protocol.md
+++ b/docs/serving/services/http-protocol.md
@@ -7,7 +7,7 @@ Operators can force HTTPS redirection for all Services. See the `http-protocol` 
 You can override the default behavior for each Service or global configuration.
 
 * **Global key:** `http-protocol`
-* **Per-revision annotation key:** `networking.knative.dev/httpOption`
+* **Per-revision annotation key:** `networking.knative.dev/http-protocol`
 * **Possible values:**
     * `enabled` &mdash; Services accept HTTP traffic.
     * `redirected` &mdash; Services send a 301 redirect for all HTTP connections and ask clients to use HTTPS instead.
@@ -23,7 +23,7 @@ You can override the default behavior for each Service or global configuration.
       name: example
       namespace: default
       annotations:
-        networking.knative.dev/httpOption: "redirected"
+        networking.knative.dev/http-protocol: "redirected"
     spec:
       ...
     ```

--- a/docs/serving/services/http-protocol.md
+++ b/docs/serving/services/http-protocol.md
@@ -48,5 +48,5 @@ You can override the default behavior for each Service or global configuration.
     spec:
       config:
         network:
-          httpProtocol: "redirected"
+          http-protocol: "redirected"
     ```

--- a/docs/serving/services/ingress-class.md
+++ b/docs/serving/services/ingress-class.md
@@ -1,21 +1,19 @@
 # Configuring Services custom ingress class
 
-<!-- TODO: Update this page when new 'ingress-class' annotation is available -->
-
-When a Knative Service is created an ingress class (`ingress.class`) is automatically assigned to it, based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the ingress class is not specified, this defaults to `istio.ingress.networking.knative.dev`. Once configured the `ingress.class` is used for all Knative Services unless it is overridden with an `ingress.class` annotation.
+When a Knative Service is created an ingress class (`ingress-class`) is automatically assigned to it, based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the ingress class is not specified, this defaults to `istio.ingress.networking.knative.dev`. Once configured the `ingress-class` is used for all Knative Services unless it is overridden with an `ingress-class` annotation.
 
 !!! warning
     Changing the ingress class in `config-network` ConfigMap will only affect newly created Services
 
 ## Using the ingress class annotation
 
-Generally it is recommended for Knative Services to use the default `ingress.class`. However, in scenarios where there are multiple networking implementations, you might want to specify different ingress class annotations for each Service.
+Generally it is recommended for Knative Services to use the default `ingress-class`. However, in scenarios where there are multiple networking implementations, you might want to specify different ingress class annotations for each Service.
 
-You can configure each Service to use a different ingress class by specifying the `networking.knative.dev/ingress.class` annotation.
+You can configure each Service to use a different ingress class by specifying the `networking.knative.dev/ingress-class` annotation.
 
 To add an ingress class annotation to a Service, run the following command:
 ```bash
-kubectl annotate kservice <service-name> networking.knative.dev/ingress.class=<ingress-type>
+kubectl annotate kservice <service-name> networking.knative.dev/ingress-class=<ingress-type>
 ```
 Where:
 
@@ -23,4 +21,4 @@ Where:
 - `<ingress-type>` is the type of ingress that is used as the ingress class for the Service.
 
 !!! note
-    This annotation overrides the `ingress.class` value specified in the `config-network` ConfigMap.
+    This annotation overrides the `ingress-class` value specified in the `config-network` ConfigMap.

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -162,16 +162,16 @@ selectors, see
 [the Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
 
 Prior to release 1.0, the fixed label
-`networking.knative.dev/disableWildcardCert: true` was used to disable
+`networking.knative.dev/disable-wildcard-cert: true` was used to disable
 certificate generation for a namespace. In 1.0 and later, other labels such as
 `kubernetes.io/metadata.name` may be used to select or restrict namespaces.
 
 To enable certificates for all namespaces except those with the
-`networking.knative.dev/disableWildcardCert: true` label, use the following
+`networking.knative.dev/disable-wildcard-cert: true` label, use the following
 command:
 
 ```bash
-kubectl patch --namespace knative-serving configmap config-network -p '{"data": {"namespace-wildcard-cert-selector": "{\"matchExpressions\": [{\"key\":\"networking.knative.dev/disableWildcardCert\", \"operator\": \"NotIn\", \"values\":[\"true\"]}]}"}}'
+kubectl patch --namespace knative-serving configmap config-network -p '{"data": {"namespace-wildcard-cert-selector": "{\"matchExpressions\": [{\"key\":\"networking.knative.dev/disable-wildcard-cert\", \"operator\": \"NotIn\", \"values\":[\"true\"]}]}"}}'
 ```
 
 This selects all namespaces where the label value is not in the set `"true"`.
@@ -322,7 +322,7 @@ be able to handle HTTPS traffic.
 
 ### Disable Auto TLS per service or route
 
-If you have Auto TLS enabled in your cluster, you can choose to disable Auto TLS for individual services or routes by adding the annotation `networking.knative.dev/disableAutoTLS: true`.
+If you have Auto TLS enabled in your cluster, you can choose to disable Auto TLS for individual services or routes by adding the annotation `networking.knative.dev/disable-auto-tls: true`.
 
 Using the previous `autoscale-go` example:
 
@@ -333,7 +333,7 @@ Using the previous `autoscale-go` example:
  metadata:
    annotations:
     ...
-     networking.knative.dev/disableAutoTLS: "true"
+     networking.knative.dev/disable-auto-tls: "true"
     ...
 ```
 2. The service URL should now be **http**, indicating that AutoTLS is disabled:

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -162,16 +162,16 @@ selectors, see
 [the Kubernetes documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
 
 Prior to release 1.0, the fixed label
-`networking.knative.dev/disable-wildcard-cert: true` was used to disable
+`networking.knative.dev/disableWildcardCert: true` was used to disable
 certificate generation for a namespace. In 1.0 and later, other labels such as
 `kubernetes.io/metadata.name` may be used to select or restrict namespaces.
 
 To enable certificates for all namespaces except those with the
-`networking.knative.dev/disable-wildcard-cert: true` label, use the following
+`networking.knative.dev/disableWildcardCert: true` label, use the following
 command:
 
 ```bash
-kubectl patch --namespace knative-serving configmap config-network -p '{"data": {"namespace-wildcard-cert-selector": "{\"matchExpressions\": [{\"key\":\"networking.knative.dev/disable-wildcard-cert\", \"operator\": \"NotIn\", \"values\":[\"true\"]}]}"}}'
+kubectl patch --namespace knative-serving configmap config-network -p '{"data": {"namespace-wildcard-cert-selector": "{\"matchExpressions\": [{\"key\":\"networking.knative.dev/disableWildcardCert\", \"operator\": \"NotIn\", \"values\":[\"true\"]}]}"}}'
 ```
 
 This selects all namespaces where the label value is not in the set `"true"`.


### PR DESCRIPTION
This makes the config maps and annotation keys consistent 

- update serving examples to use kebab-case for annotations
- update autoscaling examples to use kebab-case for annotations
- update examples to use kebab case networking annotations
- update operator config example to use kebab-case


Related:
- https://github.com/knative/serving/pull/12329
- https://github.com/knative/serving/issues/12103