### PR TITLE
chore: multi-arch support with buildx in all Dockerfiles

### DIFF
--- a/code-samples/community/serving/helloworld-clojure/README.md
+++ b/code-samples/community/serving/helloworld-clojure/README.md
@@ -109,11 +109,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-clojure .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-clojure
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-clojure" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-clojure/index.md
+++ b/code-samples/community/serving/helloworld-clojure/index.md
@@ -109,11 +109,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-clojure .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-clojure
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-clojure" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-dart/README.md
+++ b/code-samples/community/serving/helloworld-dart/README.md
@@ -64,11 +64,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-dart .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-dart
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-dart" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-dart/index.md
+++ b/code-samples/community/serving/helloworld-dart/index.md
@@ -8,7 +8,7 @@ that you can use for testing. It reads in the env variable `TARGET` and prints
 ## Prerequisites
 
 - A Kubernetes cluster with Knative installed and DNS configured. Follow the
-  [Knative installation instructions](https://knative.dev/docs/install/) if 
+  [Knative installation instructions](https://knative.dev/docs/install/) if
   you need to create one.
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).
@@ -64,11 +64,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-dart .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-dart
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-dart" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-deno/README.md
+++ b/code-samples/community/serving/helloworld-deno/README.md
@@ -83,11 +83,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-deno .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-deno
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-deno" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-deno/index.md
+++ b/code-samples/community/serving/helloworld-deno/index.md
@@ -83,11 +83,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-deno .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-deno
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-deno" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-elixir/README.md
+++ b/code-samples/community/serving/helloworld-elixir/README.md
@@ -132,11 +132,8 @@ above.
     username:
 
     ```bash
-     # Build the container on your local machine
-     docker build -t {username}/helloworld-elixir .
-
-     # Push the container to docker registry
-     docker push {username}/helloworld-elixir
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-elixir" --push .
     ```
 
 1.  After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-elixir/index.md
+++ b/code-samples/community/serving/helloworld-elixir/index.md
@@ -132,11 +132,8 @@ above.
     username:
 
     ```bash
-     # Build the container on your local machine
-     docker build -t {username}/helloworld-elixir .
-
-     # Push the container to docker registry
-     docker push {username}/helloworld-elixir
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-elixir" --push .
     ```
 
 1.  After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-haskell/README.md
+++ b/code-samples/community/serving/helloworld-haskell/README.md
@@ -135,11 +135,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-haskell .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-haskell
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-haskell" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/community/serving/helloworld-haskell/index.md
+++ b/code-samples/community/serving/helloworld-haskell/index.md
@@ -135,11 +135,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-haskell .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-haskell
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-haskell" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/community/serving/helloworld-java-micronaut/README.md
+++ b/code-samples/community/serving/helloworld-java-micronaut/README.md
@@ -215,11 +215,8 @@ your sample app to your cluster:
    following commands with your Docker Hub username.
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-java-micronaut .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-java-micronaut
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-micronaut" --push .
    ```
 
 1. Now that your container image is in the registry, you can deploy it to your

--- a/code-samples/community/serving/helloworld-java-micronaut/index.md
+++ b/code-samples/community/serving/helloworld-java-micronaut/index.md
@@ -215,11 +215,8 @@ your sample app to your cluster:
    following commands with your Docker Hub username.
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-java-micronaut .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-java-micronaut
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-micronaut" --push .
    ```
 
 1. Now that your container image is in the registry, you can deploy it to your

--- a/code-samples/community/serving/helloworld-java-quarkus/README.md
+++ b/code-samples/community/serving/helloworld-java-quarkus/README.md
@@ -218,15 +218,12 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-java-quarkus .
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-quarkus" --push .
 
    # (OR)
-   # Build the container on your local machine - Quarkus native mode
-   docker build -t {username}/helloworld-java-quarkus -f Dockerfile.native .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-java-quarkus
+   # Build and push the container on your local machine. - Quarkus native mode
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-quarkus" --push . -f Dockerfile.native
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-java-quarkus/index.md
+++ b/code-samples/community/serving/helloworld-java-quarkus/index.md
@@ -217,15 +217,12 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-java-quarkus .
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-quarkus" --push .
 
    # (OR)
-   # Build the container on your local machine - Quarkus native mode
-   docker build -t {username}/helloworld-java-quarkus -f Dockerfile.native .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-java-quarkus
+   # Build and push the container on your local machine. - Quarkus native mode
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-quarkus" --push . -f Dockerfile.native
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-r/Dockerfile
+++ b/code-samples/community/serving/helloworld-r/Dockerfile
@@ -3,6 +3,9 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.12 as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/knative/docs/helloworld-r
 COPY invoke.go .
@@ -10,7 +13,7 @@ COPY invoke.go .
 # Build the command inside the container.
 # (You may fetch or manage dependencies here,
 # either manually or with a tool like "godep".)
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o invoke
+RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o invoke
 
 # The official R base image
 # https://hub.docker.com/_/r-base

--- a/code-samples/community/serving/helloworld-r/README.md
+++ b/code-samples/community/serving/helloworld-r/README.md
@@ -131,11 +131,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-r .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-r
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-r" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-r/README.md
+++ b/code-samples/community/serving/helloworld-r/README.md
@@ -77,6 +77,9 @@ cd knative-docs/code-samples/community/serving/hello-world/helloworld-r
   # https://hub.docker.com/_/golang
   FROM golang:1.12 as builder
 
+  ARG TARGETOS
+  ARG TARGETARCH
+
   # Copy local code to the container image.
   WORKDIR /go/src/github.com/knative/docs/helloworld-r
   COPY invoke.go .
@@ -84,7 +87,7 @@ cd knative-docs/code-samples/community/serving/hello-world/helloworld-r
   # Build the command inside the container.
   # (You may fetch or manage dependencies here,
   # either manually or with a tool like "godep".)
-  RUN CGO_ENABLED=0 GOOS=linux go build -v -o invoke
+  RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o invoke
 
   # The official R base image
   # https://hub.docker.com/_/r-base

--- a/code-samples/community/serving/helloworld-r/index.md
+++ b/code-samples/community/serving/helloworld-r/index.md
@@ -131,11 +131,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-r .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-r
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-r" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-r/index.md
+++ b/code-samples/community/serving/helloworld-r/index.md
@@ -77,6 +77,9 @@ cd knative-docs/code-samples/community/serving/hello-world/helloworld-r
   # https://hub.docker.com/_/golang
   FROM golang:1.12 as builder
 
+  ARG TARGETOS
+  ARG TARGETARCH
+
   # Copy local code to the container image.
   WORKDIR /go/src/github.com/knative/docs/helloworld-r
   COPY invoke.go .
@@ -84,7 +87,7 @@ cd knative-docs/code-samples/community/serving/hello-world/helloworld-r
   # Build the command inside the container.
   # (You may fetch or manage dependencies here,
   # either manually or with a tool like "godep".)
-  RUN CGO_ENABLED=0 GOOS=linux go build -v -o invoke
+  RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o invoke
 
   # The official R base image
   # https://hub.docker.com/_/r-base

--- a/code-samples/community/serving/helloworld-rserver/README.md
+++ b/code-samples/community/serving/helloworld-rserver/README.md
@@ -102,11 +102,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-rserver .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-rserver
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-rserver" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-rserver/index.md
+++ b/code-samples/community/serving/helloworld-rserver/index.md
@@ -102,11 +102,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-rserver .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-rserver
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-rserver" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/community/serving/helloworld-rust/README.md
+++ b/code-samples/community/serving/helloworld-rust/README.md
@@ -136,11 +136,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-rust .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-rust
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-rust" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/community/serving/helloworld-rust/index.md
+++ b/code-samples/community/serving/helloworld-rust/index.md
@@ -136,11 +136,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-rust .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-rust
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-rust" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/community/serving/helloworld-swift/README.md
+++ b/code-samples/community/serving/helloworld-swift/README.md
@@ -116,11 +116,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-swift .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-swift
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-swift" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/community/serving/helloworld-swift/index.md
+++ b/code-samples/community/serving/helloworld-swift/index.md
@@ -116,11 +116,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-swift .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-swift
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-swift" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/community/serving/helloworld-vertx/README.md
+++ b/code-samples/community/serving/helloworld-vertx/README.md
@@ -183,11 +183,8 @@ your sample app to your cluster:
    following commands with your Docker Hub username.
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-vertx .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-vertx
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-vertx" --push .
    ```
 
 1. Now that your container image is in the registry, you can deploy it to your

--- a/code-samples/community/serving/helloworld-vertx/index.md
+++ b/code-samples/community/serving/helloworld-vertx/index.md
@@ -183,11 +183,8 @@ your sample app to your cluster:
    following commands with your Docker Hub username.
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-vertx .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-vertx
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-vertx" --push .
    ```
 
 1. Now that your container image is in the registry, you can deploy it to your

--- a/code-samples/community/serving/machinelearning-python-bentoml/README.md
+++ b/code-samples/community/serving/machinelearning-python-bentoml/README.md
@@ -168,11 +168,8 @@ a Dockerfile is automatically generated when saving the model.
     # instruction at https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
-    # Build the container on your local machine
-    docker build - t {username}/iris-classifier $saved_path
-
-    # Push the container to docker registry
-    docker push {username}/iris-classifier
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/iris-classifier" --push $saved_path
     ```
 
 1. In `service.yaml`, replace `{username}` with your Docker hub username:

--- a/code-samples/community/serving/machinelearning-python-bentoml/index.md
+++ b/code-samples/community/serving/machinelearning-python-bentoml/index.md
@@ -168,11 +168,8 @@ a Dockerfile is automatically generated when saving the model.
     # instruction at https://stedolan.github.io/jq/download/
     saved_path=$(bentoml get IrisClassifier:latest -q | jq -r ".uri.uri")
 
-    # Build the container on your local machine
-    docker build - t {username}/iris-classifier $saved_path
-
-    # Push the container to docker registry
-    docker push {username}/iris-classifier
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/iris-classifier" --push $saved_path
     ```
 
 1. In `service.yaml`, replace `{username}` with your Docker hub username:

--- a/code-samples/eventing/helloworld/helloworld-go/Dockerfile
+++ b/code-samples/eventing/helloworld/helloworld-go/Dockerfile
@@ -3,6 +3,9 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.14 as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Copy local code to the container image.
 WORKDIR /app
 
@@ -16,7 +19,7 @@ COPY . ./
 
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly  -v -o helloworld
+RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly  -v -o helloworld
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/code-samples/eventing/helloworld/helloworld-go/README.md
+++ b/code-samples/eventing/helloworld/helloworld-go/README.md
@@ -229,11 +229,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-go .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-go
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-go" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/eventing/helloworld/helloworld-go/README.md
+++ b/code-samples/eventing/helloworld/helloworld-go/README.md
@@ -108,6 +108,9 @@ cd knative-docs/code-samples/eventing/helloworld/helloworld-go
    # https://hub.docker.com/_/golang
    FROM golang:1.14 as builder
 
+   ARG TARGETOS
+   ARG TARGETARCH
+
    # Copy local code to the container image.
    WORKDIR /app
 
@@ -121,7 +124,7 @@ cd knative-docs/code-samples/eventing/helloworld/helloworld-go
 
    # Build the binary.
    # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-   RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly  -v -o helloworld
+   RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly  -v -o helloworld
 
    # Use a Docker multi-stage build to create a lean production image.
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/code-samples/eventing/helloworld/helloworld-python/README.md
+++ b/code-samples/eventing/helloworld/helloworld-python/README.md
@@ -161,10 +161,8 @@ folder) you're ready to build and deploy the sample app.
 1. Use Docker to build the sample code into a container. To build and push with Docker Hub, run these commands replacing `{username}` with your Docker Hub username:
 
     ```bash
-    # Build the container on your local machine
-    docker build -t {username}/helloworld-python .
-    # Push the container to docker registry
-    docker push {username}/helloworld-python
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-python" --push .
     ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/eventing/writing-event-source-easy-way/README.md
+++ b/code-samples/eventing/writing-event-source-easy-way/README.md
@@ -91,8 +91,9 @@ image, and push it to a container registry that your cluster can access.
 
     ```bash
     export REGISTRY=docker.io/myregistry
