### PR TITLE
[release-1.7] Fix guard readme link

### DIFF
--- a/docs/serving/queue-extensions.md
+++ b/docs/serving/queue-extensions.md
@@ -7,7 +7,7 @@ Knative service pods include two containers:
 
 You can extend Queue Proxy to offer additional features. The QPOptions feature of Queue Proxy allows additional runtime packages to extend Queue Proxy capabilities.
 
-For example, the [security-guard](https://knative.dev/security-guard/README.md) repository provides an extension that uses the QPOptions feature. The [QPOption](https://knative.dev/security-guard/pkg/qpoption/README.md) package enables users to add additional security features to Queue Proxy.
+For example, the [security-guard](https://knative.dev/security-guard#section-readme) repository provides an extension that uses the QPOptions feature. The [QPOption](https://knative.dev/security-guard/pkg/qpoption/README.md) package enables users to add additional security features to Queue Proxy.
 
 The runtime features available are determined when the Queue Proxy image is built. Queue Proxy defines an orderly manner to activate and to configure extensions.
 

--- a/docs/serving/queue-extensions.md
+++ b/docs/serving/queue-extensions.md
@@ -7,7 +7,7 @@ Knative service pods include two containers:
 
 You can extend Queue Proxy to offer additional features. The QPOptions feature of Queue Proxy allows additional runtime packages to extend Queue Proxy capabilities.
 
-For example, the [security-guard](https://knative.dev/security-guard#section-readme) repository provides an extension that uses the QPOptions feature. The [QPOption](https://knative.dev/security-guard/pkg/qpoption/README.md) package enables users to add additional security features to Queue Proxy.
+For example, the [security-guard](https://knative.dev/security-guard#section-readme) repository provides an extension that uses the QPOptions feature. The [QPOption](https://knative.dev/security-guard/pkg/qpoption#section-readme) package enables users to add additional security features to Queue Proxy.
 
 The runtime features available are determined when the Queue Proxy image is built. Queue Proxy defines an orderly manner to activate and to configure extensions.
 

--- a/docs/serving/services/using-queue-extensions.md
+++ b/docs/serving/services/using-queue-extensions.md
@@ -1,6 +1,6 @@
 # Using extensions enabled by QPOptions
 
-QPOptions is a Queue Proxy feature that enables extending Queue Proxy with additional Go packages. For example, the [security-guard](https://knative.dev/security-guard/README.md) repository extends Queue Proxy by adding runtime security features to protect user services.
+QPOptions is a Queue Proxy feature that enables extending Queue Proxy with additional Go packages. For example, the [security-guard](https://knative.dev/security-guard#section-readme) repository extends Queue Proxy by adding runtime security features to protect user services.
 
 Once your cluster is setup with extensions enabled by QPOptions, a Service can decide which extensions it wish to use and how to configure such extensions. Activating and configuring extensions is described here.
 


### PR DESCRIPTION
Hi, 
I noticed that the link we have for the readme file of security-guard is not working. 
Here is a fix
Best if we can fix v1.7 as well. 

Fixes https://github.com/knative/docs/issues/5197