### PR TITLE
update macro to lookup point releases for artifacts

### DIFF
--- a/hack/macros.py
+++ b/hack/macros.py
@@ -65,7 +65,7 @@ def define_env(env):
         if version == None:
             return f'https://storage.googleapis.com/knative-nightly/{repo}/latest/{file}'
 
-        version = version.removeprefix('v')
+        version = version.removeprefix('knative-v')
 
         try:
             v = semver.VersionInfo.parse(version)

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -14,7 +14,7 @@ class GithubReleases:
         self.tags_for_repo = {}
         self.client = Github(os.getenv("GITHUB_TOKEN"))
 
-    def latest_release(self, major_minor, org, repo):
+    def get_latest(self, major_minor, org, repo):
         key = f'{org}/{repo}'
 
         if key not in self.tags_for_repo:
@@ -34,7 +34,7 @@ class GithubReleases:
             return None
 
 def define_env(env):
-    g = GithubReleases()
+    releases = GithubReleases()
 
     @env.macro
     def feature(alpha="", beta="", stable=""):
@@ -69,7 +69,7 @@ def define_env(env):
 
         try:
             v = semver.VersionInfo.parse(version)
-            latest_version = g.latest_release(f'{v.major}.{v.minor}', org, repo)
+            latest_version = releases.get_latest(f'{v.major}.{v.minor}', org, repo)
 
             if latest_version is None:
                 print_to_stdout(f'repo "{org}/{repo}" has no tags using latest release for file "{file}"')

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -12,14 +12,14 @@ def print_to_stdout(*vargs):
 class GithubReleases:
     def __init__(self):
         self.tags_for_repo = {}
-        self.g = Github(os.getenv("GITHUB_TOKEN"))
+        self.client = Github(os.getenv("GITHUB_TOKEN"))
 
     def latest_release(self, major_minor, org, repo):
         key = f'{org}/{repo}'
 
         if key not in self.tags_for_repo:
             tags = []
-            for release in self.g.get_repo(key, lazy=True).get_releases():
+            for release in self.client.get_repo(key, lazy=True).get_releases():
                 tags.append(release.tag_name)
             tags = map(lambda tag: tag.removeprefix("knative-v"), tags)
             self.tags_for_repo[key] = list(tags)

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -6,8 +6,8 @@ import traceback
 from github import Github
 
 # By default mkdocs swallows print() messages from macros
-def print_to_stdout(*a):
-    print(*a, file = sys.stdout)
+def print_to_stdout(*vargs):
+    print(*vargs, file = sys.stdout)
 
 class GithubReleases:
     def __init__(self):

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -65,7 +65,8 @@ def define_env(env):
         if version == None:
             return f'https://storage.googleapis.com/knative-nightly/{repo}/latest/{file}'
 
-        version = version.removeprefix('knative-v')
+        version = version.removeprefix('knative-')
+        version = version.removeprefix('v')
 
         try:
             v = semver.VersionInfo.parse(version)

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -1,6 +1,40 @@
 import os
+import semver
+import sys
+import traceback
+
+from github import Github
+
+# By default mkdocs swallows print() messages from macros
+def print_to_stdout(*a):
+    print(*a, file = sys.stdout)
+
+class GithubReleases:
+    def __init__(self):
+        self.tags_for_repo = {}
+        self.g = Github(os.getenv("GITHUB_TOKEN"))
+
+    def latest_release(self, major_minor, org, repo):
+        key = f'{org}/{repo}'
+
+        if key not in self.tags_for_repo:
+            tags = []
+            for release in self.g.get_repo(key, lazy=True).get_releases():
+                tags.append(release.tag_name)
+            tags = map(lambda tag: tag.removeprefix("knative-v"), tags)
+            self.tags_for_repo[key] = list(tags)
+
+        tags = self.tags_for_repo[key].copy()
+        tags = list(filter(lambda tag: tag.startswith(major_minor), tags))
+        tags.sort(key=semver.VersionInfo.parse, reverse=True)
+
+        if len(tags) > 0:
+            return tags[0]  
+        else:
+            return None
 
 def define_env(env):
+    g = GithubReleases()
 
     @env.macro
     def feature(alpha="", beta="", stable=""):
