### PR TITLE
Removes blog link to old knative kind setup

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -48,7 +48,6 @@ nav:
           - articles/knative-v0-3-autoscaling-a-love-story.md
           - articles/ko-fast-kubernetes-microservice-development-in-go.md
           - articles/build-deploy-manage-modern-serverless-workloads-using-knative-on-kubernetes.md
-          - articles/set-up-a-local-knative-environment-with-kind.md
       - Steering Committee:
           - steering/toc-2022-election-announcement.md
           - steering/2022-04-14-annual-report-2021.md

--- a/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
+++ b/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
@@ -8,6 +8,10 @@ folder with media files: 'N/A'
 labels: Articles
 ---
 
+!!! warning
+
+    The [quickstart plugin](https://knative.dev/docs/getting-started/quickstart-install/) is now the recommended way to set up a local Knative environment for development purposes.
+
 Knative builds on Kubernetes to abstract away complexity for developers, and enables them to focus on delivering value to their business. The complex (and sometimes boring) parts of building apps to run on Kubernetes are managed by Knative. In this post, we will focus on setting up a lightweight environment to help you to develop modern apps faster using Knative.
 
 ## Step 1: Setting up your Kubernetes deployment using KinD


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

As discussed in the WG today, the quickstart plugin has replaced the "setup knative on kind" blog post. This PR removes the link to said blog post and adds a warning at the beginning of the docs for users to use quickstart instead. 
