### PR TITLE
Clarifications and style edits for the tutorial

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -18,7 +18,7 @@ nav:
         - Using Knative Eventing:
           - Introducing Knative Eventing: getting-started/getting-started-eventing.md
           - Sources, Brokers, Triggers, Sinks: getting-started/first-broker.md
-          - Introducing the CloudEvents Player: getting-started/first-source.md
+          - Using a Knative Service as a Source: getting-started/first-source.md
           - Creating your first Trigger: getting-started/first-trigger.md
         - What's Next?: getting-started/next-steps.md
         - Clean Up: getting-started/clean-up.md

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -18,8 +18,8 @@ nav:
         - Using Knative Eventing:
           - Introducing Knative Eventing: getting-started/getting-started-eventing.md
           - Sources, Brokers, Triggers, Sinks: getting-started/first-broker.md
-          - Using a Knative Service as a Source: getting-started/first-source.md
-          - Creating your first Trigger: getting-started/first-trigger.md
+          - Using a Knative Service as a source: getting-started/first-source.md
+          - Using Triggers and sinks: getting-started/first-trigger.md
         - What's Next?: getting-started/next-steps.md
         - Clean Up: getting-started/clean-up.md
 ###############################################################################

--- a/docs/getting-started/first-autoscale.md
+++ b/docs/getting-started/first-autoscale.md
@@ -1,5 +1,8 @@
 # Scaling to Zero
-**Remember those super powers :rocket: we talked about?** One of Knative Serving's powers is built-in automatic scaling (autoscaling). This means your Knative Service only spins up your application to perform its job -- in this case, saying "Hello world!" -- if it is needed; otherwise, it will "scale to zero" by spinning down and waiting for a new request to come in.
+
+**Remember those super powers :rocket: we talked about?** One of Knative Serving's powers is built-in automatic scaling, also known as **autoscaling**.
+This means your Knative Service only spins up your application to perform its job (in this case, saying "Hello world!") if it is needed.
+Otherwise, it will **scale to zero** by spinning down and waiting for a new request to come in.
 
 ??? question "What about scaling up to meet increased demand?"
     Knative Autoscaling also allows you to easily configure your service to scale up
