### PR TITLE
Add the instruction on how to override/add env vars for containers

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -481,6 +481,29 @@ spec:
               - ssd
 ```
 
+### Override the environment variables
+
+The KnativeEventing resource is able to override or add the environment variables for the containers in the Knative Eventing
+deployment resources. For example, if you would like to change the value of environment variable `METRICS_DOMAIN` in the
+container `eventing-controller` into "knative.dev/my-repo" for the deployment `eventing-controller`, you need to change
+your KnativeEventing CR as below:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  deployments:
+  - name: eventing-controller
+    env:
+    - container: eventing-controller
+      envVars:
+      - name: METRICS_DOMAIN
+        value: "knative.dev/my-repo"
+```
+
 ## Override system services
 
 If you would like to override some configurations for a specific service, you can override the configuration by using `spec.services` in CR.

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -595,6 +595,29 @@ spec:
               - ssd
 ```
 
+### Override the environment variables
+
+The KnativeServing resource is able to override or add the environment variables for the containers in the Knative Serving
+deployment resources. For example, if you would like to change the value of environment variable `METRICS_DOMAIN` in the
+container `controller` into "knative.dev/my-repo" for the deployment `controller`, you need to change your KnativeServing
+CR as below:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  deployments:
+  - name: controller
+    env:
+    - container: controller
+      envVars:
+      - name: METRICS_DOMAIN
+        value: "knative.dev/my-repo"
+```
+
 ## Override system services
 
 If you would like to override some configurations for a specific service, you can override the configuration by using `spec.services` in CR.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- This PR added the instruction on the feature to configure the env vars for the containers with Knative Operator.
