### PR TITLE
Remove unstable to Kafka broker ordered delivery feature

### DIFF
--- a/docs/eventing/broker/kafka-broker/README.md
+++ b/docs/eventing/broker/kafka-broker/README.md
@@ -378,7 +378,7 @@ The supported consumer delivery guarantees are:
 * `unordered`:  An unordered consumer is a non-blocking consumer that delivers messages unordered, while preserving proper offset management.
 * `ordered`: An ordered consumer is a per-partition blocking consumer that waits for a successful response from the CloudEvent subscriber before it delivers the next message of the partition.
 
-`unordered` is the default ordering guarantee, while **`ordered` is considered unstable, use with caution**.
+`unordered` is the default ordering guarantee.
 
 ### Additional information
 


### PR DESCRIPTION
This feature has been stable for quite some time, but we missed
the doc update so cherry-picks are necessary.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Remove unstable to Kafka broker ordered delivery feature
