### PR TITLE
Clarify purpose of getting started

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -8,8 +8,9 @@ nav:
 ###############################################################################
     # Getting started
 ###############################################################################
-    - Getting started:
-        - Knative Quickstart: getting-started/README.md
+    - Tutorial:
+        - Tutorial introduction: getting-started/README.md
+        - Install Knative using Quickstart: getting-started/quickstart-install.md
         - Using Knative Serving:
           - First Knative Service: getting-started/first-service.md
           - Scaling to Zero: getting-started/first-autoscale.md

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -10,7 +10,7 @@ nav:
 ###############################################################################
     - Tutorial:
         - Tutorial introduction: getting-started/README.md
-        - Install Knative using Quickstart: getting-started/quickstart-install.md
+        - Install Knative using quickstart: getting-started/quickstart-install.md
         - Using Knative Serving:
           - First Knative Service: getting-started/first-service.md
           - Scaling to Zero: getting-started/first-autoscale.md

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,28 +1,22 @@
-# Getting Started with Knative
-## Before you begin
-!!! warning
-    Knative Quickstart Environments are for experimentation use only. For production installation, see our [Installing Guide](../install/README.md)
+# Welcome to the Knative Quickstart tutorial
 
-Before you can get started with a Knative Quickstart deployment you must install kind, the Kubernetes CLI, and the Knative CLI.
+This tutorial lets you try out some of the commonly used features in Knative.
 
-### Prepare local Kubernetes cluster
+To follow this tutorial you must first install Knative locally using the Knative Quickstart plugin.
+The plugin provides a Knative deployment for development use, which has
+been configured with the components you need for this tutorial.
 
-You can use [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} (Kubernetes in Docker) or [`minikube`](https://minikube.sigs.k8s.io/docs/start/){target=_blank} to run a local Kubernetes cluster with Docker container nodes.
+Then, on your new cluster, you will carry out common tasks for Knative Serving and Knative Eventing.
+The tutorial is structured as follows:
 
-### Install the Kubernetes CLI
+1. Use the Knative Quickstart plugin to deploy Knative on a local cluster
+1. Create a Service
+1. Scale your Service
+1. Split traffic between two revisions of the Service
+1. Learn about Knative Eventing
+1. Learn about Brokers
+1. Create a Source
+1. Create a Trigger
+1. Clean up
 
-The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank}, allows you to run commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.
-
-### Install the Knative CLI
-
-The Knative CLI (`kn`) provides a quick and easy interface for creating Knative resources, such as Knative Services and Event Sources, without the need to create or modify YAML files directly.
-
-`kn` also simplifies completion of otherwise complex procedures such as autoscaling and traffic splitting.
-
---8<-- "install-kn.md"
-
-## Install the Knative "Quickstart" environment
-
-You can get started with a local deployment of Knative by using the Knative `quickstart` plugin.
-
---8<-- "quickstart-install.md"
+It is recommended that you complete the topics in this tutorial in order.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -2,21 +2,14 @@
 
 This tutorial lets you try out some of the commonly used features in Knative.
 
-To follow this tutorial you must first install Knative locally using the Knative Quickstart plugin.
+In the first lesson you will install Knative locally using the Knative Quickstart plugin.
+To follow the tutorial you must use the Quickstart plugin to install Knative.
 The plugin provides a Knative deployment for development use, which has
 been configured with the components you need for this tutorial.
 
-Then, on your new cluster, you will carry out common tasks for Knative Serving and Knative Eventing.
-The tutorial is structured as follows:
+Then, on your new cluster, you will carry out common tasks for **Knative Serving** and **Knative Eventing**.
 
-1. Use the Knative Quickstart plugin to deploy Knative on a local cluster
-1. Create a Service
-1. Scale your Service
-1. Split traffic between two revisions of the Service
-1. Learn about Knative Eventing
-1. Learn about Brokers
-1. Create a Source
-1. Create a Trigger
-1. Clean up
+We recommend that you complete the topics in this tutorial in order.
 
