### PR TITLE
Fix top-level nav in blog section

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -1,6 +1,7 @@
 nav:
     - Home: /docs/
     - Tutorial: /docs/getting-started/
+    - Concepts: /docs/concepts/
     - Installing: /docs/install/
     - Functions: /docs/functions/
     - Serving: /docs/serving/

--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -2,8 +2,10 @@ nav:
     - Home: /docs/
     - Tutorial: /docs/getting-started/
     - Installing: /docs/install/
+    - Functions: /docs/functions/
     - Serving: /docs/serving/
     - Eventing: /docs/eventing/
+    - Knative CLI: /docs/client/
     - Code samples: /docs/samples/
     - Reference: /docs/reference/
     - Community: /docs/community/


### PR DESCRIPTION
The top level navigation in the blog section did not include headers for Functions and the Knative CLI.

Signed-off-by: Lance Ball <lball@redhat.com>
