### PR TITLE
sideloading with kind tutorial

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -34,6 +34,7 @@ nav:
           - releases/announcing-knative-v0-3-release.md
           - releases/announcing-knative-v0-2-release.md
       - Articles:
+          - articles/using-sideloaded-images-with-kind.md
           - articles/google-summer-of-code-2022.md
           - articles/workflow-as-function-flow.md
           - articles/highlighting-value-knative-c-suite.md

--- a/blog/docs/articles/using-sideloaded-images-with-kind.md
+++ b/blog/docs/articles/using-sideloaded-images-with-kind.md
@@ -2,23 +2,19 @@
 title: Using Sideloaded Images with Kind
 linkTitle: Using-Sideloaded -Images-with-Kind
 author: "Ed Jung"
-date: 2022-04-30
+date: 2022-05-26
 description: How to use sideloaded images with Knative on Kind
 type: "blog"
 ---
 
-Once you've setup a kind Knative cluster with the [`quickstart` plugin](https://github.com/knative-sandbox/kn-plugin-quickstart), you may want to try it with images from your developer environment, without an image registry.  The Knative tag-to-digest resolution needs to be disabled to make this possible.
-
+Once you've setup a kind Knative cluster with the [`quickstart` plugin](https://github.com/knative-sandbox/kn-plugin-quickstart), you may want to try it with images from your developer environment, without an image registry.
 
 This document walks through these steps:
 
 * sideloading an image into kind
-* disabling tag resolution
 * creating a Knative service that uses the sideloaded image
 
 ## Pre-Requisities