@@ -12,7 +15,8 @@
 [Pod](https://kubernetes.io/docs/concepts/workloads/pods/){target=blank_} in Kubernetes where our
 Knative Service is running to watch our "Hello world!" Service scale up and down.
 
-### Run your Knative Service
+## Watch your Knative Service scale to zero
+
 Let's run our "Hello world!" Service just one more time. This time, try the Knative Service `URL` in
 your browser
 [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank}, or you
@@ -21,7 +25,7 @@ can use your terminal with `curl`.
 curl http://hello.default.127.0.0.1.sslip.io
 ```
 
-You can watch the pods and see how they scale to zero after traffic stops going to the URL.
+Now watch the pods and see how they scale to zero after traffic stops going to the URL.
 ```bash
 kubectl get pod -l serving.knative.dev/service=hello -w
 ```
@@ -30,26 +34,27 @@ kubectl get pod -l serving.knative.dev/service=hello -w
     It may take up to 2 minutes for your Pods to scale down. Pinging your service again will reset this timer.
 
 
-==**Expected output:**==
-```{ .bash .no-copy }
-NAME                                     READY   STATUS
-hello-world                              2/2     Running
-hello-world                              2/2     Terminating
-hello-world                              1/2     Terminating
-hello-world                              0/2     Terminating
-```
+!!! Success "Expected output"
+    ```{ .bash .no-copy }
+    NAME                                     READY   STATUS
+    hello-world                              2/2     Running
+    hello-world                              2/2     Terminating
+    hello-world                              1/2     Terminating
+    hello-world                              0/2     Terminating
+    ```
 
-### Scale up your Knative Service
+## Scale up your Knative Service
+
 Rerun the Knative Service in your browser [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank}, and you will see a new pod running again.
 
-==**Expected output:**==
-```{ .bash .no-copy }
-NAME                                     READY   STATUS
-hello-world                              0/2     Pending
-hello-world                              0/2     ContainerCreating
-hello-world                              1/2     Running
-hello-world                              2/2     Running
-```
+!!! Success "Expected output"
+    ```{ .bash .no-copy }
+    NAME                                     READY   STATUS
+    hello-world                              0/2     Pending
+    hello-world                              0/2     ContainerCreating
+    hello-world                              1/2     Running
+    hello-world                              2/2     Running
+    ```
 Exit the watch command with `Ctrl+c`.
 
 Some people call this **Serverless** :tada: :taco: :fire: Up next, traffic splitting!

--- a/docs/getting-started/first-broker.md
+++ b/docs/getting-started/first-broker.md
@@ -1,6 +1,6 @@
 # Sources, Brokers, Triggers, Sinks, oh my!
 
-For the purposes of this tutorial, let's keep it simple. You will focus on four powerful Eventing components: **Source, Trigger, Broker, and Sink**.
+For the purposes of this tutorial, let's keep it simple. You will focus on four powerful Eventing components: **Source**, **Trigger**, **Broker**, and **Sink**.
 
 Let's take a look at how these components interact:
 
@@ -35,17 +35,17 @@ information back and forth between your Services and these components.
 
 ## Examining the Broker
 
-As part of the `kn quickstart` install, an In-Memory Broker should have already be installed in your Cluster. Check to see that it is installed by running the command:
+As part of the `kn quickstart` install, an In-Memory Broker should already be installed in your Cluster. Check to see that it is installed by running the command:
 
 ```bash
 kn broker list
 ```
 
-==**Expected Output**==
-```{ .bash .no-copy }
-NAME             URL                                                                                AGE   CONDITIONS   READY   REASON
-example-broker   http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker     5m    5 OK / 5    True
-```
+!!! Success "Expected output"
+    ```{ .bash .no-copy }
+    NAME             URL                                                                                AGE   CONDITIONS   READY   REASON
+    example-broker   http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker     5m    5 OK / 5    True
+    ```
 !!! warning
     In-Memory Brokers are for development use only and must not be used in a production deployment.
 
@@ -55,4 +55,4 @@ example-broker   http://broker-ingress.knative-eventing.svc.cluster.local/defaul
 
     If you want to find out more about the different components of Knative Eventing, such as Channels, Sequences and Parallel flows, check out the [Knative Eventing documentation](../eventing/README.md){target=_blank}.
 
-**Next, you'll take a look at a simple implementation** of Sources, Brokers, Triggers and Sinks using an app called the Cloud Events Player.
+**Next, you'll take a look at a simple implementation** of Sources, Brokers, Triggers and Sinks using an app called the CloudEvents Player.

--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -76,6 +76,7 @@ First, deploy the Knative Service. This service accepts the environment variable
 
 
 ## Ping your Knative Service
+
 Ping your Knative Service by opening [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank} in your browser of choice or by running the command:
 
 ```

--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -2,12 +2,16 @@
 
 **In this tutorial, you will deploy a "Hello world" service.**
 
-This service will accept an environment variable, `TARGET`, and print "`Hello ${TARGET}!`."
-
 Since our "Hello world" Service is being deployed as a Knative Service, not a Kubernetes Service, it gets some **super powers out of the box** :rocket:.
 
 ## Knative Service: "Hello world!"
+
+First, deploy the Knative Service. This service accepts the environment variable,
+`TARGET`, and prints `Hello ${TARGET}!`.
+
 === "kn"
+
+    Deploy the Service by running the command:
 
     ``` bash
     kn service create hello \
@@ -20,49 +24,57 @@ Since our "Hello world" Service is being deployed as a Knative Service, not a Ku
     ??? question "Why did I pass in `revision-name`?"
         Note the name "world" which you passed in as "revision-name," naming your `Revisions` will help you to more easily identify them, but don't worry, you'll learn more about `Revisions` later.
 
-    ==**Expected output:**==
-    ```{ .bash .no-copy }
-    Service hello created to latest revision 'hello-world' is available at URL:
-    http://hello.default.127.0.0.1.sslip.io
-    ```
+    !!! Success "Expected output"
+        ```{ .bash .no-copy }
+        Service hello created to latest revision 'hello-world' is available at URL:
+        http://hello.default.127.0.0.1.sslip.io
+        ```
 
 === "YAML"
+    1. Copy the following YAML into a file named `hello.yaml`:
 
-    ``` bash
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    metadata:
-      name: hello
-    spec:
-      template:
+        ``` bash
+        apiVersion: serving.knative.dev/v1
+        kind: Service
         metadata:
-          # This is the name of our new "Revision," it must follow the convention {service-name}-{revision-name}
-          name: hello-world
+          name: hello
         spec:
-          containers:
-            - image: gcr.io/knative-samples/helloworld-go
-              ports:
-                - containerPort: 8080
-              env:
-                - name: TARGET
-                  value: "World"
-    ```
-    Once you've created your YAML file (named something like "hello.yaml"):
-    ``` bash
-    kubectl apply -f hello.yaml
-    ```
-    ??? question "Why did I pass in the second name, `hello-world`?"
-        Note the name "hello-world" which you passed in under "metadata" in your YAML file. Naming your `Revisions` will help you to more easily identify them, but don't worry if this if a bit confusing now, you'll learn more about `Revisions` later.
+          template:
+            metadata:
+              # This is the name of our new "Revision," it must follow the convention {service-name}-{revision-name}
+              name: hello-world
+            spec:
+              containers:
+                - image: gcr.io/knative-samples/helloworld-go
+                  ports:
+                    - containerPort: 8080
+                  env:
+                    - name: TARGET
+                      value: "World"
+        ```
+    1. Deploy the Knative Service by running the command:
 
-    ==**Expected output:**==
-    ```{ .bash .no-copy }
-    service.serving.knative.dev/hello created
-    ```
+        ``` bash
+        kubectl apply -f hello.yaml
+        ```
+        ??? question "Why did I pass in the second name, `hello-world`?"
+            Note the name `hello-world` which you passed in under `metadata` in your YAML file. Naming your `Revisions` will help you to more easily identify them, but don't worry if this if a bit confusing now, you'll learn more about `Revisions` later.
+        !!! Success "Expected output"
+            ```{ .bash .no-copy }
+            service.serving.knative.dev/hello created
+            ```
+    1. To see the URL where your Knative Service is hosted, leverage the `kn` CLI:
 
-    To see the URL where your Knative Service is hosted, leverage the `kn` CLI:
-    ```bash
-    kn service list
-    ```
+        ```bash
+        kn service list
+        ```
+        !!! Success "Expected output"
+            ```bash
+            NAME    URL                                          LATEST        AGE   CONDITIONS   READY   REASON
+            hello   http://hello.default.127.0.0.1.sslip.io   hello-world   13s   3 OK / 3     True
+            ```
+
+
 ## Ping your Knative Service
 Ping your Knative Service by opening [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank} in your browser of choice or by running the command:
 
@@ -70,11 +82,10 @@ Ping your Knative Service by opening [http://hello.default.127.0.0.1.sslip.io](h
 curl http://hello.default.127.0.0.1.sslip.io
 ```
 
-
-==**Expected output:**==
-```{ .bash .no-copy }
-Hello World!
-```
+!!! Success "Expected output"
+    ```{ .bash .no-copy }
+    Hello World!
+    ```
 
 ??? question "Are you seeing `curl: (6) Could not resolve host: hello.default.127.0.0.1.sslip.io`?"
 

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -1,4 +1,6 @@
-In this tutorial, you use the [CloudEvents Player](https://github.com/ruromero/cloudevents-player){target=blank} to showcase the core concepts of Knative Eventing. By the end of this tutorial, you should have an architecture that looks like this:
+# Using a Knative Service as a Source
+
+In this tutorial, you will use the [CloudEvents Player](https://github.com/ruromero/cloudevents-player){target=blank} app to showcase the core concepts of Knative Eventing. By the end of this tutorial, you should have an architecture that looks like this:
 
 ![The CloudEvents Player acts as both a Source and a Sink for CloudEvents](images/event_diagram.png)
 
@@ -9,52 +11,53 @@ The CloudEvents Player acts as a Source for CloudEvents by intaking the URL of t
 
 Create the CloudEvents Player Service:
 === "kn"
-
+    Run the command:
     ```bash
     kn service create cloudevents-player \
     --image ruromero/cloudevents-player:latest \
     --env BROKER_URL=http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker
     ```
-    ==**Expected Output**==
-    ```{ .bash .no-copy }
-    Service 'cloudevents-player' created to latest revision 'cloudevents-player-vwybw-1' is available at URL:
-    http://cloudevents-player.default.127.0.0.1.sslip.io
-    ```
+    !!! Success "Expected output"
+        ```{ .bash .no-copy }
+        Service 'cloudevents-player' created to latest revision 'cloudevents-player-vwybw-1' is available at URL:
+        http://cloudevents-player.default.127.0.0.1.sslip.io
+        ```
 
     ??? question "Why is my Revision named something different!"
         Because we didn't assign a `revision-name`, Knative Serving automatically created one for us. It's okay if your Revision is named something different.
 
 === "YAML"
-
-    ```bash
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    metadata:
-      name: cloudevents-player
-    spec:
-      template:
+    1. Copy the following YAML into a file named `cloudevents-player.yaml`:
+        ```bash
+        apiVersion: serving.knative.dev/v1
+        kind: Service
         metadata:
-          annotations:
-            autoscaling.knative.dev/min-scale: "1"
+          name: cloudevents-player
         spec:
-          containers:
-            - image: ruromero/cloudevents-player:latest
-              env:
-                - name: BROKER_URL
-                  value: http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker
-    ```
+          template:
+            metadata:
+              annotations:
+                autoscaling.knative.dev/min-scale: "1"
+            spec:
+              containers:
+                - image: ruromero/cloudevents-player:latest
+                  env:
+                    - name: BROKER_URL
+                      value: http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker
+        ```
 
-    Once you've created your YAML file, named something like `cloudevents-player.yaml`, apply it by running the command:
-    ``` bash
-    kubectl apply -f cloudevents-player.yaml
-    ```
+    1. Apply the YAML file by running the command:
+        ``` bash
+        kubectl apply -f cloudevents-player.yaml
+        ```
 
-    ==**Expected Output**==
-    ```{ .bash .no-copy }
-    service.serving.knative.dev/cloudevents-player created
-    ```
+        !!! Success "Expected output"
+            ```{ .bash .no-copy }
+            service.serving.knative.dev/cloudevents-player created
+            ```
 
 ## Examining the CloudEvents Player
+
 **You can use the CloudEvents Player to send and receive CloudEvents.** If you open the [Service URL](http://cloudevents-player.default.127.0.0.1.sslip.io){target=_blank} in your browser, the **Create Event** form appears:
 
 ![The user interface for the CloudEvents Player](images/event_form.png)
@@ -70,17 +73,21 @@ Create the CloudEvents Player Service:
 
     For more information on the CloudEvents Specification, check out the [CloudEvents Spec](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md){target=_blank}.
 
-  1. Fill in the form with whatever you data you want.
-  1. Ensure your Event Source does not contain any spaces.
-  1. Click **SEND EVENT**.
+### Sending an event
+
+Try sending an event using the CloudEvents Player interface:
+
+1. Fill in the form with whatever you data you want.
+1. Ensure your Event Source does not contain any spaces.
+1. Click **SEND EVENT**.
 
 ![CloudEvents Player Send](images/event_sent.png)
 
 ??? tip "Clicking the :fontawesome-solid-envelope: shows you the CloudEvent as the Broker sees it."
     ![Event Details](images/event_details.png){:width="500px"}
 
-??? question "Want to send events via the command line instead?"
-    As an alternative to the Web form, events can also be sent/viewed via the command line.
+??? question "Want to send events using the command line instead?"
+    As an alternative to the Web form, events can also be sent/viewed using the command line.
 
     To post an event:
     ```bash
@@ -100,4 +107,4 @@ Create the CloudEvents Player Service:
 
 The :material-send: icon in the "Status" column implies that the event has been sent to our Broker... but where has the event gone? **Well, right now, nowhere!**
 
-A Broker is simply a receptacle for events. In order for your events to be sent anywhere, you must create a Trigger which listens for your events and places them somewhere. And, you're in luck: you'll create your first Trigger on the next page!
+A Broker is simply a receptacle for events. In order for your events to be sent anywhere, you must create a Trigger which listens for your events and places them somewhere. And, you're in luck; you'll create your first Trigger on the next page!

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -1,12 +1,13 @@
-# Using a Knative Service as a Source
+# Using a Knative Service as a source
 
 In this tutorial, you will use the [CloudEvents Player](https://github.com/ruromero/cloudevents-player){target=blank} app to showcase the core concepts of Knative Eventing. By the end of this tutorial, you should have an architecture that looks like this:
 
-![The CloudEvents Player acts as both a Source and a Sink for CloudEvents](images/event_diagram.png)
+![The CloudEvents Player acts as both a source and a sink for CloudEvents](images/event_diagram.png)
 
 The above image is Figure 6.6 from [Knative in Action](https://www.manning.com/books/knative-in-action){target=_blank}.
 
-## Creating your first Source
+## Creating your first source
+
 The CloudEvents Player acts as a Source for CloudEvents by intaking the URL of the Broker as an environment variable, `BROKER_URL`. You will send CloudEvents to the Broker through the CloudEvents Player application.
 
 Create the CloudEvents Player Service:

--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -101,12 +101,12 @@ We can easily see a list of our existing revisions with the `kn` CLI.
     !!! Success "Expected output"
         ```{ .bash .no-copy }
         NAME            SERVICE   TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
-        hello-knative   hello     100%             2            30s   3 OK / 4     True    
-        hello-world     hello                      1            5m    3 OK / 4     True    
+        hello-knative   hello     100%             2            30s   3 OK / 4     True
+        hello-world     hello                      1            5m    3 OK / 4     True
         ```
 
 === "kubectl"
-     Though the following example doesn't cover it, you can peak under the hood to Kubernetes to see the revisions as Kubernetes sees them by running the command:  
+    Though the following example doesn't cover it, you can peak under the hood to Kubernetes to see the revisions as Kubernetes sees them by running the command:
     ```bash
     kubectl get revisions
     ```

--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -10,16 +10,21 @@ The last super power :rocket: of Knative Serving we'll go over in this tutorial 
 
 
 ## Creating a new Revision
-You may have noticed that when you created your Knative Service you assigned it a `revision-name`, "world". If you used `kn`, when your Service was created Knative returned both a URL and a "latest revision" for your Knative Service. **But what happens if you make a change to your Service?**
+
+You may have noticed that when you created your Knative Service you assigned it a `revision-name`, `world`. If you used `kn` when your Service was created, Knative returned both a URL and a "latest revision" for your Knative Service. **But what happens if you make a change to your Service?**
 
 ??? question "What exactly is a Revision?"
     You can think of a [Revision](../serving/README.md#serving-resources){target=_blank} as a stateless, autoscaling, snapshot-in-time of application code and configuration.
 
     A new Revision will get created each and every time you make changes to your Knative Service, whether you assign it a name or not. When splitting traffic, Knative splits traffic between different Revisions of your Knative Service.
 
-Instead of `TARGET`="World" update the environment variable `TARGET` on your Knative Service `hello` to greet "Knative" instead.  Name this new revision `hello-knative`
+### Create the Revision: hello-knative
+
+Instead of `TARGET=World` update the environment variable `TARGET` on your Knative Service `hello` to greet "Knative" instead.  Name this new revision `hello-knative`.
+
 === "kn"
 
+    Deploy the updated version of your Knative Service by running the command:
     ``` bash
     kn service update hello \
     --env TARGET=Knative \
@@ -27,91 +32,96 @@ Instead of `TARGET`="World" update the environment variable `TARGET` on your Kna
     ```
 
     As before, `kn` prints out some helpful information to the CLI.
-
-    ==**Expected output:**==
-    ```{ .bash .no-copy }
-    Service hello created to latest revision 'hello-knative' is available at URL:
-    http://hello.default.127.0.0.1.sslip.io
-    ```
+    !!! Success "Expected output"
+        ```{ .bash .no-copy }
+        Service hello created to latest revision 'hello-knative' is available at URL:
+        http://hello.default.127.0.0.1.sslip.io
+        ```
 
 === "YAML"
-    ``` bash
-    ---
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    metadata:
-      name: hello
-    spec:
-      template:
+    1. Edit your existing `hello.yaml` file to contain the following:
+        ``` bash
+        ---
+        apiVersion: serving.knative.dev/v1
+        kind: Service
         metadata:
-          name: hello-knative
+          name: hello
         spec:
-          containers:
-            - image: gcr.io/knative-samples/helloworld-go
-              ports:
-                - containerPort: 8080
-              env:
-                - name: TARGET
-                  value: "Knative"
-    ```
-    Once you've edited your existing YAML file:
-    ``` bash
-    kubectl apply -f hello.yaml
-    ```
+          template:
+            metadata:
+              name: hello-knative
+            spec:
+              containers:
+                - image: gcr.io/knative-samples/helloworld-go
+                  ports:
+                    - containerPort: 8080
+                  env:
+                    - name: TARGET
+                      value: "Knative"
+        ```
+    1. Deploy the updated version of your Knative Service by running the command:
+        ``` bash
+        kubectl apply -f hello.yaml
+        ```
 
-    ==**Expected output:**==
-    ```{ .bash .no-copy }
-    service.serving.knative.dev/hello configured
-    ```
+        !!! Success "Expected output"
+            ```{ .bash .no-copy }
+            service.serving.knative.dev/hello configured
+            ```
 
 
 Note, since we are updating an existing Knative Service `hello`, the URL doesn't change, but our new Revision should have the new name `hello-knative`
 
-Let's access our Knative Service again on your browser [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank} to see the change, or use `curl` in your terminal:
+### View the new Revision
+
+To see the change, access the Knative Service again on your browser [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank}, or use `curl` in your terminal:
 ```bash
 curl http://hello.default.127.0.0.1.sslip.io
 ```
 
-==**Expected output:**==
-```{ .bash .no-copy }
-Hello Knative!
-```
+!!! Success "Expected output"
+    ```{ .bash .no-copy }
+    Hello Knative!
+    ```
 
 ## Splitting Traffic
+
 You may at this point be wondering, "where did 'Hello World!' go?" Remember, Revisions are a stateless snapshot-in-time of application code and configuration, so your "hello-world" `Revision` is still available to you.
 
-We can easily see a list of our existing revisions with the `kn` CLI:
+### List your Revisions
+
+We can easily see a list of our existing revisions with the `kn` CLI.
 
 
 === "kn"
-
+    View a list of revisions by running the command:
     ```bash
     kn revisions list
     ```
+    !!! Success "Expected output"
+        ```{ .bash .no-copy }
+        NAME            SERVICE   TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
+        hello-knative   hello     100%             2            30s   3 OK / 4     True    
+        hello-world     hello                      1            5m    3 OK / 4     True    
+        ```
 
 === "kubectl"
-     Though the following example doesn't cover it, you can peak under the hood to Kubernetes to see the revisions as Kubernetes sees them.  
+     Though the following example doesn't cover it, you can peak under the hood to Kubernetes to see the revisions as Kubernetes sees them by running the command:  
     ```bash
     kubectl get revisions
     ```
 
-==**Expected output:**==
-```{ .bash .no-copy }
-NAME            SERVICE   TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
-hello-knative   hello     100%             2            30s   3 OK / 4     True    
-hello-world     hello                      1            5m    3 OK / 4     True    
-```
-
-The column most relevant for our purposes is `TRAFFIC`. It looks like 100% of traffic is going to our latest `Revision` ("hello-knative") and 0% of traffic is going to the Revision we configured earlier ("hello-world").
+When running the `kn` command, the column most relevant for our purposes is `TRAFFIC`. It looks like 100% of traffic is going to our latest `Revision` ("hello-knative")
+and 0% of traffic is going to the Revision we configured earlier ("hello-world").
 
 When you create a new Revision of a Knative Service, Knative defaults to directing 100% of traffic to this latest Revision. **We can change this default behavior by specifying how much traffic we want each of our Revisions to receive.**
 
+### Split traffic between Revisions
+
 Lets split traffic between our two Revisions:
 
-!!! info inline end
-    `@latest` will always point to our "latest" `Revision` which, at the moment, is `hello-knative`.
 === "kn"
-
+    Run the command:
     ```bash
     kn service update hello \
     --traffic hello-world=50 \
@@ -119,54 +129,60 @@ Lets split traffic between our two Revisions:
     ```
 
 === "YAML"
-    Add the following to the bottom of your existing YAML file:
-    ``` bash
-    apiVersion: serving.knative.dev/v1
-    kind: Service
-    metadata:
-      name: hello
-    spec:
-      template:
+    1. Add the `traffic` section to the bottom of your existing `hello.yaml` file:
+        ``` bash
+        apiVersion: serving.knative.dev/v1
+        kind: Service
         metadata:
-          name: hello-knative
+          name: hello
         spec:
-          containers:
-            - image: gcr.io/knative-samples/helloworld-go
-              ports:
-                - containerPort: 8080
-              env:
-                - name: TARGET
-                  value: "Knative"
-      traffic:
-      - latestRevision: true
-        percent: 50
-      - revisionName: hello-world
-        percent: 50
-    ```
-    Once you've edited your existing YAML file:
-    ``` bash
-    kubectl apply -f hello.yaml
-    ```
+          template:
+            metadata:
+              name: hello-knative
+            spec:
+              containers:
+                - image: gcr.io/knative-samples/helloworld-go
+                  ports:
+                    - containerPort: 8080
+                  env:
+                    - name: TARGET
+                      value: "Knative"
+          traffic:
+          - latestRevision: true
+            percent: 50
+          - revisionName: hello-world
+            percent: 50
+        ```
+    1. Apply the YAML by running the command:
+        ``` bash
+        kubectl apply -f hello.yaml
+        ```
 
-Verify traffic split configure correctly by listing the revisions again.
+!!! info
+    `@latest` will always point to our "latest" `Revision` which, at the moment, is `hello-knative`.
+
+### Verify the traffic split
+
+Verify traffic split has configured correctly by listing the revisions again.
+
 === "kn"
-
+    Run the command:
     ```bash
     kn revisions list
     ```
+    !!! Success "Expected output"
+        ```{ .bash .no-copy }
+        NAME            SERVICE   TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
+        hello-knative   hello     50%              2            10m   3 OK / 4     True
+        hello-world     hello     50%              1            36m   3 OK / 4     True
+        ```
 
 === "kubectl"
-     Though the following example doesn't cover it, you can peak under the hood to Kubernetes to see the revisions as Kubernetes sees them.  
+     Though the following example doesn't cover it, you can peak under the hood to Kubernetes to see the revisions as Kubernetes sees them by running the command:
     ```bash
     kubectl get revisions
     ```
 
-==**Expected output:**==
-```{ .bash .no-copy }
-NAME            SERVICE   TRAFFIC   TAGS   GENERATION   AGE   CONDITIONS   READY   REASON
-hello-knative   hello     50%              2            10m   3 OK / 4     True
-hello-world     hello     50%              1            36m   3 OK / 4     True
-```
 
 Access your Knative service on the browser again [http://hello.default.127.0.0.1.sslip.io](http://hello.default.127.0.0.1.sslip.io){target=_blank}, and refresh multiple times to see the different output being served by each Revision.
 
@@ -175,13 +191,13 @@ Similarly, you can `curl` the Service URL multiple times to see the traffic bein
 curl http://hello.default.127.0.0.1.sslip.io
 ```
 
-==**Expected output:**==
-```{ .bash .no-copy }
-curl http://hello.default.127.0.0.1.sslip.io
-Hello Knative!
+!!! Success "Expected output"
+    ```{ .bash .no-copy }
+    curl http://hello.default.127.0.0.1.sslip.io
+    Hello Knative!
 
-curl http://hello.default.127.0.0.1.sslip.io
-Hello World!
-```
+    curl http://hello.default.127.0.0.1.sslip.io
+    Hello World!
+    ```
 
-Congratulations, :tada: you've successfully split traffic between 2 different Revisions of a Knative Service. Up next, Knative Eventing!
+Congratulations, :tada: you've successfully split traffic between two different Revisions of a Knative Service. Up next, Knative Eventing!

--- a/docs/getting-started/first-trigger.md
+++ b/docs/getting-started/first-trigger.md
@@ -1,45 +1,55 @@
-# Creating your first Trigger
+# Triggers and Sinks
+
+TODO: Add some intro info here.
+
+## Creating your first Trigger
+
+TODO: Add some explanation here.
+
 === "kn"
 
+    To create a Trigger, run the command:
     ```bash
     kn trigger create cloudevents-trigger --sink cloudevents-player  --broker example-broker
     ```
+    !!! Success "Expected output"
+        ```{ .bash .no-copy }
+        Trigger 'cloudevents-trigger' successfully created in namespace 'default'.
+        ```
 
-    ```{ .bash .no-copy }
-    Trigger 'cloudevents-trigger' successfully created in namespace 'default'.
-    ```
 === "YAML"
-    ```bash
-    apiVersion: eventing.knative.dev/v1
-    kind: Trigger
-    metadata:
-      name: cloudevents-trigger
-      annotations:
-        knative-eventing-injection: enabled
-    spec:
-      broker: example-broker
-      subscriber:
-        ref:
-          apiVersion: serving.knative.dev/v1
-          kind: Service
-          name: cloudevents-player
-    ```
 
-    After you've created your YAML file, named something like `ce-trigger.yaml`, apply it by running the command:
-    ```bash
-    kubectl apply -f ce-trigger.yaml
-    ```
+    1. Copy the following YAML into a file named `ce-trigger.yaml`:
+        ```bash
+        apiVersion: eventing.knative.dev/v1
+        kind: Trigger
+        metadata:
+          name: cloudevents-trigger
+          annotations:
+            knative-eventing-injection: enabled
+        spec:
+          broker: example-broker
+          subscriber:
+            ref:
+              apiVersion: serving.knative.dev/v1
+              kind: Service
+              name: cloudevents-player
+        ```
 
-==**Expected Output**==
-    ```{ .bash .no-copy }
-    trigger.eventing.knative.dev/cloudevents-trigger created
-    ```
+    1. Create the Trigger by running the command:
+        ```bash
+        kubectl apply -f ce-trigger.yaml
+        ```
 
-trigger.eventing.knative.dev/cloudevents-player created
+        !!! Success "Expected output"
+            ```{ .bash .no-copy }
+            trigger.eventing.knative.dev/cloudevents-trigger created
+            ```
+
 ??? question "What CloudEvents is my Trigger listening for?"
     Because we didn't specify a `--filter` in our `kn` command, the Trigger is listening for any CloudEvents coming into the Broker.
 
-    The following example shows how to use Filters.
+    The expand the next note to see how to use Filters.
 
 Now, when we go back to the CloudEvents Player and send an Event, we see that CloudEvents are both sent and received by the CloudEvents Player:
 
@@ -57,7 +67,7 @@ You may need to refresh the page to see your changes.
       kn trigger create cloudevents-player-filter --sink cloudevents-player  --broker example-broker --filter type=some-type
     ```
 
-    If you send a CloudEvent with type "some-type," it is reflected in the CloudEvents Player UI.  The Trigger ignores any other types.
+    If you send a CloudEvent with type `some-type`, it is reflected in the CloudEvents Player UI.  The Trigger ignores any other types.
 
     You can filter on any aspect of the CloudEvent you would like to.
 

--- a/docs/getting-started/first-trigger.md
+++ b/docs/getting-started/first-trigger.md
@@ -3,7 +3,7 @@
 In the last topic we used the CloudEvents Player as an event source to send events to the Broker.
 We now want the event to go from the Broker to an event sink.
 
-In this topic, we will use the CloudEvents Player as a sink as well as a source.
+In this topic, we will use the CloudEvents Player as the sink as well as a source.
 This means we will be using the CloudEvents Player to both send and receive events.
 We will use a Trigger to listen for events in the Broker to send to the sink.
 

--- a/docs/getting-started/first-trigger.md
+++ b/docs/getting-started/first-trigger.md
@@ -1,14 +1,19 @@
-# Triggers and Sinks
+# Using Triggers and sinks
 
-TODO: Add some intro info here.
+In the last topic we used the CloudEvents Player as an event source to send events to the Broker.
+We now want the event to go from the Broker to an event sink.
+
+In this topic, we will use the CloudEvents Player as a sink as well as a source.
+This means we will be using the CloudEvents Player to both send and receive events.
+We will use a Trigger to listen for events in the Broker to send to the sink.
 
 ## Creating your first Trigger
 
-TODO: Add some explanation here.
+Create a Trigger that listens for CloudEvents from the event source and places them into the sink, which is also the CloudEvents Player app.
 
 === "kn"
 
-    To create a Trigger, run the command:
+    To create the Trigger, run the command:
     ```bash
     kn trigger create cloudevents-trigger --sink cloudevents-player  --broker example-broker
     ```
@@ -51,7 +56,7 @@ TODO: Add some explanation here.
 
     The expand the next note to see how to use Filters.
 
-Now, when we go back to the CloudEvents Player and send an Event, we see that CloudEvents are both sent and received by the CloudEvents Player:
+Now, when we go back to the CloudEvents Player and send an event, we see that CloudEvents are both sent and received by the CloudEvents Player:
 
 ![CloudEvents Player user interface](images/event_received.png){draggable=false}
 

--- a/docs/getting-started/getting-started-eventing.md
+++ b/docs/getting-started/getting-started-eventing.md
@@ -1,14 +1,15 @@
 # Introducing the Knative Eventing
 
-## Background
-With Knative Serving, we have a powerful tool which can take our containerized code and deploy it with relative ease. **With Knative Eventing, you gain a few new super powers :rocket:** that allow you to build Event-Driven Applications.
+With Knative Serving, we have a powerful tool which can take our containerized code and deploy it with relative ease. **With Knative Eventing, you gain a few new super powers :rocket:** that allow you to build **Event-Driven Applications**.
 
 ??? question "What are Event Driven Applications?"
     Event-driven applications are designed to detect events as they occur, and then deal with them using some event-handling procedure. Producing and consuming events with an "event-handling procedure" is precisely what Knative Eventing enables.
 
     Want to find out more about Event-Driven Architecture and Knative Eventing? Check out this CNCF Session aptly named ["Event-driven architecture with Knative events"](https://www.cncf.io/online-programs/event-driven-architecture-with-knative-events/){target=blank}
 
-==**Knative Eventing acts as the "glue" between the disparate parts of your architecture**== and allows you to easily communicate between those parts in a fault-tolerant way. Some examples include:
+## Knative Eventing examples
+
+**Knative Eventing acts as the "glue" between the disparate parts of your architecture** and allows you to easily communicate between those parts in a fault-tolerant way. Some examples include:
 
 :material-file-document: [Creating and responding to Kubernetes API events](../eventing/sources/apiserversource/README.md){target=blank}
 
@@ -18,4 +19,4 @@ With Knative Serving, we have a powerful tool which can take our containerized c
 --8<-- "YouTube_icon.svg"
 [Facilitating AI workloads at the edge in large-scale, drone-powered sustainable agriculture projects](https://www.youtube.com/watch?v=lVfJ5WEQ5_s){target=blank}
 
-As you can see by the mentioned examples, Knative Eventing implementations can range from simplistic to extremely complex. For now, you'll start with simplistic and learn about the most basic components of Knative Eventing: Sources, Brokers, Triggers and Sinks.
+As you can see by the mentioned examples, Knative Eventing implementations can range from simplistic to extremely complex. For now, you'll start with simplistic and learn about the most basic components of Knative Eventing: **Sources**, **Brokers**, **Triggers**, and **Sinks**.

--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -4,27 +4,29 @@ The `kn` CLI also simplifies completion of otherwise complex procedures such as 
 
 === "Using Homebrew"
 
-    - To install `kn` by using [Homebrew](https://brew.sh){target=_blank}:
+    Do one of the following:
+
+    - To install `kn` by using [Homebrew](https://brew.sh){target=_blank}, run the command:
 
         ```bash
         brew install kn
         ```
 
-    - To upgrade an existing install to the latest version by running the command:
+    - To upgrade an existing `kn` install to the latest version, run the command:
 
         ```bash
         brew upgrade kn
         ```
 
-    ??? bug "Having issues upgrading `kn` using Homebrew?"
+        ??? bug "Having issues upgrading `kn` using Homebrew?"
 
-        If you are having issues upgrading using Homebrew, it might be due to a change to a CLI repository where the `master` branch was renamed to `main`. Resolve this issue by running the command:
+            If you are having issues upgrading using Homebrew, it might be due to a change to a CLI repository where the `master` branch was renamed to `main`. Resolve this issue by running the command:
 
-        ```bash
-        brew tap --repair
-        brew update
-        brew upgrade kn
-        ```
+            ```bash
+            brew tap --repair
+            brew update
+            brew upgrade kn
+            ```
 
 === "Using a binary"
 

--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -4,13 +4,13 @@ The `kn` CLI also simplifies completion of otherwise complex procedures such as 
 
 === "Using Homebrew"
 
-    - Install `kn` by using [Homebrew](https://brew.sh){target=_blank}:
+    - To install `kn` by using [Homebrew](https://brew.sh){target=_blank}:
 
         ```bash
         brew install kn
         ```
 
-    - Upgrade an existing install to the latest version by running the command:
+    - To upgrade an existing install to the latest version by running the command:
 
         ```bash
         brew upgrade kn

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -121,7 +121,7 @@ To get a local deployment of Knative, run the `quickstart` plugin:
         ```bash
         minikube profile list
         ```
-    1. To finish setting up networking for minikube, run the following command in a separate terminal window:
+    1. To finish setting up networking for minikube, start the `minikube tunnel` process in a separate terminal window:
         ```bash
         minikube tunnel --profile knative
         ```

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -125,7 +125,7 @@ To get a local deployment of Knative, run the `quickstart` plugin:
         ```bash
         minikube tunnel --profile knative
         ```
-        The tunnel must continue running in a terminal window while you are using your Knative `quickstart` environment.
+        The tunnel must continue to run in a terminal window while you are using your Knative `quickstart` environment.
 
         !!! note
             To terminate the process and clean up network routes, enter `Ctrl-C`.

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -31,13 +31,16 @@ You can use `kubectl` to deploy applications, inspect and manage cluster resourc
 To get started, install the Knative `quickstart` plugin:
 
 === "Using Homebrew"
-    - To install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}:
+
+    Do one of the following:
+
+    - To install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}, run the command:
 
         ```bash
         brew install knative-sandbox/kn-plugins/quickstart
         ```
 
-    - To upgrade an existing install to the latest version by running the command:
+    - To upgrade an existing `quickstart` install to the latest version, run the command:
 
         ```bash
         brew upgrade knative-sandbox/kn-plugins/quickstart
@@ -118,3 +121,12 @@ To get a local deployment of Knative, run the `quickstart` plugin:
         ```bash
         minikube profile list
         ```
+    1. To finish setting up networking for minikube, run the following command in a separate terminal window:
+        ```bash
+        minikube tunnel --profile knative
+        ```
+        The tunnel must continue running in a terminal window while you are using your Knative `quickstart` environment.
+
+        !!! note
+            To terminate the process and clean up network routes, enter `Ctrl-C`.
+            For more information about the `minikube tunnel` command, see the [minikube documentation](https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-tunnel).

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -31,13 +31,13 @@ You can use `kubectl` to deploy applications, inspect and manage cluster resourc
 To get started, install the Knative `quickstart` plugin:
 
 === "Using Homebrew"
-    - Install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}:
+    - To install the `quickstart` plugin by using [Homebrew](https://brew.sh){target=_blank}:
 
         ```bash
         brew install knative-sandbox/kn-plugins/quickstart
         ```
 
-    - Upgrade an existing install to the latest version by running the command:
+    - To upgrade an existing install to the latest version by running the command:
 
         ```bash
         brew upgrade knative-sandbox/kn-plugins/quickstart


### PR DESCRIPTION
Fixes #4554
Fixes #4736 

- Style edits to all pages in the tutorial
- Added a step for running `minikube tunnel` to the quickstart install page
- Changed the name of some of the Eventing tutorial pages to make it clearer that the tutorial covers sources and sinks