### PR TITLE
fix: remove duplicate 'in' on home page

### DIFF
--- a/overrides/home.html
+++ b/overrides/home.html
@@ -9,7 +9,7 @@
           <h1 class="main-headline">
             Knative is an open-source enterprise-level<br>
             solution for leveraging Kubernetes in<br>
-            in serverless applications.
+            serverless applications.
           </h1>
           <h2>Serverless workloads in Kubernetes environments.</h2>
           <p style="display: block">


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Removes one of the 'in's in "Knative is an open-source enterprise-level solution for leveraging Kubernetes in in serverless applications."

