### PR TITLE
Remove unsupported Ambassador networking layer from docs

### DIFF
--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -303,69 +303,6 @@ Knative Serving with different ingresses:
 
         Save this for configuring DNS later.
 
-=== "Ambassador"
-
-    The following steps install Ambassador and enable its Knative integration:
-
-    1. Create a namespace to install Ambassador in:
-
-        ```bash
-        kubectl create namespace ambassador
-        ```
-
-    1. Install Ambassador:
-
-        ```bash
-        kubectl apply --namespace ambassador \
-          --filename https://getambassador.io/yaml/ambassador/ambassador-crds.yaml \
-          --filename https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
-          --filename https://getambassador.io/yaml/ambassador/ambassador-service.yaml
-        ```
-
-    1. Give Ambassador the required permissions:
-
-        ```bash
-        kubectl patch clusterrolebinding ambassador -p '{"subjects":[{"kind": "ServiceAccount", "name": "ambassador", "namespace": "ambassador"}]}'
-        ```
-
-    1. Enable Knative support in Ambassador:
-
-        ```bash
-        kubectl set env --namespace ambassador  deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
-        ```
-
-    1. To configure Knative Serving to use Ambassador, add `spec.config.network`
-    to your Serving CR YAML file as follows:
-
-        ```yaml
-        apiVersion: operator.knative.dev/v1alpha1
-        kind: KnativeServing
-        metadata:
-          name: knative-serving
-          namespace: knative-serving
-        spec:
-          # ...
-          config:
-            network:
-              ingress-class: "ambassador.ingress.networking.knative.dev"
-        ```
-
-    1. Apply the YAML file for your Serving CR by running the command:
-
-        ```bash
-        kubectl apply -f <filename>.yaml
-        ```
-
-        Where `<filename>` is the name of your Serving CR file.
-
-    1. Fetch the External IP or CNAME by running the command:
-
-        ```bash
-        kubectl --namespace ambassador get service ambassador
-        ```
-
-        Save this for configuring DNS later.
-
 === "Contour"
 
     The following steps install Contour and enable its Knative integration:

