### PR TITLE
Fixed wrong docs for DomainMapping API

### DIFF
--- a/docs/serving/services/custom-domains.md
+++ b/docs/serving/services/custom-domains.md
@@ -77,7 +77,7 @@ DomainMappings in that namespace to use the domain name.
                 kind: Service
                 apiVersion: serving.knative.dev/v1
               tls:
-                secret: <cert-secret>
+                secretName: <cert-secret>
             ```
             Where:
 


### PR DESCRIPTION
DomainMapping API uses `secretName`, not `secret`, see https://knative.dev/docs/reference/api/serving-api/#serving.knative.dev/v1alpha1.SecretTLS