-    docker build . -t $REGISTRY/node-heartbeat-source:v1
-    docker push $REGISTRY/node-heartbeat-source:v1
+
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "$REGISTRY/node-heartbeat-source:v1" --push .
     ```
 
 1. Create the event display service which logs any CloudEvents posted to it:

--- a/code-samples/serving/cloudevents/cloudevents-dotnet/README.md
+++ b/code-samples/serving/cloudevents/cloudevents-dotnet/README.md
@@ -53,8 +53,8 @@ cd knative-docs/code-samples/serving/cloudevents/cloudevents-dotnet
    and push this to your registry of choice via:
 
    ```bash
-   docker build -t <image> .
-   docker push <image>
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "<image>" --push .
    ```
 
 1. If you look in `service.yaml`, take the `<image>` name and insert it

--- a/code-samples/serving/cloudevents/cloudevents-go/Dockerfile
+++ b/code-samples/serving/cloudevents/cloudevents-go/Dockerfile
@@ -3,6 +3,9 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.13 as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -13,7 +16,7 @@ COPY . ./
 # Also builds the binary
 ENV GO111MODULE=on
 RUN go mod init cloudevents.go \
-    && CGO_ENABLED=0 GOOS=linux go build -v -o server
+    && CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o server
 
 # Allows the container builds to reuse downloaded dependencies.
 RUN go mod download

--- a/code-samples/serving/cloudevents/cloudevents-go/README.md
+++ b/code-samples/serving/cloudevents/cloudevents-go/README.md
@@ -53,8 +53,8 @@ cd knative-docs/code-samples/serving/cloudevents/cloudevents-go
 
  * If you look in `Dockerfile`, you will see a method for pulling in the dependencies and building a small Go container based on Alpine. You can build and push this to your registry of choice via:
 ```bash
