### PR TITLE
Update ApiServerSource apiVersion in example.yaml

### DIFF
--- a/docs/eventing/troubleshooting/example.yaml
+++ b/docs/eventing/troubleshooting/example.yaml
@@ -11,7 +11,7 @@ metadata:
 
 # The event source.
 
-apiVersion: sources.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1
 kind: ApiServerSource
 metadata:
   name: src


### PR DESCRIPTION
In the docs for debugging eventing (https://knative.dev/docs/eventing/troubleshooting/) the referenced example.yaml contains an deprecated/ now unavailable api version for the ApiServerSource:
https://github.com/knative/docs/blob/e9bb939b7e023b9d0dafcca882cfb05105fb0287/docs/eventing/troubleshooting/example.yaml#L14

This leads to an error on applying the yaml:
```
$ k apply -f example.yaml                                                                                                                                                                                                                                                                                                          
namespace/knative-debug created
inmemorychannel.messaging.knative.dev/chan created
subscription.messaging.knative.dev/sub created
service/svc created
deployment.apps/fn created
serviceaccount/service-account created
role.rbac.authorization.k8s.io/event-watcher created
rolebinding.rbac.authorization.k8s.io/k8s-ra-event-watcher created
error: unable to recognize "example.yaml": no matches for kind "ApiServerSource" in version "sources.knative.dev/v1alpha1"
```

This PR addresses it and updates the api version to the supported `v1`:
https://github.com/knative/docs/blob/9822963bd4ee7755f0c8b95a04df9f5ee098fb08/docs/eventing/troubleshooting/example.yaml#L14
 

The other ApiServerSource examples in the docs seems to use the correct api version...