### PR TITLE
Redirect to Go package docs from a real browser

### DIFF
--- a/golang/_redirects
+++ b/golang/_redirects
@@ -60,13 +60,14 @@
 /networking/* go-get=1 /golang/networking.html 200
 /operator/* go-get=1 /golang/operator.html 200
 /pkg/* go-get=1 /golang/pkg.html 200
+/pkg/* https://pkg.go.dev/knative.dev/pkg/:splat
 /reconciler-test/* go-get=1 /golang/reconciler-test.html 200
 /release/* go-get=1 /golang/release.html 200
 /sample-controller/* go-get=1 /golang/sample-controller.html 200
 /sample-source/* go-get=1 /golang/sample-source.html 200
 /serving/* go-get=1 /golang/serving.html 200
+/serving/* https://pkg.go.dev/knative.dev/serving/:splat
 /specs/* go-get=1 /golang/specs.html 200
 /test-infra/* go-get=1 /golang/test-infra.html 200
 /ux/* go-get=1 /golang/ux.html 200
-/website/* go-get=1 /golang/website.html 200
 /wg-repository/* go-get=1 /golang/wg-repository.html 200

--- a/tools/redir-gen/redirtemplate.gohtml
+++ b/tools/redir-gen/redirtemplate.gohtml
@@ -1,4 +1,0 @@
-<html><head>
-    <meta name="go-import" content="knative.dev/{{.Repo}} git https://github.com/{{.Org}}/{{.Repo}}">
-    <meta name="go-source" content="knative.dev/{{.Repo}}     https://github.com/{{.Org}}/{{.Repo}} https://github.com/{{.Org}}/{{.Repo}}/tree/master{/dir} https://github.com/{{.Org}}/{{.Repo}}/blob/master{/dir}/{file}#L{line}">
-</head></html>


### PR DESCRIPTION
Opening this to start a conversation, feel free to close if this has been proposed and rejected before.

Basically, I'd love to be able to browse to https://knative.dev/serving, https://knative.dev/pkg, etc., and not get a 404. With this change, these URLs should be processed by real browsers with a client-side redirect to https://pkg.go.dev/... where any available Go package docs will be served.

If the repo doesn't have Go packages, this will redirect to a 404 over there. But for knative.dev/pkg, etc., this would be more useful. We can talk about adding some configuration to only redirect if the package has Go code, maybe? 🤷 

The only real code change is in `tools/redir-gen/main.go` (at the bottom of the list of changed files in this PR), the rest is generated by running that script. I've also deleted `tools/redir-gen/redirtemplate.gohtml` which appears to be unused.