### PR TITLE
Release note blog 1.3

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -14,6 +14,7 @@ nav:
     - Blog:
       - index.md
       - Releases:
+          - releases/announcing-knative-v1-3-release.md
           - releases/announcing-knative-v1-2-release.md
           - releases/announcing-knative-v1-1-release.md
           - releases/announcing-knative-v1-0-release.md

--- a/blog/docs/index.md
+++ b/blog/docs/index.md
@@ -20,25 +20,25 @@ Follow this blog to keep up-to-date with Knative.
 
     Find out where the Knative team will be talking next, and where they've been.
 
-# Featured Posts
+## Featured Posts
 
-## Knative joins the CNCF
+### Knative joins the CNCF
 This is a big milestone for our project and we are excited to join the [CNCF](https://www.cncf.io)
 
 [Read more :octicons-arrow-right-24:](steering/cncf.md){ .md-button }
 
-## Knative 1.3 is out!
+### Knative 1.3 is out!
 Details on the 1.3 release of the Knative project.
 
 [Read more :octicons-arrow-right-24:](releases/announcing-knative-v1-3-release.md){ .md-button }
 
-## Highlighting the value of Knative for the c-suite
+### Highlighting the value of Knative for the c-suite
 
 Deploy faster and more cost-effectively without hard-to-find, specialized expertise. Knative—building on Kubernetes—supports serverless code  development and deployment. This allows your developers to focus on creating code and deploying resilient applications fast without having to become experts on Kubernetes...
 
 [Read more :octicons-arrow-right-24:](articles/highlighting-value-knative-c-suite.md){ .md-button }
 
-## Distributed tracing with Knative, OpenTelemetry and Jaeger
+### Distributed tracing with Knative, OpenTelemetry and Jaeger
 
 When trying to understand and diagnose our systems, one of the most basic tools we learn to lean on is the stack trace. Stack traces give us a structured view of the flow of logic that our program is executing in order to help us wrap our heads ...
 

--- a/blog/docs/index.md
+++ b/blog/docs/index.md
@@ -27,10 +27,10 @@ This is a big milestone for our project and we are excited to join the [CNCF](ht
 
 [Read more :octicons-arrow-right-24:](steering/cncf.md){ .md-button }
 
-## Knative 1.2 is out!
-Details on the 1.2 release of the Knative project.
+## Knative 1.3 is out!
+Details on the 1.3 release of the Knative project.
 
-[Read more :octicons-arrow-right-24:](releases/announcing-knative-v1-2-release.md){ .md-button }
+[Read more :octicons-arrow-right-24:](releases/announcing-knative-v1-3-release.md){ .md-button }
 
 ## Highlighting the value of Knative for the c-suite
 

--- a/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
+++ b/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
@@ -16,7 +16,7 @@ A new version of Knative is now available across multiple components.
 Follow the instructions in the documentation
 [Installing Knative](https://knative.dev/docs/install/) for the respective component.
 
-### Table of Contents
+## Table of Contents
 - [Highlights](#highlights)
 - [Serving TODO-KNATIVE-VERSION](#serving-TODO-KNATIVE-VERSION-NOSPACES)
 - [Eventing TODO-KNATIVE-VERSION](#eventing-TODO-KNATIVE-VERSION-NOSPACES)

--- a/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
+++ b/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
@@ -9,14 +9,14 @@ type: "blog"
 ---
 
 
-### Announcing Knative TODO-KNATIVE-VERSION Release
+## Announcing Knative TODO-KNATIVE-VERSION Release
 
 A new version of Knative is now available across multiple components.
 
 Follow the instructions in the documentation
 [Installing Knative](https://knative.dev/docs/install/) for the respective component.
 
-#### Table of Contents
+### Table of Contents
 - [Highlights](#highlights)
 - [Serving TODO-KNATIVE-VERSION](#serving-TODO-KNATIVE-VERSION-NOSPACES)
 - [Eventing TODO-KNATIVE-VERSION](#eventing-TODO-KNATIVE-VERSION-NOSPACES)
@@ -28,105 +28,108 @@ Follow the instructions in the documentation
 - [Thank you contributors](#thank-you-contributors)
 
 
-### Highlights
+## Highlights
 
 - TODO: Add list of highlights for the release
 
 
-### Serving TODO-KNATIVE-VERSION
+## Serving TODO-KNATIVE-VERSION
 
 <!-- Original notes are here: https://github.com/knative/serving/releases/tag/knative-TODO-KNATIVE-VERSION -->
 
-#### 🚨 Breaking or Notable Changes
+### 🚨 Breaking or Notable Changes
 
 - TODO: Add any breaking or notable changes, using format `TEXT ([#PR-NUMBER](PR-URL))`
 
-#### 💫 New Features & Changes
+### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-#### 🐞 Bug Fixes
+### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
-### Eventing TODO-KNATIVE-VERSION
+## Eventing TODO-KNATIVE-VERSION
 
 <!-- Original notes are here: https://github.com/knative/eventing/releases/tag/knative-TODO-KNATIVE-VERSION -->
 
-#### 🚨 Breaking or Notable Changes
+### 🚨 Breaking or Notable Changes
 
 - TODO: Add any breaking or notable changes
 
-#### 💫 New Features & Changes
+### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-#### 🐞 Bug Fixes
+### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
-### Eventing Extensions
+## Eventing Extensions
 
-#### Apache Kafka Broker TODO-KNATIVE-VERSION
+### Apache Kafka Broker TODO-KNATIVE-VERSION
 
 <!-- Original notes are here: https://github.com/knative-sandbox/eventing-kafka-broker/releases/tag/knative-TODO-KNATIVE-VERSION -->
 
-#### 💫 New Features & Changes
+### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-#### 🐞 Bug Fixes
+### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
-#### RabbitMQ Broker and Source TODO-KNATIVE-VERSION
+### RabbitMQ Broker and Source TODO-KNATIVE-VERSION
 
 <!-- Original notes are here: https://github.com/knative-sandbox/eventing-rabbitmq/releases/tag/knative-TODO-KNATIVE-VERSION -->
 
 
-#### 💫 New Features & Changes
+### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-#### 🐞 Bug Fixes
+### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
-### Client TODO-KNATIVE-VERSION
+## Client TODO-KNATIVE-VERSION
 
 <!-- Original notes are here: https://github.com/knative/client/blob/main/CHANGELOG.adoc#TODO-CLI-CHANGELOG-ENTRY -->
 
-#### 💫 New Features & Changes
+### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-#### 🐞 Bug Fixes
+### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
-### Operator TODO-KNATIVE-VERSION
+## Operator TODO-KNATIVE-VERSION
 
 <!-- Original notes are here: https://github.com/knative/operator/releases/tag/knative-TODO-KNATIVE-VERSION   -->
 
-#### 💫 New Features & Changes
+### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-#### 🐞 Bug Fixes
+### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
-### Thank you, contributors
+## Thank you, contributors
+
+Release Leads: TODO: Add release leads here
+
+Contributors:
 
 - TODO:Add list of authors to PRs in this release and the release leads. Use fomat `[@username](https://github.com/username)` and sorted
 
-
-### Learn more
+## Learn more
 
 Knative is an open source project that anyone in the [community](https://knative.dev/docs/community/) can use, improve, and enjoy. We'd love you to join us!
 
-- [Welcome to Knative](https://knative.dev/docs)
-- [Getting started documentation](https://knative.dev/docs/getting-started)
+- [Knative docs](https://knative.dev/docs)
+- [Quickstart tutorial](https://knative.dev/docs/getting-started)
 - [Samples](https://knative.dev/docs/samples)
 - [Knative working groups](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md)
 - [Knative User Mailing List](https://groups.google.com/forum/#!forum/knative-users)

--- a/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
+++ b/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
@@ -118,11 +118,13 @@ Follow the instructions in the documentation
 
 ## Thank you, contributors
 
-Release Leads: TODO: Add release leads here
+Release Leads:
+
+- TODO: List the release leads here. Use format `[@username](https://github.com/username)`.
 
 Contributors:
 
-- TODO:Add list of authors to PRs in this release and the release leads. Use fomat `[@username](https://github.com/username)` and sorted
+- TODO: Add a list of authors to PRs in this release. Use format `[@username](https://github.com/username)` and sort alphabetically.
 
 ## Learn more
 

--- a/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
+++ b/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
@@ -13,8 +13,8 @@ type: "blog"
 
 A new version of Knative is now available across multiple components.
 
-Follow the instructions in the documentation
-[Installing Knative](https://knative.dev/docs/install/) for the respective component.
+Follow the instructions in
+[Installing Knative](https://knative.dev/docs/install/) to install the components you require.
 
 ## Table of Contents
 - [Highlights](#highlights)

--- a/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
+++ b/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
@@ -120,11 +120,11 @@ Follow the instructions in the documentation
 
 Release Leads:
 
-- TODO: List the release leads here. Use format `[@username](https://github.com/username)`.
+- TODO: List the release leads. Use format `[@username](https://github.com/username)`.
 
 Contributors:
 
-- TODO: Add a list of authors to PRs in this release. Use format `[@username](https://github.com/username)` and sort alphabetically.
+- TODO: Add a list of authors of the PRs listed these release notes. Use format `[@username](https://github.com/username)` and sort alphabetically.
 
 ## Learn more
 

--- a/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
+++ b/blog/docs/releases/_template-announcing-knative-v1-X-release.txt
@@ -71,11 +71,11 @@ Follow the instructions in the documentation
 
 <!-- Original notes are here: https://github.com/knative-sandbox/eventing-kafka-broker/releases/tag/knative-TODO-KNATIVE-VERSION -->
 
-### 💫 New Features & Changes
+#### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-### 🐞 Bug Fixes
+#### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
@@ -84,11 +84,11 @@ Follow the instructions in the documentation
 <!-- Original notes are here: https://github.com/knative-sandbox/eventing-rabbitmq/releases/tag/knative-TODO-KNATIVE-VERSION -->
 
 
-### 💫 New Features & Changes
+#### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-### 🐞 Bug Fixes
+#### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 

--- a/blog/docs/releases/announcing-knative-v1-2-release.md
+++ b/blog/docs/releases/announcing-knative-v1-2-release.md
@@ -3,7 +3,7 @@ title: "v1.2 release"
 linkTitle: "v1.2 release"
 Author: "Samia Nneji"
 Author handle: https://github.com/snneji
-date: 2021-01-25
+date: 2022-01-25
 description: "Knative v1.2 release announcement"
 type: "blog"
 ---

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -8,7 +8,6 @@ description: "Knative v1.3 release announcement"
 type: "blog"
 ---
 
-
 ## Announcing Knative v1.3 Release
 
 A new version of Knative is now available across multiple components.
@@ -40,15 +39,26 @@ Follow the instructions in the documentation
 
 ## 🚨 Breaking or Notable Changes
 
-- TODO: Add any breaking or notable changes, using format `TEXT ([#PR-NUMBER](PR-URL))`
+- Dropped the alpha field `RevisionSpec.MaxDurationSeconds` in favour of fixing the behavior of the existing `Timeout` field. ([#12635](https://github.com/knative/serving/pull/12635))
+
 
 ### 💫 New Features & Changes
 
-- TODO: Add new features and changes here
+- Allow the readiness probe port to be different than the user container port. ([#12606](https://github.com/knative/serving/pull/12606))
+- `net-certmanager` starts testing cert-manager v1.7.1. ([#12605](https://github.com/knative/serving/pull/12605))
 
 ### 🐞 Bug Fixes
 
-- TODO: Add bugs here
+- Bump prometheus/client_golang to v1.11.1 in order to address [CVE-2022-21698](https://github.com/advisories/GHSA-cg3q-j54f-5p7p). ([#12653](https://github.com/knative/serving/pull/12653))
+- Ensure the activator drains properly and the autoscaler rolls out conservatively.
+This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.com/knative/serving/pull/12617))
+- Fix an activator crash that could disrupt traffic (503). ([#12679](https://github.com/knative/serving/pull/12679))
+- Fix the tag to digest resolution when the registry credential is in a Kubernetes secret. ([#12655](https://github.com/knative/serving/pull/12655))
+- Provides more detailed error messages for invalid values of `autoscaling.knative.dev/initial-scale`. ([#12704](https://github.com/knative/serving/pull/12704))
+- Remove an unnecessary start delay when resolving a tag to digest. ([#12668](https://github.com/knative/serving/pull/12668))
+- Switches selectors for Knative resources to use the recommended `app.kubernetes.io` labels. ([#12587](https://github.com/knative/serving/pull/12587))
+- The validating webhook returns a more accurate error for invalid `autoscaling.knative.dev/target` values. ([#12698](https://github.com/knative/serving/pull/12698))
+- Updates serving configmap validating webhook to use an objectSelector to reduce unnecessary webhook invocations. ([#12612](https://github.com/knative/serving/pull/12612))
 
 ## Eventing v1.3
 
@@ -131,9 +141,14 @@ Release leads:
 
 Contributors:
 
+- [@dprotaso](https://github.com/dprotaso)
 - [@dsimansk](https://github.com/dsimansk)
 - [@itsmurugappan](https://github.com/itsmurugappan)
+- [@izabelacg](https://github.com/izabelacg)
 - [@kobayashi](https://github.com/kobayashi)
+- [@nak3](https://github.com/nak3)
+- [@psschwei](https://github.com/psschwei)
+- [@qu1queee](https://github.com/qu1queee)
 - [@vyasgun](https://github.com/vyasgun)
 
 ## Learn more

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -133,7 +133,7 @@ Now if the user set the configuration of the RabbitMQ Source Exchange and Queue 
 
 ### 💫 New Features & Changes
 
-- Added Knative Eventtype support. ([#1598](https://github.com/knative/client/pull/1598))
+- Added Knative eventtype support. ([#1598](https://github.com/knative/client/pull/1598))
 
 ### 🐞 Bug Fixes
 

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -37,58 +37,70 @@ Follow the instructions in the documentation
 
 <!-- Original notes are here: https://github.com/knative/serving/releases/tag/knative-v1.3.0 -->
 
-## 🚨 Breaking or Notable Changes
+### 🚨 Breaking or Notable Changes
 
 - Dropped the alpha field `RevisionSpec.MaxDurationSeconds` in favour of fixing the behavior of the existing `Timeout` field. ([#12635](https://github.com/knative/serving/pull/12635))
 
 
 ### 💫 New Features & Changes
 
-- Allow the readiness probe port to be different than the user container port. ([#12606](https://github.com/knative/serving/pull/12606))
+- Allows the readiness probe port to be different than the user container port. ([#12606](https://github.com/knative/serving/pull/12606))
 - `net-certmanager` starts testing cert-manager v1.7.1. ([#12605](https://github.com/knative/serving/pull/12605))
 
 ### 🐞 Bug Fixes
 
-- Bump prometheus/client_golang to v1.11.1 in order to address [CVE-2022-21698](https://github.com/advisories/GHSA-cg3q-j54f-5p7p). ([#12653](https://github.com/knative/serving/pull/12653))
+- Bumped prometheus/client_golang to v1.11.1 in order to address [CVE-2022-21698](https://github.com/advisories/GHSA-cg3q-j54f-5p7p). ([#12653](https://github.com/knative/serving/pull/12653))
 - Ensure the activator drains properly and the autoscaler rolls out conservatively.
 This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.com/knative/serving/pull/12617))
-- Fix an activator crash that could disrupt traffic (503). ([#12679](https://github.com/knative/serving/pull/12679))
-- Fix the tag to digest resolution when the registry credential is in a Kubernetes secret. ([#12655](https://github.com/knative/serving/pull/12655))
+- Fixed an activator crash that could disrupt traffic (503). ([#12679](https://github.com/knative/serving/pull/12679))
+- Fixed the tag to digest resolution when the registry credential is in a Kubernetes secret. ([#12655](https://github.com/knative/serving/pull/12655))
 - Provides more detailed error messages for invalid values of `autoscaling.knative.dev/initial-scale`. ([#12704](https://github.com/knative/serving/pull/12704))
-- Remove an unnecessary start delay when resolving a tag to digest. ([#12668](https://github.com/knative/serving/pull/12668))
+- Removed an unnecessary start delay when resolving a tag to digest. ([#12668](https://github.com/knative/serving/pull/12668))
 - Switches selectors for Knative resources to use the recommended `app.kubernetes.io` labels. ([#12587](https://github.com/knative/serving/pull/12587))
 - The validating webhook returns a more accurate error for invalid `autoscaling.knative.dev/target` values. ([#12698](https://github.com/knative/serving/pull/12698))
 - Updates serving configmap validating webhook to use an objectSelector to reduce unnecessary webhook invocations. ([#12612](https://github.com/knative/serving/pull/12612))
 
+
 ## Eventing v1.3
 
-<!-- Original notes are here: https://github.com/knative/eventing/releases/tag/knative-v1.3.0 -->
+<!-- Original notes are here: https://github.com/knative/eventing/releases/tag/knative-v1.3.1 -->
 
 ### 🚨 Breaking or Notable Changes
 
-- TODO: Add any breaking or notable changes
+- The sql field of the [new trigger filters](https://knative.dev/docs/eventing/experimental-features/new-trigger-filters/) experimental feature is now called cesql. ([#6148](https://github.com/knative/eventing/pull/6148))
 
 ### 💫 New Features & Changes
 
-- TODO: Add new features and changes here
+- Added missing Kubernetes labels to post install manifests. ([#6184](https://github.com/knative/eventing/pull/6184))
+- Set dead letter sink URI in the Channel status. ([#6261](https://github.com/knative/eventing/pull/6261))
+- `SubscriptionSpec.Delivery` is now mutable. ([#6139](https://github.com/knative/eventing/pull/6139))
 
 ### 🐞 Bug Fixes
 
-- TODO: Add bugs here
+- When the new-trigger-filters experimental feature is enabled, a bug was fixed where some invalid CE SQL expressions caused the Eventing webhook to crash. Now, those expressions will be considered invalid and the webhook will continue functioning normally. ([#6140](https://github.com/knative/eventing/pull/6140))
+
 
 ## Eventing Extensions
 
 ### Apache Kafka Broker v1.3
 
-<!-- Original notes are here: https://github.com/knative-sandbox/eventing-kafka-broker/releases/tag/knative-v1.3.0 -->
+<!-- Original notes are here: https://github.com/knative-sandbox/eventing-kafka-broker/releases/tag/knative-v1.3.1 -->
 
 #### 💫 New Features & Changes
 
-- TODO: Add new features and changes here
+- Shows an error in the Broker and Channel status when resolving sink failures. ([#1833](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1833))
+- Added KafkaSource migration logic as a post-install job (`eventing-kafka-post-install.yaml`). ([#1889](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1889))
+- Added Storage-Version-Migrator for KafkaSource and KafkaChannel. ([#1869](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1869))
+- KafkaChannel is now conformant with the spec. Conformance tests are now run with every code change. ([#1825](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1825))
 
 #### 🐞 Bug Fixes
 
-- TODO: Add bugs here
+- Added support for Brokers with long namespace and name values. ([#1971](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1971))
+- KafkaChannel reconciler checks for empty subscriber URI. ([#1905](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1905))
+
+#### Known issues
+
+- The reference information for metrics is not built successfully for Kafka channels. ([#1824](https://github.com/knative-sandbox/eventing-kafka-broker/pull/1824))
 
 ### RabbitMQ Broker and Source v1.3
 
@@ -96,15 +108,14 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 #### 💫 New Features & Changes
 
-- Add publisher confirms to ingress. Return HTTP Status 200 only when RabbitMQ confirms receiving and storing the message. See issue [#334](https://github.com/knative-sandbox/eventing-rabbitmq/issues/334). ([#568](https://github.com/knative-sandbox/eventing-rabbitmq/pull/568))
-- The Source Adapter and Broker Dispatcher's Prefetch Count behavior is the same. Updated the Trigger's webhook to validate:
+- Added publisher confirms to ingress. Return HTTP Status 200 only when RabbitMQ confirms receiving and storing the message. See issue [#334](https://github.com/knative-sandbox/eventing-rabbitmq/issues/334). ([#568](https://github.com/knative-sandbox/eventing-rabbitmq/pull/568))
+- The Source Adapter and Broker Dispatcher's Prefetch Count behavior is now the same. Updated the Trigger's webhook to validate:
     - Has a default value of 1. FIFO behavior
     - Have limits: 1 ≤ prefetchCount ≤ 1000 ([#536](https://github.com/knative-sandbox/eventing-rabbitmq/pull/536))
 - All core Knative Eventing RabbitMQ pods should now be able to run in the restricted pod security standard profile. ([#541](https://github.com/knative-sandbox/eventing-rabbitmq/pull/541))
 - Various refactorings and code health improvements. ([#552](https://github.com/knative-sandbox/eventing-rabbitmq/pull/552), [#572](https://github.com/knative-sandbox/eventing-rabbitmq/pull/572))
 - Makefile-based worklow, includes migrating GitHub Actions. ([#525](https://github.com/knative-sandbox/eventing-rabbitmq/pull/525), [#569](https://github.com/knative-sandbox/eventing-rabbitmq/pull/569), [#579](https://github.com/knative-sandbox/eventing-rabbitmq/pull/579))
 - Improved Broker and Source README docs and Samples description and files. ([#555](https://github.com/knative-sandbox/eventing-rabbitmq/pull/555))
-
 
 #### 🐞 Bug Fixes
 
@@ -119,32 +130,33 @@ Now if the user set the configuration of the RabbitMQ Source Exchange and Queue 
 
 ### 💫 New Features & Changes
 
-- Add Knative Eventtype support. ([#1598](https://github.com/knative/client/pull/1598))
+- Added Knative Eventtype support. ([#1598](https://github.com/knative/client/pull/1598))
 
 ### 🐞 Bug Fixes
 
-- Fix traffic split auto-redirection to only consider the active revisions. ([#1617](https://github.com/knative/client/pull/1617))
-- Fix missing Azure auth provider. ([#1616](https://github.com/knative/client/pull/1616))
-- Remove hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603))
-- Fix display version of Serving and Eventing. ([#1601](https://github.com/knative/client/pull/1601))
+- Fixed traffic split auto-redirection to only consider the active revisions. ([#1617](https://github.com/knative/client/pull/1617))
+- Fixed missing Azure auth provider. ([#1616](https://github.com/knative/client/pull/1616))
+- Removed the hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603))
+- Fixed the display version of Serving and Eventing. ([#1601](https://github.com/knative/client/pull/1601))
 
 
 ## Operator v1.3
 
-<!-- Original notes are here: https://github.com/knative/operator/releases/tag/knative-v1.3.0   -->
+<!-- Original notes are here: https://github.com/knative/operator/releases/tag/knative-v1.3.1   -->
 
 ### 💫 New Features & Changes
 
-- Refactor the common functions for the APIs for the API transition. ([#941](https://github.com/knative/operator/pull/941))
-- Add v1beta1 API into the Knative Operator. ([#945](https://github.com/knative/operator/pull/945))
-- Add the conversion function for v1alpha1 and v1beta1. ([#948](https://github.com/knative/operator/pull/948))
-- Add conversion webhook module. ([#936](https://github.com/knative/operator/pull/936))
-- Enable v1beta1 APIs. ([#968](https://github.com/knative/operator/pull/968))
-- Promote v1beta1 as the storage version. ([#969](https://github.com/knative/operator/pull/969))
+- Refactored the common functions for the APIs for the API transition. ([#941](https://github.com/knative/operator/pull/941))
+- Added v1beta1 API into the Knative Operator. ([#945](https://github.com/knative/operator/pull/945))
+- Added the conversion function for v1alpha1 and v1beta1. ([#948](https://github.com/knative/operator/pull/948))
+- Added conversion webhook module. ([#936](https://github.com/knative/operator/pull/936))
+- Enabled v1beta1 APIs. ([#968](https://github.com/knative/operator/pull/968))
+- Promoted v1beta1 as the storage version. ([#969](https://github.com/knative/operator/pull/969))
 
 ### 🐞 Bug Fixes
 
 - Keep the default image name the same as the original. ([#958](https://github.com/knative/operator/pull/958))
+
 
 ## Thank you, contributors
 
@@ -156,9 +168,11 @@ Release leads:
 
 Contributors:
 
+- [@aliok](https://github.com/aliok)
 - [@benmoss](https://github.com/benmoss)
 - [@ChunyiLyu](https://github.com/ChunyiLyu)
 - [@dprotaso](https://github.com/dprotaso)
+- [@devguyio](https://github.com/devguyio)
 - [@dsimansk](https://github.com/dsimansk)
 - [@gabo1208](https://github.com/gabo1208)
 - [@gvmw](https://github.com/gvmw)
@@ -167,7 +181,9 @@ Contributors:
 - [@itsmurugappan](https://github.com/itsmurugappan)
 - [@izabelacg](https://github.com/izabelacg)
 - [@kobayashi](https://github.com/kobayashi)
+- [@matzew](https://github.com/matzew)
 - [@nak3](https://github.com/nak3)
+- [@pierDipi](https://github.com/pierDipi)
 - [@psschwei](https://github.com/psschwei)
 - [@qu1queee](https://github.com/qu1queee)
 - [@vyasgun](https://github.com/vyasgun)

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -30,8 +30,11 @@ Follow the instructions in the documentation
 
 ## Highlights
 
-- TODO: Add list of highlights for the release
-
+- The readiness probe port can now be different than the user container port.
+- `net-certmanager` is now testing cert-manager v1.7.1.
+- Various improvements and bug fixes for Eventing.
+- The `kn` CLI has added Knative EventType support.
+- The Knative Operator has enabled v1beta1 API.
 
 ## Serving v1.3
 

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -12,8 +12,8 @@ type: "blog"
 
 A new version of Knative is now available across multiple components.
 
-Follow the instructions in the documentation
-[Installing Knative](https://knative.dev/docs/install/) for the respective component.
+Follow the instructions in
+[Installing Knative](https://knative.dev/docs/install/) to install the components you require.
 
 ## Table of Contents
 

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -125,7 +125,7 @@ Now if the user set the configuration of the RabbitMQ Source Exchange and Queue 
 
 - Fix traffic split auto-redirection to only consider the active revisions. ([#1617](https://github.com/knative/client/pull/1617))
 - Fix missing Azure auth provider. ([#1616](https://github.com/knative/client/pull/1616))
-- Remove hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603)) 
+- Remove hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603))
 - Fix display version of Serving and Eventing. ([#1601](https://github.com/knative/client/pull/1601))
 
 
@@ -135,11 +135,16 @@ Now if the user set the configuration of the RabbitMQ Source Exchange and Queue 
 
 ### 💫 New Features & Changes
 
-- TODO: Add new features and changes here
+- Refactor the common functions for the APIs for the API transition ([#941](https://github.com/knative/operator/pull/941))
+- Add v1beta1 api into the Knative Operator ([#945](https://github.com/knative/operator/pull/945))
+- Add the conversion function for v1alpha1 and v1beta1 ([#948](https://github.com/knative/operator/pull/948))
+- Add conversion webhook module ([#936](https://github.com/knative/operator/pull/936))
+- Enable v1beta1 APIs ([#968](https://github.com/knative/operator/pull/968))
+- Promote v1beta1 as the storage version ([#969](https://github.com/knative/operator/pull/969))
 
 ### 🐞 Bug Fixes
 
-- TODO: Add bugs here
+- Keep the default image name the same as the original ([#958](https://github.com/knative/operator/pull/958))
 
 ## Thank you, contributors
 
@@ -157,6 +162,7 @@ Contributors:
 - [@dsimansk](https://github.com/dsimansk)
 - [@gabo1208](https://github.com/gabo1208)
 - [@gvmw](https://github.com/gvmw)
+- [@houshengbo](https://github.com/houshengbo)
 - [@ikvmw](https://github.com/ikvmw)
 - [@itsmurugappan](https://github.com/itsmurugappan)
 - [@izabelacg](https://github.com/izabelacg)

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -33,7 +33,7 @@ Follow the instructions in the documentation
 - The readiness probe port can now be different than the user container port.
 - `net-certmanager` is now testing cert-manager v1.7.1.
 - Various improvements and bug fixes for Eventing.
-- The `kn` CLI has added Knative EventType support.
+- The `kn` CLI has added Knative `eventtype` support.
 - The Knative Operator has enabled v1beta1 API.
 
 ## Serving v1.3

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -1,0 +1,152 @@
+---
+title: "v1.3 release"
+linkTitle: "v1.3 release"
+Author: "Samia Nneji"
+Author handle: https://github.com/snneji
+date: 2022-03-08
+description: "Knative v1.3 release announcement"
+type: "blog"
+---
+
+
+## Announcing Knative v1.3 Release
+
+A new version of Knative is now available across multiple components.
+
+Follow the instructions in the documentation
+[Installing Knative](https://knative.dev/docs/install/) for the respective component.
+
+## Table of Contents
+
+- [Highlights](#highlights)
+- [Serving v1.3](#serving-v13)
+- [Eventing v1.3](#eventing-v13)
+- [Eventing Extensions](#eventing-extensions)
+    - [Apache Kafka Broker v1.3](#apache-kafka-broker-v13)
+    - [RabbitMQ Broker and Source v1.3](#rabbitmq-broker-and-source-v13)
+- `kn` [CLI v1.3](#client-v13)
+- [Knative Operator v1.3](#operator-v13)
+- [Thank you contributors](#thank-you-contributors)
+
+
+## Highlights
+
+- TODO: Add list of highlights for the release
+
+
+## Serving v1.3
+
+<!-- Original notes are here: https://github.com/knative/serving/releases/tag/knative-v1.3.0 -->
+
+## 🚨 Breaking or Notable Changes
+
+- TODO: Add any breaking or notable changes, using format `TEXT ([#PR-NUMBER](PR-URL))`
+
+### 💫 New Features & Changes
+
+- TODO: Add new features and changes here
+
+### 🐞 Bug Fixes
+
+- TODO: Add bugs here
+
+## Eventing v1.3
+
+<!-- Original notes are here: https://github.com/knative/eventing/releases/tag/knative-v1.3.0 -->
+
+### 🚨 Breaking or Notable Changes
+
+- TODO: Add any breaking or notable changes
+
+### 💫 New Features & Changes
+
+- TODO: Add new features and changes here
+
+### 🐞 Bug Fixes
+
+- TODO: Add bugs here
+
+## Eventing Extensions
+
+### Apache Kafka Broker v1.3
+
+<!-- Original notes are here: https://github.com/knative-sandbox/eventing-kafka-broker/releases/tag/knative-v1.3.0 -->
+
+### 💫 New Features & Changes
+
+- TODO: Add new features and changes here
+
+### 🐞 Bug Fixes
+
+- TODO: Add bugs here
+
+### RabbitMQ Broker and Source v1.3
+
+<!-- Original notes are here: https://github.com/knative-sandbox/eventing-rabbitmq/releases/tag/knative-v1.3.0 -->
+
+
+### 💫 New Features & Changes
+
+- TODO: Add new features and changes here
+
+### 🐞 Bug Fixes
+
+- TODO: Add bugs here
+
+## Client v1.3
+
+<!-- Original notes are here: https://github.com/knative/client/blob/main/CHANGELOG.adoc#v130-2022-03-08 -->
+
+### 💫 New Features & Changes
+
+- Add Knative Eventtype support. ([#1598](https://github.com/knative/client/pull/1598))
+
+### 🐞 Bug Fixes
+
+- Fix traffic split auto-redirection to only consider the active revisions. ([#1617](https://github.com/knative/client/pull/1617))
+- Fix missing Azure auth provider. ([#1616](https://github.com/knative/client/pull/1616))
+- Remove hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603)) <!-- Tell CLI team to update link in changelog. -->
+- Fix display version of Serving and Eventing. ([#1601](https://github.com/knative/client/pull/1601))
+
+
+## Operator TODO-KNATIVE-VERSION
+
+<!-- Original notes are here: https://github.com/knative/operator/releases/tag/knative-v1.3.0   -->
+
+### 💫 New Features & Changes
+
+- TODO: Add new features and changes here
+
+### 🐞 Bug Fixes
+
+- TODO: Add bugs here
+
+## Thank you, contributors
+
+Release leads:
+
+- [@carlisia](https://github.com/carlisia)
+- [@kvmware](https://github.com/kvmware)
+- [@xtreme-sameer-vohra](https://github.com/xtreme-sameer-vohra)
+
+Contributors:
+
+- [@dsimansk](https://github.com/dsimansk)
+- [@itsmurugappan](https://github.com/itsmurugappan)
+- [@kobayashi](https://github.com/kobayashi)
+- [@vyasgun](https://github.com/vyasgun)
+
+## Learn more
+
+Knative is an open source project that anyone in the [community](https://knative.dev/docs/community/) can use, improve, and enjoy. We'd love you to join us!
+
+- [Knative docs](https://knative.dev/docs)
+- [Quickstart documentation](https://knative.dev/docs/getting-started)
+- [Samples](https://knative.dev/docs/samples)
+- [Knative working groups](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md)
+- [Knative User Mailing List](https://groups.google.com/forum/#!forum/knative-users)
+- [Knative Development Mailing List](https://groups.google.com/forum/#!forum/knative-dev)
+- Knative on Twitter [@KnativeProject](https://twitter.com/KnativeProject)
+- Knative on [StackOverflow](https://stackoverflow.com/questions/tagged/knative)
+- Knative [Slack](https://slack.knative.dev)
+- Knative on [YouTube](https://www.youtube.com/channel/UCq7cipu-A1UHOkZ9fls1N8A)

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -135,16 +135,16 @@ Now if the user set the configuration of the RabbitMQ Source Exchange and Queue 
 
 ### 💫 New Features & Changes
 
-- Refactor the common functions for the APIs for the API transition ([#941](https://github.com/knative/operator/pull/941))
-- Add v1beta1 api into the Knative Operator ([#945](https://github.com/knative/operator/pull/945))
-- Add the conversion function for v1alpha1 and v1beta1 ([#948](https://github.com/knative/operator/pull/948))
-- Add conversion webhook module ([#936](https://github.com/knative/operator/pull/936))
-- Enable v1beta1 APIs ([#968](https://github.com/knative/operator/pull/968))
-- Promote v1beta1 as the storage version ([#969](https://github.com/knative/operator/pull/969))
+- Refactor the common functions for the APIs for the API transition. ([#941](https://github.com/knative/operator/pull/941))
+- Add v1beta1 API into the Knative Operator. ([#945](https://github.com/knative/operator/pull/945))
+- Add the conversion function for v1alpha1 and v1beta1. ([#948](https://github.com/knative/operator/pull/948))
+- Add conversion webhook module. ([#936](https://github.com/knative/operator/pull/936))
+- Enable v1beta1 APIs. ([#968](https://github.com/knative/operator/pull/968))
+- Promote v1beta1 as the storage version. ([#969](https://github.com/knative/operator/pull/969))
 
 ### 🐞 Bug Fixes
 
-- Keep the default image name the same as the original ([#958](https://github.com/knative/operator/pull/958))
+- Keep the default image name the same as the original. ([#958](https://github.com/knative/operator/pull/958))
 
 ## Thank you, contributors
 

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -82,11 +82,11 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 <!-- Original notes are here: https://github.com/knative-sandbox/eventing-kafka-broker/releases/tag/knative-v1.3.0 -->
 
-### 💫 New Features & Changes
+#### 💫 New Features & Changes
 
 - TODO: Add new features and changes here
 
-### 🐞 Bug Fixes
+#### 🐞 Bug Fixes
 
 - TODO: Add bugs here
 
@@ -94,14 +94,24 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 <!-- Original notes are here: https://github.com/knative-sandbox/eventing-rabbitmq/releases/tag/knative-v1.3.0 -->
 
+#### 💫 New Features & Changes
 
-### 💫 New Features & Changes
+- Add publisher confirms to ingress. Return HTTP Status 200 only when RabbitMQ confirms receiving and storing the message. See issue [#334](https://github.com/knative-sandbox/eventing-rabbitmq/issues/334). ([#568](https://github.com/knative-sandbox/eventing-rabbitmq/pull/568))
+- The Source Adapter and Broker Dispatcher's Prefetch Count behavior is the same. Updated the Trigger's webhook to validate:
+    - Has a default value of 1. FIFO behavior
+    - Have limits: 1 ≤ prefetchCount ≤ 1000 ([#536](https://github.com/knative-sandbox/eventing-rabbitmq/pull/536))
+- All core Knative Eventing RabbitMQ pods should now be able to run in the restricted pod security standard profile. ([#541](https://github.com/knative-sandbox/eventing-rabbitmq/pull/541))
+- Various refactorings and code health improvements. ([#552](https://github.com/knative-sandbox/eventing-rabbitmq/pull/552), [#572](https://github.com/knative-sandbox/eventing-rabbitmq/pull/572))
+- Makefile-based worklow, includes migrating GitHub Actions. ([#525](https://github.com/knative-sandbox/eventing-rabbitmq/pull/525), [#569](https://github.com/knative-sandbox/eventing-rabbitmq/pull/569), [#579](https://github.com/knative-sandbox/eventing-rabbitmq/pull/579))
+- Improved Broker and Source README docs and Samples description and files. ([#555](https://github.com/knative-sandbox/eventing-rabbitmq/pull/555))
 
-- TODO: Add new features and changes here
 
-### 🐞 Bug Fixes
+#### 🐞 Bug Fixes
 
-- TODO: Add bugs here
+- Removing the dead letter sink on a trigger will now properly fall back to the Broker's dead letter sink, if one is defined. ([#533](https://github.com/knative-sandbox/eventing-rabbitmq/pull/533))
+- Configuring messages sent into the RabbitMQ Broker to be persistent as the Queues used by the Broker are always durable.
+Now if the user set the configuration of the RabbitMQ Source Exchange and Queue to be durable, the messages are also durable. ([#560](https://github.com/knative-sandbox/eventing-rabbitmq/pull/560))
+
 
 ## Client v1.3
 
@@ -115,11 +125,11 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 - Fix traffic split auto-redirection to only consider the active revisions. ([#1617](https://github.com/knative/client/pull/1617))
 - Fix missing Azure auth provider. ([#1616](https://github.com/knative/client/pull/1616))
-- Remove hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603)) <!-- Tell CLI team to update link in changelog. -->
+- Remove hardcoded `kn` for usage and error. ([#1603](https://github.com/knative/client/pull/1603)) 
 - Fix display version of Serving and Eventing. ([#1601](https://github.com/knative/client/pull/1601))
 
 
-## Operator TODO-KNATIVE-VERSION
+## Operator v1.3
 
 <!-- Original notes are here: https://github.com/knative/operator/releases/tag/knative-v1.3.0   -->
 
@@ -141,8 +151,13 @@ Release leads:
 
 Contributors:
 
+- [@benmoss](https://github.com/benmoss)
+- [@ChunyiLyu](https://github.com/ChunyiLyu)
 - [@dprotaso](https://github.com/dprotaso)
 - [@dsimansk](https://github.com/dsimansk)
+- [@gabo1208](https://github.com/gabo1208)
+- [@gvmw](https://github.com/gvmw)
+- [@ikvmw](https://github.com/ikvmw)
 - [@itsmurugappan](https://github.com/itsmurugappan)
 - [@izabelacg](https://github.com/izabelacg)
 - [@kobayashi](https://github.com/kobayashi)


### PR DESCRIPTION
Adds the blog post for 1.3 release notes. I also made a some changes to the heading levels in the template.

I made a guess at which items from the release notes seemed like highlights because it seems like this release mainly consists of various small improvements and bug fixes.

Fixes #4790 