### PR TITLE
Update NOT and CESQL which are not working 

### DIFF
--- a/docs/eventing/experimental-features/new-trigger-filters.md
+++ b/docs/eventing/experimental-features/new-trigger-filters.md
@@ -134,7 +134,7 @@ spec:
   filters:
       - not:
           exact:
-              type: com.github.push 
+              type: com.github.push
 ```
 ### `cesql`
 

--- a/docs/eventing/experimental-features/new-trigger-filters.md
+++ b/docs/eventing/experimental-features/new-trigger-filters.md
@@ -132,9 +132,9 @@ metadata:
 spec:
   ...
   filters:
-    - not:
-        - exact:
-            type: com.github.push 
+      - not:
+          exact:
+              type: com.github.push 
 ```
 ### `cesql`
 
@@ -169,7 +169,7 @@ spec:
       myextension: my-extension-value
   # Enhanced filters field. This will override the old filter field.
   filters:
-    - cesql: "type == 'dev.knative.foo.bar' AND myextension == 'my-extension-value'"
+    - cesql: "type = 'dev.knative.foo.bar' AND myextension = 'my-extension-value'"
   subscriber:
     ref:
       apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
`not` do not expect a list of filters, it only expects only one filter. [not_filter.go](https://github.com/knative/eventing/blob/f6ca59b33fb42ff981367b43dc0280841ac324b6/pkg/eventfilter/subscriptionsapi/not_filter.go#L27-L29)

The equality parameter in `cesql` should be `=` instead of `==` to work. [INFO](https://github.com/knative/eventing/discussions/6717#discussioncomment-4859920)



## Proposed Changes 

- change the code part with those fix

