### PR TITLE
Iter8 load testing tutorial

### DIFF
--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -27,5 +27,6 @@ A list of links to Knative code samples located outside of Knative repos:
 - [Knative Eventing (Cloud Events) example using spring-boot and spring-cloud-streams + Kafka](https://salaboy.com/2020/02/20/getting-started-with-knative-2020/)
 - [Image processing pipeline using Knative Eventing on GKE, Google Cloud Vision API and ImageSharp library](https://github.com/meteatamel/knative-tutorial/blob/master/docs/image-processing-pipeline.md)
 - [BigQuery processing pipeline using Knative Eventing on GKE, Cloud Scheduler, BigQuery, mathplotlib and SendGrid](https://github.com/meteatamel/knative-tutorial/blob/master/docs/bigquery-processing-pipeline.md)
+- [Load testing with SLO validation for Knative HTTP services](https://iter8.tools/0.8/tutorials/load-test/community/knative/loadtest/)
 
 _Please add links to your externally hosted Knative code sample._


### PR DESCRIPTION
Signed-off-by: Srinivasan Parthasarathy <spartha@us.ibm.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

This PR adds a link to an Iter8 tutorial, that demonstrates how  to load test a Knative service and validate SLOs, in a simple manner.
***
The last time I presented Iter8 in the Knative community meetup, I received a suggestion to create/add/link docs on how to effectively use Iter8 with Knative. This is the first of those docs. We hope to follow up with more docs on topics such as auto-rollouts, gitops, and A/B/n testing with Knative using Iter8. 