### PR TITLE
Fix bugs: delete indented code block in installing istio

### DIFF
--- a/docs/install/serving/installing-istio.md
+++ b/docs/install/serving/installing-istio.md
@@ -51,9 +51,9 @@ Enter the following command to install Istio:
 
 To install Istio without sidecar injection:
 
-    ```sh
-    istioctl install -y
-    ```
+```sh
+istioctl install -y
+```
 
 #### Installing Istio with sidecar injection
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->
- [In the part of install istio](https://knative.dev/docs/install/serving/installing-istio/#choosing-an-istio-installation), unnecessary back quotes and string `sh` is shown (see the image below).
- This bug is caused by the rule of Markdown. If we indent 4 spaces or more, markdown makes a code block ([ref](https://dosenbachlab.wustl.edu/wiki/markdown-guide/#:~:text=To%20produce%20a%20code%20block,This%20is%20a%20code%20block.&text=A%20code%20block%20continues%20until,the%20end%20of%20the%20article)).
- To solve the bug, I just deleted indents.
- I already checked by my forked [github-pages](https://shunpoco.github.io/docs/install/serving/installing-istio/#choosing-an-istio-installation).

![Screenshot from 2021-12-29 22-06-18](https://user-images.githubusercontent.com/25903627/147665475-5d259e4e-0073-441c-b7a3-55c38ba94e34.png)