-It is recommended that you complete the topics in this tutorial in order.
+!!! tip
+    Hit ++"."++ on your keyboard to move forward in the tutorial. Use ++","++ to go back at any time.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -12,4 +12,4 @@ Then, on your new cluster, you will carry out common tasks for **Knative Serving
 We recommend that you complete the topics in this tutorial in order.
 
 !!! tip
-    Hit ++"."++ on your keyboard to move forward in the tutorial. Use ++","++ to go back at any time.
+    Hit ++"."++ (period) on your keyboard to move forward in the tutorial. Use ++","++ (comma) to go back at any time.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -2,8 +2,8 @@
 
 This tutorial lets you try out some of the commonly used features in Knative.
 
-In the first lesson you will install Knative locally using the Knative Quickstart plugin.
-To follow the tutorial you must use the Quickstart plugin to install Knative.
+In the first lesson you will install Knative locally using the Knative `quickstart` plugin.
+To follow the tutorial you must use the `quickstart` plugin to install Knative.
 The plugin provides a Knative deployment for development use, which has
 been configured with the components you need for this tutorial.
 

--- a/docs/getting-started/first-broker.md
+++ b/docs/getting-started/first-broker.md
@@ -1,5 +1,6 @@
-## Sources, Brokers, Triggers, Sinks, oh my!
-For the purposes of this tutorial, let's keep it simple. You will focus on four powerful Eventing components: Source, Trigger, Broker, and Sink.
+# Sources, Brokers, Triggers, Sinks, oh my!
+
+For the purposes of this tutorial, let's keep it simple. You will focus on four powerful Eventing components: **Source, Trigger, Broker, and Sink**.
 
 Let's take a look at how these components interact:
 
@@ -15,7 +16,8 @@ Let's take a look at how these components interact:
 !!! note "A note on Sources and Sinks"
     A Knative Service can act as both a Source and a Sink for events, and for good reason. You may want to consume events from the Broker and send modified events back to the Broker, as you would in any pipeline use-case.
 
