### PR TITLE
chore: add redirects for func

### DIFF
--- a/golang/_redirects
+++ b/golang/_redirects
@@ -30,6 +30,7 @@
 /eventing-prometheus/* go-get=1 /golang/eventing-prometheus.html 200
 /eventing-rabbitmq/* go-get=1 /golang/eventing-rabbitmq.html 200
 /eventing-redis/* go-get=1 /golang/eventing-redis.html 200
+/func/* go-get=1 /golang/func.html 200
 /func-tastic/* go-get=1 /golang/func-tastic.html 200
 /hack/* go-get=1 /golang/hack.html 200
 /homebrew-client/* go-get=1 /golang/homebrew-client.html 200

--- a/golang/func.html
+++ b/golang/func.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="knative.dev/func git https://github.com/knative/func">
+    <meta name="go-source" content="knative.dev/func     https://github.com/knative/func https://github.com/knative/func/tree/main{/dir} https://github.com/knative/func/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
Note that I did not change knative-sandbox/kn-plugin-func. These should be removed after the move.

See: https://github.com/knative/community/issues/1169

Signed-off-by: Lance Ball <lball@redhat.com>
