### PR TITLE
Add documentation for active-min-scale

### DIFF
--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -184,10 +184,10 @@ When the Revision is created, the larger of initial scale and lower bound is aut
 
 ## Scale Up Minimum
 
-This value controls the minimum number of replicas that will be created when the Revision scales up from zero. 
+This value controls the minimum number of replicas that will be created when the Revision scales up from zero.
 
 * **Global key:** n/a
-* **Per-revision annotation key:** `autoscaling.knative.dev/active-min-scale`
+* **Per-revision annotation key:** `autoscaling.knative.dev/activation-scale`
 * **Possible values:** integer
 * **Default:** `1`
 
@@ -205,7 +205,7 @@ This value controls the minimum number of replicas that will be created when the
       template:
         metadata:
           annotations:
-            autoscaling.knative.dev/active-min-scale: "5"
+            autoscaling.knative.dev/activation-scale: "5"
         spec:
           containers:
             - image: gcr.io/knative-samples/helloworld-go

--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -182,6 +182,35 @@ When the Revision is created, the larger of initial scale and lower bound is aut
           allow-zero-initial-scale: "true"
     ```
 
+## Scale Up Minimum
+
+This value controls the minimum number of replicas that will be created when the Revision scales up from zero. 
+
+* **Global key:** n/a
+* **Per-revision annotation key:** `autoscaling.knative.dev/active-min-scale`
+* **Possible values:** integer
+* **Default:** `1`
+
+
+**Example:**
+
+=== "Per Revision"
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      name: helloworld-go
+      namespace: default
+    spec:
+      template:
+        metadata:
+          annotations:
+            autoscaling.knative.dev/active-min-scale: "5"
+        spec:
+          containers:
+            - image: gcr.io/knative-samples/helloworld-go
+    ```
+
 ## Scale Down Delay
 
 Scale Down Delay specifies a time window which must pass at reduced concurrency


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

Adds documentation for the `active-min-scale` annotation added in https://github.com/knative/serving/pull/13136

There's an ongoing discussion over the name of this annotation on [slack](https://knative.slack.com/archives/C9CV04DNJ/p1658938603476139), so this may need an update. But since the serving PR has already merged, may as well start getting the docs in for it.