### PR TITLE
Fix stale links in functions-templates-intro snippet

### DIFF
--- a/docs/snippets/functions-templates-intro.md
+++ b/docs/snippets/functions-templates-intro.md
@@ -5,9 +5,9 @@ Knative Functions provides templates that can be used to create basic functions,
 
 Templates allow you to choose the language and invocation format for your function. The following templates are available with both CloudEvent and HTTP invocation formats:
 
-- [Node.js](https://github.com/knative/func/blob/main/docs/function-developers/nodejs.md){target=_blank}
-- [Python](https://github.com/knative/func/blob/main/docs/function-developers/python.md){target=_blank}
-- [Go](https://github.com/knative/func/blob/main/docs/function-developers/golang.md){target=_blank}
-- [Quarkus](https://github.com/knative/func/blob/main/docs/function-developers/quarkus.md){target=_blank}
-- [Rust](https://github.com/knative/func/blob/main/docs/function-developers/rust.md){target=_blank}
-- [TypeScript](https://github.com/knative/func/blob/main/docs/function-developers/typescript.md){target=_blank}
+- [Node.js](https://github.com/knative/func/blob/main/docs/function-templates/nodejs.md){target=_blank}
+- [Python](https://github.com/knative/func/blob/main/docs/function-templates/python.md){target=_blank}
+- [Go](https://github.com/knative/func/blob/main/docs/function-templates/golang.md){target=_blank}
+- [Quarkus](https://github.com/knative/func/blob/main/docs/function-templates/quarkus.md){target=_blank}
+- [Rust](https://github.com/knative/func/blob/main/docs/function-templates/rust.md){target=_blank}
+- [TypeScript](https://github.com/knative/func/blob/main/docs/function-templates/typescript.md){target=_blank}


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

Fixes #5334 

## Proposed Changes

- Update links to point to `function-templates` instead

