### PR TITLE
fix(functions): include --registry flag for `run`

### DIFF
--- a/docs/snippets/proc-running-function.md
+++ b/docs/snippets/proc-running-function.md
@@ -6,10 +6,10 @@ The `run` command builds an image for your function if required, and runs this i
 
 === "func"
 
-    Run the function locally, by running the command inside the project directory:
+    Run the function locally by running the command inside the project directory. If you have not yet built the function you will need to provide the `--registry` flag:
 
     ```bash
-    func run
+    func run [--registry <registry>]
     ```
 
     Using this command also builds the function if necessary.


### PR DESCRIPTION
Indicate that when running a function, if it has not yet been built, the developer will need to provide the `--registry` flag.

Fixes: https://github.com/knative/docs/issues/5309

/kind fix

Signed-off-by: Lance Ball <lball@redhat.com>
