### PR TITLE
point to the new ghcr.io images

### DIFF
--- a/blog/docs/articles/knative-serving-in-k0s.md
+++ b/blog/docs/articles/knative-serving-in-k0s.md
@@ -404,7 +404,7 @@ spec:
         autoscaling.knative.dev/minScale: "1"
     spec:
       containers:
-        - image: gcr.io/knative-samples/helloworld-go
+        - image: ghcr.io/knative/helloworld-go:latest
           env:
             - name: TARGET
               value: "Edge!!"

--- a/blog/docs/articles/quickstart-with-knative.md
+++ b/blog/docs/articles/quickstart-with-knative.md
@@ -44,7 +44,7 @@ $ kn quickstart kind
 
 Use the Knative client to create a Knative service:
 ```
-$ kn service create hello --image gcr.io/knative-samples/helloworld-go
+$ kn service create hello --image ghcr.io/knative/helloworld-go:latest
 ```
 
 Ready to try it out? Head over to the [Getting Started with Knative](https://knative.dev/docs/getting-started/) guide to learn how to download the plugin and get started with Knative!

--- a/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
+++ b/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
@@ -300,7 +300,7 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/knative-samples/helloworld-go # The URL to the image of the app
+        - image: ghcr.io/knative/helloworld-go:latest # The URL to the image of the app
           env:
             - name: TARGET # The environment variable printed out by the sample app
               value: "Hello Knative Serving is up and running with Kourier!!"

--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -8,7 +8,7 @@ In this tutorial, you will deploy a "Hello world" Knative Service that accepts t
 
     ```bash
     kn service create hello \
-    --image gcr.io/knative-samples/helloworld-go \
+    --image ghcr.io/knative/helloworld-go:latest \
     --port 8080 \
     --env TARGET=World
     ```
@@ -32,7 +32,7 @@ In this tutorial, you will deploy a "Hello world" Knative Service that accepts t
           template:
             spec:
               containers:
-                - image: gcr.io/knative-samples/helloworld-go
+                - image: ghcr.io/knative/helloworld-go:latest
                   ports:
                     - containerPort: 8080
                   env:

--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -36,7 +36,7 @@ Instead of `TARGET=World`, update the environment variable `TARGET` on your Knat
           template:
             spec:
               containers:
-                - image: gcr.io/knative-samples/helloworld-go
+                - image: ghcr.io/knative/helloworld-go:latest
                   ports:
                     - containerPort: 8080
                   env:
@@ -124,7 +124,7 @@ Split the traffic between the two Revisions:
           template:
             spec:
               containers:
-                - image: gcr.io/knative-samples/helloworld-go
+                - image: ghcr.io/knative/helloworld-go:latest
                   ports:
                     - containerPort: 8080
                   env:

--- a/docs/serving/app-security/security-guard-quickstart.md
+++ b/docs/serving/app-security/security-guard-quickstart.md
@@ -32,7 +32,7 @@ Create a sample securedService:
                   qpoption.knative.dev/guard-activate: enable
             spec:
               containers:
-                - image: gcr.io/knative-samples/helloworld-go
+                - image: ghcr.io/knative/helloworld-go:latest
                   env:
                     - name: TARGET
                       value: "Secured World"
@@ -52,7 +52,7 @@ Create a sample securedService:
 
     ```
     kn service create helloworld-go \
-        --image gcr.io/knative-samples/helloworld-go \
+        --image ghcr.io/knative/helloworld-go:latest \
         --env "TARGET=Secured World" \
         --annotation features.knative.dev/queueproxy-podinfo=enabled \
         --annotation qpoption.knative.dev/guard-activate=enable

--- a/docs/serving/autoscaling/autoscale-go/README.md
+++ b/docs/serving/autoscaling/autoscale-go/README.md
@@ -168,7 +168,7 @@ autoscaler classes built into Knative:
            autoscaling.knative.dev/metric: cpu
        spec:
          containers:
-           - image: gcr.io/knative-samples/autoscale-go:0.1
+           - image: ghcr.io/knative/autoscale-go:latest
    ```
 
    Additionally the autoscaler targets and scaling bounds can be specified in
@@ -195,7 +195,7 @@ autoscaler classes built into Knative:
            autoscaling.knative.dev/max-scale: "100"
        spec:
          containers:
-           - image: gcr.io/knative-samples/autoscale-go:0.1
+           - image: ghcr.io/knative/autoscale-go:latest
    ```
 
 !!! note

--- a/docs/serving/autoscaling/autoscaler-types.md
+++ b/docs/serving/autoscaling/autoscaler-types.md
@@ -43,7 +43,7 @@ The type of Autoscaler implementation (KPA or HPA) can be configured by using th
             autoscaling.knative.dev/class: "kpa.autoscaling.knative.dev"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"

--- a/docs/serving/autoscaling/concurrency.md
+++ b/docs/serving/autoscaling/concurrency.md
@@ -156,7 +156,7 @@ Requests numbered 7 to 10 will still be sent to the existing replicas, but this 
             autoscaling.knative.dev/target-utilization-percentage: "80"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"

--- a/docs/serving/autoscaling/kpa-specific.md
+++ b/docs/serving/autoscaling/kpa-specific.md
@@ -42,7 +42,7 @@ Stable mode is used for general operation, while panic mode by default has a muc
             autoscaling.knative.dev/window: "40s"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"
@@ -98,7 +98,7 @@ This value indicates how the window over which historical data is evaluated will
             autoscaling.knative.dev/panic-window-percentage: "20.0"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"
@@ -159,7 +159,7 @@ The default setting of `200.0` means that panic mode will be started if traffic 
             autoscaling.knative.dev/panic-threshold-percentage: "150.0"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"

--- a/docs/serving/autoscaling/rps-target.md
+++ b/docs/serving/autoscaling/rps-target.md
@@ -24,7 +24,7 @@ This setting specifies a target for requests-per-second per replica of an applic
             autoscaling.knative.dev/metric: "rps"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"

--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -34,7 +34,7 @@ Knative will attempt to never have less than this number of replicas at any one 
             autoscaling.knative.dev/min-scale: "3"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"
@@ -93,7 +93,7 @@ When `max-scale-limit` is set to a positive value, a revision with a max scale a
             autoscaling.knative.dev/max-scale: "3"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 
@@ -154,7 +154,7 @@ When the Revision is created, the larger of initial scale and lower bound is aut
             autoscaling.knative.dev/initial-scale: "0"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"
@@ -208,7 +208,7 @@ This value controls the minimum number of replicas that will be created when the
             autoscaling.knative.dev/activation-scale: "5"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 ## Scale Down Delay
@@ -243,7 +243,7 @@ delay period.
             autoscaling.knative.dev/scale-down-delay: "15m"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"
@@ -296,7 +296,7 @@ The stable window defines the sliding time window over which metrics are average
             autoscaling.knative.dev/window: "40s"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"

--- a/docs/serving/autoscaling/scale-to-zero.md
+++ b/docs/serving/autoscaling/scale-to-zero.md
@@ -113,7 +113,7 @@ This contrasts with the `scale-to-zero-grace-period` flag, which determines the 
             autoscaling.knative.dev/scale-to-zero-pod-retention-period: "1m5s"
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 === "Global (ConfigMap)"

--- a/docs/serving/configuration/config-defaults.md
+++ b/docs/serving/configuration/config-defaults.md
@@ -72,7 +72,7 @@ The revision timeout value determines the default number of seconds to use for t
           spec:
             timeoutSeconds: 300
             containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
     ```
 
 ### Max revision timeout seconds
@@ -134,7 +134,7 @@ The `revision-cpu-request` value determines the CPU allocation assigned to revis
       template:
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               resources:
                 requests:
                   cpu: "400m"
@@ -175,7 +175,7 @@ to revisions by default. If this value is omitted, the system default is used. T
       template:
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               resources:
                 requests:
                   memory: "100M"
@@ -216,7 +216,7 @@ allocation assigned to revisions by default. If this value is omitted, the syste
       template:
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               resources:
                 requests:
                   ephemeral-storage: "500M"
@@ -256,7 +256,7 @@ The `revision-cpu-limit` value determines the default CPU allocation limit for r
       template:
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               resources:
                 requests:
                   cpu: "1000m"
@@ -296,7 +296,7 @@ The `revision-memory-limit` value determines the default memory allocation limit
       template:
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               resources:
                 requests:
                   memory: "200M"
@@ -336,7 +336,7 @@ The `revision-ephemeral-storage-limit` value determines the default ephemeral st
       template:
         spec:
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               resources:
                 requests:
                   ephemeral-storage: "750M"
@@ -378,7 +378,7 @@ container name if no container name is specified. This field supports Go templat
         spec:
           containers:
             - name: user-container
-              image: gcr.io/knative-samples/helloworld-go
+              image: ghcr.io/knative/helloworld-go:latest
     ```
 
 ### Container concurrency

--- a/docs/serving/configuration/feature-flags.md
+++ b/docs/serving/configuration/feature-flags.md
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: first-container
-          image: gcr.io/knative-samples/helloworld-go
+          image: ghcr.io/knative/helloworld-go:latest
           ports:
             - containerPort: 8080
         - name: second-container
@@ -258,7 +258,7 @@ spec:
     spec:
       containers:
         - name: user-container
-          image: gcr.io/knative-samples/helloworld-go
+          image: ghcr.io/knative/helloworld-go:latest
           env:
             - name: MY_NODE_NAME
               valueFrom:
@@ -377,7 +377,7 @@ spec:
  template:
   spec:
    containers:
-     - image: gcr.io/knative-samples/helloworld-go
+     - image: ghcr.io/knative/helloworld-go:latest
        env:
          - name: TARGET
            value: "Go Sample v1"

--- a/docs/serving/deploying-from-private-registry.md
+++ b/docs/serving/deploying-from-private-registry.md
@@ -76,7 +76,7 @@ You can configure your Knative cluster to deploy images from a private registry 
           imagePullSecrets:
           - name: <secret-name>
           containers:
-            - image: gcr.io/knative-samples/helloworld-go
+            - image: ghcr.io/knative/helloworld-go:latest
               ports:
                 - containerPort: 8080
               env:

--- a/docs/serving/services/creating-services.md
+++ b/docs/serving/services/creating-services.md
@@ -31,7 +31,7 @@ Create a sample service:
           template:
             spec:
               containers:
-                - image: gcr.io/knative-samples/helloworld-go
+                - image: ghcr.io/knative/helloworld-go:latest
                   env:
                     - name: TARGET
                       value: "Go Sample v1"
@@ -47,7 +47,7 @@ Create a sample service:
 === "kn CLI"
 
     ```
-    kn service create helloworld-go --image gcr.io/knative-samples/helloworld-go
+    kn service create helloworld-go --image ghcr.io/knative/helloworld-go:latest
     ```
 
 After the service has been created, Knative performs the following tasks:

--- a/docs/serving/services/using-queue-extensions.md
+++ b/docs/serving/services/using-queue-extensions.md
@@ -54,7 +54,7 @@ Create a sample Service:
                   qpoption.knative.dev/testgate-config-sender: Joe
             spec:
               containers:
-                - image: gcr.io/knative-samples/helloworld-go
+                - image: ghcr.io/knative/helloworld-go:latest
                   env:
                     - name: TARGET
                       value: "World"
@@ -71,7 +71,7 @@ Create a sample Service:
 
     ```
     kn service create helloworld-go \
-        --image gcr.io/knative-samples/helloworld-go \
+        --image ghcr.io/knative/helloworld-go:latest \
         --env TARGET=World \
         --annotation features.knative.dev/queueproxy-podinfo=enabled \
         --annotation qpoption.knative.dev/testgate-activate=enable \


### PR DESCRIPTION
We created new images since `gcr.io/knative-samples` no longer exists

helloworld-go - https://github.com/knative/docs/pull/5550
autoscale-go  https://github.com/knative/docs/pull/5554