### PR TITLE
Update upgrading docs versions

### DIFF
--- a/docs/install/upgrade/upgrade-installation-with-operator.md
+++ b/docs/install/upgrade/upgrade-installation-with-operator.md
@@ -119,7 +119,7 @@ You can verify the status of a Knative component by checking that the custom res
 
 ## Rollback to an earlier version
 
-If the upgrade fails, you can rollback to restore your Knative to the previous version. For example, if something goes wrong with an upgrade to 0.23, and your previous version is 0.22, you can apply the following custom resources to restore Knative Serving and Knative Eventing to version 0.22.
+If the upgrade fails, you can rollback to restore your Knative to the previous version. For example, if something goes wrong with an upgrade to 1.2, and your previous version is 1.1, you can apply the following custom resources to restore Knative Serving and Knative Eventing to version 1.1.
 
 === "Knative Serving"
 

--- a/docs/install/upgrade/upgrade-installation-with-operator.md
+++ b/docs/install/upgrade/upgrade-installation-with-operator.md
@@ -6,7 +6,7 @@ If you installed using YAML, see [Upgrading with kubectl](upgrade-installation.m
 The attribute `spec.version` is the only field you need to change in the
 Serving or Eventing custom resource to perform an upgrade. You do not need to specify the version for the `patch` number, because the Knative Operator matches the latest available `patch` number, as long as you specify `major.minor` for the version. For example, you only need to specify `"0.23"` to upgrade to the 0.23 release, you do not need to specify the exact `patch` number.
 
-The Knative Operator supports up to the last three major releases. For example, if the current version of the Operator is 0.23, it bundles and supports the installation of Knative versions 0.20, 0.21, 0.22 and 0.23.
+The Knative Operator supports up to the last three major releases. For example, if the current version of the Operator is 1.5, it bundles and supports the installation of Knative versions 1.4, 1.3, 1.2 and 1.1.
 
 !!! note
     In the following examples, Knative Serving custom resources are installed in the `knative-serving` namespace, and  Knative Eventing custom resources are installed in the `knative-eventing` namespace.
@@ -46,7 +46,7 @@ You can confirm that your Knative components have upgraded successfully, by view
     Enter the following command to view information about pods in the `knative-serving` namespace:
 
     ```bash
-    kubectl get pods --namespace knative-serving
+    kubectl get pods -n knative-serving
     ```
 
     The command returns an output similar to the following:
@@ -67,7 +67,7 @@ You can confirm that your Knative components have upgraded successfully, by view
     Enter the following command to view information about pods in the `knative-eventing` namespace:
 
     ```bash
-    kubectl get pods --namespace knative-eventing
+    kubectl get pods -n knative-eventing
     ```
 
     The command returns an output similar to the following:
@@ -93,27 +93,27 @@ You can verify the status of a Knative component by checking that the custom res
 === "Knative Serving"
 
     ```bash
-    kubectl get KnativeServing knative-serving --namespace knative-serving
+    kubectl get KnativeServing knative-serving -n knative-serving
     ```
 
     This command returns an output similar to the following:
 
     ```{ .bash .no-copy }
     NAME              VERSION         READY   REASON
-    knative-serving   0.20.0          True
+    knative-serving   1.1.0          True
     ```
 
 === "Knative Eventing"
 
     ```bash
-    kubectl get KnativeEventing knative-eventing --namespace knative-eventing
+    kubectl get KnativeEventing knative-eventing -n knative-eventing
     ```
 
     This command returns an output similar to the following:
 
     ```{ .bash .no-copy }
     NAME               VERSION        READY   REASON
-    knative-eventing   0.20.0         True
+    knative-eventing   1.1.0         True
     ```
     <!--- END snippet-->
 

--- a/docs/install/upgrade/upgrade-installation-with-operator.md
+++ b/docs/install/upgrade/upgrade-installation-with-operator.md
@@ -4,7 +4,7 @@ This topic describes how to upgrade Knative if you installed using the Operator.
 If you installed using YAML, see [Upgrading with kubectl](upgrade-installation.md).
 
 The attribute `spec.version` is the only field you need to change in the
-Serving or Eventing custom resource to perform an upgrade. You do not need to specify the version for the `patch` number, because the Knative Operator matches the latest available `patch` number, as long as you specify `major.minor` for the version. For example, you only need to specify `"0.23"` to upgrade to the 0.23 release, you do not need to specify the exact `patch` number.
+Serving or Eventing custom resource to perform an upgrade. You do not need to specify the version for the `patch` number, because the Knative Operator matches the latest available `patch` number, as long as you specify `major.minor` for the version. For example, you only need to specify `"1.1"` to upgrade to the 1.1 release, you do not need to specify the exact `patch` number.
 
 The Knative Operator supports up to the last three major releases. For example, if the current version of the Operator is 1.5, it bundles and supports the installation of Knative versions 1.4, 1.3, 1.2 and 1.1.
 

--- a/docs/install/upgrade/upgrade-installation.md
+++ b/docs/install/upgrade/upgrade-installation.md
@@ -31,11 +31,11 @@ namespace. For example, if you are upgrading Knative Serving and Eventing, enter
 each namespace:
 
 ```bash
-kubectl get pods --namespace knative-serving
+kubectl get pods -n knative-serving
 ```
 
 ```bash
-kubectl get pods --namespace knative-eventing
+kubectl get pods -n knative-eventing
 ```
 
 ### Upgrade plugins
@@ -45,12 +45,12 @@ you upgrade your Knative components.
 
 ### Run pre-install tools before upgrade
 
-In some upgrades there are some steps that must happen before the actual
-upgrade, and these are identified in the release notes.
+For some upgrades, there are steps that must be completed before the actual
+upgrade. These steps, where applicable, are identified in the release notes.
 
 ### Upgrade existing resources to the latest stored version
 
-Our custom resources are stored within Kubernetes at a particular version.
+Knative custom resources are stored within Kubernetes at a particular version.
 As we introduce newer and remove older supported versions, you must migrate the resources to the designated stored version. This ensures removing older versions
 will succeed when upgrading.
 
@@ -59,13 +59,14 @@ For the various subprojects there is a K8s job to help operators perform this mi
 ## Performing the upgrade
 
 To upgrade, apply the YAML files for the subsequent minor versions of all your installed Knative components and features, remembering to only upgrade by one minor version at a time.
+
 Before upgrading, [check your Knative version](check-install-version.md).
 
-For a cluster running version 0.22 of the Knative Serving and Knative Eventing components, the following command upgrades the installation to v0.23.0:
+For a cluster running version 1.1 of the Knative Serving and Knative Eventing components, the following command upgrades the installation to version 1.1:
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/v0.23.0/serving-core.yaml \
--f https://github.com/knative/eventing/releases/download/v0.23.0/eventing.yaml \
+kubectl apply -f https://github.com/knative/serving/releases/download/v1.2.0/serving-core.yaml \
+-f https://github.com/knative/eventing/releases/download/v1.2.0/eventing.yaml \
 ```
 
 ### Run post-install tools after the upgrade
@@ -80,11 +81,11 @@ All pods will restart during the upgrade and their age will reset.
 If you upgraded Knative Serving and Eventing, enter the following commands to get information about the pods for each namespace:
 
 ```bash
-kubectl get pods --namespace knative-serving
+kubectl get pods -n knative-serving
 ```
 
 ```bash
-kubectl get pods --namespace knative-eventing
+kubectl get pods -n knative-eventing
 ```
 
 These commands return something similar to:

--- a/docs/install/upgrade/upgrade-installation.md
+++ b/docs/install/upgrade/upgrade-installation.md
@@ -65,8 +65,8 @@ Before upgrading, [check your Knative version](check-install-version.md).
 For a cluster running version 1.1 of the Knative Serving and Knative Eventing components, the following command upgrades the installation to version 1.2:
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/v1.2.0/serving-core.yaml \
--f https://github.com/knative/eventing/releases/download/v1.2.0/eventing.yaml \
+kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.2.0/serving-core.yaml \
+-f https://github.com/knative/eventing/releases/download/knative-v1.2.0/eventing.yaml \
 ```
 
 ### Run post-install tools after the upgrade

--- a/docs/install/upgrade/upgrade-installation.md
+++ b/docs/install/upgrade/upgrade-installation.md
@@ -62,7 +62,7 @@ To upgrade, apply the YAML files for the subsequent minor versions of all your i
 
 Before upgrading, [check your Knative version](check-install-version.md).
 
-For a cluster running version 1.1 of the Knative Serving and Knative Eventing components, the following command upgrades the installation to version 1.1:
+For a cluster running version 1.1 of the Knative Serving and Knative Eventing components, the following command upgrades the installation to version 1.2:
 
 ```bash
 kubectl apply -f https://github.com/knative/serving/releases/download/v1.2.0/serving-core.yaml \


### PR DESCRIPTION
Fixes https://github.com/knative/docs/issues/4863

## Proposed Changes

- Updates versions to use 1.1+
- This change can maybe be cherrypicked back to older versions still supported (1.1, 1.2, 1.3, 1.4)

NOTE: A better long term solution would be either to make it part of the release process to update these docs for every version, or to find a way to make the docs not version specific.

Preview links:

- https://deploy-preview-4984--knative.netlify.app/docs/install/upgrade/upgrade-installation/#performing-the-upgrade
- https://deploy-preview-4984--knative.netlify.app/docs/install/upgrade/upgrade-installation-with-operator/