### PR TITLE
Relabel tab to 'No DNS'

### DIFF
--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -269,7 +269,7 @@ Knative Serving with different ingresses:
 <!-- These are snippets from the docs/snippets directory -->
 {% include "dns.md" %}
 {% include "real-dns-operator.md" %}
-{% include "temporary-dns.md" %}
+{% include "no-dns.md" %}
 
 ## Install Knative Eventing
 

--- a/docs/install/yaml-install/serving/install-serving-with-yaml.md
+++ b/docs/install/yaml-install/serving/install-serving-with-yaml.md
@@ -148,7 +148,7 @@ Follow the procedure for the networking layer of your choice:
 <!-- These are snippets from the docs/snippets directory -->
 {% include "dns.md" %}
 {% include "real-dns-yaml.md" %}
-{% include "temporary-dns.md" %}
+{% include "no-dns.md" %}
 
 ## Install optional Serving extensions
 

--- a/docs/snippets/dns.md
+++ b/docs/snippets/dns.md
@@ -17,4 +17,4 @@ Follow the procedure for the DNS of your choice:
         like minikube unless [`minikube tunnel`](https://minikube.sigs.k8s.io/docs/commands/tunnel/)
         is running.
 
-        In these cases, see the "Real DNS" or "Temporary DNS" tabs.
+        In these cases, see the "Real DNS" or "No DNS" tabs.

--- a/docs/snippets/no-dns.md
+++ b/docs/snippets/no-dns.md
@@ -1,4 +1,4 @@
-=== "Temporary DNS"
+=== "No DNS"
 
     If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (sslip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using,
     for example, minikube locally or IPv6 clusters.


### PR DESCRIPTION
'Temporary DNS' is confusing since we are not actually setting up DNS in this instance