### PR TITLE
Improve overall structure of kubecon blog post

### DIFF
--- a/blog/docs/events/knative-at-kubecon-na-2022.md
+++ b/blog/docs/events/knative-at-kubecon-na-2022.md
@@ -15,27 +15,37 @@ its progress in the past year.
 
 ## Monday, October 24 KnativeCon
 
+**All Day**
+
 Join us for a full day of Knative content at KnativeCon. This year we have a
 variety of talks covering Knative's core components, use cases, and the future of
 the project. Check out the full schedule on [Sched](https://knativeconna22.sched.com/).
 
 ## Tuesday, October 25 KubeCon
 
+**1:00 - 5:00 PM**
+
 On Tuesday, October 25, we have a 4-hour open
 [Knative project meeting](https://sched.co/1BaTW) for maintainers
-and others who are contributing to the project. The meeting will last from 1 to 5pm
-and will be a great opportunity for Knative contributors to meet and discuss the
+and others who are contributing to the project. The meeting will
+will be a great opportunity for Knative contributors to meet and discuss the
 the status and future of the project.
+
+**5:45 PM**
 
 Afterwards, Lance Ball will be giving a
 [5 minute lighting talk](https://sched.co/184sX) on building a Twitter
-bot with Knative Functions. The talk will be at 5:45pm and should be a lot of fun!
+bot with Knative Functions. The talk will be on the big stage and should be a lot of fun!
 
 ## Wednesday, October 26 KubeCon
 
-On Wednesday, from 11am to 12:30pm, Evan Andersen and Paul Schweigert will be hosting a
+**11:00 AM - 12:30pm**
+
+Evan Andersen and Paul Schweigert will be hosting a
 [Knative ContribFest](https://sched.co/182Pu) where you can get involved in the project
 by learning the tools and processes for contributing to Knative. Join them to develop the skills and knowledge to be a part of the exciting the Knative project.
+
+**3:25 - 4:00 PM**
 
 Later that afternoon, Evan will again be on the stage, this time with Naina Singh,
 Lance Ball, and Mauricio Salatino, to talk about Knative Functions, a new addition


### PR DESCRIPTION
Basically, make it easy for readers to see when an event is occurring.

Signed-off-by: Lance Ball <lball@redhat.com>

/cc @evankanderson - thanks for your belated input on https://github.com/knative/docs/pull/5291. I have addressed your concerns in a follow up PR. I did not include information about vendor booths. If you want to help out with some wording on that, I'd be happy to include it. As far as Red Hat goes, we'll have Serverless demos at our booth, but those will be part of a larger set of demos that feature other tech and I don't really have a schedule for that. Not sure what IBM will be doing.
