### PR TITLE
Fix & Simplify ApiServerSource docs

### DIFF
--- a/docs/eventing/sources/apiserversource/getting-started.md
+++ b/docs/eventing/sources/apiserversource/getting-started.md
@@ -186,14 +186,14 @@ command:
               --mode "Resource" \
               --resource "Event:v1" \
               --service-account <service-account> \
-              --sink <sink-name>
+              --sink <sink>
             ```
             Where:
 
             - `<apiserversource>` is the name of the source that you want to create.
             - `<namespace>` is the name of the namespace that you created in step 1 earlier.
             - `<service-account>` is the name of the ServiceAccount that you created in step 2 earlier.
-            - `<sink-name>` is the name of your sink, for example, `http://event-display.pingsource-example.svc.cluster.local`.
+            - `<sink>` is the sink you created in step 5 earlier, for example, Service url: `http://event-display.<namespace>.svc.cluster.local`
 
             For a list of available options, see the [Knative client documentation](https://github.com/knative/client/blob/main/docs/cmd/kn_source_apiserver_create.md#kn-source-apiserver-create).
 
@@ -208,24 +208,22 @@ command:
              namespace: <namespace>
             spec:
              serviceAccountName: <service-account>
-             mode: <event-mode>
+             mode: Resource
              resources:
                - apiVersion: v1
                  kind: Event
              sink:
                ref:
                  apiVersion: v1
-                 kind: <sink-kind>
-                 name: <sink-name>
+                 kind: Service
+                 name: event-display
             ```
             Where:
 
             - `<apiserversource-name>` is the name of the source that you want to create.
             - `<namespace>` is the name of the namespace that you created in step 1 earlier.
             - `<service-account>` is the name of the ServiceAccount that you created in step 2 earlier.
-            - `<event-mode>` is either `Resource` or `Reference`. If set to `Resource`, the event payload contains the entire resource that the event is for. If set to `Reference`, the event payload only contains a reference to the resource that the event is for. The default is `Reference`.
-            - `<sink-kind>` is any supported Addressable object that you want to use as a sink, for example, a `Service` or `Deployment`.
-            - `<sink-name>` is the name of your sink.
+            - `kind: Service` and `name: event-display` is the name of the service that you created in step 5 earlier.
 
             For more information about the fields you can configure for the ApiServerSource object, see [ApiServerSource reference](reference.md).
 

--- a/docs/eventing/sources/apiserversource/getting-started.md
+++ b/docs/eventing/sources/apiserversource/getting-started.md
@@ -223,7 +223,8 @@ command:
             - `<apiserversource-name>` is the name of the source that you want to create.
             - `<namespace>` is the name of the namespace that you created in step 1 earlier.
             - `<service-account>` is the name of the ServiceAccount that you created in step 2 earlier.
-            - `kind: Service` and `name: event-display` is the name of the service that you created in step 5 earlier.
+            - `kind: Service` is any supported Addressable object that you want to use as a sink
+            - `name: event-display` is the name of the Service that you created in step 5 earlier.
 
             For more information about the fields you can configure for the ApiServerSource object, see [ApiServerSource reference](reference.md).
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- issue: pingsource-example is from another tutorial, it is `<namespace>`
- confusion: `<sink-name>` used for kn is not a name, use `<sink>` instead
- simplify: for yaml - 3 values can be provided directly, for details there is a link to additional documentation
