### PR TITLE
Adds Github Action for building on push to release branch

### DIFF
--- a/.github/workflows/knative-dot-release-build.yaml
+++ b/.github/workflows/knative-dot-release-build.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+name: Build site for dot releases
+
+on:
+  push:
+    branches: [ 'release-1.*' ]
+
+jobs:
+  dot-release:
+    name: dot-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: curl
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        uses: wei/curl@v1
+        with:
+          args: -X POST -d '{}' "$NETLIFY_BUILD_HOOK"

--- a/.github/workflows/knative-dot-release-build.yaml
+++ b/.github/workflows/knative-dot-release-build.yaml
@@ -17,7 +17,7 @@ name: Build site for dot releases
 
 on:
   push:
-    branches: [ 'release-1.3' ]
+    branches: [ 'release-1.*' ]
 
 jobs:
   dot-release:

--- a/.github/workflows/knative-dot-release-build.yaml
+++ b/.github/workflows/knative-dot-release-build.yaml
@@ -17,7 +17,7 @@ name: Build site for dot releases
 
 on:
   push:
-    branches: [ 'release-1.*' ]
+    branches: [ 'release-1.3' ]
 
 jobs:
   dot-release:

--- a/.github/workflows/knative-nightly-site-build.yaml
+++ b/.github/workflows/knative-nightly-site-build.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 The Knative Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+name: Build site nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  dot-release:
+    name: dot-release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: curl
+        env:
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        uses: wei/curl@v1
+        with:
+          args: -X POST -d '{}' "$NETLIFY_BUILD_HOOK"

--- a/contribute-to-docs/docs-release-process.md
+++ b/contribute-to-docs/docs-release-process.md
@@ -9,7 +9,6 @@ To release a new version of the docs you must:
 1. [Check dependencies](#check-dependencies)
 1. [Create a release branch](#create-a-release-branch)
 1. [Generate the new docs version](#generate-the-new-docs-version)
-1. [Update the dot-release job](#update-the-dot-release-job)
 
 ## Check dependencies
 
@@ -53,16 +52,6 @@ to include the new version, and remove the oldest. Order matters, most recent fi
     ```
 
 1. PR the result to main.
-
-## Update the dot release job
-
-Edit the [`.github/workflows/knative-dot-release-build.yaml`](../.github/workflows/knative-dot-release-build.yaml) file to the new release. For example, if you have just cut v1.2:
-
-```yaml
-on:
-  push:
-    branches: [ 'release-1.2' ]
-```
 
 ## How GitHub and Netlify are hooked up
 

--- a/contribute-to-docs/docs-release-process.md
+++ b/contribute-to-docs/docs-release-process.md
@@ -53,6 +53,16 @@ to include the new version, and remove the oldest. Order matters, most recent fi
 
 1. PR the result to main.
 
+## Update the dot-release Job
+
+Edit the `.github/workflows/knative-dot-release-build.yaml` file to the just-cut release. For example, if v1.2 was the version just cut:
+
+```yaml
+on:
+  push:
+    branches: [ 'release-1.2' ]
+```
+
 ## How GitHub and Netlify are hooked up
 
 TODO: add information about how the docs are built and served using Netlify

--- a/contribute-to-docs/docs-release-process.md
+++ b/contribute-to-docs/docs-release-process.md
@@ -9,6 +9,7 @@ To release a new version of the docs you must:
 1. [Check dependencies](#check-dependencies)
 1. [Create a release branch](#create-a-release-branch)
 1. [Generate the new docs version](#generate-the-new-docs-version)
+1. [Update the dot-release job](#update-the-dot-release-job)
 
 ## Check dependencies
 
@@ -53,7 +54,7 @@ to include the new version, and remove the oldest. Order matters, most recent fi
 
 1. PR the result to main.
 
-## Update the dot-release Job
+## Update the dot release job
 
 Edit the [`.github/workflows/knative-dot-release-build.yaml`](../.github/workflows/knative-dot-release-build.yaml) file to the new release. For example, if you have just cut v1.2:
 

--- a/contribute-to-docs/docs-release-process.md
+++ b/contribute-to-docs/docs-release-process.md
@@ -55,7 +55,7 @@ to include the new version, and remove the oldest. Order matters, most recent fi
 
 ## Update the dot-release Job
 
-Edit the `.github/workflows/knative-dot-release-build.yaml` file to the just-cut release. For example, if v1.2 was the version just cut:
+Edit the [`.github/workflows/knative-dot-release-build.yaml`](../.github/workflows/knative-dot-release-build.yaml) file to the new release. For example, if you have just cut v1.2:
 
 ```yaml
 on:


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #4840 

## Proposed Changes 

This adds a github action to trigger a build of the website on any push to the `release-1.*` branch (the current version of the docs). 

It also adds an action to build the site nightly (so as to automatically pick up any dot releases for Knative components in a timely manner)

/assign @csantanapr (for branch strategy)
/assign @dprotaso (for a second pair of eyes on the GA syntax)

