### PR TITLE
create autoscale-go image

### DIFF
--- a/.github/workflows/knative-docs-image.yaml
+++ b/.github/workflows/knative-docs-image.yaml
@@ -39,3 +39,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: ./code-samples/serving/hello-world/helloworld-go
           tags: ghcr.io/knative/helloworld-go:latest
+
+      - name: Build autoscale-go image
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          platforms: linux/amd64,linux/arm64
+          context: ./docs/serving/autoscaling/autoscale-go
+          tags: ghcr.io/knative/autoscale-go:latest

--- a/docs/serving/autoscaling/autoscale-go/Dockerfile
+++ b/docs/serving/autoscaling/autoscale-go/Dockerfile
@@ -14,10 +14,14 @@
 
 FROM golang AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 WORKDIR /go/src/app
 COPY . /go/src/app
-RUN CGO_ENABLED=0 go build -o /bin/autoscale-go .
-RUN CGO_ENABLED=0 go build -o /bin/load-generator ./test
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/autoscale-go .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/load-generator ./test
 
 FROM gcr.io/distroless/base
 EXPOSE 8080

--- a/docs/serving/autoscaling/autoscale-go/go.mod
+++ b/docs/serving/autoscaling/autoscale-go/go.mod
@@ -1,0 +1,3 @@
+module autoscale-go
+
+go 1.20


### PR DESCRIPTION
This created an `autoscale-go` image to replace the one hosted on `gcr.io/knative-samples` (which was removed)