### PR TITLE
Pin jinja version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ mkdocs-redirects>=1.0.3
 mkdocs-rss-plugin>=0.18.0
 pygithub==1.55
 semver==2.13.0
+jinja2==3.0.3
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Looks like [Jinja released a new version recently](https://pypi.org/project/Jinja2/#history) and it's breaking the build. It gets pulled in by mkdocs as a dependency, but because we don't directly use it we aren't pinning it's version in [requirements.txt](https://github.com/knative/docs/blob/main/requirements.txt).

This can be fixed by pinning the Jinja2 version to 3.0.3 (which was the latest version up until yesterday), but we'll also need to track upstream to see if/when this gets fixed.