### PR TITLE
Fix image url of autoscale-go service

### DIFF
--- a/docs/serving/autoscaling/autoscale-go/service.yaml
+++ b/docs/serving/autoscaling/autoscale-go/service.yaml
@@ -24,4 +24,4 @@ spec:
         autoscaling.knative.dev/target: "10"
     spec:
       containers:
-      - image: gcr.io/knative-samples/autoscale-go:0.1
+      - image: ghcr.io/knative/autoscale-go:latest


### PR DESCRIPTION
## Proposed Changes
- Fix image url of autoscale-go service

Fixes https://github.com/knative/serving/issues/14000

/cherry-pick release-1.10