-docker build -t <image> .
-docker push <image>
+# Build and push the container on your local machine.
+docker buildx build --platform linux/arm64,linux/amd64 -t "<image>" --push .
 ```
 
  ### ko

--- a/code-samples/serving/cloudevents/cloudevents-nodejs/README.md
+++ b/code-samples/serving/cloudevents/cloudevents-nodejs/README.md
@@ -54,8 +54,8 @@ In the `Dockerfile`, you can see how the dependencies are installed using npm.
 You can build and push this to your registry of choice via:
 
  ```bash
- docker build -t <image> .
- docker push <image>
+ # Build and push the container on your local machine.
+ docker buildx build --platform linux/arm64,linux/amd64 -t "<image>" --push .
  ```
 
 ### yaml

--- a/code-samples/serving/cloudevents/cloudevents-rust/README.md
+++ b/code-samples/serving/cloudevents/cloudevents-rust/README.md
@@ -47,7 +47,8 @@ cargo build --target x86_64-unknown-linux-musl --release
 This will build a statically linked binary, in order to create an image from scratch. Now build the docker image:
 
 ```bash
-docker build -t <image> .
+# Build and push the container on your local machine.
+docker buildx build --platform linux/arm64,linux/amd64 -t "<image>" --push .
 ```
 ### yaml
 

--- a/code-samples/serving/gitwebhook-go/Dockerfile
+++ b/code-samples/serving/gitwebhook-go/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM golang AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # copy the source
 ADD .   /go/src/github.com/knative/docs/code-samples/serving/gitwebhook-go
 WORKDIR /go/src/github.com/knative/docs/code-samples/serving/gitwebhook-go
@@ -25,7 +28,7 @@ RUN go get gopkg.in/go-playground/webhooks.v3
 RUN go get gopkg.in/go-playground/webhooks.v3/github
 
 # build the sample
-RUN CGO_ENABLED=0 go build -o /go/bin/webhook-sample .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/webhook-sample .
 
 FROM golang:alpine
 

--- a/code-samples/serving/gitwebhook-go/README.md
+++ b/code-samples/serving/gitwebhook-go/README.md
@@ -35,11 +35,8 @@ You must meet the following requirements to run this sample:
    ```bash
    export DOCKER_HUB_USERNAME=username
 
