### PR TITLE
Adding a little sentence on the CE mode of knative kafka broker

### DIFF
--- a/docs/eventing/broker/kafka-broker/README.md
+++ b/docs/eventing/broker/kafka-broker/README.md
@@ -11,6 +11,8 @@ Notable features are:
 - Ordered delivery of events based on [CloudEvents partitioning extension](https://github.com/cloudevents/spec/blob/v1.0.1/extensions/partitioning.md)
 - Support any Kafka version, see [compatibility matrix](https://cwiki.apache.org/confluence/display/KAFKA/Compatibility+Matrix)
 
+The Knative Kafka Broker stores incoming CloudEvents as Kafka records, using the [binary content mode](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/kafka-protocol-binding.md#32-binary-content-mode). This means all CloudEvent attributes and extensions are mapped as [headers on the Kafka record](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/bindings/kafka-protocol-binding.md#323-metadata-headers), while the `data` of the CloudEvent corresponds to the value of the Kafka record.
+
 ## Prerequisites
 
 1. [Installing Eventing using YAML files](../../../install/yaml-install/eventing/install-eventing-with-yaml.md).


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

- adding little note about the CE content mode that the broker uses and pointing to the notion of using kafka headser for "CE metadata"


/assign @pierDipi 