### PR TITLE
Replace `ingress.class` with `ingress-class`

### DIFF
--- a/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
+++ b/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
@@ -192,7 +192,7 @@ Now you will need to set Kourier as the default networking layer for Knative Ser
 $ kubectl patch configmap/config-network \
   --namespace knative-serving \
   --type merge \
-  --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+  --patch '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
 ```
 
 If you want to validate that the patch command was successful, run the command:
@@ -203,7 +203,7 @@ $ kubectl describe configmap/config-network --namespace knative-serving
 
 ```bash
 ... (abbreviated for readability)
-ingress.class:
+ingress-class:
 ----
 kourier.ingress.networking.knative.dev
 ...

--- a/docs/install/yaml-install/serving/install-serving-with-yaml.md
+++ b/docs/install/yaml-install/serving/install-serving-with-yaml.md
@@ -45,7 +45,7 @@ Follow the procedure for the networking layer of your choice:
       kubectl patch configmap/config-network \
         --namespace knative-serving \
         --type merge \
-        --patch '{"data":{"ingress.class":"kourier.ingress.networking.knative.dev"}}'
+        --patch '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
       ```
 
     1. Fetch the External IP address or CNAME by running the command:

--- a/tutorials/katacoda/1-serving-intro/step1.md
+++ b/tutorials/katacoda/1-serving-intro/step1.md
@@ -16,5 +16,5 @@
     kubectl patch configmap/config-network \
       --namespace knative-serving \
       --type merge \
-      --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
+      --patch '{"data":{"ingress-class":"contour.ingress.networking.knative.dev"}}'
     ```{{execute}}

--- a/tutorials/katacoda/2-serving-intro-yaml/step1.md
+++ b/tutorials/katacoda/2-serving-intro-yaml/step1.md
@@ -16,5 +16,5 @@
     kubectl patch configmap/config-network \
       --namespace knative-serving \
       --type merge \
-      --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
+      --patch '{"data":{"ingress-class":"contour.ingress.networking.knative.dev"}}'
     ```{{execute}}

--- a/tutorials/katacoda/3-eventing-intro-channels/scripts/install-dependencies.sh
+++ b/tutorials/katacoda/3-eventing-intro-channels/scripts/install-dependencies.sh
@@ -14,5 +14,5 @@ kubectl apply --filename https://github.com/knative/net-contour/releases/downloa
 kubectl patch configmap/config-network \
       --namespace knative-serving \
       --type merge \
-      --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
+      --patch '{"data":{"ingress-class":"contour.ingress.networking.knative.dev"}}'
 echo "Knative Serving Installed."

--- a/tutorials/katacoda/4-eventing-intro-broker/scripts/install-dependencies.sh
+++ b/tutorials/katacoda/4-eventing-intro-broker/scripts/install-dependencies.sh
@@ -14,5 +14,5 @@ kubectl apply --filename https://github.com/knative/net-contour/releases/downloa
 kubectl patch configmap/config-network \
       --namespace knative-serving \
       --type merge \
-      --patch '{"data":{"ingress.class":"contour.ingress.networking.knative.dev"}}'
+      --patch '{"data":{"ingress-class":"contour.ingress.networking.knative.dev"}}'
 echo "Knative Serving Installed."


### PR DESCRIPTION
As per title, this patch replace `ingress.class` with `ingress-class`.

The style was updated by https://github.com/knative/networking/pull/522. The old `ingress.class` is still available but it should be consistent in the docs.
Note, only Kong uses `ingress.class` in the code tree so I leave it as it is after opening https://github.com/Kong/kubernetes-ingress-controller/issues/2344.

Fix https://github.com/knative/docs/issues/4855