-### CloudEvents
+## CloudEvents
+
 Knative Eventing uses
 [CloudEvents](https://github.com/cloudevents/spec/blob/v1.0.1/primer.md){target=blank_} to send
 information back and forth between your Services and these components.
@@ -32,6 +34,7 @@ information back and forth between your Services and these components.
 
 
 ## Examining the Broker
+
 As part of the `kn quickstart` install, an In-Memory Broker should have already be installed in your Cluster. Check to see that it is installed by running the command:
 
 ```bash

--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -1,6 +1,4 @@
 # Deploying your first Knative Service
-!!! tip
-    Hit ++"."++ on your keyboard to move forward in the tutorial. Use ++","++ to go back at any time.
 
 **In this tutorial, you will deploy a "Hello world" service.**
 

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -77,7 +77,7 @@ Create the CloudEvents Player Service:
 ![CloudEvents Player Send](images/event_sent.png)
 
 ??? tip "Clicking the :fontawesome-solid-envelope: shows you the CloudEvent as the Broker sees it."
-    ![Event_Details](images/event_details.
+    ![Event Details](images/event_details.png){:width="500px"}
 
 ??? question "Want to send events via the command line instead?"
     As an alternative to the Web form, events can also be sent/viewed via the command line.

--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -1,5 +1,5 @@
 # Basics of Traffic Splitting
-The last super power :rocket: of Knative Serving we'll go over in this tutorial is traffic splitting.
+The last super power :rocket: of Knative Serving we'll go over in this tutorial is **traffic splitting**.
 
 ??? question "What are some common traffic splitting use-cases?"
     Splitting traffic is useful for a number of very common modern infrastructure needs, such as

--- a/docs/getting-started/first-trigger.md
+++ b/docs/getting-started/first-trigger.md
@@ -1,4 +1,4 @@
-## Creating your first Trigger
+# Creating your first Trigger
 === "kn"
 
     ```bash

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -5,7 +5,7 @@ the Knative Quickstart plugin.
 The plugin installs a preconfigured Knative deployment on a local Kubernetes cluster.
 
 !!! warning
-    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing with YAML](../install/serving/README.md) or [Installing with the Operator](../install/operator/knative-with-operators/).
+    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing with YAML](../install/serving/install-serving-with-yaml.md) or [Installing with the Operator](../install/operator/knative-with-operators.md).
 
 ## Before you begin
 

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -1,4 +1,4 @@
-# Install Knative using the quickstart plugin
+# Install Knative using quickstart
 
 This topic describes how to install a local deployment of Knative Serving and Eventing using
 the Knative `quickstart` plugin.

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -1,0 +1,107 @@
+# Install Knative using Quickstart
+
+This topic describes how to install Knative Serving and Eventing using
+the Knative Quickstart plugin.
+The plugin installs a preconfigured Knative deployment on a local Kubernetes cluster.
+
+!!! warning
+    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing with YAML](/docs/install/yaml-install/) or [Installing with the Operator](/docs/install/operator/knative-with-operators/).
+
+## Before you begin
+
+Before you can get started with a Knative Quickstart deployment you must install kind, the Kubernetes CLI, and the Knative CLI.
+
+### Prepare a local Kubernetes cluster
+
+You can use [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} (Kubernetes in Docker) or [`minikube`](https://minikube.sigs.k8s.io/docs/start/){target=_blank} to run a local Kubernetes cluster with Docker container nodes.
+
+### Install the Kubernetes CLI
+
+The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank}, allows you to run commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.
+
+### Install the Knative CLI
+
+The Knative CLI (`kn`) provides a quick and easy interface for creating Knative resources, such as Knative Services and Event Sources, without the need to create or modify YAML files directly.
+
+`kn` also simplifies completion of otherwise complex procedures such as autoscaling and traffic splitting.
+
+--8<-- "install-kn.md"
+
+## Install the Knative "Quickstart" environment
+
+You can get started with a local deployment of Knative by using the Knative `quickstart` plugin.
+
+!!! todo "Installing the `quickstart` plugin"
+    === "Using Homebrew"
+        For macOS, you can install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}.
+            ```
+            brew install knative-sandbox/kn-plugins/quickstart
+            ```
+
+    === "Using a binary"
+         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it on your `PATH` (for example, in `/usr/local/bin`).
+
+         A link to the latest stable binary release is available on the [`quickstart` release page](https://github.com/knative-sandbox/kn-plugin-quickstart/releases){target=_blank}.
+
+    === "Using Go"
+        1. Check out the `kn-plugin-quickstart` repository:
+
+              ```
+              git clone https://github.com/knative-sandbox/kn-plugin-quickstart.git
+              cd kn-plugin-quickstart/
+              ```
+
+        1. Build an executable binary:
+
+              ```
+              hack/build.sh
+              ```
+
+        1. Move the executable binary file to a directory on your `PATH`:
+
+             ```
+             mv kn-quickstart /usr/local/bin
+             ```
+
+         1. Verify that the plugin is working, for example:
+
+             ```
+             kn quickstart --help
+             ```
+
+The `quickstart` plugin completes the following functions:
+
+1. **Checks if you have the selected Kubernetes instance installed,** and creates a cluster called `knative`.
+2. **Installs Knative Serving with Kourier** as the default networking layer, and sslip.io as the DNS.
+3. **Installs Knative Eventing** and creates an in-memory Broker and Channel implementation.
+
+
+!!! todo "Install Knative and Kubernetes locally"
+    === "Using kind"
+
+        Install Knative and Kubernetes on a local Docker daemon by running:
+        ```bash
+        kn quickstart kind
+        ```
+
+        After the plugin is finished, verify you have a cluster called `knative`:
+        ```bash
+        kind get clusters
+        ```
+
+    === "Using minikube"
+
+        Install Knative and Kubernetes in a minikube instance by running:
+        ```bash
+        kn quickstart minikube
+        ```
+
+        After the plugin is finished, verify you have a cluster called `knative`:
+        ```bash
+        minikube profile list
+        ```
+
+## Next steps
+
+Now you've installed Knative, learn how to deploy your first Service in the
+next topic in this tutorial.

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -9,7 +9,7 @@ The plugin installs a preconfigured Knative deployment on a local Kubernetes clu
 
 ## Before you begin
 
-Before you can get started with a Knative Quickstart deployment you must install kind, the Kubernetes CLI, and the Knative CLI.
+Before you can get started with a Knative Quickstart deployment you must install kind or minikube, the Kubernetes CLI, and the Knative CLI.
 
 ### Prepare a local Kubernetes cluster
 

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -5,7 +5,7 @@ the Knative Quickstart plugin.
 The plugin installs a preconfigured Knative deployment on a local Kubernetes cluster.
 
 !!! warning
-    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing with YAML](/docs/install/yaml-install/) or [Installing with the Operator](/docs/install/operator/knative-with-operators/).
+    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing with YAML](../install/serving/README.md) or [Installing with the Operator](../install/operator/knative-with-operators/).
 
 ## Before you begin
 

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -1,102 +1,109 @@
-# Install Knative using Quickstart
+# Install Knative using the quickstart plugin
 
