### PR TITLE
Using RPS as scaling metric always requires an annotation

### DIFF
--- a/docs/serving/autoscaling/rps-target.md
+++ b/docs/serving/autoscaling/rps-target.md
@@ -1,6 +1,6 @@
 # Configuring the requests per second (RPS) target
 
-This setting specifies a target for requests-per-second per replica of an application. Your revision must also be configured to use the `rps` [metric annotation](autoscaling-metrics.md)).
+This setting specifies a target for requests-per-second per replica of an application. Your revision must also be configured to use the `rps` [metric annotation](autoscaling-metrics.md).
 
 * **Global key:** `requests-per-second-target-default`
 * **Per-revision annotation key:** `autoscaling.knative.dev/target` 

--- a/docs/serving/autoscaling/rps-target.md
+++ b/docs/serving/autoscaling/rps-target.md
@@ -3,7 +3,7 @@
 This setting specifies a target for requests-per-second per replica of an application. Your revision must also be configured to use the `rps` [metric annotation](autoscaling-metrics.md).
 
 * **Global key:** `requests-per-second-target-default`
-* **Per-revision annotation key:** `autoscaling.knative.dev/target` 
+* **Per-revision annotation key:** `autoscaling.knative.dev/target`
 * **Possible values:** An integer.
 * **Default:** `"200"`
 

--- a/docs/serving/autoscaling/rps-target.md
+++ b/docs/serving/autoscaling/rps-target.md
@@ -1,9 +1,9 @@
 # Configuring the requests per second (RPS) target
 
-This setting specifies a target for requests-per-second per replica of an application.
+This setting specifies a target for requests-per-second per replica of an application. Your revision must also be configured to use the `rps` [metric annotation](autoscaling-metrics.md)).
 
 * **Global key:** `requests-per-second-target-default`
-* **Per-revision annotation key:** `autoscaling.knative.dev/target` (your revision must also be configured to use the `rps` [metric annotation](autoscaling-metrics.md))
+* **Per-revision annotation key:** `autoscaling.knative.dev/target` 
 * **Possible values:** An integer.
 * **Default:** `"200"`
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

Making it clear in the docs that when using RPS for autoscaling, users need to set the scaling metric annotation regardless of if the target is set per-revision or via the global configmap.

Issue surfaced in [slack discussion](https://knative.slack.com/archives/C93E33SN8/p1662019087164369)