### PR TITLE
only build main branch for deploy preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,6 +13,10 @@
 [context.deploy-preview]
   publish = "site"
 
+# Envvars for deploy preview
+[context.deploy-preview.environment]
+  BUILD_VERSIONS="no"
+
 [[redirects]]
   from = "/contributing/"
   to = "/docs/community/"


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Sets `BUILD_VERSIONS="no"` for deploy previews to only build `main` branch and not the various release versions

Fixes #4525 
(see also [slack discussion](https://knative.slack.com/archives/C9CV04DNJ/p1647874975497899))

