### PR TITLE
RabbitMQ Source docs

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -150,6 +150,7 @@ nav:
           - PingSource:
             - Creating a PingSource object: eventing/sources/ping-source/README.md
             - PingSource reference: eventing/sources/ping-source/reference.md
+          - RabbitMQSource: eventing/sources/rabbitmq-source/README.md
         # BYO event source
         - Custom event sources:
           - Custom event sources overview: eventing/custom-event-source/README.md

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -106,7 +106,7 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
       name: <rabbitmq-broker-config-name>
     spec:
       rabbitmqClusterReference:
-        # if a local cluster is being used, name and connectionSecret cannot be set at the same time 
+        # if a local cluster is being used. name and connectionSecret cannot be set at the same time
         name: <cluster-name>
         # if an external rabbitmq cluster is being used
         connectionSecret:

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -7,8 +7,7 @@ This topic describes how to create a RabbitMQBroker.
 1. You have installed [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
 1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
 1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
-1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator).
-For more information about configuring the `RabbitmqCluster` CRD, see the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
+1. You have access to a working RabbitMQ instance. You can create a RabbitMQ instance by using the [RabbitMQ Cluster Kubernetes Operator](https://github.com/rabbitmq/cluster-operator). For more information see the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html).
 
 ## Install the RabbitMQ controller
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -7,7 +7,7 @@ This topic describes how to create a RabbitMQBroker.
 1. You have installed [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
 1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
 1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
-1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator). 
+1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator).
 For more information about configuring the `RabbitmqCluster` CRD, see the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
 
 ## Install the RabbitMQ controller

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -1,6 +1,6 @@
 # Creating a RabbitMQBroker object
 
-This topic describes how to create a RabbitMQBroker object.
+This topic describes how to create a RabbitMQ Broker.
 
 ## Prerequisites
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -1,4 +1,4 @@
-# Creating a RabbitMQBroker
+# Creating a RabbitMQBroker object
 
 This topic describes how to create a RabbitMQBroker.
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -1,15 +1,14 @@
-# Creating a RabbitMQ Broker
+# Creating a RabbitMQBroker
 
-This topic describes how to create a RabbitMQ Broker.
+This topic describes how to create a RabbitMQBroker.
 
 ## Prerequisites
 
