### PR TITLE
Fix channel links

### DIFF
--- a/docs/eventing/channels/channels-crds.md
+++ b/docs/eventing/channels/channels-crds.md
@@ -17,8 +17,8 @@ This is a non-exhaustive list of the available Channels for Knative Eventing.
 
 Name | Status | Maintainer | Description
 --- | --- | --- | ---
-[InMemoryChannel](https://github.com/knative/eventing/tree/{{version}}/config/channels/in-memory-channel/README.md) | Stable | Knative | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
-[KafkaChannel](https://github.com/knative-sandbox/eventing-kafka-broker/tree/{{version}}/README.md) | Beta | Knative | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
-[NatssChannel](https://github.com/knative-sandbox/eventing-natss/tree/{{version}}/config/README.md) | Alpha | Knative | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
+[InMemoryChannel](https://github.com/knative/eventing/tree/{{ branch }}/config/channels/in-memory-channel/README.md) | Stable | Knative | In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
+[KafkaChannel](https://github.com/knative-sandbox/eventing-kafka-broker/tree/{{ branch }}/README.md) | Beta | Knative | Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
+[NatssChannel](https://github.com/knative-sandbox/eventing-natss/tree/{{ branch }}/config/README.md) | Alpha | Knative | Channels are backed by [NATS Streaming](https://github.com/nats-io/nats-streaming-server#configuring).
 
 

--- a/docs/eventing/channels/channels.yaml
+++ b/docs/eventing/channels/channels.yaml
@@ -1,19 +1,19 @@
 # List of available Channel implementation for persistence of the events associated with a given channel
 channels:
   - name: InMemoryChannel
-    url: https://github.com/knative/eventing/tree/{{version}}/config/channels/in-memory-channel/README.md
+    url: https://github.com/knative/eventing/tree/{{ branch }}/config/channels/in-memory-channel/README.md
     status: Stable
     maintainer: Knative
     description: >
       In-memory channels are a best effort Channel. They should NOT be used in Production. They are useful for development.
   - name: KafkaChannel
-    url: https://github.com/knative-sandbox/eventing-kafka-broker/tree/{{version}}/README.md
+    url: https://github.com/knative-sandbox/eventing-kafka-broker/tree/{{ branch }}/README.md
     status: Beta
     maintainer: Knative
     description: >
       Channels are backed by [Apache Kafka](http://kafka.apache.org/) topics.
   - name: NatssChannel
-    url: https://github.com/knative-sandbox/eventing-natss/tree/{{version}}/config/README.md
+    url: https://github.com/knative-sandbox/eventing-natss/tree/{{ branch }}/config/README.md
     status: Alpha
     maintainer: Knative
     description: >


### PR DESCRIPTION
Currently the different channel links in the [docs](https://knative.dev/docs/eventing/channels/channels-crds/), lead to a 404 (e.g. to `https://github.com/knative/eventing/tree/%7B'provider':%20'mike'%7D/config/channels/in-memory-channel/README.md`). This PR addresses it and fixes the links to resolve correctly.

What did I do?
* Fix the URLs in `docs/eventing/channels/channels.yaml`
* run `go run eventing/channels/generator/main.go`