### PR TITLE
Fixes website banner for v1.0

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -4,6 +4,7 @@
 <meta name="theme-color" content="#1a7dc9" />
 {% endblock %}
 
+{% block announce %}
 {% if config.extra.version_warning %}
 <div class="versionwarning" style="margin: .6rem auto; padding: 0 .8rem">
   <h1>⚠ You are viewing an archived snapshot of the documentation for Knative version: {{ config.extra.knative_version }}</h1>
@@ -11,11 +12,11 @@
   Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The documentation you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="{{ base_url }}/../docs/">the latest version</a>.
   </p>
 </div>
-{% endif %}
-{% block announce %}
+{% else %}
 <div class="versionwarning" style="display: flex; justify-content: center;">
   <p>Knative is 1.0! 🎉  Check out our announcement on the <a href=https://knative.dev/blog/articles/knative-1.0/>Knative Blog<a/></p>
 </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Fixes #4593 

## Proposed Changes 

This fixes an issue where the warning message "You are viewing an archived snapshot of the documentation for Knative version 1.0" was not properly displaying. This fix creates an if-then-else announce block whereby the link to the 1.0 blog is shown on the current version, and past versions will show the you're looking at old docs" warning. 

It seems that the warning not being in the announce block was what was causing the problem with the 1.0 docs. It didn't show up as an issue prior to this because the link to the 1.0 blog was only added in the v1.0 docs.

Since this is a file change, I believe it will need to be cherry picked into the 1.0 release branch to take effect on https://knative.dev
/cherry-pick release-1.0


/assign @csantanapr 