### PR TITLE
Cleanup: remove ioutil for new go version

### DIFF
--- a/code-samples/serving/multi-container/README.md
+++ b/code-samples/serving/multi-container/README.md
@@ -39,7 +39,7 @@ You can do this by copying the following code into the `servingcontainer.go` fil
    package main   
    import (
    	"fmt"
-   	"io/ioutil"
+   	"io"
    	"log"
    	"net/http"
    )
@@ -49,7 +49,7 @@ You can do this by copying the following code into the `servingcontainer.go` fil
    	if err != nil {
    		log.Fatal(err)
    	}
-   	resp, err := ioutil.ReadAll(res.Body)
+   	resp, err := io.ReadAll(res.Body)
    	if err != nil {
    		log.Fatal(err)
    	}

--- a/code-samples/serving/multi-container/servingcontainer/servingcontainer.go
+++ b/code-samples/serving/multi-container/servingcontainer/servingcontainer.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 )
@@ -29,7 +29,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	resp, err := ioutil.ReadAll(res.Body)
+	resp, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/docs/eventing/channels/generator/main.go
+++ b/docs/eventing/channels/generator/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -42,7 +41,7 @@ func main() {
 }
 
 func parseYaml() *yamlChannels {
-	fileBytes, err := ioutil.ReadFile(*yamlFile)
+	fileBytes, err := os.ReadFile(*yamlFile)
 	if err != nil {
 		log.Fatalf("Unable to read the YAML file '%s': %v", *yamlFile, err)
 	}
@@ -79,7 +78,7 @@ type channel struct {
 }
 
 func createTemplate() *template.Template {
-	fileBytes, err := ioutil.ReadFile(*templateFile)
+	fileBytes, err := os.ReadFile(*templateFile)
 	if err != nil {
 		log.Fatalf("Unable to read the template file '%s': %v", *templateFile, err)
 	}

--- a/test/sampleapp/config.go
+++ b/test/sampleapp/config.go
@@ -18,7 +18,7 @@ package sampleapp
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -60,7 +60,7 @@ func (lc *LanguageConfig) UseDefaultIfNotProvided() {
 // GetConfigs parses a config yaml file and return AllConfigs struct
 func GetConfigs(configPath string) (AllConfigs, error) {
 	var lcs AllConfigs
-	content, err := ioutil.ReadFile(configPath)
+	content, err := os.ReadFile(configPath)
 	if nil == err {
 		err = yaml.Unmarshal(content, &lcs)
 	}


### PR DESCRIPTION
Remove ioutil for new go version: https://go.dev/doc/go1.16#ioutil