### PR TITLE
docs: add links to stateless and event-driven

### DIFF
--- a/docs/snippets/about-functions.md
+++ b/docs/snippets/about-functions.md
@@ -3,7 +3,7 @@
 -->
 Knative Functions provides a simple programming model for using functions on Knative, without requiring in-depth knowledge of Knative, Kubernetes, containers, or dockerfiles.
 
-Knative Functions enables you to easily create, build, and deploy stateless, event-driven functions as Knative Services by using the `func` CLI.
+Knative Functions enables you to easily create, build, and deploy [stateless](https://www.techtarget.com/whatis/definition/stateless-app){target=_blank}, [event-driven](https://en.wikipedia.org/wiki/Event-driven_programming){target=_blank} functions as Knative Services by using the `func` CLI.
 
 When you build or run a function, an [Open Container Initiative (OCI) format](https://opencontainers.org/about/overview/){target=_blank} container image is generated automatically for you, and is stored in a container registry. Each time you update your code and then run or deploy it, the container image is also updated.
 


### PR DESCRIPTION
Where used in the Functions text, "stateless" and "event-driven" link to techtarget.com and wikipedia respectively.

Fixes: https://github.com/knative/docs/issues/5403