@@ -25,24 +59,32 @@ def define_env(env):
         empty this links to googlestorage, otherwise it links via
         the matching release in github.
         """
+
         version = os.environ.get("KNATIVE_VERSION")
+
         if version == None:
-            return 'https://storage.googleapis.com/knative-nightly/{repo}/latest/{file}'.format(
-                    repo=repo,
-                    file=file)
-        else:
-            if version.startswith("v1."):
-                return 'https://github.com/{org}/{repo}/releases/download/knative-{version}/{file}'.format(
-                    repo=repo,
-                    file=file,
-                    version=version,
-                    org=org)
+            return f'https://storage.googleapis.com/knative-nightly/{repo}/latest/{file}'
+        
+        version = version.removeprefix('v')
+
+        try:            
+            v = semver.VersionInfo.parse(version)
+            latest_version = g.latest_release(f'{v.major}.{v.minor}', org, repo)
+
+            if latest_version is None:
+                print_to_stdout(f'repo "{org}/{repo}" has no tags using latest release for file "{file}"')
+                return f'https://github.com/{org}/{repo}/releases/latest/download/{file}'
+            elif version.startswith("1."):
+                return f'https://github.com/{org}/{repo}/releases/download/knative-v{latest_version}/{file}'
             else:
-                return 'https://github.com/{org}/{repo}/releases/download/{version}/{file}'.format(
-                    repo=repo,
-                    file=file,
-                    version=version,
-                    org=org)
+                return f'https://github.com/{org}/{repo}/releases/download/{latest_version}/{file}'
+        except:
+            # We use sys.exit(1) otherwise the mkdocs build doesn't 
+            # fail on exceptions in macros
+            print_to_stdout(f'exception raised for {org}/{repo}/{file}\n', traceback.format_exc())
+            sys.exit(1)
+
+
 
     @env.macro
     def clientdocs():

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -81,7 +81,7 @@ def define_env(env):
             latest_version = releases.get_latest(f'{v.major}.{v.minor}', org, repo)
 
             if latest_version is None:
-                print_to_stdout(f'repo "{org}/{repo}" has no tags using latest release for file "{file}"')
+                print_to_stdout(f'repo "{org}/{repo}" has no tags for version "{version}" using latest release for file "{file}"')
                 return f'https://github.com/{org}/{repo}/releases/latest/download/{file}'
             else:
                 return f'https://github.com/{org}/{repo}/releases/download/knative-v{latest_version}/{file}'

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -74,10 +74,8 @@ def define_env(env):
             if latest_version is None:
                 print_to_stdout(f'repo "{org}/{repo}" has no tags using latest release for file "{file}"')
                 return f'https://github.com/{org}/{repo}/releases/latest/download/{file}'
-            elif version.startswith("1."):
-                return f'https://github.com/{org}/{repo}/releases/download/knative-v{latest_version}/{file}'
             else:
-                return f'https://github.com/{org}/{repo}/releases/download/{latest_version}/{file}'
+                return f'https://github.com/{org}/{repo}/releases/download/knative-v{latest_version}/{file}'
         except:
             # We use sys.exit(1) otherwise the mkdocs build doesn't
             # fail on exceptions in macros

--- a/hack/macros.py
+++ b/hack/macros.py
@@ -29,7 +29,7 @@ class GithubReleases:
         tags.sort(key=semver.VersionInfo.parse, reverse=True)
 
         if len(tags) > 0:
-            return tags[0]  
+            return tags[0]
         else:
             return None
 
@@ -64,10 +64,10 @@ def define_env(env):
 
         if version == None:
             return f'https://storage.googleapis.com/knative-nightly/{repo}/latest/{file}'
-        
+
         version = version.removeprefix('v')
 
-        try:            
+        try:
             v = semver.VersionInfo.parse(version)
             latest_version = g.latest_release(f'{v.major}.{v.minor}', org, repo)
 
@@ -79,7 +79,7 @@ def define_env(env):
             else:
                 return f'https://github.com/{org}/{repo}/releases/download/{latest_version}/{file}'
         except:
-            # We use sys.exit(1) otherwise the mkdocs build doesn't 
+            # We use sys.exit(1) otherwise the mkdocs build doesn't
             # fail on exceptions in macros
             print_to_stdout(f'exception raised for {org}/{repo}/{file}\n', traceback.format_exc())
             sys.exit(1)


### PR DESCRIPTION
Note - the way the build script works now we'll need to cherry pick this change to older release branches

We should also confirm the netlify builds use a valid GITHUB_TOKEN so we don't hit any rate limiting