### PR TITLE
Fix eventing spec links

### DIFF
--- a/docs/eventing/broker/README.md
+++ b/docs/eventing/broker/README.md
@@ -31,7 +31,7 @@ Before you can use the MT channel-based broker, you must install a
 
 ### Alternative broker implementations
 
-In the Knative Eventing ecosystem, alternative broker implementations are welcome as long as they respect the [broker specifications](https://github.com/knative/specs/blob/main/specs/eventing/broker.md).
+In the Knative Eventing ecosystem, alternative broker implementations are welcome as long as they respect the [broker specifications](https://github.com/knative/specs/blob/main/specs/eventing/overview.md#broker).
 
 The following is a list of brokers provided by the community or vendors:
 
@@ -52,4 +52,4 @@ For more information, see [RabbitMQ Broker](rabbitmq-broker/README.md) or [the d
 
 - Create an [MT channel-based broker](create-mtbroker.md).
 - Configure [default broker ConfigMap settings](../configuration/broker-configuration.md).
-- View the [broker specifications](https://github.com/knative/specs/blob/main/specs/eventing/broker.md).
+- View the [broker specifications](https://github.com/knative/specs/blob/main/specs/eventing/overview.md#broker).

--- a/docs/eventing/sinks/README.md
+++ b/docs/eventing/sinks/README.md
@@ -57,7 +57,7 @@ spec:
 
 To use a Kubernetes custom resource (CR) as a sink for events, you must:
 
-1. Make the CR Addressable. You must ensure that the CR contains a `status.address.url`. For more information, see the spec for [Addressable resources](https://github.com/knative/specs/blob/main/specs/eventing/interfaces.md#addressable).
+1. Make the CR Addressable. You must ensure that the CR contains a `status.address.url`. For more information, see the spec for [Addressable resources](https://github.com/knative/specs/blob/main/specs/eventing/overview.md#addressable).
 
 1. Create an Addressable-resolver ClusterRole to obtain the necessary RBAC rules for the sink to receive events.
 


### PR DESCRIPTION

## Fixes

- 3 link pointing to the spec docs fixed.
- There is a [slightly related PR at spec](https://github.com/knative/specs/pull/99) that should improve further navigation.