### PR TITLE
Fix issues in broker docs

### DIFF
--- a/docs/eventing/brokers/broker-developer-config-options.md
+++ b/docs/eventing/brokers/broker-developer-config-options.md
@@ -32,7 +32,7 @@ spec:
 ```
 
 - You can specify any valid `name` for your broker. Using `default` will create a broker named `default`.
-- The `namespace` must be an existing namespace in your cluster. Using `default` will create the broker in the current namespace.
+- The `namespace` must be an existing namespace in your cluster. Using `default` will create the broker in the `default` namespace.
 - You can set the `eventing.knative.dev/broker.class` annotation to change the class of the broker. The default broker class is `MTChannelBasedBroker`, but Knative also supports use of the `Kafka` broker class. For more information about Kafka brokers, see the [Apache Kafka Broker](../brokers/broker-types/kafka-broker/README.md) documentation.
 - `spec.config` is used to specify the default backing channel configuration for MT channel-based broker implementations. For more information on configuring the default channel type, see the documentation on [Configure Broker defaults](../configuration/broker-configuration.md).
 - `spec.delivery` is used to configure event delivery options. Event delivery options specify what happens to an event that fails to be delivered to an event sink. For more information, see the documentation on [Event delivery](../event-delivery.md).

--- a/docs/eventing/brokers/broker-developer-config-options.md
+++ b/docs/eventing/brokers/broker-developer-config-options.md
@@ -33,6 +33,6 @@ spec:
 
 - You can specify any valid `name` for your broker. Using `default` will create a broker named `default`.
 - The `namespace` must be an existing namespace in your cluster. Using `default` will create the broker in the `default` namespace.
-- You can set the `eventing.knative.dev/broker.class` annotation to change the class of the broker. The default broker class is `MTChannelBasedBroker`, but Knative also supports use of the `Kafka` broker class. For more information about Kafka brokers, see the [Apache Kafka Broker](../brokers/broker-types/kafka-broker/README.md) documentation.
+- You can set the `eventing.knative.dev/broker.class` annotation to change the class of the broker. The default broker class is `MTChannelBasedBroker`, but Knative also supports use of the `Kafka` and `RabbitMQBroker` broker class. For more information see the [Apache Kafka Broker](../brokers/broker-types/kafka-broker/README.md) or [RabbitMQ Broker](../brokers/broker-types/rabbitmq-broker/README.md) documentation.
 - `spec.config` is used to specify the default backing channel configuration for MT channel-based broker implementations. For more information on configuring the default channel type, see the documentation on [Configure Broker defaults](../configuration/broker-configuration.md).
 - `spec.delivery` is used to configure event delivery options. Event delivery options specify what happens to an event that fails to be delivered to an event sink. For more information, see the documentation on [Event delivery](../event-delivery.md).

--- a/docs/eventing/brokers/broker-developer-config-options.md
+++ b/docs/eventing/brokers/broker-developer-config-options.md
@@ -8,27 +8,27 @@ The following is a full example of a multi-tenant (MT) channel-based Broker obje
 apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
-   name: default
-   namespace: default
-   annotations:
-     eventing.knative.dev/broker.class: MTChannelBasedBroker
- spec:
-   config:
-     apiVersion: v1
-     kind: ConfigMap
-     name: config-br-default-channel
-     namespace: knative-eventing
-   delivery:
-     deadLetterSink:
-       ref:
-         kind: Service
-         namespace: example-namespace
-         name: example-service
-         apiVersion: v1
-       uri: example-uri
-     retry: 5
-     backoffPolicy: exponential
-     backoffDelay: "2007-03-01T13:00:00Z/P1Y2M10DT2H30M"
+  name: default
+  namespace: default
+  annotations:
+    eventing.knative.dev/broker.class: MTChannelBasedBroker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: config-br-default-channel
+    namespace: knative-eventing
+  delivery:
+    deadLetterSink:
+      ref:
+        kind: Service
+        namespace: example-namespace
+        name: example-service
+        apiVersion: v1
+      uri: example-uri
+    retry: 5
+    backoffPolicy: exponential
+    backoffDelay: "2007-03-01T13:00:00Z/P1Y2M10DT2H30M"
 ```
 
 - You can specify any valid `name` for your broker. Using `default` will create a broker named `default`.

--- a/docs/eventing/brokers/broker-types/rabbitmq-broker/README.md
+++ b/docs/eventing/brokers/broker-types/rabbitmq-broker/README.md
@@ -106,6 +106,7 @@ metadata:
   annotations:
     rabbitmq.eventing.knative.dev/parallelism: "10"
 ...
+```
 
 ## Additional information
 


### PR DESCRIPTION
PR fixes:
* some markdown syntax in the RabbitMQ Broker doc, so the code example is displayed properly (048ba6d8ae5beff5a01f6fc3ec84d223eca3224c)
* some broker spec indentation in the Broker configuration example (e9eb2d51d4a43f29d364ab419a2e13453884eebf)
* use correct target namespace for broker in broker configuration example, as the current namespace depends on the used kubeconfig context (6e41f0645d48cb2d4b381570c4b91d885c280e79)
* states support for RabbitMQ broker in configuration example (009f6d1bc8f06c8d45ee2e01a953eacbd7c3ac33)
