### PR TITLE
Update links in document to Knative v1.0.0

### DIFF
--- a/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
+++ b/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
@@ -26,7 +26,7 @@ Next, create a Kubernetes cluster using KinD, and expose the ports the ingress g
 ```bash
 cat > clusterconfig.yaml <<EOF
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 nodes:
 - role: control-plane
   extraPortMappings:
@@ -68,7 +68,7 @@ Have a nice day! 👋
 Now that the cluster is running, you can add Knative components using the Knative CRDs. At the time of writing, the latest available version is 0.15.
 
 ```bash
-$ kubectl apply --filename https://github.com/knative/serving/releases/download/v0.15.0/serving-crds.yaml
+$ kubectl apply --filename https://github.com/knative/serving/releases/download/knative-v1.0.0/serving-crds.yaml
 ```
 
 ```bash
@@ -87,7 +87,7 @@ customresourcedefinition.apiextensions.k8s.io/images.caching.internal.knative.de
 After the CRDs, the core components are next to be installed on your cluster. For brevity, the unchanged components are removed from the response.
 
 ```bash
-$ kubectl apply --filename https://github.com/knative/serving/releases/download/v0.15.0/serving-core.yaml
+$ kubectl apply --filename https://github.com/knative/serving/releases/download/knative-v1.0.0/serving-core.yaml
 ```
 
 ```bash
@@ -132,7 +132,7 @@ Next, choose a networking layer. This example uses Kourier. Kourier is the optio
 To install Kourier and make it available as a service leveraging the node ports, you’ll need to download the YAML file first and make a few changes.
 
 ```bash
-curl -Lo kourier.yaml https://github.com/knative-sandbox/net-kourier/releases/download/v0.15.0/kourier.yaml
+curl -Lo kourier.yaml https://github.com/knative/net-kourier/releases/download/knative-v1.0.0/kourier.yaml
 ```
 
 By default, the Kourier service is set to be of type `LoadBalancer`. On local machines, this type doesn’t work, so you’ll have to change the type to `NodePort` and add `nodePort` elements to the two listed ports.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Update documents to reflect changes for knative v1.0.0.
