### PR TITLE
fix: first-service.md uses `bash` rather than `yaml` for YAML

### DIFF
--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -33,7 +33,7 @@ First, deploy the Knative Service. This service accepts the environment variable
 === "YAML"
     1. Copy the following YAML into a file named `hello.yaml`:
 
-        ``` bash
+        ``` yaml
         apiVersion: serving.knative.dev/v1
         kind: Service
         metadata:


### PR DESCRIPTION

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- This PR fixes a blockquote that erroneously specifies a `bash` as the language, when the content is `yaml`.