-   # Build the container, run from the project folder
-   docker build -t ${DOCKER_HUB_USERNAME}/gitwebhook-go .
-
-   # Push the container to the registry
-   docker push ${DOCKER_HUB_USERNAME}/gitwebhook-go
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "${DOCKER_HUB_USERNAME}/gitwebhook-go" --push .
    ```
 
 1. Create a secret that holds two values from GitHub:

--- a/code-samples/serving/grpc-ping-go/Dockerfile
+++ b/code-samples/serving/grpc-ping-go/Dockerfile
@@ -17,6 +17,9 @@
 # https://hub.docker.com/_/golang
 FROM golang as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/knative/docs/code-samples/serving/grpc-ping-go
 COPY . ./
@@ -26,8 +29,8 @@ RUN go mod tidy
 
 # Build the command inside the container.
 # To facilitate gRPC testing, this container includes a client command.
-RUN CGO_ENABLED=0 go build -tags=grpcping -o ./ping-server
-RUN CGO_ENABLED=0 go build -tags=grpcping -o ./ping-client ./client
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags=grpcping -o ./ping-server
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -tags=grpcping -o ./ping-client ./client
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/code-samples/serving/grpc-ping-go/README.md
+++ b/code-samples/serving/grpc-ping-go/README.md
@@ -32,11 +32,8 @@ for production containers.
   Replace `{username}` with your Docker Hub username then run the commands:
 
   ```bash
