### PR TITLE
Fixed markdown syntax in helloworld-java-spring/README.md

### DIFF
--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -185,10 +185,10 @@ This will wait until your service is deployed and ready, and ultimately it will 
 
     Example:
 
-```bash
-NAME                      URL
-helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.xip.io
-```
+    ```bash
+    NAME                      URL
+    helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.xip.io
+    ```
 
 ### kn
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -215,7 +215,7 @@ Example:
     curl $(kn service describe helloworld-java-spring -o url)
     ```
 
-**Tip:** Add `-v` option to get more detail if the `curl` command fails.
+    **Tip:** Add `-v` option to get more detail if the `curl` command fails.
 
 ## Deleting the app
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -159,9 +159,9 @@ To deploy the app:
 
 1. Apply the YAML file by running the command:
 
-```bash
-kubectl apply -f service.yaml
-```
+    ```bash
+    kubectl apply -f service.yaml
+    ```
 
 ### kn
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -183,7 +183,7 @@ This will wait until your service is deployed and ready, and ultimately it will 
     kubectl get ksvc helloworld-java-spring  --output=custom-columns=NAME:.metadata.name,URL:.status.url
     ```
 
-Example:
+    Example:
 
 ```bash
 NAME                      URL

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -196,7 +196,7 @@ This will wait until your service is deployed and ready, and ultimately it will 
     kn service describe helloworld-java-spring -o url
     ```
 
-Example:
+    Example:
 
     ```bash
     http://helloworld-java-spring.default.1.2.3.4.xip.io

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -207,9 +207,9 @@ Example:
 
     Example:
 
-```bash
-curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
-Hello Spring Boot Sample v1!
+    ```bash
+    curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
+    Hello Spring Boot Sample v1!
 
 # Even easier with kn:
 curl $(kn service describe helloworld-java-spring -o url)

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -32,10 +32,10 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
     unzip helloworld.zip
     ```
 
