### PR TITLE
Knative services are private by default

### DIFF
--- a/docs/serving/services/private-services.md
+++ b/docs/serving/services/private-services.md
@@ -1,20 +1,17 @@
 # Configuring private Services
 
-By default, Services deployed through Knative are published to an external IP
-address, making them public Services on a public IP address and with a public URL.
+By default, Services deployed through Knative use the `.svc.cluster.local` domain, meaning
+they are private and thus do not have a public IP address or a public URL.
 
-Knative provides two ways to enable private services which are only available
-inside the cluster:
+In order to make Knative Services public (with a public IP address and public URL) by default,
+[configure a domain name](../using-a-custom-domain.md) for the Service.
+This can be done for a single Service or for all Services on a cluster.
 
-1. To make all Knative Services private, change the default domain to
-   `svc.cluster.local` by [editing the `config-domain` ConfigMap](https://github.com/knative/serving/blob/main/config/core/configmaps/domain.yaml). This changes all Services deployed through Knative to only be published to the cluster.
-1. To make an individual Service private, the Service or Route can be
-   labelled with `networking.knative.dev/visibility=cluster-local` so that it is not published to the external gateway.
 
-## Using the cluster-local label
+## Making individual services private
 
-To configure a Knative Service so that it is only available on the cluster-local network, and not on the public internet, you can apply the
-`networking.knative.dev/visibility=cluster-local` label to a Knative Service, a route or a Kubernetes Service object.
+To make an individual Service private, the Service or Route can be labelled with
+`networking.knative.dev/visibility=cluster-local` so that it is not published to the external gateway.
 
 - To label a Knative Service:
 

--- a/docs/serving/using-a-custom-domain.md
+++ b/docs/serving/using-a-custom-domain.md
@@ -1,6 +1,6 @@
 # Configuring domain names
 
-You can customize the domain of an individual Knative Service, or set a global default domain for all Services created on a cluster. The fully qualified domain name for a route by default is `{route}.{namespace}.example.com`.
+You can customize the domain of an individual Knative Service, or set a global default domain for all Services created on a cluster. The fully qualified domain name for a route by default is `{route}.{namespace}.svc.cluster.local`.
 
 ## Configuring a domain for a single Knative Service
 
@@ -18,7 +18,7 @@ You can change the default domain for all Knative Services on a cluster by modif
     kubectl edit configmap config-domain -n knative-serving
     ```
 
-1. Edit the file to replace `example.com` with the domain you want to use, then remove the `_example` key and save your changes. In this example, `knative.dev` is configured as the domain for all routes:
+1. Edit the file to replace `svc.cluster.local` with the domain you want to use, then remove the `_example` key and save your changes. In this example, `knative.dev` is configured as the domain for all routes:
 
     ```yaml
     apiVersion: v1


### PR DESCRIPTION
Fixes #5509 

## Proposed Changes <!-- Describe the changes the PR makes. -->

Updates the docs on creating private services with the detail that services are private by default.

/cc @dprotaso @ReToCode @nak3 

/cherrypick release-1.8
/cherrypick release-1.9