-This topic describes how to install Knative Serving and Eventing using
-the Knative Quickstart plugin.
+This topic describes how to install a local deployment of Knative Serving and Eventing using
+the Knative `quickstart` plugin.
+
 The plugin installs a preconfigured Knative deployment on a local Kubernetes cluster.
 
 !!! warning
-    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing Knative](../install/README.md).
+    Knative `quickstart` environments are for experimentation use only. For a production ready installation, see [Installing Knative](../install/README.md).
 
 ## Before you begin
 
-Before you can get started with a Knative Quickstart deployment you must install kind or minikube, the Kubernetes CLI, and the Knative CLI.
+Before you can get started with a Knative `quickstart` deployment you must intstall:
 
-### Prepare a local Kubernetes cluster
-
-You can use [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} (Kubernetes in Docker) or [`minikube`](https://minikube.sigs.k8s.io/docs/start/){target=_blank} to run a local Kubernetes cluster with Docker container nodes.
-
-### Install the Kubernetes CLI
-
-The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank}, allows you to run commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start){target=_blank} (Kubernetes in Docker) or [minikube](https://minikube.sigs.k8s.io/docs/start/){target=_blank} to enable you to run a local Kubernetes cluster with Docker container nodes.
+- The [Kubernetes CLI (`kubectl`)](https://kubernetes.io/docs/tasks/tools/install-kubectl){target=_blank} to run commands against Kubernetes clusters. You can use `kubectl` to deploy applications, inspect and manage cluster resources, and view logs.
+- The Knative CLI (`kn`) v0.25 or later. For instructions, see the next section.
 
 ### Install the Knative CLI
 
-The Knative CLI (`kn`) provides a quick and easy interface for creating Knative resources, such as Knative Services and Event Sources, without the need to create or modify YAML files directly.
-
-`kn` also simplifies completion of otherwise complex procedures such as autoscaling and traffic splitting.
-
 --8<-- "install-kn.md"
 
-## Install the Knative "Quickstart" environment
+## Install the Knative quickstart plugin
 
-You can get started with a local deployment of Knative by using the Knative `quickstart` plugin.
+To get started, install the Knative `quickstart` plugin:
 
-!!! todo "Installing the `quickstart` plugin"
-    === "Using Homebrew"
-        For macOS, you can install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}.
-            ```
-            brew install knative-sandbox/kn-plugins/quickstart
-            ```
+=== "Using Homebrew"
+    For macOS, you can install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}:
 
-    === "Using a binary"
-         You can install the `quickstart` plugin by downloading the executable binary for your system and placing it on your `PATH` (for example, in `/usr/local/bin`).
+    ```bash
+    brew install knative-sandbox/kn-plugins/quickstart
+    ```
 