-  # Build the container on your local machine.
-  docker build --tag "{username}/grpc-ping-go" .
-
-  # Push the container to docker registry.
-  docker push "{username}/grpc-ping-go"
+  # Build and push the container on your local machine.
+  docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/grpc-ping-go" --push .
   ```
 
 3. Update the `service.yaml` file in the project to reference the published image from step 1.

--- a/code-samples/serving/hello-world/helloworld-csharp/README.md
+++ b/code-samples/serving/hello-world/helloworld-csharp/README.md
@@ -121,11 +121,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-csharp .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-csharp
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-csharp" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/serving/hello-world/helloworld-go/README.md
+++ b/code-samples/serving/hello-world/helloworld-go/README.md
@@ -111,11 +111,8 @@ go mod init github.com/knative/docs/code-samples/serving/hello-world/helloworld-
 To build the sample code into a container, and push using Docker Hub, enter the following commands and replace `{username}` with your Docker Hub username:
 
 ```bash
-# Build the container on your local machine
-docker build -t {username}/helloworld-go .
-
-# Push the container to docker registry
-docker push {username}/helloworld-go
+# Build and push the container on your local machine.
+docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-go" --push .
 ```
 
 ### Deploying to knative

--- a/code-samples/serving/hello-world/helloworld-java-spark/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spark/README.md
@@ -65,10 +65,8 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java
 1. To build the sample code into a container, and push using Docker Hub, enter the following commands and replace `{username}` with your Docker Hub username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-java .
-   # Push the container to docker registry
-   docker push {username}/helloworld-java
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java" --push .
    ```
 
 ## Deploy

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -113,11 +113,8 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
 1. Use Docker to build the sample code into a container, then push the container to the Docker registry:
 
     ```bash
-    # Build the container on your local machine
-    docker build -t {username}/helloworld-java-spring .
-
-    # Push the container to docker registry
-    docker push {username}/helloworld-java-spring
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-spring" --push .
     ```
    Where `{username}` is your Docker Hub username.
 

