### PR TITLE
Update instructions for using temporary DNS in installation section

### DIFF
--- a/docs/snippets/temporary-dns.md
+++ b/docs/snippets/temporary-dns.md
@@ -5,6 +5,14 @@
 
     To access your application using `curl` using this method:
 
+    1. Configure Knative to use a domain reachable from outside the cluster:
+      ```bash
+      kubectl patch configmap/config-domain \
+            --namespace knative-serving \
+            --type merge \
+            --patch '{"data":{"example.com":""}}'
+      ```
+
     1. After starting your application, get the URL of your application:
       ```bash
       kubectl get ksvc


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

Fixes #5316 

We updated the default domain in knative/serving#13259 to `svc.cluster.local`, which is not reachable outside of the cluster. As a result, users who want to use the temporary DNS option will first need to patch in a domain (for example, `example.com`) before they'll be able to reach the service.