### PR TITLE
Mention optional attributes for CloudEvents in event sources overview

### DIFF
--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -22,6 +22,8 @@ All Sources are part of the `sources` category.
     kubectl get sources
     ```
 
+Please note: Event Sources which import events from other messaging technologies (such as Kafka or Rabbit) are not responsible for setting [Optional Attributes](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#optional-attributes) such as the `datacontenttype`. This is considered a responsibility of the original event producer, and the Source will simply append attributes if they exist.
+
 ## Knative Sources
 
 | Name | API Version | Maintainer | Description |

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -22,7 +22,8 @@ All Sources are part of the `sources` category.
     kubectl get sources
     ```
 
-Please note: Event Sources which import events from other messaging technologies (such as Kafka or Rabbit) are not responsible for setting [Optional Attributes](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#optional-attributes) such as the `datacontenttype`. This is considered a responsibility of the original event producer, and the Source will simply append attributes if they exist.
+!!! note
+    Event Sources that import events from other messaging technologies such as Kafka or RabbitMQ are not responsible for setting [Optional Attributes](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#optional-attributes) such as the `datacontenttype`. This is a responsibility of the original event producer; the Source just appends attributes if they exist.
 
 ## Knative Sources
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

This PR adds clarification that event sources which import messages from technologies such as Kafka, don't create/set optional attributes such as the `datacontenttype`.  That's a responsibility on the event producer.