### PR TITLE
🧹 remove defunct markdown checking varibles from scripts

### DIFF
--- a/test/presubmit-link-check.sh
+++ b/test/presubmit-link-check.sh
@@ -18,9 +18,6 @@
 # It is started by prow for each PR.
 # For convenience, it can also be executed manually.
 
-# Force presubmit link checking only.
-DISABLE_MD_LINTING=1
-
 source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh
 
 initialize_environment

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -18,10 +18,6 @@
 # It is started by prow for each PR.
 # For convenience, it can also be executed manually.
 
-# markdown linting is too picky for our docs; disabling it for now.
-DISABLE_MD_LINTING=1
-DISABLE_MD_LINK_CHECK=1
-
 source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
Two markdown checking variables are no longer valid, removing them from associated scripts.

Addresses: https://github.com/knative/hack/issues/200