### PR TITLE
fix broken link for on cluster build

### DIFF
--- a/docs/functions/building-functions.md
+++ b/docs/functions/building-functions.md
@@ -21,7 +21,7 @@ If you do not have a local Docker daemon running, or you are using a CI/CD pipel
 ### Prerequisites
 
 - The function must exist in a Git repository.
-- You must configure your cluster to use Tekton Pipelines. See the [on-cluster build](https://github.com/knative/func/blob/main/docs/reference/on_cluster_build.md){target=_blank} documentation.
+- You must configure your cluster to use Tekton Pipelines. See the [on-cluster build](https://github.com/knative/func/blob/main/docs/building-functions/on_cluster_build.md){target=_blank} documentation.
 
 ### Procedure
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

"Fixes a broken link for the on cluster build documentation"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update the link
