### PR TITLE
Deprecate documentation for container-freezer

### DIFF
--- a/docs/serving/autoscaling/README.md
+++ b/docs/serving/autoscaling/README.md
@@ -15,4 +15,4 @@ To use autoscaling for your application if it is enabled on your cluster, you mu
 * Try out the [Go Autoscale Sample App](autoscale-go/README.md).
 * Configure your Knative deployment to use the Kubernetes Horizontal Pod Autoscaler (HPA) instead of the default KPA. For how to install HPA, see [Install optional Serving extensions](../../install/yaml-install/serving/install-serving-with-yaml.md#install-optional-serving-extensions).
 * Configure the [types of metrics](autoscaling-metrics.md) that the Autoscaler consumes.
-* Configure your Knative Service to use [container-freezer](container-freezer.md), which freezes the running process when the pod's traffic drops to zero. The most valuable benefit is reducing the cold-start time within this configuration.
+* [Deprecated] Configure your Knative Service to use [container-freezer](container-freezer.md), which freezes the running process when the pod's traffic drops to zero. The most valuable benefit is reducing the cold-start time within this configuration.

--- a/docs/serving/autoscaling/container-freezer.md
+++ b/docs/serving/autoscaling/container-freezer.md
@@ -1,5 +1,8 @@
 # Configuring container-freezer
 
+!!! warning "Deprecated"
+    Container-freezer will be deprecated and removed in Knative v1.10
+
 When container-freezer is enabled, queue-proxy calls an endpoint API when its traffic drops to zero or scales up from zero.
 
 Within the community-maintained endpoint API implementation container-freezer, the running process is frozen when the pod's traffic drops to zero, and resumed when the pod's traffic scales up from zero. However, users can also run their own implementation instead (for example, as a billing component to log when requests are being handled).

--- a/docs/serving/configuration/deployment.md
+++ b/docs/serving/configuration/deployment.md
@@ -112,6 +112,9 @@ data:
 
 ## Enable container-freezer service
 
+!!! warning "Deprecated"
+    Container-freezer will be deprecated and removed in Knative v1.10
+
 You can configure queue-proxy to pause pods when not in use by enabling the `container-freezer` service. It calls a stand-alone service (via a user-specified endpoint) when a pod's traffic drops to zero or scales up from zero. To enable it, set `concurrency-state-endpoint` to a non-empty value. With this configuration, you can achieve some features like freezing running processes in pods or billing based on the time it takes to process the requests.
 
 Before you configure this, you need to implement the endpoint API. The official implementation is container-freezer. You can install it by following the installation instructions in the [container-freezer README](https://github.com/knative-sandbox/container-freezer).


### PR DESCRIPTION
Bringing changes from #5516 into the 1.9 release branch (though with a deprecation note instead of just deleting the docs).

/assign @dprotaso 