### PR TITLE
fix: Update the knative-operator supported versions example

### DIFF
--- a/docs/install/upgrade/upgrade-installation-with-operator.md
+++ b/docs/install/upgrade/upgrade-installation-with-operator.md
@@ -6,7 +6,7 @@ If you installed using YAML, see [Upgrading with kubectl](upgrade-installation.m
 The attribute `spec.version` is the only field you need to change in the
 Serving or Eventing custom resource to perform an upgrade. You do not need to specify the version for the `patch` number, because the Knative Operator matches the latest available `patch` number, as long as you specify `major.minor` for the version. For example, you only need to specify `"1.1"` to upgrade to the 1.1 release, you do not need to specify the exact `patch` number.
 
-The Knative Operator supports up to the last three major releases. For example, if the current version of the Operator is 1.5, it bundles and supports the installation of Knative versions 1.4, 1.3, 1.2 and 1.1.
+The Knative Operator supports up to the last three major releases. For example, if the current version of the Operator is 1.5, it bundles and supports the installation of Knative versions 1.5, 1.4, 1.3 and 1.2.
 
 !!! note
     In the following examples, Knative Serving custom resources are installed in the `knative-serving` namespace, and  Knative Eventing custom resources are installed in the `knative-eventing` namespace.


### PR DESCRIPTION
Fixes the ["Upgrading with the Knative Operator"](https://knative.dev/docs/install/upgrade/upgrade-installation-with-operator/) example which states the versions a knative operator release supports with an example.

Currently it states a knative operator version 1.5 would even support 1.1 which is different then the infos in the knative 1.5 release information.


## Proposed Changes 

- Fixing the example for supported changes
- Got supported versions from knative 1.5.1 release: https://github.com/knative/operator/releases/tag/knative-v1.5.1
