### PR TITLE
We do not have an activator in Eventing

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -419,7 +419,7 @@ affinity:
           - ssd
 ```
 
-to the deployment `activator`, you need to change your KnativeEventing CR as below:
+to the deployment `eventing-controller`, you need to change your KnativeEventing CR as below:
 
 ```yaml
 apiVersion: operator.knative.dev/v1beta1
@@ -429,7 +429,7 @@ metadata:
   namespace: knative-eventing
 spec:
   deployments:
-  - name: activator
+  - name: eventing-controller
     affinity:
       nodeAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Fixes #5277

## Proposed Changes <!-- Describe the changes the PR makes. -->

- describing `affinity` on a different deployment, since there is no activator in Eventing



NOTE: this just fixing the problem w/ the `ACTIVATOR`, not trying to address https://github.com/knative/docs/issues/5276  (which is a separate issue)