### PR TITLE
[release-1.4] Correct the instruction on system resource settings

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -12,7 +12,6 @@ You can configure Knative Eventing with the following options:
 - [Download images from different repositories without secrets](#download-images-from-different-repositories-without-secrets)
 - [Download images with secrets](#download-images-with-secrets)
 - [Configuring the default broker class](#configuring-the-default-broker-class)
-- [System resource settings](#system-resource-settings)
 - [Override system deployments](#override-system-deployments)
 
 ## Installing a specific version of Eventing
@@ -349,45 +348,6 @@ metadata:
   namespace: knative-eventing
 spec:
   defaultBrokerClass: MTChannelBasedBroker
-```
-
-## System resource settings
-
-The KnativeEventing CR allows you to configure system resources for Knative system containers.
-
-Requests and limits can be configured for the following containers:
-
-- `eventing-controller`
-- `eventing-webhook`
-- `imc-controller`
-- `imc-dispatcher`
-- `mt-broker-ingress`
-- `mt-broker-ingress`
-- `mt-broker-controller`
-
-To override resource settings for a specific container, you must create an entry in the `spec.resources` list with the container name and the [Kubernetes resource settings](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container).
-
-!!! info
-    If multiple deployments share the same container name, the configuration in `spec.resources` for that certain container will apply to all the deployments.
-    Visit [Override System Resources based on the deployment](#override-the-resources) to specify the resources for a container within a specific deployment.
-
-For example, the following KnativeEventing CR configures the `eventing-webhook` container to request 0.3 CPU and 100MB of RAM, and sets hard limits of 1 CPU, 250MB RAM, and 4GB of local storage:
-
-```yaml
-apiVersion: operator.knative.dev/v1beta1
-kind: KnativeEventing
-metadata:
-  name: knative-eventing
-  namespace: knative-eventing
-spec:
-  resources:
-  - container: eventing-webhook
-    requests:
-      cpu: 300m
-      memory: 100Mi
-    limits:
-      cpu: 1000m
-      memory: 250Mi
 ```
 
 ## Override system deployments

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -10,7 +10,6 @@ You can configure Knative Serving with the following options:
 - [Replace the knative-ingress-gateway gateway](#replace-the-knative-ingress-gateway-gateway)
 - [Cluster local gateway](#configuration-of-cluster-local-gateway)
 - [High availability](#high-availability)
-- [System resource settings](#system-resource-settings)
 - [Override system deployments](#override-system-deployments)
 
 ## Version configuration
@@ -415,69 +414,38 @@ If you configure `replicas: 2`, which is less than `minReplicas`, the operator t
 
 If you configure `replicas: 6`, which is more than `maxReplicas`, the operator transforms `maxReplicas` to `maxReplicas + (replicas - minReplicas)` which is `8`.
 
-## System Resource Settings
-
-The operator custom resource allows you to configure system resources for the Knative system containers.
-Requests and limits can be configured for the following containers: `activator`, `autoscaler`, `controller`, `webhook`, `autoscaler-hpa`,
-`net-istio-controller` and `queue-proxy`.
-
-!!! info
-    If multiple deployments share the same container name, the configuration in `spec.resources` for that certain container will apply to all the deployments.
-
-To override resource settings for a specific container, create an entry in the `spec.resources` list with the container name and the [Kubernetes resource settings](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container).
-
-For example, the following KnativeServing resource configures the `activator` to request 0.3 CPU and 100MB of RAM, and sets hard limits of 1 CPU, 250MB RAM, and 4GB of local storage:
-
-```yaml
-apiVersion: operator.knative.dev/v1beta1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: knative-serving
-spec:
-  resources:
-  - container: activator
-    requests:
-      cpu: 300m
-      memory: 100Mi
-    limits:
-      cpu: 1000m
-      memory: 250Mi
-      ephemeral-storage: 4Gi
-```
-
-If you would like to add another container `autoscaler` with the same configuration, you need to change your CR as follows:
-
-```yaml
-apiVersion: operator.knative.dev/v1beta1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: knative-serving
-spec:
-  resources:
-  - container: activator
-    requests:
-      cpu: 300m
-      memory: 100Mi
-    limits:
-      cpu: 1000m
-      memory: 250Mi
-      ephemeral-storage: 4Gi
-  - container: autoscaler
-    requests:
-      cpu: 300m
-      memory: 100Mi
-    limits:
-      cpu: 1000m
-      memory: 250Mi
-      ephemeral-storage: 4Gi
-```
-
 ## Override system deployments
 
 If you would like to override some configurations for a specific deployment, you can override the configuration by using `spec.deployments` in CR.
 Currently `replicas`, `labels`, `annotations` and `nodeSelector` are supported.
+
+### Override the resources
+
+The KnativeServing custom resource is able to configure system resources for the Knative system containers based on the deployment.
+Requests and limits can be configured for all the available containers within the deployment, like `activator`, `autoscaler`,
+`controller`, etc.
+
+For example, the following KnativeServing resource configures the container `controller` in the deployment `controller` to request
+0.3 CPU and 100MB of RAM, and sets hard limits of 1 CPU and 250MB RAM:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  deployments:
+  - name: controller
+    resources:
+    - container: controller
+      requests:
+        cpu: 300m
+        memory: 100Mi
+      limits:
+        cpu: 1000m
+        memory: 250Mi
+```
 
 ### Override replicas, labels and annotations
 

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -417,7 +417,7 @@ If you configure `replicas: 6`, which is more than `maxReplicas`, the operator t
 ## Override system deployments
 
 If you would like to override some configurations for a specific deployment, you can override the configuration by using `spec.deployments` in CR.
-Currently `replicas`, `labels`, `annotations` and `nodeSelector` are supported.
+Currently `resources`, `replicas`, `labels`, `annotations` and `nodeSelector` are supported.
 
 ### Override the resources
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- This is a critical doc issue in 1.4 for knative operator. We need to drop the incorrect system resource configuration for knative operator.