-
-It's assumed that you already have a kind cluster with Knative installed.
 
 This tutorial assumes you have cluster running as from [Getting Started with Knative](https://knative.dev/docs/getting-started/),
  and will sideload the helloworld-go image, but you may substitute your own image.
@@ -32,17 +28,19 @@ This tutorial assumes you have cluster running as from [Getting Started with Kna
   docker pull gcr.io/knative-samples/helloworld-go
   ```
 
-2. Rename this image for demonstration purposes. Renaming it will make clear that the image is not being
-pulled from the public registry.
+2. Rename this image using a host name of `dev.local`, `kind.local`, or `ko.local`. Knative will skip tag resolution for these special names by default.
 
   ```
-docker tag gcr.io/knative-samples/helloworld-go my.example.com/helloworld-go
+docker tag gcr.io/knative-samples/helloworld-go dev.local/helloworld-go
   ```
 
-3. Load the image into the cluster using `kind`
+  (*Note: To use other host names in your images, you will need to manually configure Knative to skip resolution for those names. See* [`registries-skipping-tag-resolving`](https://knative.dev/docs/serving/configuration/deployment/#skipping-tag-resolution))
+
+
+3. Sideload the image into the cluster using `kind`
 
   ```
-kind load docker-image --name knative my.example.com/helloworld-go
+kind load docker-image --name knative dev.local/helloworld-go
   ```
 
 4. [Optional] Check that it exists in the cluster.
@@ -51,68 +49,19 @@ kind load docker-image --name knative my.example.com/helloworld-go
 docker exec -it knative-control-plane crictl images | grep helloworld
   ```
 
-## Disable Tag-to-Digest Resolution
+# Create the Knative Service
 
-1. Get a local copy of the Knative configmap yaml that controls deployment.
+1. Create the service with an image pull policy of `Never` or `IfNotPresent`
 
-  ```
-kubectl -n knative-serving get -o yaml configmap config-deployment > config-deployment.yaml
-  ```
-
-2. Open this configmap file and add the config for `registries-skipping-tag-resolving`:
 
   ```
-apiVersion: v1
-data:
-  registries-skipping-tag-resolving: "my.example.com"
-...
+kn service create dev.local/helloworld-go --pull-policy Never --env TARGET=world
 
   ```
 
-3. Save the file and apply it to the kind cluster
-
-  ```
-kubectl apply -f config-deployment.yaml
-  ```
-
-  New services will now skip tag-to-digest resolution if their image name starts with `my.example.com` and
-allow your sideloaded image to be used.
-
-  **Note**: This will not affect existing services because they have already
-passed through the tag resolution stage. You will need to create a new revision of those services.
 
 
-# Create your Knative Service Resource
-
-1. Create the service, either using the `kn` CLI or `kubectl`, with an image pull policy of `Never` or `IfNotPresent`
-
-When using `kn`,
-  ```
-kn service create my.example.com/helloworld-go --pull-policy never
-
-  ```
-
-If you prefer kubectl, then apply a `service.yaml` with the contents below.
-
-  ```
-apiVersion: serving.knative.dev/v1 # Current version of Knative
-kind: Service
-metadata:
-  name: helloworld # The name of the app
-  namespace: default # The namespace the app will use
-spec:
-  template:
-    spec:
-      containers:
-        - image: my.example.com/helloworld-go
-          imagePullPolicy: Never
-          env:
-            - name: TARGET
-              value: "there!"
-  ```
-
-
-3. Check the service to make sure it is ready.
+3. Check the service to make sure it's ready.
 
   ```
 kubectl get ksvc

--- a/blog/docs/articles/using-sideloaded-images-with-kind.md
+++ b/blog/docs/articles/using-sideloaded-images-with-kind.md
@@ -84,8 +84,15 @@ passed through the tag resolution stage. You will need to create a new revision 
 
 # Create your Knative Service Resource
 
-1. Create a file named `service.yaml` with the contents below for your Knative service. The `imagePullPolicy` should be `Never` or `IfNotPresent` to skip
-pulling the image.
+1. Create the service, either using the `kn` CLI or `kubectl`, with an image pull policy of `Never` or `IfNotPresent`
+
+When using `kn`,
+  ```
+kn service create my.example.com/helloworld-go --pull-policy never
+
+  ```
+
+If you prefer kubectl, then apply a `service.yaml` with the contents below.
 
   ```
 apiVersion: serving.knative.dev/v1 # Current version of Knative
@@ -102,12 +109,6 @@ spec:
           env:
             - name: TARGET
               value: "there!"
-  ```
-
-2. Apply this service.
-
-  ```
-kubectl apply -f service.yaml
   ```
 
 

--- a/blog/docs/articles/using-sideloaded-images-with-kind.md
+++ b/blog/docs/articles/using-sideloaded-images-with-kind.md
@@ -1,0 +1,119 @@
+---
+title: Using Sideloaded Images with Kind
+linkTitle: Using-Sideloaded -Images-with-Kind
+author: "Ed Jung"
+date: 2022-04-30
+description: How to use sideloaded images with Knative on Kind
+type: "blog"
+---
+
+Once you've setup a kind Knative cluster with the [`quickstart` plugin](https://github.com/knative-sandbox/kn-plugin-quickstart), you may want to try it with images from your developer environment, without an image registry.  The Knative tag-to-digest resolution needs to be disabled to make this possible.
+
+
+This document walks through these steps:
+
+* sideloading an image into kind
+* disabling tag resolution
+* creating a Knative service that uses the sideloaded image
+
+## Pre-Requisities
+
+It's assumed that you already have a kind cluster with Knative installed.
+
+This tutorial assumes you have cluster running as from [Getting Started with Knative](https://knative.dev/docs/getting-started/),
+ and will sideload the helloworld-go image, but you may substitute your own image.
+
+
+## Sideload Your Image into the Cluster
+
+1. Pull the hello-world-go image into you local dev environment.
+
+  ```
+  docker pull gcr.io/knative-samples/helloworld-go
+  ```
+
+2. Rename this image for demonstration purposes. Renaming it will make clear that the image is not being
+pulled from the public registry.
+
+  ```
+docker tag gcr.io/knative-samples/helloworld-go my.example.com/helloworld-go
+  ```
+
+3. Load the image into the cluster using `kind`
+
+  ```
+kind load docker-image --name knative my.example.com/helloworld-go
+  ```
+
+4. [Optional] Check that it exists in the cluster.
+
+  ```
+docker exec -it knative-control-plane crictl images | grep helloworld
+  ```
+
+## Disable Tag-to-Digest Resolution
+
+1. Get a local copy of the Knative configmap yaml that controls deployment.
+
+  ```
+kubectl -n knative-serving get -o yaml configmap config-deployment > config-deployment.yaml
+  ```
+
+2. Open this configmap file and add the config for `registries-skipping-tag-resolving`:
+
+  ```
+apiVersion: v1
+data:
+  registries-skipping-tag-resolving: "my.example.com"
+...
+
+  ```
+
+3. Save the file and apply it to the kind cluster
+
+  ```
+kubectl apply -f config-deployment.yaml
+  ```
+
+  New services will now skip tag-to-digest resolution if their image name starts with `my.example.com` and
+allow your sideloaded image to be used.
+
+  **Note**: This will not affect existing services because they have already
+passed through the tag resolution stage. You will need to create a new revision of those services.
+
+
+# Create your Knative Service Resource
+
+1. Create a file named `service.yaml` with the contents below for your Knative service. The `imagePullPolicy` should be `Never` or `IfNotPresent` to skip
+pulling the image.
+
+  ```
+apiVersion: serving.knative.dev/v1 # Current version of Knative
+kind: Service
+metadata:
+  name: helloworld # The name of the app
+  namespace: default # The namespace the app will use
+spec:
+  template:
+    spec:
+      containers:
+        - image: my.example.com/helloworld-go
+          imagePullPolicy: Never
+          env:
+            - name: TARGET
+              value: "there!"
+  ```
+
+2. Apply this service.
+
+  ```
+kubectl apply -f service.yaml
+  ```
+
+
+3. Check the service to make sure it is ready.
+
+  ```
+kubectl get ksvc
+  ```
+

--- a/blog/docs/articles/using-sideloaded-images-with-kind.md
+++ b/blog/docs/articles/using-sideloaded-images-with-kind.md
@@ -49,7 +49,7 @@ kind load docker-image --name knative dev.local/helloworld-go
 docker exec -it knative-control-plane crictl images | grep helloworld
   ```
 
-# Create the Knative Service
+## Create the Knative Service
 
 1. Create the service with an image pull policy of `Never` or `IfNotPresent`
 


### PR DESCRIPTION
Adds a tutorial for disabling tag resolution with a kind quickstart cluster, and sideloading images.
