### PR TITLE
fix: correct bad link to reference page

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -8,7 +8,7 @@ nav:
     - Eventing: /docs/eventing/
     - Knative CLI: /docs/client/
     - Code samples: /docs/samples/
-    - Reference: /docs/reference/
+    - Reference: /docs/reference/security/
     - Community: /docs/community/
     - About: /docs/about/testimonials/
   #####################################################

--- a/docs/reference/relnotes/README.md
+++ b/docs/reference/relnotes/README.md
@@ -3,6 +3,7 @@
 For details about the Knative releases, see the following pages:
 
 - [Knative CLI releases](https://github.com/knative/client/releases)
+- [Knative Functions releases](https://github.com/knative/func/releases)
 - [Knative Eventing releases](https://github.com/knative/eventing/releases)
 - [Knative Serving releases](https://github.com/knative/serving/releases)
 - [Knative Operator releases](https://github.com/knative/operator/releases)


### PR DESCRIPTION
Clicking the "References" link in the top menu bar while within the "Blog" section of the site, produced a 404 error. This corrects the navigation link from that section and also adds Knative Functions to the releases page.

