### PR TITLE
Updating client configuration details

### DIFF
--- a/docs/install/client/configure-kn.md
+++ b/docs/install/client/configure-kn.md
@@ -22,11 +22,11 @@ eventing:
 
 Where
 
-- `path-lookup` specifies whether `kn` should look for [plugins](kn-plugins.md) in the `PATH` environment variable. This is a boolean configuration option. The default value is `false`.
-- `directory` specifies the directory where `kn` will look for plugins. The default path depends on the operating system, as described earlier. This can be any directory that is visible to the user.
+- `path-lookup` specifies whether `kn` should look for [plugins](kn-plugins.md) in the `PATH` environment variable. This is a boolean configuration option (default: `true`). Note: the `path-lookup` option has been deprecated and will be removed in a future version where path lookup will be enabled unconditionally.
+- `directory` specifies the directory where `kn` will look for plugins. The default path depends on the operating system, as described earlier. This can be any directory that is visible to the user (default: `$base_dir/plugins`, where `$base_dir` is the directory where this configuration file is stored).
 - `sink-mappings` defines the Kubernetes Addressable resource that is used when you use the `--sink` flag with a `kn` CLI command.
     - `prefix`: The prefix you want to use to describe your sink. Service, `svc`, `channel`, and `broker` are predefined prefixes in `kn`.
     <!--can be a prefix be anything? Otherwise let's provide a full list of what's allowed, limitations, etc.-->
     - `group`: The API group of the Kubernetes resource.
     - `version`: The version of the Kubernetes resource.
-    - `resource`: The plural name of the Kubernetes resource type. For example, `services` or `brokers`.
+    - `resource`: The lowercased, plural name of the Kubernetes resource type. For example, `services` or `brokers`.


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

As discussed in WG in Feb, updating the client configuration details to note that `path-lookup` is enabled by default. Also some minor syncing between the docs text and what's in https://github.com/knative/client/tree/main/docs#options