### PR TITLE
Ignore duplicate case-studies images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ hack/__pycache__
 /node_modules/
 venv/
 
+# TODO clean up images copied between blog/ and docs/
+blog/docs/images/case-studies/
 
 .settings/
 .classpath


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

When building the website locally, the `docs/images/case-studies` directory gets copied to `blog/docs/images/case-studies`, creating a local copy that isn't needed. This would prevent that directory from being merged (and make the local experience a bit nicer by not having an untracked git directory sitting around).