### PR TITLE
Add link to springboot for function-templates

### DIFF
--- a/docs/snippets/functions-templates-intro.md
+++ b/docs/snippets/functions-templates-intro.md
@@ -10,4 +10,5 @@ Templates allow you to choose the language and invocation format for your functi
 - [Go](https://github.com/knative/func/blob/main/docs/function-templates/golang.md){target=_blank}
 - [Quarkus](https://github.com/knative/func/blob/main/docs/function-templates/quarkus.md){target=_blank}
 - [Rust](https://github.com/knative/func/blob/main/docs/function-templates/rust.md){target=_blank}
+- [Spring Boot](https://github.com/knative/func/blob/main/docs/function-templates/springboot.md){target=_blank}
 - [TypeScript](https://github.com/knative/func/blob/main/docs/function-templates/typescript.md){target=_blank}


### PR DESCRIPTION
Signed-off-by: Thomas Risberg <risbergt@vmware.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](help/contributing/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

Adds missing link to springboot template doc to "Function templates" section of the "Knative Functions overview" page 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- adds a line for "Spring Boot" to the list of function templates