-To use the RabbitMQ Broker, you must have the following installed:
-
-1. [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
-1. [RabbitMQ Cluster Operator (optional)](https://github.com/rabbitmq/cluster-operator) - our recommendation is [latest release](https://github.com/rabbitmq/cluster-operator/releases/latest)
-1. [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
-1. [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
+1. You have installed [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
+1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
+1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
+1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator). 
+For more information about configuring the `RabbitmqCluster` CRD, see the[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
 
 ## Install the RabbitMQ controller
 
@@ -35,68 +34,7 @@ To use the RabbitMQ Broker, you must have the following installed:
     rabbitmq-broker-webhook        1/1     1            1           4s
     ```
 
-## Create a RabbitMQ cluster (optional)
-
-1. Deploy a RabbitMQ cluster:
-
-    1. Create a YAML file using the following template:
-
-        ```yaml
-        apiVersion: rabbitmq.com/v1beta1
-        kind: RabbitmqCluster
-        metadata:
-          name: <cluster-name>
-          annotations:
-            # A single RabbitMQ cluster per Knative Eventing installation
-            rabbitmq.com/topology-allowed-namespaces: "*"
-        ```
-        Where `<cluster-name>` is the name you want for your RabbitMQ cluster,
-        for example, `rabbitmq`.
-
-    1. Apply the YAML file by running the command:
-
-        ```bash
-        kubectl create -f <filename>
-        ```
-        Where `<filename>` is the name of the file you created in the previous step.
-
-1. Wait for the cluster to become ready. When the cluster is ready, `ALLREPLICASREADY`
-will be `true` in the output of the following command:
-
-    ```bash
-    kubectl get rmq <cluster-name>
-    ```
-    Where `<cluster-name>` is the name you gave your cluster in the step above.
-
-    Example output:
-
-    ```{ .bash .no-copy }
-    NAME          ALLREPLICASREADY   RECONCILESUCCESS   AGE
-    rabbitmq      True               True               38s
-    ```
-
-For more information about configuring the `RabbitmqCluster` CRD, see the
-[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html).
-
-## Reference an external RabbitMQ Cluster
-
-1. Create a Secret that stores the external RabbitMQ cluster credentials and URI:
-
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: rabbitmq-secret-credentials
-    # This is just a sample, don't use it this way in production
-    stringData:
-      username: $EXTERNAL_RABBITMQ_USERNAME
-      password: $EXTERNAL_RABBITMQ_PASSWORD
-      uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
-    ```
-
-You will reference this Secret in the RabbitMQ Broker config later
-
-## Create a RabbitMQ Broker config object
+## Create a RabbitMQBrokerConfig object
 
 1. Create a YAML file using the following template:
     ```yaml
@@ -106,7 +44,7 @@ You will reference this Secret in the RabbitMQ Broker config later
       name: <rabbitmq-broker-config-name>
     spec:
       rabbitmqClusterReference:
-        # Configure name if a local cluster is being used.
+        # Configure name if a RabbitMQ Cluster Operator is being used.
         name: <cluster-name>
         # Configure connectionSecret if an external RabbitMQ cluster is being used.
         connectionSecret:
@@ -115,11 +53,11 @@ You will reference this Secret in the RabbitMQ Broker config later
     ```
     Where:
 
-    - <rabbitmq-broker-config-name> is the name you want for your RabbitMQ Broker config object.
+    - <rabbitmq-broker-config-name> is the name you want for your RabbitMQBrokerConfig object.
     - <cluster-name> is the name of the RabbitMQ cluster you created earlier.
 
     !!! note
-        You cannot set `name` and `connectionSecret` at the same time.
+        You cannot set `name` and `connectionSecret` at the same time, since `name` is for a RabbitMQ Cluster Operator instance running in the same cluster as the Broker, and `connectionSecret` is for an external RabbitMQ server.
 
 1. Apply the YAML file by running the command:
 
@@ -128,7 +66,7 @@ You will reference this Secret in the RabbitMQ Broker config later
     ```
    Where `<filename>` is the name of the file you created in the previous step.
 
-## Create a RabbitMQ Broker object
+## Create a RabbitMQBroker object
 
 1. Create a YAML file using the following template:
 
@@ -145,7 +83,7 @@ You will reference this Secret in the RabbitMQ Broker config later
         kind: RabbitmqBrokerConfig
         name: <rabbitmq-broker-config-name>
     ```
-    Where `<rabbitmq-broker-config-name>` is the name you gave your RabbitMQ Broker config in the step above.
+    Where `<rabbitmq-broker-config-name>` is the name you gave your RabbitMQBrokerConfig in the step above.
 
 1. Apply the YAML file by running the command:
 
@@ -156,4 +94,5 @@ You will reference this Secret in the RabbitMQ Broker config later
 
 ## Additional information
 
-To report a bug or request a feature, open an issue in the [eventing-rabbitmq repository](https://github.com/knative-sandbox/eventing-rabbitmq).
+- For more samples visit the [`eventing-rabbitmq` Github repository samples directory](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples)
+- To report a bug or request a feature, open an issue in the [`eventing-rabbitmq` Github repository](https://github.com/knative-sandbox/eventing-rabbitmq).

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -8,7 +8,7 @@ This topic describes how to create a RabbitMQBroker.
 1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
 1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
 1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator). 
-For more information about configuring the `RabbitmqCluster` CRD, see the[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
+For more information about configuring the `RabbitmqCluster` CRD, see the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
 
 ## Install the RabbitMQ controller
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -80,7 +80,7 @@ For more information about configuring the `RabbitmqCluster` CRD, see the
 
 ## Reference an external RabbitMQ Cluster
 
-1. Create a Secret that stores the external RabbitMQ Cluster Credentials and URI:
+1. Create a Secret that stores the external RabbitMQ cluster credentials and URI:
 
     ```yaml
     apiVersion: v1

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -1,6 +1,6 @@
 # Creating a RabbitMQBroker object
 
-This topic describes how to create a RabbitMQBroker.
+This topic describes how to create a RabbitMQBroker object.
 
 ## Prerequisites
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -113,7 +113,13 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
           name: rabbitmq-secret-credentials
       queueType: quorum
     ```
-    Where <cluster-name> is the name of the RabbitMQ cluster created in the step above.
+    Where: 
+    
+    - <rabbitmq-broker-config-name> is the name you want for your RabbitMQ Broker config object.
+    - <cluster-name> is the name of the RabbitMQ cluster you created earlier.
+    
+    !!! note
+        You cannot set `name` and `connectionSecret` at the same time.
 
 1. Apply the YAML file by running the command:
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -7,7 +7,7 @@ This topic describes how to create a RabbitMQ Broker.
 To use the RabbitMQ Broker, you must have the following installed:
 
 1. [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
-1. [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator) - our recommendation is [latest release](https://github.com/rabbitmq/cluster-operator/releases/latest)
+1. [RabbitMQ Cluster Operator (optional)](https://github.com/rabbitmq/cluster-operator) - our recommendation is [latest release](https://github.com/rabbitmq/cluster-operator/releases/latest)
 1. [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
 1. [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
 
@@ -35,7 +35,7 @@ To use the RabbitMQ Broker, you must have the following installed:
     rabbitmq-broker-webhook        1/1     1            1           4s
     ```
 
-## Create a RabbitMQ cluster
+## Create a RabbitMQ cluster (optional)
 
 1. Deploy a RabbitMQ cluster:
 
@@ -78,7 +78,25 @@ will be `true` in the output of the following command:
 For more information about configuring the `RabbitmqCluster` CRD, see the
 [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html).
 
-## Create a RabbitMQ broker config object
+## Reference an external RabbitMQ Cluster
+
+1. Create a Secret that store the external RabbitMQ Cluster Credentials and uri
+
+  ```yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: rabbitmq-secret-credentials
+  # This is just a sample, don't use it this way in production
+  stringData:
+    username: $EXTERNAL_RABBITMQ_USERNAME
+    password: $EXTERNAL_RABBITMQ_PASSWORD
+    uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
+  ```
+
+and in the next step reference the secret in the `RabbitMQ Broker Config`
+
+## Create a RabbitMQ Broker config object
 
 1. Create a YAML file using the following template:
     ```yaml
@@ -88,7 +106,11 @@ For more information about configuring the `RabbitmqCluster` CRD, see the
       name: <rabbitmq-broker-config-name>
     spec:
       rabbitmqClusterReference:
+        # if a local cluster is being used, name and connectionSecret cannot be set at the same time 
         name: <cluster-name>
+        # if an external rabbitmq cluster is being used
+        connectionSecret:
+          name: rabbitmq-secret-credentials
       queueType: quorum
     ```
     Where <cluster-name> is the name of the RabbitMQ cluster created in the step above.
@@ -100,7 +122,7 @@ For more information about configuring the `RabbitmqCluster` CRD, see the
     ```
    Where `<filename>` is the name of the file you created in the previous step.
 
-## Create a RabbitMQ broker object
+## Create a RabbitMQ Broker object
 
 1. Create a YAML file using the following template:
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -1,4 +1,4 @@
-# Creating a RabbitMQBroker object
+# Creating a RabbitMQ Broker
 
 This topic describes how to create a RabbitMQ Broker.
 

--- a/docs/eventing/broker/rabbitmq-broker/README.md
+++ b/docs/eventing/broker/rabbitmq-broker/README.md
@@ -80,21 +80,21 @@ For more information about configuring the `RabbitmqCluster` CRD, see the
 
 ## Reference an external RabbitMQ Cluster
 
-1. Create a Secret that store the external RabbitMQ Cluster Credentials and uri
+1. Create a Secret that stores the external RabbitMQ Cluster Credentials and URI:
 
-  ```yaml
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: rabbitmq-secret-credentials
-  # This is just a sample, don't use it this way in production
-  stringData:
-    username: $EXTERNAL_RABBITMQ_USERNAME
-    password: $EXTERNAL_RABBITMQ_PASSWORD
-    uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
-  ```
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: rabbitmq-secret-credentials
+    # This is just a sample, don't use it this way in production
+    stringData:
+      username: $EXTERNAL_RABBITMQ_USERNAME
+      password: $EXTERNAL_RABBITMQ_PASSWORD
+      uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
+    ```
 
-and in the next step reference the secret in the `RabbitMQ Broker Config`
+You will reference this Secret in the RabbitMQ Broker config later
 
 ## Create a RabbitMQ Broker config object
 
@@ -106,18 +106,18 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
       name: <rabbitmq-broker-config-name>
     spec:
       rabbitmqClusterReference:
-        # if a local cluster is being used. name and connectionSecret cannot be set at the same time
+        # Configure name if a local cluster is being used.
         name: <cluster-name>
-        # if an external rabbitmq cluster is being used
+        # Configure connectionSecret if an external RabbitMQ cluster is being used.
         connectionSecret:
           name: rabbitmq-secret-credentials
       queueType: quorum
     ```
-    Where: 
-    
+    Where:
+
     - <rabbitmq-broker-config-name> is the name you want for your RabbitMQ Broker config object.
     - <cluster-name> is the name of the RabbitMQ cluster you created earlier.
-    
+
     !!! note
         You cannot set `name` and `connectionSecret` at the same time.
 

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -1,19 +1,18 @@
-# Creating a RabbitMQ Source
+# Creating a RabbitMQSource
 
-This topic describes how to create a RabbitMQ Source.
+This topic describes how to create a RabbitMQSource.
 
 ## Prerequisites
 
-To use the RabbitMQ Source, you must have the following installed:
-
-1. [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
-1. [RabbitMQ Cluster Operator (optional)](https://github.com/rabbitmq/cluster-operator) - our recommendation is [latest release](https://github.com/rabbitmq/cluster-operator/releases/latest)
-1. [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
-1. [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
+1. You have installed [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
+1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
+1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
+1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator). 
+For more information about configuring the `RabbitmqCluster` CRD, see the[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
 
 ## Install the RabbitMQ controller
 
-1. Install the RabbitMQ Source controller by running the command:
+1. Install the RabbitMQSource controller by running the command:
 
     ```bash
     kubectl apply -f {{ artifact(org="knative-sandbox", repo="eventing-rabbitmq", file="rabbitmq-source.yaml") }}
@@ -33,111 +32,9 @@ To use the RabbitMQ Source, you must have the following installed:
     rabbitmq-webhook                1/1     1            1           4s
     ```
 
-## Create a RabbitMQ cluster (optional)
+{% include "event-display.md" %}
 
-1. Deploy a RabbitMQ cluster:
-
-    1. Create a YAML file using the following template:
-
-        ```yaml
-        apiVersion: rabbitmq.com/v1beta1
-        kind: RabbitmqCluster
-        metadata:
-          name: <cluster-name>
-          annotations:
-            # A single RabbitMQ cluster per Knative Eventing installation
-            rabbitmq.com/topology-allowed-namespaces: "*"
-        ```
-        Where `<cluster-name>` is the name you want for your RabbitMQ cluster,
-        for example, `rabbitmq`.
-
-    1. Apply the YAML file by running the command:
-
-        ```bash
-        kubectl create -f <filename>
-        ```
-        Where `<filename>` is the name of the file you created in the previous step.
-
-1. Wait for the cluster to become ready. When the cluster is ready, `ALLREPLICASREADY`
-will be `true` in the output of the following command:
-
-    ```bash
-    kubectl get rmq <cluster-name>
-    ```
-    Where `<cluster-name>` is the name you gave your cluster in the step above.
-
-    Example output:
-
-    ```{ .bash .no-copy }
-    NAME          ALLREPLICASREADY   RECONCILESUCCESS   AGE
-    rabbitmq      True               True               38s
-    ```
-
-For more information about configuring the `RabbitmqCluster` CRD, see the
-[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html).
-
-## Reference an external RabbitMQ Cluster
-
-1. Create a Secret that stores the external RabbitMQ Cluster Credentials and URI:
-
-    ```yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: rabbitmq-secret-credentials
-    # This is just a sample, don't use it this way in production
-    stringData:
-      username: $EXTERNAL_RABBITMQ_USERNAME
-      password: $EXTERNAL_RABBITMQ_PASSWORD
-      uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
-    ```
-
-You will reference this Secret in the RabbitMQ Source object later.
-
-## Create a Service
-
-1. Create the `event-display` Service as a YAML file:
-
-     ```yaml
-     apiVersion: serving.knative.dev/v1
-     kind: Service
-     metadata:
-       name: event-display
-       namespace: default
-     spec:
-       template:
-         spec:
-           containers:
-             - # This corresponds to
-               # https://github.com/knative/eventing/tree/main/cmd/event_display/main.go
-               image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
-     ```
-
-1. Apply the YAML file by running the command:
-
-    ```bash
-    kubectl apply -f <filename>.yaml
-    ```
-    Where `<filename>` is the name of the file you created in the previous step.
-
-    Example output:
-    ```{ .bash .no-copy }
-    service.serving.knative.dev/event-display created
-    ```
-
-1. Ensure that the Service Pod is running, by running the command:
-
-    ```bash
-    kubectl get pods
-    ```
-
-    The Pod name is prefixed with `event-display`:
-    ```{ .bash .no-copy }
-    NAME                                            READY     STATUS    RESTARTS   AGE
-    event-display-00001-deployment-5d5df6c7-gv2j4   2/2       Running   0          72s
-    ```
-
-## Create a RabbitMQ Source object
+## Create a RabbitMQSource object
 
 1. Create a YAML file using the following template:
 
@@ -148,7 +45,7 @@ You will reference this Secret in the RabbitMQ Source object later.
       name: <source-name>
     spec:
       rabbitmqClusterReference:
-        # Configure name if a local cluster is being used.
+        # Configure name if a RabbitMQ Cluster Operator is being used.
         name: <cluster-name>
         # Configure connectionSecret if an external RabbitMQ cluster is being used.
         connectionSecret:
@@ -169,11 +66,11 @@ You will reference this Secret in the RabbitMQ Source object later.
     ```
     Where:
 
-    - `<source-name>` is the name you want for your RabbitMQ Source object.
+    - `<source-name>` is the name you want for your RabbitMQSource object.
     - `<cluster-name>` is the name of the RabbitMQ cluster you created earlier.
 
     !!! note
-        You cannot set `name` and `connectionSecret` at the same time.
+        You cannot set `name` and `connectionSecret` at the same time, since `name` is for a RabbitMQ Cluster Operator instance running in the same cluster as the Source, and `connectionSecret` is for an external RabbitMQ server.
 
 1. Apply the YAML file by running the command:
 
@@ -206,14 +103,27 @@ It might take a while for the Source to start sending events to the Sink.
     }
 ```
 
-Congratulations! Your new RabbitMQ Source is working!
-
 ### Cleanup
 
-```sh
-kubectl delete -f <source-yaml-filename> <service-yaml-filename> <secret-yaml-filename> <cluster-yaml-filename>
-```
+1. Delete the RabbitMQSource:
+
+    ```sh
+    kubectl delete -f <source-yaml-filename>
+    ```
+
+1. Delete the RabbitMQ credentials secret:
+
+    ```sh
+    kubectl delete -f <secret-yaml-filename>
+    ```
+
+1. Delete the event display Service:
+
+    ```sh
+    kubectl delete -f <service-yaml-filename>
+    ```
 
 ## Additional information
 
-To report a bug or request a feature, open an issue in the [`eventing-rabbitmq` Github repository](https://github.com/knative-sandbox/eventing-rabbitmq).
+- For more samples visit the [`eventing-rabbitmq` Github repository samples directory](https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples)
+- To report a bug or request a feature, open an issue in the [`eventing-rabbitmq` Github repository](https://github.com/knative-sandbox/eventing-rabbitmq).

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -8,7 +8,7 @@ This topic describes how to create a RabbitMQSource.
 1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
 1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
 1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator). 
-For more information about configuring the `RabbitmqCluster` CRD, see the[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
+For more information about configuring the `RabbitmqCluster` CRD, see the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
 
 ## Install the RabbitMQ controller
 

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -216,4 +216,4 @@ kubectl delete -f <source-yaml-filename> <service-yaml-filename> <secret-yaml-fi
 
 ## Additional information
 
-To report a bug or request a feature, open an issue in the [eventing-rabbitmq repository](https://github.com/knative-sandbox/eventing-rabbitmq).
+To report a bug or request a feature, open an issue in the [`eventing-rabbitmq` Github repository](https://github.com/knative-sandbox/eventing-rabbitmq).

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -184,7 +184,7 @@ You will reference this Secret in the RabbitMQ Source object later.
 
 ### Verify
 
-Check the event-display service to see if it is receiving events.
+Check the event-display Service to see if it is receiving events.
 It might take a while for the Source to start sending events to the Sink.
 
 ```sh

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -148,7 +148,7 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
       name: <source-name>
     spec:
       rabbitmqClusterReference:
-        # if a local cluster is being used, name and connectionSecret cannot be set at the same time 
+        # if a local cluster is being used. name and connectionSecret cannot be set at the same time
         name: <cluster-name>
         # if an external rabbitmq cluster is being used
         connectionSecret:

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -1,0 +1,212 @@
+# Creating a RabbitMQ Source
+
+This topic describes how to create a RabbitMQ Source.
+
+## Prerequisites
+
+To use the RabbitMQ Source, you must have the following installed:
+
+1. [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
+1. [RabbitMQ Cluster Operator (optional)](https://github.com/rabbitmq/cluster-operator) - our recommendation is [latest release](https://github.com/rabbitmq/cluster-operator/releases/latest)
+1. [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
+1. [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
+
+## Install the RabbitMQ controller
+
+1. Install the RabbitMQ Source controller by running the command:
+
+    ```bash
+    kubectl apply -f {{ artifact(org="knative-sandbox", repo="eventing-rabbitmq", file="rabbitmq-source.yaml") }}
+    ```
+
+1. Verify that `rabbitmq-controller-manager` and `rabbitmq-webhook` are running:
+
+    ```bash
+    kubectl get deployments.apps -n knative-sources
+    ```
+
+    Example output:
+
+    ```{ .bash .no-copy }
+    NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+    rabbitmq-controller-manager     1/1     1            1           3s
+    rabbitmq-webhook                1/1     1            1           4s
+    ```
+
+## Create a RabbitMQ cluster (optional)
+
+1. Deploy a RabbitMQ cluster:
+
+    1. Create a YAML file using the following template:
+
+        ```yaml
+        apiVersion: rabbitmq.com/v1beta1
+        kind: RabbitmqCluster
+        metadata:
+          name: <cluster-name>
+          annotations:
+            # A single RabbitMQ cluster per Knative Eventing installation
+            rabbitmq.com/topology-allowed-namespaces: "*"
+        ```
+        Where `<cluster-name>` is the name you want for your RabbitMQ cluster,
+        for example, `rabbitmq`.
+
+    1. Apply the YAML file by running the command:
+
+        ```bash
+        kubectl create -f <filename>
+        ```
+        Where `<filename>` is the name of the file you created in the previous step.
+
+1. Wait for the cluster to become ready. When the cluster is ready, `ALLREPLICASREADY`
+will be `true` in the output of the following command:
+
+    ```bash
+    kubectl get rmq <cluster-name>
+    ```
+    Where `<cluster-name>` is the name you gave your cluster in the step above.
+
+    Example output:
+
+    ```{ .bash .no-copy }
+    NAME          ALLREPLICASREADY   RECONCILESUCCESS   AGE
+    rabbitmq      True               True               38s
+    ```
+
+For more information about configuring the `RabbitmqCluster` CRD, see the
+[RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html).
+
+## Reference an external RabbitMQ Cluster
+
+1. Create a Secret that store the external RabbitMQ Cluster Credentials and uri
+
+  ```yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: rabbitmq-secret-credentials
+  # This is just a sample, don't use it this way in production
+  stringData:
+    username: $EXTERNAL_RABBITMQ_USERNAME
+    password: $EXTERNAL_RABBITMQ_PASSWORD
+    uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
+  ```
+
+and in the next step reference the secret in the `RabbitMQ Broker Config`
+
+## Create a Service
+
+1. Create the `event-display` Service as a YAML file:
+
+     ```yaml
+     apiVersion: serving.knative.dev/v1
+     kind: Service
+     metadata:
+       name: event-display
+       namespace: default
+     spec:
+       template:
+         spec:
+           containers:
+             - # This corresponds to
+               # https://github.com/knative/eventing/tree/main/cmd/event_display/main.go
+               image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
+     ```
+
+1. Apply the YAML file by running the command:
+
+    ```bash
+    kubectl apply -f <filename>.yaml
+    ```
+    Where `<filename>` is the name of the file you created in the previous step.
+
+    Example output:
+    ```{ .bash .no-copy }
+    service.serving.knative.dev/event-display created
+    ```
+
+1. Ensure that the Service Pod is running, by running the command:
+
+    ```bash
+    kubectl get pods
+    ```
+
+    The Pod name is prefixed with `event-display`:
+    ```{ .bash .no-copy }
+    NAME                                            READY     STATUS    RESTARTS   AGE
+    event-display-00001-deployment-5d5df6c7-gv2j4   2/2       Running   0          72s
+    ```
+
+## Create a RabbitMQ Source object
+
+1. Create a YAML file using the following template:
+
+    ```yaml
+    apiVersion: sources.knative.dev/v1alpha1
+    kind: RabbitmqSource
+    metadata:
+      name: <source-name>
+    spec:
+      rabbitmqClusterReference:
+        # if a local cluster is being used, name and connectionSecret cannot be set at the same time 
+        name: <cluster-name>
+        # if an external rabbitmq cluster is being used
+        connectionSecret:
+          name: rabbitmq-secret-credentials
+      rabbitmqResourcesConfig:
+        parallelism: 10
+        exchangeName: "eventing-rabbitmq-source"
+        queueName: "eventing-rabbitmq-source"
+      delivery:
+        retry: 5
+        backoffPolicy: "linear"
+        backoffDelay: "PT1S"
+      sink:
+        ref:
+          apiVersion: serving.knative.dev/v1
+          kind: Service
+          name: event-display
+    ```
+
+1. Apply the YAML file by running the command:
+
+    ```bash
+    kubectl apply -f <filename>
+    ```
+    Where `<filename>` is the name of the file you created in the previous step.
+
+### Verify
+
+Check the event-display service to see if it is receiving events.
+It may take a while for the Source to start sending events to the Sink, so be patient :p!
+
+```sh
+  kubectl -l='serving.knative.dev/service=event-display' logs -c user-container
+  ☁️  cloudevents.Event
+  Context Attributes,
+    specversion: 1.0
+    type: dev.knative.rabbitmq.event
+    source: /apis/v1/namespaces/default/rabbitmqsources/<source-name>
+    subject: f147099d-c64d-41f7-b8eb-a2e53b228349
+    id: f147099d-c64d-41f7-b8eb-a2e53b228349
+    time: 2021-12-16T20:11:39.052276498Z
+    datacontenttype: application/json
+  Data,
+    {
+      ...
+      Random Data
+      ...
+    }
+```
+
+Congratulations! Your new RabbitMQ Source its working!
+
+### Cleanup
+
+```sh
+kubectl delete -f <source-yaml-filename> <service-yaml-filename> <secret-yaml-filename> <cluster-yaml-filename>
+```
+
+## Additional information
+
+To report a bug or request a feature, open an issue in the [eventing-rabbitmq repository](https://github.com/knative-sandbox/eventing-rabbitmq).

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -7,7 +7,7 @@ This topic describes how to create a RabbitMQSource.
 1. You have installed [Knative Eventing](../../../install/yaml-install/eventing/install-eventing-with-yaml.md)
 1. You have installed [CertManager v1.5.4](https://github.com/jetstack/cert-manager/releases/tag/v1.5.4) - easiest integration with RabbitMQ Messaging Topology Operator
 1. You have installed [RabbitMQ Messaging Topology Operator](https://github.com/rabbitmq/messaging-topology-operator) - our recommendation is [latest release](https://github.com/rabbitmq/messaging-topology-operator/releases/latest) with CertManager
-1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator). 
+1. A working RabbitMQ Instance, we recommend to create one Using the [RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator).
 For more information about configuring the `RabbitmqCluster` CRD, see the [RabbitMQ website](https://www.rabbitmq.com/kubernetes/operator/using-operator.html)
 
 ## Install the RabbitMQ controller

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -185,7 +185,7 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
 ### Verify
 
 Check the event-display service to see if it is receiving events.
-It may take a while for the Source to start sending events to the Sink, so be patient :p!
+It might take a while for the Source to start sending events to the Sink.
 
 ```sh
   kubectl -l='serving.knative.dev/service=event-display' logs -c user-container

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -167,6 +167,13 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
           kind: Service
           name: event-display
     ```
+    Where:
+
+    - `<source-name>` is the name you want for your RabbitMQ Source object.
+    - `<cluster-name>` is the name of the RabbitMQ cluster you created earlier.
+
+    !!! note
+        You cannot set `name` and `connectionSecret` at the same time.
 
 1. Apply the YAML file by running the command:
 

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -206,7 +206,7 @@ It might take a while for the Source to start sending events to the Sink.
     }
 ```
 
-Congratulations! Your new RabbitMQ Source its working!
+Congratulations! Your new RabbitMQ Source is working!
 
 ### Cleanup
 

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -78,21 +78,21 @@ For more information about configuring the `RabbitmqCluster` CRD, see the
 
 ## Reference an external RabbitMQ Cluster
 
-1. Create a Secret that store the external RabbitMQ Cluster Credentials and uri
+1. Create a Secret that stores the external RabbitMQ Cluster Credentials and URI:
 
-  ```yaml
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: rabbitmq-secret-credentials
-  # This is just a sample, don't use it this way in production
-  stringData:
-    username: $EXTERNAL_RABBITMQ_USERNAME
-    password: $EXTERNAL_RABBITMQ_PASSWORD
-    uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
-  ```
+    ```yaml
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: rabbitmq-secret-credentials
+    # This is just a sample, don't use it this way in production
+    stringData:
+      username: $EXTERNAL_RABBITMQ_USERNAME
+      password: $EXTERNAL_RABBITMQ_PASSWORD
+      uri: $EXTERNAL_RABBITMQ_MANAGEMENT_UI_URI:$PORT
+    ```
 
-and in the next step reference the secret in the `RabbitMQ Broker Config`
+You will reference this Secret in the RabbitMQ Source object later.
 
 ## Create a Service
 
@@ -148,9 +148,9 @@ and in the next step reference the secret in the `RabbitMQ Broker Config`
       name: <source-name>
     spec:
       rabbitmqClusterReference:
-        # if a local cluster is being used. name and connectionSecret cannot be set at the same time
+        # Configure name if a local cluster is being used.
         name: <cluster-name>
-        # if an external rabbitmq cluster is being used
+        # Configure connectionSecret if an external RabbitMQ cluster is being used.
         connectionSecret:
           name: rabbitmq-secret-credentials
       rabbitmqResourcesConfig:

--- a/docs/snippets/event-display.md
+++ b/docs/snippets/event-display.md
@@ -1,0 +1,42 @@
+## Create a Service
+
+1. Create the `event-display` Service as a YAML file:
+
+     ```yaml
+     apiVersion: serving.knative.dev/v1
+     kind: Service
+     metadata:
+       name: event-display
+       namespace: default
+     spec:
+       template:
+         spec:
+           containers:
+             - # This corresponds to
+               # https://github.com/knative/eventing/tree/main/cmd/event_display/main.go
+               image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
+     ```
+
+1. Apply the YAML file by running the command:
+
+    ```bash
+    kubectl apply -f <filename>.yaml
+    ```
+    Where `<filename>` is the name of the file you created in the previous step.
+
+    Example output:
+    ```{ .bash .no-copy }
+    service.serving.knative.dev/event-display created
+    ```
+
+1. Ensure that the Service Pod is running, by running the command:
+
+    ```bash
+    kubectl get pods
+    ```
+
+    The Pod name is prefixed with `event-display`:
+    ```{ .bash .no-copy }
+    NAME                                            READY     STATUS    RESTARTS   AGE
+    event-display-00001-deployment-5d5df6c7-gv2j4   2/2       Running   0          72s
+    ```


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Right now, the RabbitMQ Source does not have an entry in the docs. This PR adds it to the Sources section and also updating the Broker docs to show that the RabbitMQ Cluster operator is no longer needed for Eventing RabbitMQ to work.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Added RabbitMQ Source docs to Sources
- Fixed minor typos in Broker readme
- Specified that creating a Cluster with the RabbitMQ Cluster operator is now optional for the Eventing RabbitMQ CRDs
