### PR TITLE
Remove outdated blog OWNERS file

### DIFF
--- a/blog/OWNERS
+++ b/blog/OWNERS
@@ -1,4 +1,0 @@
-# Maria is managing Knative community matters from Google.
-approvers:
-- macruzbar
-


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

The top-level docs OWNERS file include the docs WG leads and the TOC, so post CNCF move we shouldn't need separate approvers for the blog.