### PR TITLE
Remove note about requirement to use http-protocol enabled with http01 challenge

### DIFF
--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -41,7 +41,7 @@ Knative supports the following Auto TLS modes:
 
 1.  Using HTTP-01 challenge
 
-    - In this type, your cluster does not need to be able to talk to your DNS server. You must map your domain to the IP of the cluser ingress.
+    - In this type, your cluster does not need to be able to talk to your DNS server. You must map your domain to the IP of the cluster ingress.
     - When using HTTP-01 challenge, **a certificate will be provisioned per Knative Service.**
     - **HTTP-01 does not support provisioning a certificate per namespace.**
 
@@ -272,9 +272,6 @@ Update the [`config-network` ConfigMap](https://github.com/knative/serving/blob/
       http-protocol: Redirected
       ...
     ```
-
-    !!! note
-        When using HTTP-01 challenge, `http-protocol` field has to be set to `Enabled` to make sure HTTP-01 challenge requests can be accepted by the cluster.
 
 1.  Ensure that the file was updated successfully:
 

--- a/docs/serving/using-auto-tls.md
+++ b/docs/serving/using-auto-tls.md
@@ -249,7 +249,6 @@ Update the [`config-network` ConfigMap](https://github.com/knative/serving/blob/
     Supported `http-protocol` values:
 
     - `Enabled`: Serve HTTP traffic.
-    - `Disabled`: Rejects all HTTP traffic.
     - `Redirected`: Responds to HTTP request with a `302` redirect to ask the
       clients to use HTTPS.
 


### PR DESCRIPTION
## Proposed Changes

- Remove note about requirement to use http-protocol enabled with http01 challenge. 
  It seems to imply that http-01 challenge will work only with http-protocol set to enabled, but it does work with "Redirected". This seems to be have been an issue in the past [#423](https://github.com/knative-sandbox/net-contour/issues/423) before  being solved by this PR #610: 
- Typo in cluster

_PS_: There is also a mention to a deprecated value (Disabled) for http-protocol, but it seems to be still valid to use. Not sure if it should be removed or not from line 252.
