### PR TITLE
update mkdocs to 8.2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.1.10
+mkdocs-material==8.2.7
 mkdocs-exclude>=1.0
 mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5


### PR DESCRIPTION
Fixes an issue with jinja2 module that was breaking the build

Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Once this merges, we should close #4872  (which fixed the issue by pinning the jinja2 version, before I realized mkdocs-material already had a new release out with the fix)

/assign @csantanapr 