### PR TITLE
Update docs to use batch/v1

### DIFF
--- a/docs/eventing/custom-event-source/sinkbinding/create-a-sinkbinding.md
+++ b/docs/eventing/custom-event-source/sinkbinding/create-a-sinkbinding.md
@@ -134,7 +134,7 @@ any extra overrides given by `CE_OVERRIDES`.
 1. Create a YAML file for the CronJob using the following example:
 
     ```yaml
-    apiVersion: batch/v1beta1
+    apiVersion: batch/v1
     kind: CronJob
     metadata:
       name: heartbeat-cron

--- a/docs/eventing/custom-event-source/sinkbinding/reference.md
+++ b/docs/eventing/custom-event-source/sinkbinding/reference.md
@@ -67,7 +67,7 @@ metadata:
   name: bind-heartbeat
 spec:
   subject:
-    apiVersion: batch/v1beta1
+    apiVersion: batch/v1
     kind: Job
     namespace: default
     selector:


### PR DESCRIPTION
At two places in the docs the api version `batch/v1beta1` was still used. For `CronJob`s this was deprecated in kubernetes 1.21 and unavailable since v1.25 (see [deprecation-guide CronJob v1.25](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125)).

This PR addresses it and changes the api version for the examples to use `batch/v1`
