### PR TITLE
[release-1.9] Update the usage of Apache Kafka term

### DIFF
--- a/docs/eventing/brokers/broker-types/README.md
+++ b/docs/eventing/brokers/broker-types/README.md
@@ -14,9 +14,9 @@ In the Knative Eventing ecosystem, alternative broker implementations are welcom
 
 The following is a list of brokers provided by the community or vendors:
 
-### Apache Kafka broker
+### Knative Broker for Apache Kafka
 
-This broker implementation uses [Apache Kafka](https://kafka.apache.org/) as its backing technology. For more information, see [Apache Kafka Broker](kafka-broker/README.md).
+This broker implementation uses [Apache Kafka](https://kafka.apache.org/) as its backing technology. For more information, see [here](kafka-broker/README.md).
 
 ### RabbitMQ broker
 

--- a/docs/eventing/brokers/broker-types/kafka-broker/README.md
+++ b/docs/eventing/brokers/broker-types/kafka-broker/README.md
@@ -1,7 +1,6 @@
-# Knative Kafka Broker
+# Knative Broker for Apache Kafka
 
-The Knative Kafka Broker is an Apache Kafka native implementation of the Knative Broker API that reduces
-network hops, supports any Kafka version, and has a better integration with Kafka for the Broker and Trigger model.
+The Knative Broker for Apache Kafka is an implementation of the Knative Broker API natively targeting Apache Kafka to reduce network hops and offering a better integration with Apache Kafka for the Broker and Trigger API model.
 
 Notable features are:
 

--- a/docs/eventing/configuration/kafka-channel-configuration.md
+++ b/docs/eventing/configuration/kafka-channel-configuration.md
@@ -1,4 +1,4 @@
-# Configure Kafka Channels
+# Configure Channels for Apache Kafka
 
 !!! note
     This guide assumes Knative Eventing is installed in the `knative-eventing` namespace. If you have installed Knative Eventing in a different namespace, replace `knative-eventing` with the name of that namespace.

--- a/docs/eventing/event-registry.md
+++ b/docs/eventing/event-registry.md
@@ -12,7 +12,7 @@ This topic provides information about how you can populate the event registry, h
 ## About EventType objects
 
 EventType objects represent a type of event that can be consumed from a Broker,
-such as Kafka messages or GitHub pull requests.
+such as Apache Kafka messages or GitHub pull requests.
 EventType objects are used to populate the event registry and persist event type
 information in the cluster datastore.
 

--- a/docs/eventing/sinks/kafka-sink.md
+++ b/docs/eventing/sinks/kafka-sink.md
@@ -1,4 +1,4 @@
-# Apache Kafka Sink
+# Knative Sink for Apache Kafka
 
 This page shows how to install and configure an Apache KafkaSink.
 

--- a/docs/eventing/sources/kafka-source/README.md
+++ b/docs/eventing/sources/kafka-source/README.md
@@ -1,4 +1,4 @@
-# Apache Kafka Source
+# Knative Source for Apache Kafka
 
 ![stage](https://img.shields.io/badge/Stage-stable-green?style=flat-square)
 ![version](https://img.shields.io/badge/API_Version-v1beta1-yellow?style=flat-square)


### PR DESCRIPTION
Manual cherry-pick (:cherries:) for https://github.com/knative/docs/pull/5461

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The PR underlines that we offer implementation/apis for Apache Kafka, not the other way around