### PR TITLE
Add double quote for version number in KnativeServing CR

### DIFF
--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -15,7 +15,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  version: 1.5
+  version: "1.5"
 ```
 
 You can also run the following command to make the equivalent change:


### PR DESCRIPTION
When creating the CR by the yaml explained in the doc,  it fails due to the type mismatch of number vs string.

```yaml
apiVersion: operator.knative.dev/v1beta1
kind: KnativeServing
metadata:
  name: knative-serving
  namespace: knative-serving
spec:
  version: 1.5
```

Here is the error:

```shell
$ kubectl  apply -f a.yaml 
The KnativeServing "knative-serving" is invalid: spec.version: Invalid value: "number": spec.version in body must be of type string: "number"
```

To fix it, this patch adds the double quote in the version number.
