### PR TITLE
Update contributing call to action and links

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -6,7 +6,7 @@ nav:
     - Eventing: /docs/eventing/
     - Code samples: /docs/samples/
     - Reference: /docs/reference/
-    - "Community ➠": /docs/community/
+    - "Community": /docs/community/
     - Case studies: /docs/about/case-studies/deepc
   #####################################################
     # Blog

--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -6,7 +6,7 @@ nav:
     - Eventing: /docs/eventing/
     - Code samples: /docs/samples/
     - Reference: /docs/reference/
-    - "Join the Community ➠": /docs/community/
+    - "Community ➠": /docs/community/
     - Case studies: /docs/about/case-studies/deepc
   #####################################################
     # Blog

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -224,8 +224,8 @@ nav:
         - Eventing: reference/api/eventing-api.md
       - Concepts:
         - Duck types: reference/concepts/duck-typing.md
-    - "Join the Community ➠":
-      - Community Overview: community/README.md
+    - "Community ➠":
+      - Welcome to the community: community/README.md
       - Contribute to Knative: community/contributing.md
       - About the community: community/about.md
     - Case studies:

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -224,7 +224,7 @@ nav:
         - Eventing: reference/api/eventing-api.md
       - Concepts:
         - Duck types: reference/concepts/duck-typing.md
-    - "Community ➠":
+    - "Community":
       - Welcome to the community: community/README.md
       - Contribute to Knative: community/contributing.md
       - About the community: community/about.md

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -146,7 +146,6 @@ plugins:
       eventing/sources/containersource.md: eventing/custom-event-source/containersource/README.md
       eventing/sources/pingsource/index.md: eventing/sources/ping-source/README.md
       eventing/triggers/index.md: eventing/broker/triggers/README.md
-      help/contributor/README.md: https://github.com/knative/docs/blob/main/contribute-to-docs/README.md
       install/collecting-logs/index.md: serving/observability/logging/collecting-logs.md
       install/collecting-metrics/index.md: serving/observability/metrics/collecting-metrics.md
       install/getting-started-knative-app/index.md: getting-started/README.md

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,6 +1,4 @@
-# Join the community!
-
-Welcome to the Knative community!
+# Welcome to the Knative community!
 
 Knative is an open source project that anyone in the community can use, improve, and enjoy.
 We'd love you to join us!

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,6 +30,6 @@
   status = 301
 
 [[redirects]]
-  from = "/help/contributor/*"
+  from = "/docs/help/contributor/*"
   to = "https://github.com/knative/docs/blob/main/contribute-to-docs/README.md"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,3 +28,8 @@
   from = "/about-analytics-cookies/"
   to = "/development/about-analytics-cookies/"
   status = 301
+
+[[redirects]]
+  from = "/help/contributor/*"
+  to = "https://github.com/knative/docs/blob/main/contribute-to-docs/README.md"
+  status = 301

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -175,7 +175,7 @@
             {% include ".icons/fontawesome/brands/github.svg" %}
           </div>
           <h4>Contributions Welcome</h4>
-          <a href="https://github.com/knative/community/blob/main/CONTRIBUTING.md" title="Contributing Link" class="md-button">Contribute</a>
+          <a href="./community/contributing/" title="Contributing Link" class="md-button">Contribute</a>
           <p>Want to join the fun on Github? New users are always welcome!</p>
         </div>
         <div class="pane">


### PR DESCRIPTION
Fixes #4576

- Update the contribute call to action on home page 
- Change "Join the Community" to "Community" in the menu
- Update Community overview page name
- Redirect away from old docs contributor guide.