### PR TITLE
Updates instructions on running mkdocs locally in docker

### DIFF
--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -1,29 +1,5 @@
 # Development notes for working with mkdocs
 
-You can use a Docker container and run MkDocs from the container, so no local installation of mkdocs is required:
-
-- You need to have [Docker](https://www.docker.com) installed and running on your system
-- There are helper configurations installed if you have npm from [Node.JS](https://nodejs.org) installed.
-- Build the development docker container image, this is only need it once if the dependencies have not changed.
-    ```bash
-    npm run dev:build
-    ```
-- To start developing run the following command in the root directory of the git repo (where **package.json** and **mkdocs.yaml** are located)
-    ```bash
-    npm run dev
-    ```
-- Open a browser to http://localhost:8000, where you will see the documentation site.  This will live update as you save changes to the Markdown files in the `docs` directory.
-- To stop developing run the following command in another terminal window, which will terminate the docker container
-    ```bash
-    npm run dev:stop
-    ```
-- To build the static HTML files including both mkdocs and hugo run the following command.
-    ```bash
-    npm test
-    ```
-- To view additional npm scripts run the following command
-    ```bash
-    npm run
-    ```
+For details of how to use a container for local development, see the "Use the Docker container" section of the [Previewing Docs Locally](../../contribute-to-docs/getting-started/previewing-docs-locally.md#option-1-use-the-docker-container) page.    
 
 

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -1,3 +1,3 @@
 # Development notes for working with mkdocs
 
-For details of how to use a container for local development, see the "Use the Docker container" section of the [Previewing Docs Locally](../../contribute-to-docs/getting-started/previewing-docs-locally.md#option-1-use-the-docker-container) page.
+For details about how to use a container for local development, see [Use the Docker container](../../contribute-to-docs/getting-started/previewing-docs-locally.md#option-1-use-the-docker-container) on the Previewing Docs Locally page.

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -1,5 +1,3 @@
 # Development notes for working with mkdocs
 
-For details of how to use a container for local development, see the "Use the Docker container" section of the [Previewing Docs Locally](../../contribute-to-docs/getting-started/previewing-docs-locally.md#option-1-use-the-docker-container) page.    
-
-
+For details of how to use a container for local development, see the "Use the Docker container" section of the [Previewing Docs Locally](../../contribute-to-docs/getting-started/previewing-docs-locally.md#option-1-use-the-docker-container) page.


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #4832 

## Proposed Changes <!-- Describe the changes the PR makes. -->

Removes the references to using `npm` for running the Docker container and instead points to the "contributing to the docs" page with the same info. This will also allow us to have a single source of truth for future edits, etc.