--- a/code-samples/serving/hello-world/helloworld-kotlin/README.md
+++ b/code-samples/serving/hello-world/helloworld-kotlin/README.md
@@ -143,11 +143,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-kotlin .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-kotlin
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-kotlin" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/serving/hello-world/helloworld-nodejs/README.md
+++ b/code-samples/serving/hello-world/helloworld-nodejs/README.md
@@ -151,11 +151,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-nodejs .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-nodejs
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-nodejs" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/code-samples/serving/hello-world/helloworld-php/README.md
+++ b/code-samples/serving/hello-world/helloworld-php/README.md
@@ -96,12 +96,9 @@ Choose one of the following methods:
  1. Use Docker to build the sample code into a container. To build and push with Docker Hub, run these commands replacing `{username}` with your Docker Hub username:
 
     ```bash
-     # Build the container on your local machine
-     docker build -t {username}/helloworld-php .
-
-     # Push the container to docker registry
-     docker push {username}/helloworld-php
-     ```
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-php" --push .
+    ```
 
  1. After the build has completed and the container is pushed to docker hub, you can deploy the app into your cluster. Ensure that the container image value in `service.yaml` matches the container you built in the previous step. Apply the configuration using `kubectl`:
 

--- a/code-samples/serving/hello-world/helloworld-python/README.md
+++ b/code-samples/serving/hello-world/helloworld-python/README.md
@@ -101,11 +101,8 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-python
    to the Docker registry:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-python .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-python
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-python" --push .
    ```
 
 ## Deploying the app

--- a/code-samples/serving/hello-world/helloworld-shell/README.md
+++ b/code-samples/serving/hello-world/helloworld-shell/README.md
@@ -71,11 +71,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/helloworld-shell .
-
-   # Push the container to docker registry
-   docker push {username}/helloworld-shell
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-shell" --push .
    ```
 
 ## Deploying

--- a/code-samples/serving/knative-routing-go/Dockerfile
+++ b/code-samples/serving/knative-routing-go/Dockerfile
@@ -14,10 +14,13 @@
 
 FROM golang AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /go/src/github.com/knative/docs/
 ADD . /go/src/github.com/knative/docs/
 
-RUN CGO_ENABLED=0 go build ./code-samples/serving/knative-routing-go/
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ./code-samples/serving/knative-routing-go/
 
 FROM gcr.io/distroless/base
 

--- a/code-samples/serving/knative-routing-go/README.md
+++ b/code-samples/serving/knative-routing-go/README.md
@@ -67,21 +67,14 @@ your dockerhub username and run the following command:
 export REPO="docker.io/<username>"
 ```
 
-3. Use Docker to build your application container:
+3. Use Docker to build and push your application container:
 
 ```
-docker build \
-  --tag "${REPO}/knative-routing-go" \
-  --file=code-samples/serving/knative-routing-go/Dockerfile .
+# Build and push the container on your local machine.
+docker buildx build --platform linux/arm64,linux/amd64 -t "${REPO}/knative-routing-go" --push . -f code-samples/serving/knative-routing-go/Dockerfile
 ```
 
-4. Push your container to a container registry:
-
-```
-docker push "${REPO}/knative-routing-go"
-```
-
-5. Replace the image reference path with our published image path in the
+4. Replace the image reference path with our published image path in the
    configuration file `code-samples/serving/knative-routing-go/sample.yaml`:
 
    - Manually replace:

