### PR TITLE
Add missing serving feature flags to site

### DIFF
--- a/docs/serving/configuration/feature-flags.md
+++ b/docs/serving/configuration/feature-flags.md
@@ -436,3 +436,64 @@ metadata:
   annotations: features.knative.dev/queueproxy-podinfo: enabled
 ...
 ```
+
+### Kubernetes Topology Spread Constraints
+
+* **Type**: Extension
+* **ConfigMap key:** `kubernetes.podspec-topologyspreadconstraints`
+
+This flag controls whether [`topology spread constraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) can be specified.
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+...
+spec:
+  template:
+    spec:
+      ...
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: node
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            foo: bar
+...
+```
+
+### Kubernetes DNS Policy
+
+* **Type**: Extension
+* **ConfigMap key:** `kubernetes.podspec-dnspolicy`
+
+This flag controls whether a [`DNS policy`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/) can be specified.
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+...
+spec:
+  template:
+    spec:
+      dnsPolicy: ClusterFirstWithHostNet
+...
+```
+
+### Kubernetes Scheduler Name
+
+* **Type**: Extension
+* **ConfigMap key:** `kubernetes.podspec-schedulername`
+
+This flag controls whether a [`scheduler name`](https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/) can be specified.
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+...
+spec:
+  template:
+    spec:
+      ...
+      schedulerName: custom-scheduler-example
+...
+```


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

## Proposed Changes <!-- Describe the changes the PR makes. -->

This PR adds three missing feature flags to the Serving docs. This gets all of the active feature flags on the site.

(There's a fourth, `autodetect-http2`, that hasn't been implemented, and thus not adding it to the docs at this time)