### PR TITLE
Istio supported versions change

### DIFF
--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -16,8 +16,7 @@ You need:
 
 ## Supported Istio versions
 
-You can see which version is the latest to have been tested [in the most recent net-istio releases](https://github.com/knative-sandbox/net-istio/releases).
-
+You can view the latest tested Istio version on the [Knative Net Istio releases page](https://github.com/knative-sandbox/net-istio/releases).
 
 ## Installing Istio
 

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -16,8 +16,8 @@ You need:
 
 ## Supported Istio versions
 
-The current known-to-be-stable version of Istio tested in conjunction with Knative is **v1.12**.
-Versions in the 1.12 line are generally fine too.
+You can see which version is the latest to have been tested [in the most recent net-istio releases](https://github.com/knative-sandbox/net-istio/releases).
+
 
 ## Installing Istio
 


### PR DESCRIPTION
Link to the net-istio releases github page as the source of truth for supported versions per release instead of having a hard coded value.

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->
**Description of problem the PR solves:**
Received messages on slack asking which versions of Istio we support and the docs page is out of date.
Linking to the net-istio releases page seems a better strategy in combination with [this issue](https://github.com/knative-sandbox/net-istio/issues/958) as opposed to updating the documentation every time. 

Worst case scenario the release notes can be updated manually instead of new documentation PRs.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Link to the net-istio release page to show supported Istio version instead of hard coding.

