### PR TITLE
Fix 1.0 banner again

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -52,7 +52,7 @@ else
     git clone --depth 1 -b ${DOCS_BRANCHES[$i+1]} https://github.com/knative/docs "$TEMP/docs-$version"
     curl -f -L --show-error https://raw.githubusercontent.com/knative/serving/${RELEASE_BRANCHES[i+1]}/docs/serving-api.md -s > "$TEMP/docs-$version/docs/reference/api/serving-api.md"
     curl -f -L --show-error https://raw.githubusercontent.com/knative/eventing/${RELEASE_BRANCHES[i+1]}/docs/eventing-api.md -s > "$TEMP/docs-$version/docs/reference/api/eventing-api.md"
-    pushd "$TEMP/docs-$version"; KNATIVE_VERSION=${RELEASE_BRANCHES[i+1]} SAMPLES_BRANCH="${DOCS_BRANCHES[i+1]}" VERSION_WARNING=true mkdocs build -d "$SITE/v$version-docs"; popd
+    pushd "$TEMP/docs-$version"; KNATIVE_VERSION=${RELEASE_BRANCHES[i+1]//knative-} SAMPLES_BRANCH="${DOCS_BRANCHES[i+1]}" VERSION_WARNING=true mkdocs build -d "$SITE/v$version-docs"; popd
 
   done
 

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -31,7 +31,14 @@ def define_env(env):
                     repo=repo,
                     file=file)
         else:
-            return 'https://github.com/{org}/{repo}/releases/download/{version}/{file}'.format(
+            if version.startswith("v1."):
+                return 'https://github.com/{org}/{repo}/releases/download/knative-{version}/{file}'.format(
+                    repo=repo,
+                    file=file,
+                    version=version,
+                    org=org)
+            else:
+                return 'https://github.com/{org}/{repo}/releases/download/{version}/{file}'.format(
                     repo=repo,
                     file=file,
                     version=version,


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

The 1.0 docs were displaying the "old version" incorrectly:

![image](https://user-images.githubusercontent.com/44698588/146577450-541d3271-1246-4506-afe7-fd851ceb1d48.png)

This fixes the issue by stripping `knative-` out of the version number and then adding it back to the artifact paths in macros.py.