--- a/code-samples/serving/kong-routing-go/Dockerfile
+++ b/code-samples/serving/kong-routing-go/Dockerfile
@@ -14,10 +14,13 @@
 
 FROM golang AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /go/src/github.com/knative/docs/
 ADD . /go/src/github.com/knative/docs/
 
-RUN CGO_ENABLED=0 go build ./code-samples/serving/kong-routing-go/
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build ./code-samples/serving/kong-routing-go/
 
 FROM gcr.io/distroless/base
 

--- a/code-samples/serving/kong-routing-go/README.md
+++ b/code-samples/serving/kong-routing-go/README.md
@@ -72,18 +72,11 @@ Build the application container and publish it to a container registry:
     export REPO="docker.io/<username>"
     ```
 
-1.  Use Docker to build your application container:
+1. Use Docker to build and push your application container:
 
     ```bash
-    docker build \
-      --tag "${REPO}/kong-routing-go" \
-      --file=code-samples/serving/kong-routing-go/Dockerfile .
-    ```
-
-1.  Push your container to a container registry:
-
-    ```bash
-    docker push "${REPO}/kong-routing-go"
+    # Build and push the container on your local machine.
+    docker buildx build --platform linux/arm64,linux/amd64 -t "${REPO}/kong-routing-go" --push . -f code-samples/serving/kong-routing-go/Dockerfile
     ```
 
 1.  Replace the image reference path with our published image path in the

--- a/code-samples/serving/multi-container/README.md
+++ b/code-samples/serving/multi-container/README.md
@@ -36,7 +36,7 @@ You can update the default files and YAML by using the steps outlined in this se
 You can do this by copying the following code into the `servingcontainer.go` file:
 
    ```go
