### PR TITLE
Fx typo in event-display Service template spec

### DIFF
--- a/docs/eventing/flows/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/flows/sequence/sequence-reply-to-sequence/README.md
@@ -206,7 +206,7 @@ metadata:
 spec:
   template:
     spec:
-      containerers:
+      containers:
         - image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
 ```
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

In the [Sequence wired to another Sequence](https://knative.dev/docs/eventing/flows/sequence/sequence-reply-to-sequence/) example the knative Service for event-display has a typo in the template spec.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fixed typo `containerers ` --> `containers`
