### PR TITLE
chore: remove TOC election banner

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -12,12 +12,6 @@
   Knative {{ config.extra.knative_version }} documentation is no longer actively maintained. The documentation you are currently viewing is a static snapshot. For up-to-date documentation, see <a href="{{ base_url }}/../docs/">the latest version</a>.
   </p>
 </div>
-{% else %}
-<div class="versionwarning" style="display: flex; justify-content: center;">
-  <p>Knative TOC Elections are underway. Voting ends May 27.
-  <a href="https://github.com/knative/community/tree/main/elections/2023-TOC">Learn more</a> about the voting process or
-  <a href="https://elections.knative.dev/app/elections/2023-TOC">vote now!</a></p>
-</div>
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Removes the TOC election banner from the website now that the election is over.