### PR TITLE
Fix eventing-rabbitmq release notes for Release Blog v1.3

### DIFF
--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -111,7 +111,7 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 #### 💫 New Features & Changes
 
-- Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>` ([#587](https://github.com/knative-sandbox/eventing-rabbitmq/pull/587))
+- Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>`. ([#587](https://github.com/knative-sandbox/eventing-rabbitmq/pull/587))
 - Short testing guide for contributors, .env -> (direnv friendly).envrc ([#599](https://github.com/knative-sandbox/eventing-rabbitmq/pull/599))
 
 ## Client v1.3

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -111,8 +111,8 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 #### 💫 New Features & Changes
 
-- Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>` (#587, @gab-satchi)
-- Short testing guide for contributors, .env -> (direnv friendly).envrc (#599, @ikvmw)
+- Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>` ([#587](https://github.com/knative-sandbox/eventing-rabbitmq/pull/587))
+- Short testing guide for contributors, .env -> (direnv friendly).envrc ([#599](https://github.com/knative-sandbox/eventing-rabbitmq/pull/599))
 
 ## Client v1.3
 
@@ -165,6 +165,7 @@ Contributors:
 - [@devguyio](https://github.com/devguyio)
 - [@dsimansk](https://github.com/dsimansk)
 - [@gabo1208](https://github.com/gabo1208)
+- [@gab-satchi](https://github.com/gab-satchi)
 - [@gvmw](https://github.com/gvmw)
 - [@houshengbo](https://github.com/houshengbo)
 - [@ikvmw](https://github.com/ikvmw)

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -112,7 +112,7 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 #### 💫 New Features & Changes
 
 - Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>`. ([#587](https://github.com/knative-sandbox/eventing-rabbitmq/pull/587))
-- Short testing guide for contributors, .env -> (direnv friendly).envrc ([#599](https://github.com/knative-sandbox/eventing-rabbitmq/pull/599))
+- Short testing guide for contributors, converting from `.env` -> to `(direnv friendly).envrc` environment files. ([#599](https://github.com/knative-sandbox/eventing-rabbitmq/pull/599))
 
 ## Client v1.3
 

--- a/blog/docs/releases/announcing-knative-v1-3-release.md
+++ b/blog/docs/releases/announcing-knative-v1-3-release.md
@@ -107,25 +107,12 @@ This helps to avoid hitting 503 errors during upgrade. ([#12617](https://github.
 
 ### RabbitMQ Broker and Source v1.3
 
-<!-- Original notes are here: https://github.com/knative-sandbox/eventing-rabbitmq/releases/tag/knative-v1.3.0 -->
+<!-- Original notes are here: https://github.com/knative-sandbox/eventing-rabbitmq/releases/tag/knative-v1.3.1 -->
 
 #### 💫 New Features & Changes
 
-- Added publisher confirms to ingress. Return HTTP Status 200 only when RabbitMQ confirms receiving and storing the message. See issue [#334](https://github.com/knative-sandbox/eventing-rabbitmq/issues/334). ([#568](https://github.com/knative-sandbox/eventing-rabbitmq/pull/568))
-- The Source Adapter and Broker Dispatcher's Prefetch Count behavior is now the same. Updated the Trigger's webhook to validate:
-    - Has a default value of 1. FIFO behavior
-    - Have limits: 1 ≤ prefetchCount ≤ 1000 ([#536](https://github.com/knative-sandbox/eventing-rabbitmq/pull/536))
-- All core Knative Eventing RabbitMQ pods should now be able to run in the restricted pod security standard profile. ([#541](https://github.com/knative-sandbox/eventing-rabbitmq/pull/541))
-- Various refactorings and code health improvements. ([#552](https://github.com/knative-sandbox/eventing-rabbitmq/pull/552), [#572](https://github.com/knative-sandbox/eventing-rabbitmq/pull/572))
-- Makefile-based worklow, includes migrating GitHub Actions. ([#525](https://github.com/knative-sandbox/eventing-rabbitmq/pull/525), [#569](https://github.com/knative-sandbox/eventing-rabbitmq/pull/569), [#579](https://github.com/knative-sandbox/eventing-rabbitmq/pull/579))
-- Improved Broker and Source README docs and Samples description and files. ([#555](https://github.com/knative-sandbox/eventing-rabbitmq/pull/555))
-
-#### 🐞 Bug Fixes
-
-- Removing the dead letter sink on a trigger will now properly fall back to the Broker's dead letter sink, if one is defined. ([#533](https://github.com/knative-sandbox/eventing-rabbitmq/pull/533))
-- Configuring messages sent into the RabbitMQ Broker to be persistent as the Queues used by the Broker are always durable.
-Now if the user set the configuration of the RabbitMQ Source Exchange and Queue to be durable, the messages are also durable. ([#560](https://github.com/knative-sandbox/eventing-rabbitmq/pull/560))
-
+- Broker URLs updated to be `http://<broker-URL>/<namespace>/<broker-name>` (#587, @gab-satchi)
+- Short testing guide for contributors, .env -> (direnv friendly).envrc (#599, @ikvmw)
 
 ## Client v1.3
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fixes the eventing-rabbitmq release notes to use the v1.3.1 release notes. It appears as though they were using v1.2 release notes.