-         A link to the latest stable binary release is available on the [`quickstart` release page](https://github.com/knative-sandbox/kn-plugin-quickstart/releases){target=_blank}.
+=== "Using a binary"
+    1. Download the executable binary for your system from the [`quickstart` release page](https://github.com/knative-sandbox/kn-plugin-quickstart/releases){target=_blank}.
 
-    === "Using Go"
-        1. Check out the `kn-plugin-quickstart` repository:
+    1. Move the executable binary file to a directory on your `PATH`, for example, in `/usr/local/bin`.
 
-              ```
-              git clone https://github.com/knative-sandbox/kn-plugin-quickstart.git
-              cd kn-plugin-quickstart/
-              ```
+    1. Verify that the plugin is working, for example:
 
-        1. Build an executable binary:
+        ```bash
+        kn quickstart --help
+        ```
 
-              ```
-              hack/build.sh
-              ```
+=== "Using Go"
+    1. Check out the `kn-plugin-quickstart` repository:
 
-        1. Move the executable binary file to a directory on your `PATH`:
+          ```bash
+          git clone https://github.com/knative-sandbox/kn-plugin-quickstart.git
+          cd kn-plugin-quickstart/
+          ```
 
-             ```
-             mv kn-quickstart /usr/local/bin
-             ```
+    1. Build an executable binary:
 
-         1. Verify that the plugin is working, for example:
+          ```bash
+          hack/build.sh
+          ```
 
-             ```
-             kn quickstart --help
-             ```
+    1. Move the executable binary file to a directory on your `PATH`:
+
+          ```bash
+          mv kn-quickstart /usr/local/bin
+          ```
+
+     1. Verify that the plugin is working, for example:
+
+          ```bash
+          kn quickstart --help
+          ```
+
+## Run the Knative quickstart plugin
 
 The `quickstart` plugin completes the following functions:
 
-1. **Checks if you have the selected Kubernetes instance installed,** and creates a cluster called `knative`.
-2. **Installs Knative Serving with Kourier** as the default networking layer, and sslip.io as the DNS.
-3. **Installs Knative Eventing** and creates an in-memory Broker and Channel implementation.
+1. **Checks if you have the selected Kubernetes instance installed**
+1. **Creates a cluster called `knative`**
+1. **Installs Knative Serving** with Kourier as the default networking layer, and sslip.io as the DNS
+1. **Installs Knative Eventing** and creates an in-memory Broker and Channel implementation
 
 
-!!! todo "Install Knative and Kubernetes locally"
-    === "Using kind"
+To get a local deployment of Knative, run the `quickstart` plugin:
 
-        Install Knative and Kubernetes on a local Docker daemon by running:
+=== "Using kind"
+
+    1. Install Knative and Kubernetes on a local Docker daemon by running:
+
         ```bash
         kn quickstart kind
         ```
 
-        After the plugin is finished, verify you have a cluster called `knative`:
+    1. After the plugin is finished, verify you have a cluster called `knative`:
+
         ```bash
         kind get clusters
         ```
 
-    === "Using minikube"
+=== "Using minikube"
 
-        Install Knative and Kubernetes in a minikube instance by running:
+    1. Install Knative and Kubernetes in a minikube instance by running:
+
         ```bash
         kn quickstart minikube
         ```
 
-        After the plugin is finished, verify you have a cluster called `knative`:
+    1. After the plugin is finished, verify you have a cluster called `knative`:
+
         ```bash
         minikube profile list
         ```

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -5,7 +5,7 @@ the Knative Quickstart plugin.
 The plugin installs a preconfigured Knative deployment on a local Kubernetes cluster.
 
 !!! warning
-    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing with YAML](../install/serving/install-serving-with-yaml.md) or [Installing with the Operator](../install/operator/knative-with-operators.md).
+    Knative Quickstart Environments are for experimentation use only. For a production ready installation, see [Installing Knative](../install/README.md).
 
 ## Before you begin
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,7 +1,8 @@
 # Installing Knative
 
 !!! tip
-    You can install a local distribution of Knative for development use by following the [Getting started guide](../getting-started/README.md){_blank}.
+    You can install a local distribution of Knative for development purposes
+    using the [Knative Quickstart plugin](../getting-started/quickstart-install.md).
 
 You can install the Serving component, Eventing component, or both on your cluster by using one of the following deployment options:
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,7 +2,7 @@
 
 !!! tip
     You can install a local distribution of Knative for development purposes
-    using the [Knative Quickstart plugin](../getting-started/quickstart-install.md).
+    using the [Knative `quickstart` plugin](../getting-started/quickstart-install.md).
 
 You can install the Serving component, Eventing component, or both on your cluster by using one of the following deployment options:
 

--- a/docs/install/client/install-kn.md
+++ b/docs/install/client/install-kn.md
@@ -2,9 +2,11 @@
 
 This guide provides details about how you can install the Knative `kn` CLI.
 
+## Install the kn CLI
+
 --8<-- "install-kn.md"
 
-### Install kn using the nightly-built binary
+## Install kn using the nightly-built binary
 !!! warning
     Nightly container images include features which may not be included in the latest Knative release and are not considered to be stable.
 

--- a/docs/install/serving/installing-istio.md
+++ b/docs/install/serving/installing-istio.md
@@ -214,7 +214,8 @@ See the [Uninstall Istio](https://istio.io/docs/setup/install/istioctl/#uninstal
 
 ## What's next
 
-- Try the [Getting Started guide](../../getting-started/README.md) for Knative Serving.
+- View the [Knative Serving documentation](../../serving/README.md).
+- Try some Knative Serving [code samples](../../samples/README.md).
 
 [1]:
   https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#manual-sidecar-injection

--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -1,86 +1,86 @@
-!!! todo "Installing the `kn` CLI"
+The Knative CLI (`kn`) provides a quick and easy interface for creating Knative resources, such as Knative Services and Event Sources, without the need to create or modify YAML files directly.
 
-    === "Using Homebrew"
-        For macOS, you can install `kn` by using [Homebrew](https://brew.sh){target=_blank}.
+The `kn` CLI also simplifies completion of otherwise complex procedures such as autoscaling and traffic splitting.
 
-        ```
-        brew install kn
-        ```
+=== "Using Homebrew"
+    For macOS, you can install `kn` by using [Homebrew](https://brew.sh){target=_blank}:
 
-        !!! note
-            Quickstart requires `kn` version 0.25 or later. To upgrade an existing install to the latest version, run `brew upgrade kn`.
-
-    === "Using a binary"
-
-        You can install `kn` by downloading the executable binary for your system and placing it in the system path. Note that you will need `kn` version 0.25 or later.
-
-        1. Download the binary for your system from the [`kn` release page](https://github.com/knative/client/releases){target=_blank}.
-
-        1. Rename the binary to `kn` and make it executable by running the commands:
-
-            ```
-            mv <path-to-binary-file> kn
-            chmod +x kn
-            ```
-
-            Where `<path-to-binary-file>` is the path to the binary file you downloaded in the previous step, for example, `kn-darwin-amd64` or `kn-linux-amd64`.
-
-        1. Move the executable binary file to a directory on your PATH by running the command:
-
-            ```
-            mv kn /usr/local/bin
-            ```
-
-        1. Verify that the plugin is working by running the command:
-
-            ```
-            kn version
-            ```
-
-    === "Using Go"
-
-        1. Check out the `kn` client repository:
-
-              ```
-              git clone https://github.com/knative/client.git
-              cd client/
-              ```
-
-        1. Build an executable binary:
-
-              ```
-              hack/build.sh -f
-              ```
-
-        1. Move `kn` into your system path, and verify that `kn` commands are working properly. For example:
-
-              ```
-              kn version
-              ```
-
-    === "Using a container image"
-
-        Links to images are available here:
-
-        - [Latest release](https://gcr.io/knative-releases/knative.dev/client/cmd/kn){target=_blank}
-
-        You can run `kn` from a container image. For example:
-
-        ```
-        docker run --rm -v "$HOME/.kube/config:/root/.kube/config" gcr.io/knative-releases/knative.dev/client/cmd/kn:latest service list
-        ```
-
-        !!! note
-            Running `kn` from a container image does not place the binary on a permanent path. This procedure must be repeated each time you want to use `kn`.
-
-??? bug "Having issues upgrading `kn`?"
-
-    If you are having issues upgrading using Homebrew, it may be due to a change to a `CLI` repository, where `master` branch was renamed to `main`. If so, run
-
-    ```
-    brew tap --repair
-    brew update
-    brew upgrade kn
+    ```bash
+    brew install kn
     ```
 
-    to resolve the issue.
+    !!! note
+        The `quickstart` plugin requires `kn` v0.25 or later. To upgrade an existing install to the latest version, run `brew upgrade kn`.
+
+    ??? bug "Having issues upgrading `kn` using Homebrew?"
+
+        If you are having issues upgrading using Homebrew, it might be due to a change to a CLI repository where the `master` branch was renamed to `main`. Resolve this issue by running the command:
+
+        ```bash
+        brew tap --repair
+        brew update
+        brew upgrade kn
+        ```
+
+=== "Using a binary"
+
+    You can install `kn` by downloading the executable binary for your system and placing it in the system path. Note that you will need `kn` v0.25 or later.
+
+    1. Download the binary for your system from the [`kn` release page](https://github.com/knative/client/releases){target=_blank}.
+
+    1. Rename the binary to `kn` and make it executable by running the commands:
+
+        ```bash
+        mv <path-to-binary-file> kn
+        chmod +x kn
+        ```
+
+        Where `<path-to-binary-file>` is the path to the binary file you downloaded in the previous step, for example, `kn-darwin-amd64` or `kn-linux-amd64`.
+
+    1. Move the executable binary file to a directory on your PATH by running the command:
+
+        ```bash
+        mv kn /usr/local/bin
+        ```
+
+    1. Verify that the plugin is working by running the command:
+
+        ```bash
+        kn version
+        ```
+
+=== "Using Go"
+
+    1. Check out the `kn` client repository:
+
+          ```bash
+          git clone https://github.com/knative/client.git
+          cd client/
+          ```
+
+    1. Build an executable binary:
+
+          ```bash
+          hack/build.sh -f
+          ```
+
+    1. Move `kn` into your system path, and verify that `kn` commands are working properly. For example:
+
+          ```bash
+          kn version
+          ```
+
+=== "Using a container image"
+
+    Links to images are available here:
+
+    - [Latest release](https://gcr.io/knative-releases/knative.dev/client/cmd/kn){target=_blank}
+
+    You can run `kn` from a container image. For example:
+
+    ```bash
+    docker run --rm -v "$HOME/.kube/config:/root/.kube/config" gcr.io/knative-releases/knative.dev/client/cmd/kn:latest service list
+    ```
+
+    !!! note
+        Running `kn` from a container image does not place the binary on a permanent path. This procedure must be repeated each time you want to use `kn`.

--- a/docs/snippets/prerequisites.md
+++ b/docs/snippets/prerequisites.md
@@ -5,7 +5,8 @@ Before installing Knative, you must meet the following prerequisites:
 - **For prototyping purposes**, Knative works on most local deployments of Kubernetes. For example, you can use a local, one-node cluster that has 2&nbsp;CPUs and 4&nbsp;GB of memory.
 
     !!! tip
-        You can install a local distribution of Knative for development use by following the [Getting started guide](/docs/getting-started/){_blank}.
+        You can install a local distribution of Knative for development purposes
+        using the [Knative Quickstart plugin](/docs/getting-started/quickstart-install.md)
 
 - **For production purposes**, it is recommended that:
 


### PR DESCRIPTION
Fixes #4197 

- Renamed getting started section to Tutorial
- Added an introductory page for the tutorial
- Made it clear that you must install using Quickstart to follow the tutorial
- Removed reference to getting started on Istio page because Istio is for an advanced install
