### PR TITLE
Shorten Spring Boot Hello World nav Entry

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -229,7 +229,7 @@ nav:
           - .NET: serving/samples/hello-world/helloworld-csharp/README.md
           - Go: serving/samples/hello-world/helloworld-go/README.md
           - Java (Spark): serving/samples/hello-world/helloworld-java-spark/README.md
-          - Hello World - Spring Boot Java: serving/samples/hello-world/helloworld-java-spring/README.md
+          - Java (Spring Boot): serving/samples/hello-world/helloworld-java-spring/README.md
           - Kotlin: serving/samples/hello-world/helloworld-kotlin/README.md
           - Node.js: serving/samples/hello-world/helloworld-nodejs/README.md
           - PHP: serving/samples/hello-world/helloworld-php/README.md


### PR DESCRIPTION
Currently the Spring Boot Hello World Example stands out from the rest of the navigation entries:

<a href="https://knative.dev/docs/serving/samples/hello-world/helloworld-java-spring/"><img width="400" alt="Screen Shot 2021-11-26 at 11 04 33" src="https://user-images.githubusercontent.com/10284694/143563369-b75061e2-c7f7-4c82-86b4-03de4c0742e4.png"></a>

It is the only entry that takes up two lines (at least on a laptop) and includes a "Hello World" prefix. This PR changes it to `Java (Spring Boot)`, to be more aligned with the other navigation entries (especially the other Java one).

This only changes the title in the navigation, all headings in the linked document are fine as is.

## Proposed Changes 

- Change the nav entry of the Hello World Java Spring Boot App from `Hello World - Spring Boot Java` to `Java (Spring Boot)`

