### PR TITLE
Document Kafka Broker commit offset interval

### DIFF
--- a/docs/eventing/broker/kafka-broker/README.md
+++ b/docs/eventing/broker/kafka-broker/README.md
@@ -227,6 +227,40 @@ kubectl create secret --namespace <namespace> generic <my_secret> \
 !!! note
     `ca.crt` can be omitted to fallback to use system's root CA set.
 
+## Consumer Offsets Commit Interval
+
+Kafka consumers keep track of the last successfully sent events by committing offsets.
+
+For performance reasons, it's not recommended committing offsets every time an event is successfully sent to a
+subscriber.
+
+Knative Kafka Broker commits the offset every `auto.commit.interval.ms` milliseconds.
+
+`auto.commit.interval.ms` can be changed by changing the `config-kafka-broker-data-plane` `ConfigMap`
+in the `knative-eventing` namespace by changing the parameter `auto.commit.interval.ms` as follows:
+
+```yaml
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-kafka-broker-data-plane
+  namespace: knative-eventing
+data:
+  # Some configurations omitted ...
+  config-kafka-broker-consumer.properties: |
+    # Some configurations omitted ...
+
+    # Commit the offset every 5000 millisecods (5 seconds)
+    auto.commit.interval.ms=5000
+```
+
+!!! note
+    While Knative Kafka Broker guarantees at least once delivery, hence your applications may
+    receive duplicate events, the higher the commit interval is the higher is the probability
+    of receiving duplicate events since when a Consumer restarts, it starts again from last
+    committed offsets.
+
 ## Kafka Producer and Consumer configurations
 
 Knative exposes all available Kafka producer and consumer configurations that can be modified to suit your workloads.

--- a/docs/eventing/broker/kafka-broker/README.md
+++ b/docs/eventing/broker/kafka-broker/README.md
@@ -231,13 +231,14 @@ kubectl create secret --namespace <namespace> generic <my_secret> \
 
 Kafka consumers keep track of the last successfully sent events by committing offsets.
 
-For performance reasons, it's not recommended committing offsets every time an event is successfully sent to a
-subscriber.
-
 Knative Kafka Broker commits the offset every `auto.commit.interval.ms` milliseconds.
 
-`auto.commit.interval.ms` can be changed by changing the `config-kafka-broker-data-plane` `ConfigMap`
-in the `knative-eventing` namespace by changing the parameter `auto.commit.interval.ms` as follows:
+!!! note
+    To prevent negative impacts to performance, it is not recommended committing
+    offsets every time an event is successfully sent to a subscriber.
+
+The interval can be changed by changing the `config-kafka-broker-data-plane` `ConfigMap`
+in the `knative-eventing` namespace by modifying the parameter `auto.commit.interval.ms` as follows:
 
 ```yaml
 
@@ -256,10 +257,10 @@ data:
 ```
 
 !!! note
-    While Knative Kafka Broker guarantees at least once delivery, hence your applications may
-    receive duplicate events, the higher the commit interval is the higher is the probability
-    of receiving duplicate events since when a Consumer restarts, it starts again from last
-    committed offsets.
+    Knative Kafka Broker guarantees at least once delivery, which means that your applications may
+    receive duplicate events. A higher commit interval means that there is a higher probability of
+    receiving duplicate events, because when a Consumer restarts, it restarts from the last
+    committed offset.
 
 ## Kafka Producer and Consumer configurations
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Fixes #4460

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Document Kafka Broker commit offset interval
