### PR TITLE
More explicit net-istio-controller controller registry override in Operator CR

### DIFF
--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -123,7 +123,7 @@ spec:
       controller: docker.io/knative-images-repo3/controller:v0.13.0
       webhook: docker.io/knative-images-repo4/webhook:v0.13.0
       autoscaler-hpa: docker.io/knative-images-repo5/autoscaler-hpa:v0.13.0
-      net-istio-controller: docker.io/knative-images-repo6/prefix-net-istio-controller:v0.13.0
+      net-istio-controller/controller: docker.io/knative-images-repo6/prefix-net-istio-controller:v0.13.0
       net-istio-webhook/webhook: docker.io/knative-images-repo6/net-istio-webhook:v0.13.0
       queue-proxy: docker.io/knative-images-repo7/queue-proxy-suffix:v0.13.0
 ```


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, add the corresponding "cherrypick-0.X"
label to the original PR; for example, "cherrypick-0.12".
Best practice is to open a PR for the cherry-pick yourself after your original PR has been merged
into the main branch.
After the cherry-pick PR has merged, remove the cherry-pick label from the original PR.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

There's a pitfall when following the doc to use Operator CR to override container registry. 
In the CR, when directly using `net-istio-controller` as the key, it somehow falls back to the knative serving `controller` image without any warning, thus we got `IngressNotConfigured` error when starting an ksvc.

There has been some discussions about it but the doc is still somewhat misleading.
- https://github.com/knative/operator/issues/519#issuecomment-827447017
- https://github.com/knative/serving/issues/12413#issuecomment-989966245
- https://github.com/knative/operator/issues/860

Therefore, it would be better to use explicit `net-istio-controller/controller` instead.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Replace `net-istio-controller` with `net-istio-controller/controller`
