### PR TITLE
functions: update deploy docs

### DIFF
--- a/docs/functions/deploying-functions.md
+++ b/docs/functions/deploying-functions.md
@@ -6,7 +6,7 @@
 
 - You have a Docker daemon on your local machine. This is already provided if you have used the Quickstart installation.
 
-- You have access to a container registry and are able to push images to this registry.
+- You have access to a container registry and are able to push images to this registry. Note that some image registries set newly pushed images to private by default. If you are deploying a function for the first time, you may need to ensure that your images are set to public.
 
 ## Procedure
 

--- a/docs/getting-started/build-run-deploy-func.md
+++ b/docs/getting-started/build-run-deploy-func.md
@@ -22,7 +22,7 @@ After you have created a function project, you can build, run, or deploy your fu
 
 - You have a Docker daemon on your local machine. This is already provided if you have used the Quickstart installation.
 
-- You have access to a container registry and are able to push images to this registry.
+- You have access to a container registry and are able to push images to this registry. Note that some image registries set newly pushed images to private by default. If you are deploying a function for the first time, you may need to ensure that your images are set to public.
 
 ### Procedure
 


### PR DESCRIPTION
Ensure that the user is aware that the repository may be private and should be set to public in order for `func deploy` to work correctly.

/kind functions

Fixes: https://github.com/knative/docs/issues/5310

Signed-off-by: Lance Ball <lball@redhat.com>
