### PR TITLE
Update autoscaling-metrics.md for modifications

### DIFF
--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -34,7 +34,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "concurrency"
     ```
 
-=== "Rps"
+=== "Requests per second"
 
     ```yaml
     apiVersion: serving.knative.dev/v1
@@ -49,7 +49,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "rps"
     ```
 
-=== "Cpu"
+=== "CPU"
 
     ```yaml
     apiVersion: serving.knative.dev/v1

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -15,11 +15,11 @@ The possible metric types that can be configured per revision depend on the type
 For more information about KPA and HPA, see the documentation on [Supported Autoscaler types](autoscaler-types.md).
 
 * **Per-revision annotation key:** `autoscaling.knative.dev/metric`
-* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `"cpu"`, `"memory"`, and `"custom"` metrics are only supported on revisions that use the HPA class.
+* **Possible values:** `"concurrency"`, `"rps"`, `"cpu"`, `"memory"` or any custom metric name, depending on your Autoscaler type. The `"cpu"`, `"memory"`, and custom metrics are supported on revisions that use the HPA class.
 * **Default:** `"concurrency"`
 
 
-=== "Per-revision concurrency configuration"
+=== "Concurrency"
 
     ```yaml
     apiVersion: serving.knative.dev/v1
@@ -34,7 +34,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "concurrency"
     ```
 
-=== "Per-revision rps configuration"
+=== "Rps"
 
     ```yaml
     apiVersion: serving.knative.dev/v1
@@ -49,7 +49,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "rps"
     ```
 
-=== "Per-revision cpu configuration"
+=== "Cpu"
 
     ```yaml
     apiVersion: serving.knative.dev/v1
@@ -65,7 +65,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "cpu"
     ```
 
-=== "Per-revision memory configuration"
+=== "Memory"
 
     ```yaml
     apiVersion: serving.knative.dev/v1
@@ -81,7 +81,7 @@ For more information about KPA and HPA, see the documentation on [Supported Auto
             autoscaling.knative.dev/metric: "memory"
     ```
 
-=== "Per-revision custom metric configuration"
+=== "Custom metric"
 
     You can create an HPA to scale the revision by a metric that you specify.
     The HPA will be configured to use the **average value** of your metric over all the Pods of the revision.


### PR DESCRIPTION
Fixes #5566  

Have modified the autoscaling-metrics.md based on the changes mentioned in the issue

- Modified `"custom"` metrics are only supported to custom metrics are supported
- Removed `per-revision` prefix and `configuration` suffix in all tabs


