### PR TITLE
Add the configuration of podDisruptionBudget for knative operator

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -508,8 +508,11 @@ kn operator configure selectors --component eventing --serviceName eventing-webh
 
 ## Override system podDisruptionBudgets
 
-You can configure the `minAvailable` for a specific podDisruptionBudget resource based on the name. For example, if you would like
-to change `minAvailable` into 70% for the podDisruptionBudget named `eventing-webhook`, you need to change your KnativeEventing CR as below:
+A Pod Disruption Budget (PDB) allows you to limit the disruption to your application when its pods need to be rescheduled
+for maintenance reasons. Knative Operator allows you to configure the `minAvailable` for a specific podDisruptionBudget
+resource in Eventing based on the name. To understand more about the configuration of the resource podDisruptionBudget, click [here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+For example, if you would like to change `minAvailable` into 70% for the podDisruptionBudget named `eventing-webhook`,
+you need to change your KnativeEventing CR as below:
 
 ```yaml
 apiVersion: operator.knative.dev/v1beta1

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -505,3 +505,20 @@ kn operator configure labels --component eventing --serviceName eventing-webhook
 kn operator configure annotations --component eventing --serviceName eventing-webhook --key myannotations --value bar -n knative-eventing
 kn operator configure selectors --component eventing --serviceName eventing-webhook --key myselector --value bar -n knative-eventing
 ```
+
+## Override system podDisruptionBudgets
+
+You can configure the `minAvailable` for a specific podDisruptionBudget resource based on the name. For example, if you would like
+to change `minAvailable` into 70% for the podDisruptionBudget named `eventing-webhook`, you need to change your KnativeEventing CR as below:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  podDisruptionBudgets:
+  - name: eventing-webhook
+    minAvailable: 70%
+```

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -675,3 +675,20 @@ kn operator configure labels --component serving --serviceName webhook --key myl
 kn operator configure annotations --component serving --serviceName webhook --key myannotations --value bar -n knative-serving
 kn operator configure selectors --component serving --serviceName webhook --key myselector --value bar -n knative-serving
 ```
+
+## Override system podDisruptionBudgets
+
+You can configure the `minAvailable` for a specific podDisruptionBudget resource based on the name. For example, if you would like
+to change `minAvailable` into 70% for the podDisruptionBudget named `activator-pdb`, you need to change your KnativeServing CR as below:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  podDisruptionBudgets:
+  - name: activator-pdb
+    minAvailable: 70%
+```

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -678,8 +678,11 @@ kn operator configure selectors --component serving --serviceName webhook --key 
 
 ## Override system podDisruptionBudgets
 
-You can configure the `minAvailable` for a specific podDisruptionBudget resource based on the name. For example, if you would like
-to change `minAvailable` into 70% for the podDisruptionBudget named `activator-pdb`, you need to change your KnativeServing CR as below:
+A Pod Disruption Budget (PDB) allows you to limit the disruption to your application when its pods need to be rescheduled
+for maintenance reasons. Knative Operator allows you to configure the `minAvailable` for a specific podDisruptionBudget
+resource in Serving based on the name. To understand more about the configuration of the resource podDisruptionBudget, click [here](https://kubernetes.io/docs/tasks/run-application/configure-pdb/).
+For example, if you would like to change `minAvailable` into 70% for the podDisruptionBudget named `activator-pdb`, you
+need to change your KnativeServing CR as below:
 
 ```yaml
 apiVersion: operator.knative.dev/v1beta1


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->


## Proposed Changes <!-- Describe the changes the PR makes. -->

- Added the instruction on how to configure the podDisruptionBudget with the knative operator.
