### PR TITLE
added note for knative installation on kind

### DIFF
--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -78,15 +78,16 @@ To get a local deployment of Knative, run the `quickstart` plugin:
 
 
     1. Install Knative and Kubernetes using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) by running:
-        !!! note
-            Make sure Port 80 is not binded or busy with any services, otherwise installtion will lead to an error. So, stop the service using that Port.
-            To check port 80 busy or not
-            ```bash
-            netstat -tnlp | grep 80
-            ```
         ```bash
         kn quickstart kind
         ```
+
+        !!! note
+            Quickstart uses Port 80, and it will fail to install if any other services are bound on that port. If you have a service using Port 80, you'll need to stop it before using Quickstart.
+            To check if another service is using Port 80:
+            ```bash
+            netstat -tnlp | grep 80
+            ```
 
     1. After the plugin is finished, verify you have a cluster called `knative`:
 

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -78,7 +78,12 @@ To get a local deployment of Knative, run the `quickstart` plugin:
 
 
     1. Install Knative and Kubernetes using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) by running:
-
+        !!! note
+            Make sure Port 80 is not binded or busy with any services, otherwise installtion will lead to an error. So, stop the service using that Port.
+            To check port 80 busy or not
+            ```bash
+            netstat -tnlp | grep 80
+            ```
         ```bash
         kn quickstart kind
         ```


### PR DESCRIPTION
Signed-off-by: Vivek Kumar Sahu <vivekkumarsahu650@gmail.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

This PR adds a NOTE before installation of Knative on kind. While Installing Knative on kind could lead to error something like: 
```
Error starting userland proxy: listen tcp4 127.0.0.1:80: bind: address already in use.
```
Basically knative will use Port 80. So, if Port 80 is already is use then you can get above errors.

Solution:
Check the Port is already is in use or not:
```
netstat -tnlp | grep 80
```
If it in use, stop that service using port 80. 
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Added NOTE to make sure Port 80 is free before installing knative on Kind.
