### PR TITLE
Fix typo in Traffic Splitting getting started page

### DIFF
--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -143,7 +143,7 @@ Split the traffic between the two Revisions:
         ```
 
 !!! info
-    `@latest` always point to the "latest" Revision which in this case is `hello-00002`.
+    `@latest` always points to the "latest" Revision, which in this case is `hello-00002`.
 
 ## Verify the traffic split
 

--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -143,7 +143,7 @@ Split the traffic between the two Revisions:
         ```
 
 !!! info
-    `@latest` alwayss point to the "latest" Revision which in this case is `hello-00002`.
+    `@latest` always point to the "latest" Revision which in this case is `hello-00002`.
 
 ## Verify the traffic split
 


### PR DESCRIPTION
Fix 'alwayss' to 'always' in traffic splitting.

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix type in Traffic Splitting (getting started) https://knative.dev/docs/getting-started/first-traffic-split/#verify-the-traffic-split :
 alwayss -> always