--- a/docs/install/serving/install-serving-with-yaml.md
+++ b/docs/install/serving/install-serving-with-yaml.md
@@ -86,56 +86,6 @@ Follow the procedure for the networking layer of your choice:
             Save this to use in the following [Configure DNS](#configure-dns) section.
 
 
-=== "Ambassador"
-
-    The following commands install Ambassador and enable its Knative integration.
-
-    1. Create a namespace in which to install Ambassador by running the command:
-
-        ```bash
-        kubectl create namespace ambassador
-        ```
-
-    1. Install Ambassador by running the command:
-
-        ```bash
-        kubectl apply --namespace ambassador \
-          -f https://getambassador.io/yaml/ambassador/ambassador-crds.yaml \
-          -f https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
-          -f https://getambassador.io/yaml/ambassador/ambassador-service.yaml
-        ```
-
-    1. Give Ambassador the required permissions by running the command:
-
-        ```bash
-        kubectl patch clusterrolebinding ambassador -p '{"subjects":[{"kind": "ServiceAccount", "name": "ambassador", "namespace": "ambassador"}]}'
-        ```
-
-    1. Enable Knative support in Ambassador by running the command:
-
-        ```bash
-        kubectl set env --namespace ambassador  deployments/ambassador AMBASSADOR_KNATIVE_SUPPORT=true
-        ```
-
-    1. Configure Knative Serving to use Ambassador by default by running the command:
-
-        ```bash
-        kubectl patch configmap/config-network \
-          --namespace knative-serving \
-          --type merge \
-          --patch '{"data":{"ingress-class":"ambassador.ingress.networking.knative.dev"}}'
-        ```
-
-    1. Fetch the External IP address or CNAME by running the command:
-
-        ```bash
-        kubectl --namespace ambassador get service ambassador
-        ```
-
-        !!! tip
-            Save this to use in the following [Configure DNS](#configure-dns) section.
-
-
 === "Contour"
 
     The following commands install Contour and enable its Knative integration.

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -58,27 +58,6 @@ Follow the relevant procedure to uninstall the networking layer you installed:
 <!-- This indentation is important for things to render properly. -->
 
 
-=== "Ambassador"
-
-    The following commands uninstall Ambassador and enable its Knative integration.
-
-    1. Uninstall Ambassador by running:
-
-       ```bash
-       kubectl delete --namespace ambassador \
-        -f https://getambassador.io/yaml/ambassador/ambassador-crds.yaml \
-        -f https://getambassador.io/yaml/ambassador/ambassador-rbac.yaml \
-        -f https://getambassador.io/yaml/ambassador/ambassador-service.yaml
-       ```
-
-    1. Delete the Ambassador namespace:
-
-       ```bash
-       kubectl delete namespace ambassador
-       ```
-
-
-
 === "Contour"
 
     The following commands uninstall Contour and enable its Knative integration.

--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -4,7 +4,7 @@ Knative Serving provides components that enable:
 
 - Rapid deployment of serverless containers.
 - Autoscaling, including scaling pods down to zero.
-- Support for multiple networking layers, such as Ambassador, Contour, Kourier, Gloo, and Istio, for integration into existing environments.
+- Support for multiple networking layers, such as Contour, Kourier, and Istio, for integration into existing environments.
 - Point-in-time snapshots of deployed code and configurations.
 
 Knative Serving supports both HTTP and [HTTPS](using-a-tls-cert.md) networking protocols.

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -10,10 +10,7 @@ Services. To learn more about using secure connections in Knative, see
 The following must be installed on your Knative cluster:
 
 - [Knative Serving](../install/serving/install-serving-with-yaml.md).
-- A Networking layer such as Kourier, Istio with SDS v1.3 or higher, Contour v1.1 or higher, or Gloo v0.18.16 or higher. See [Install a networking layer](../install/serving/install-serving-with-yaml.md#install-a-networking-layer) or [Istio with SDS, version 1.3 or higher](../install/serving/installing-istio.md#installing-istio-with-SDS-to-secure-the-ingress-gateway).
-
-    !!! note
-        Currently, [Ambassador](https://github.com/datawire/ambassador) is unsupported for use with Auto TLS.
+- A Networking layer such as Kourier, Istio with SDS v1.3 or higher, Contour v1.1 or higher. See [Install a networking layer](../install/serving/install-serving-with-yaml.md#install-a-networking-layer) or [Istio with SDS, version 1.3 or higher](../install/serving/installing-istio.md#installing-istio-with-SDS-to-secure-the-ingress-gateway).
 
 - [`cert-manager` version `1.0.0` or higher](../install/serving/installing-cert-manager.md).
 - Your Knative cluster must be configured to use a [custom domain](using-a-custom-domain.md).

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -10,7 +10,7 @@ Services. To learn more about using secure connections in Knative, see
 The following must be installed on your Knative cluster:
 
 - [Knative Serving](../install/serving/install-serving-with-yaml.md).
-- A Networking layer such as Kourier, Istio with SDS v1.3 or higher, Contour v1.1 or higher. See [Install a networking layer](../install/serving/install-serving-with-yaml.md#install-a-networking-layer) or [Istio with SDS, version 1.3 or higher](../install/serving/installing-istio.md#installing-istio-with-SDS-to-secure-the-ingress-gateway).
+- A Networking layer such as Kourier, Istio with SDS v1.3 or higher, or Contour v1.1 or higher. See [Install a networking layer](../install/serving/install-serving-with-yaml.md#install-a-networking-layer) or [Istio with SDS, version 1.3 or higher](../install/serving/installing-istio.md#installing-istio-with-SDS-to-secure-the-ingress-gateway).
 
 - [`cert-manager` version `1.0.0` or higher](../install/serving/installing-cert-manager.md).
 - Your Knative cluster must be configured to use a [custom domain](using-a-custom-domain.md).


### PR DESCRIPTION
Per this [Slack thread](https://knative.slack.com/archives/C0186KU7STW/p1637152982231400), we should probably remove Ambassador as a supported networking layer. 

See also #2050 