### PR TITLE
Default to a single RabbitMQ cluster per Knative Eventing installation

### DIFF
--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -46,6 +46,9 @@ To use the RabbitMQ Broker, you must have the following installed:
         kind: RabbitmqCluster
         metadata:
           name: <cluster-name>
+          annotations:
+            # A single RabbitMQ cluster per Knative Eventing installation
+            rabbitmq.com/topology-allowed-namespaces: "*"
         ```
         Where `<cluster-name>` is the name you want for your RabbitMQ cluster,
         for example, `rabbitmq`.


### PR DESCRIPTION
This is what most users expect. Without it, the Messaging Topology Operator will not be able to manage objects from a different namespace. The implications are that all Brokers / Triggers / Sinks need to be created in the same namespace as the RabbitmqCluster. This annotation addresses that limitation.

More context:
- https://github.com/knative-sandbox/eventing-rabbitmq/issues/454
- https://github.com/rabbitmq/messaging-topology-operator/pull/201