### PR TITLE
Adds security page to site

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -239,6 +239,7 @@ nav:
       - Client: reference/client/README.md
       - Concepts:
         - Duck types: reference/concepts/duck-typing.md
+      - Security: reference/security/README.md
     - Community:
       - Welcome to the community: community/README.md
       - Contribute to Knative: community/contributing.md

--- a/docs/reference/security/README.md
+++ b/docs/reference/security/README.md
@@ -10,7 +10,7 @@ This page describes Knative security and disclosure information.
 
 We're extremely grateful for security researchers and users that report vulnerabilities to the Knative Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
 
-To make a report, please email the private security@knative.team list with the s ecurity detauls and the details expected for all Knative bug reports. 
+To make a report, please email the private security@knative.team list with the security detauls and the details expected for all Knative bug reports.
 
 ### When Should I Report a Vulnerability?
 

--- a/docs/reference/security/README.md
+++ b/docs/reference/security/README.md
@@ -1,0 +1,37 @@
+# Knative Security and Disclosure Information
+
+This page describes Knative security and disclosure information.
+
+## Knative threat model
+
+* [Threat model](https://github.com/knative/community/blob/main/working-groups/security/threat-model.md)
+
+## Report a vulnerability
+
+We're extremely grateful for security researchers and users that report vulnerabilities to the Knative Open Source Community. All reports are thoroughly investigated by a set of community volunteers.
+
+To make a report, please email the private security@knative.team list with the s ecurity detauls and the details expected for all Knative bug reports. 
+
+### When Should I Report a Vulnerability?
+
+* You think you discovered a potential security vulnerability in Knative
+* You are unsure how a vulnerability affects Knative
+* You think you discovered a vulnerability in another project that Knative depends on
+    * For projects with their own vulnerability reporting and disclosure process, please report it directly there
+
+### When Should I NOT Report a Vulnerability?
+
+* You need help tuning Knative components for security
+* You need help applying security related updates
+* Your issue is not security related
+
+## Vulnerability response
+
+* [Early disclosure of security vulnerabilities](https://github.com/knative/community/blob/main/working-groups/security/disclosure.md)
+* [Vulnerability disclosure response policy](https://github.com/knative/community/blob/main/working-groups/security/responding.md)
+
+## Security working group
+
+* [General information](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#security)
+* [Security Working Group Charter](https://github.com/knative/community/blob/main/working-groups/security/CHARTER.md)
+


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

Adds security page to the website. Modeled after the [Kubernetes page on the same topic](https://kubernetes.io/docs/reference/issues-security/security/)

Fixes #4672 

/assign @evankanderson for WG review
/assign @csantanapr @snneji for DUX review