-    If you don't have `curl` installed, you can accomplish the same by visiting the
-    [Spring Initializr](https://start.spring.io/) page. Specify Artifact as
-    `helloworld` and add the `Web` dependency. Then click **Generate Project**,
-    download and unzip the sample archive.
+   If you don't have `curl` installed, you can accomplish the same by visiting the
+   [Spring Initializr](https://start.spring.io/) page. Specify Artifact as
+   `helloworld` and add the `Web` dependency. Then click **Generate Project**,
+   download and unzip the sample archive.
 
 1. Update the `SpringBootApplication` class in
    `src/main/java/com/example/helloworld/HelloworldApplication.java` by adding a
@@ -77,7 +77,7 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
     ./mvnw package && java -jar target/helloworld-0.0.1-SNAPSHOT.jar
     ```
 
-    Go to `http://localhost:8080/` to see your `Hello World!` message.
+   Go to `http://localhost:8080/` to see your `Hello World!` message.
 
 1. In your project directory, create a file named `Dockerfile` and copy the following code block into it:
 
@@ -105,9 +105,9 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
     CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/helloworld.jar"]
 
     ```
-    For detailed instructions on dockerizing a Spring Boot app, see [Spring Boot with Docker](https://spring.io/guides/gs/spring-boot-docker/).
+   For detailed instructions on dockerizing a Spring Boot app, see [Spring Boot with Docker](https://spring.io/guides/gs/spring-boot-docker/).
 
-    For additional information on multi-stage docker builds for Java see [Creating Smaller Java Image using Docker Multi-stage Build](http://blog.arungupta.me/smaller-java-image-docker-multi-stage-build/).
+   For additional information on multi-stage docker builds for Java see [Creating Smaller Java Image using Docker Multi-stage Build](http://blog.arungupta.me/smaller-java-image-docker-multi-stage-build/).
 
 1. Use Docker to build the sample code into a container, then push the container to the Docker registry:
 
@@ -118,7 +118,7 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
     # Push the container to docker registry
     docker push {username}/helloworld-java-spring
     ```
-    Where `{username}` is your Docker Hub username.
+   Where `{username}` is your Docker Hub username.
 
 
 ## Deploying the app
@@ -133,101 +133,100 @@ During the creation of a Service, Knative performs the following steps:
 
 To deploy the app:
 
-=== "YAML"
+### YAML
 
-    1. Create a new file named `service.yaml` and copy the following service definition
-    into the file:
+1. Create a new file named `service.yaml` and copy the following service definition
+   into the file:
 
-        ```yaml
-        apiVersion: serving.knative.dev/v1
-        kind: Service
-        metadata:
-          name: helloworld-java-spring
-          namespace: default
-        spec:
-          template:
-            spec:
-              containers:
-                - image: docker.io/{username}/helloworld-java-spring
-                  env:
-                    - name: TARGET
-                      value: "Spring Boot Sample v1"
-        ```
-        Where `{username}` is your Docker Hub username.
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: helloworld-java-spring
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+        - image: docker.io/{username}/helloworld-java-spring
+          env:
+            - name: TARGET
+              value: "Spring Boot Sample v1"
+```
+Where `{username}` is your Docker Hub username.
 
-        **Note:** Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
+**Note:** Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
 
-    1. Apply the YAML file by running the command:
+1. Apply the YAML file by running the command:
 
-        ```bash
-        kubectl apply -f service.yaml
-        ```
+```bash
+kubectl apply -f service.yaml
+```
 
-=== "kn"
+### kn
 
-       With `kn` you can deploy the service with
+With `kn` you can deploy the service with
 
-       ```bash
-       kn service create helloworld-java-spring --image=docker.io/{username}/helloworld-java-spring --env TARGET="Spring Boot Sample v1"
-       ```
+```bash
+kn service create helloworld-java-spring --image=docker.io/{username}/helloworld-java-spring --env TARGET="Spring Boot Sample v1"
+```
 
-       This will wait until your service is deployed and ready, and ultimately it will print the URL through which you can access the service.
-
+This will wait until your service is deployed and ready, and ultimately it will print the URL through which you can access the service.
 
 ## Verification
 
 1. Find the domain URL for your service:
 
-    === "kubectl"
-           ```bash
-           kubectl get ksvc helloworld-java-spring  --output=custom-columns=NAME:.metadata.name,URL:.status.url
-           ```
+### kubectl
 
-           Example:
+```bash
+kubectl get ksvc helloworld-java-spring  --output=custom-columns=NAME:.metadata.name,URL:.status.url
+```
 
-           ```bash
-           NAME                      URL
-           helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.xip.io
-           ```
+Example:
 
+```bash
+NAME                      URL
+helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.xip.io
+```
 
-    === "kn"
+### kn
 
-           ```bash
-           kn service describe helloworld-java-spring -o url
-           ```
+```bash
+kn service describe helloworld-java-spring -o url
+```
 
-           Example:
+Example:
 
-           ```bash
-           http://helloworld-java-spring.default.1.2.3.4.xip.io
-           ```
+```bash
+http://helloworld-java-spring.default.1.2.3.4.xip.io
+```
 
 1. Make a request to your app and observe the result. Replace
    the following URL with the URL returned in the previous command.
 
-    Example:
+Example:
 
-    ```bash
-    curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
-    Hello Spring Boot Sample v1!
+```bash
+curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
+Hello Spring Boot Sample v1!
 
-    # Even easier with kn:
-    curl $(kn service describe helloworld-java-spring -o url)
-    ```
+# Even easier with kn:
+curl $(kn service describe helloworld-java-spring -o url)
+```
 
-    **Tip:** Add `-v` option to get more detail if the `curl` command fails.
+**Tip:** Add `-v` option to get more detail if the `curl` command fails.
 
 ## Deleting the app
 
 To remove the sample app from your cluster, delete the service.
 
-=== "kubectl"
-    ```bash
-    kubectl delete -f service.yaml
-    ```
+### kubectl
+```bash
+kubectl delete -f service.yaml
+```
 
-=== "kn"
-    ```bash
-    kn service delete helloworld-java-spring
-    ```
+### kn
+```bash
+kn service delete helloworld-java-spring
+```

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -192,9 +192,9 @@ This will wait until your service is deployed and ready, and ultimately it will 
 
     - For kn, run:
 
-```bash
-kn service describe helloworld-java-spring -o url
-```
+    ```bash
+    kn service describe helloworld-java-spring -o url
+    ```
 
 Example:
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -155,7 +155,7 @@ To deploy the app:
     ```
     Where `{username}` is your Docker Hub username.
 
-**Note:** Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
+    **Note:** Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
 
 1. Apply the YAML file by running the command:
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -177,7 +177,7 @@ This will wait until your service is deployed and ready, and ultimately it will 
 
 1. Find the domain URL for your service:
 
-### kubectl
+    - For kubectl, run:
 
 ```bash
 kubectl get ksvc helloworld-java-spring  --output=custom-columns=NAME:.metadata.name,URL:.status.url

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -198,9 +198,9 @@ kn service describe helloworld-java-spring -o url
 
 Example:
 
-```bash
-http://helloworld-java-spring.default.1.2.3.4.xip.io
-```
+    ```bash
+    http://helloworld-java-spring.default.1.2.3.4.xip.io
+    ```
 
 1. Make a request to your app and observe the result. Replace
    the following URL with the URL returned in the previous command.

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -179,9 +179,9 @@ This will wait until your service is deployed and ready, and ultimately it will 
 
     - For kubectl, run:
 
-```bash
-kubectl get ksvc helloworld-java-spring  --output=custom-columns=NAME:.metadata.name,URL:.status.url
-```
+    ```bash
+    kubectl get ksvc helloworld-java-spring  --output=custom-columns=NAME:.metadata.name,URL:.status.url
+    ```
 
 Example:
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -138,22 +138,22 @@ To deploy the app:
 1. Create a new file named `service.yaml` and copy the following service definition
    into the file:
 
-```yaml
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: helloworld-java-spring
-  namespace: default
-spec:
-  template:
+    ```yaml
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    metadata:
+      name: helloworld-java-spring
+      namespace: default
     spec:
-      containers:
-        - image: docker.io/{username}/helloworld-java-spring
-          env:
-            - name: TARGET
-              value: "Spring Boot Sample v1"
-```
-Where `{username}` is your Docker Hub username.
+      template:
+        spec:
+          containers:
+            - image: docker.io/{username}/helloworld-java-spring
+              env:
+                - name: TARGET
+                  value: "Spring Boot Sample v1"
+    ```
+    Where `{username}` is your Docker Hub username.
 
 **Note:** Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
 

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -205,7 +205,7 @@ Example:
 1. Make a request to your app and observe the result. Replace
    the following URL with the URL returned in the previous command.
 
-Example:
+    Example:
 
 ```bash
 curl http://helloworld-java-spring.default.1.2.3.4.sslip.io

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -190,7 +190,7 @@ This will wait until your service is deployed and ready, and ultimately it will 
     helloworld-java-spring    http://helloworld-java-spring.default.1.2.3.4.xip.io
     ```
 
-### kn
+    - For kn, run:
 
 ```bash
 kn service describe helloworld-java-spring -o url

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -211,9 +211,9 @@ Example:
     curl http://helloworld-java-spring.default.1.2.3.4.sslip.io
     Hello Spring Boot Sample v1!
 
-# Even easier with kn:
-curl $(kn service describe helloworld-java-spring -o url)
-```
+    # Even easier with kn:
+    curl $(kn service describe helloworld-java-spring -o url)
+    ```
 
 **Tip:** Add `-v` option to get more detail if the `curl` command fails.
 


### PR DESCRIPTION
This PR fixes the syntax of `code-samples/serving/hello-world/helloworld-java-spring/README.md`, which is mixing Markdown and Asciidoc syntaxes.