### PR TITLE
Add github token to local docker build

### DIFF
--- a/contribute-to-docs/getting-started/previewing-docs-locally.md
+++ b/contribute-to-docs/getting-started/previewing-docs-locally.md
@@ -37,6 +37,8 @@ The build output is the entire static site located in `./site`.
 
 You can preview the website locally by running a webserver using this directory like `npx http-server site -p 8000` if you have Node.js or `python3 -m http.server 8000` if you have Python 3.
 
+To run this script, you will need to set the `GITHUB_TOKEN` environmental variable to your [Github Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+
 
 ## (Option 2) Using native Python mkdocs CLI
 

--- a/hack/docker/test.sh
+++ b/hack/docker/test.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env sh
 
+if [ -z $GITHUB_TOKEN ]; then
+    echo "Please set a value for the GITHUB_TOKEN environmental variable"
+    exit 1
+fi
+
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 IMAGE=${1:-ghcr.io/knative/knative-docs:latest}
 
 set -x
 
 docker pull ${IMAGE}
-docker run --rm -v "${SCRIPT_DIR}/../../:/site" -it --entrypoint "" ${IMAGE} hack/build.sh
+docker run --rm -v "${SCRIPT_DIR}/../../:/site" -e GITHUB_TOKEN -it --entrypoint "" ${IMAGE} hack/build.sh


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Fixes #4930 

## Proposed Changes <!-- Describe the changes the PR makes. -->

Updates the local full site build using Docker to include a required github token (provided by user)

/assign @csantanapr 