-   package main   
+   package main
    import (
    	"fmt"
    	"io"
@@ -140,9 +140,9 @@ You can do this by copying the following code into the `sidecarcontainer.go` fil
    # https://hub.docker.com/_/alpine
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
    FROM alpine:3
-   RUN apk add --no-cache ca-certificates   
+   RUN apk add --no-cache ca-certificates
    # Copy the binary to the production image from the builder stage.
-   COPY --from=builder /app/sidecarcontainer /sidecarcontainer   
+   COPY --from=builder /app/sidecarcontainer /sidecarcontainer
    # Run the web service on container startup.
    CMD ["/sidecarcontainer"]
    ```
@@ -198,16 +198,14 @@ After you have modified the sample code files you can build and deploy the sampl
    username:
 
    ```bash
-   # Build the container on your local machine
+   # Build and push the container on your local machine.
    cd -
    cd knative-docs/code-samples/serving/multi-container/servingcontainer
-   docker build -t {username}/servingcontainer .
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/servingcontainer" --push .
+
    cd -
    cd knative-docs/code-samples/serving/multi-container/sidecarcontainer
-   docker build -t {username}/sidecarcontainer .
-   # Push the container to docker registry
-   docker push {username}/servingcontainer
-   docker push {username}/sidecarcontainer
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/sidecarcontainer" --push .
    ```
 
 1. After the build has completed and the container is pushed to Docker Hub, you

--- a/code-samples/serving/multi-container/README.md
+++ b/code-samples/serving/multi-container/README.md
@@ -68,6 +68,10 @@ You can do this by copying the following code into the `servingcontainer.go` fil
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
    FROM golang:1.15 as builder
+
+   ARG TARGETOS
+   ARG TARGETARCH
+
    # Create and change to the app directory.
    WORKDIR /app
    # Retrieve application dependencies using go modules.
@@ -78,7 +82,7 @@ You can do this by copying the following code into the `servingcontainer.go` fil
    COPY . ./
    # Build the binary.
    # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-   RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o servingcontainer
+   RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly -v -o servingcontainer
    # Use the official Alpine image for a lean production container.
    # https://hub.docker.com/_/alpine
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
@@ -125,6 +129,10 @@ You can do this by copying the following code into the `sidecarcontainer.go` fil
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
    FROM golang:1.15 as builder
+
+   ARG TARGETOS
+   ARG TARGETARCH
+
    # Create and change to the app directory.
    WORKDIR /app
    # Retrieve application dependencies using go modules.
@@ -135,7 +143,7 @@ You can do this by copying the following code into the `sidecarcontainer.go` fil
    COPY . ./
    # Build the binary.
    # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-   RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o sidecarcontainer
+   RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly -v -o sidecarcontainer
    # Use the official Alpine image for a lean production container.
    # https://hub.docker.com/_/alpine
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/code-samples/serving/multi-container/servingcontainer/Dockerfile
+++ b/code-samples/serving/multi-container/servingcontainer/Dockerfile
@@ -3,6 +3,9 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.15 as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -16,7 +19,7 @@ COPY . ./
 
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o servingcontainer
+RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly -v -o servingcontainer
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine

--- a/code-samples/serving/multi-container/sidecarcontainer/Dockerfile
+++ b/code-samples/serving/multi-container/sidecarcontainer/Dockerfile
@@ -3,6 +3,9 @@
 # https://hub.docker.com/_/golang
 FROM golang:1.15 as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Create and change to the app directory.
 WORKDIR /app
 
@@ -16,7 +19,7 @@ COPY . ./
 
 # Build the binary.
 # -mod=readonly ensures immutable go.mod and go.sum in container builds.
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -v -o sidecarcontainer
+RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly -v -o sidecarcontainer
 
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine

--- a/code-samples/serving/secrets-go/Dockerfile
+++ b/code-samples/serving/secrets-go/Dockerfile
@@ -3,12 +3,15 @@
 # https://hub.docker.com/_/golang
 FROM golang as builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 # Copy local code to the container image.
 WORKDIR /go/src/github.com/knative/docs/hellosecrets
 COPY . .
 
 # Build the output command inside the container.
-RUN CGO_ENABLED=0 GOOS=linux go build -v -o hellosecrets
+RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o hellosecrets
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/code-samples/serving/secrets-go/README.md
+++ b/code-samples/serving/secrets-go/README.md
@@ -95,12 +95,15 @@ cd knative-docs/code-samples/serving/secrets-go
    # https://hub.docker.com/_/golang
    FROM golang as builder
 
+   ARG TARGETOS
+   ARG TARGETARCH
+
    # Copy local code to the container image.
    WORKDIR /go/src/github.com/knative/docs/hellosecrets
    COPY . .
 
    # Build the output command inside the container.
-   RUN CGO_ENABLED=0 GOOS=linux go build -v -o hellosecrets
+   RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -o hellosecrets
 
    # Use a Docker multi-stage build to create a lean production image.
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/code-samples/serving/secrets-go/README.md
+++ b/code-samples/serving/secrets-go/README.md
@@ -198,11 +198,8 @@ folder) you're ready to build and deploy the sample app.
    username:
 
    ```bash
-   # Build the container on your local machine
-   docker build -t {username}/secrets-go .
-
-   # Push the container to docker registry
-   docker push {username}/secrets-go
+   # Build and push the container on your local machine.
+   docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/secrets-go" --push .
    ```
 
 1. After the build has completed and the container is pushed to docker hub, you

--- a/hack/docker/build-image.sh
+++ b/hack/docker/build-image.sh
@@ -4,5 +4,4 @@ SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 set -x
 
-docker build -t ghcr.io/knative/knative-docs:latest -f $SCRIPT_DIR/Dockerfile $SCRIPT_DIR/../..
-
+docker buildx build --platform linux/arm64,linux/amd64 -t "ghcr.io/knative/knative-docs:latest" --push -f $SCRIPT_DIR/Dockerfile $SCRIPT_DIR/../..


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

I deployed a docker image built on M1 mac to an intel cluster and got a cpu architecture error.
Now that support for both amd and arm is expanding, I think it is better for users to use buildx to build both to try out the sample.
