### PR TITLE
update configure-kn.md to include channel-type-mappings and add comments to sample yaml

### DIFF
--- a/docs/client/configure-kn.md
+++ b/docs/client/configure-kn.md
@@ -36,7 +36,7 @@ eventing:
     # Api group of the mapped resource
     group: messaging.knative.dev
     # Api version of the mapped resource
-    version: v1alpha1
+    version: v1beta1
     # Kind of the resource
     kind: KafkaChannel
 ```

--- a/docs/client/configure-kn.md
+++ b/docs/client/configure-kn.md
@@ -9,15 +9,36 @@ You can customize your `kn` CLI setup by creating a `config.yaml` configuration 
 ## Example configuration file
 
 ```yaml
+# Plugins related configuration
 plugins:
+  # Whether to lookup configuration in the execution path (default: true). This option is deprecated and will be removed in a future version where path lookup will be enabled unconditionally
   path-lookup: true
+  # Directory from where plugins with the prefix "kn-" are looked up. (default: "$base_dir/plugins"
+  # where "$base_dir" is the directory where this configuration file is stored)
   directory: ~/.config/kn/plugins
+# Eventing related configuration
 eventing:
+  # List of sink mappings that allow custom prefixes wherever a sink
+  # specification is used (like for the --sink option of a broker)
   sink-mappings:
+    # Prefix as used in the command (e.g. "--sink svc:myservice")
   - prefix: svc
+    # Api group of the mapped resource
     group: core
+    # Api version of the mapped resource
     version: v1
+    # Resource name (lowercased plural form of the 'kind')
     resource: services
+  # Channel mappings that you can use in --channel options
+  channel-type-mappings:
+    # Alias that can be used as a type for a channel option (e.g. "kn create channel mychannel --type Kafka")
+  - alias: Kafka
+    # Api group of the mapped resource
+    group: messaging.knative.dev
+    # Api version of the mapped resource
+    version: v1alpha1
+    # Kind of the resource
+    kind: KafkaChannel
 ```
 
 Where
@@ -30,3 +51,8 @@ Where
     - `group`: The API group of the Kubernetes resource.
     - `version`: The version of the Kubernetes resource.
     - `resource`: The lowercased, plural name of the Kubernetes resource type. For example, `services` or `brokers`.
+- `channel-type-mappings` can be used to define aliases for custom channel types that can be used wherever a channel type is required (as in `kn channel create --type`). This configuration section defines an array of entries with the following fields:
+  - `alias`: The name that can be used as the type
+  - `group`: The APIGroup of the channel CRD.
+  - `version`: The version of the channel CRD.
+  - `kind`: Kind of the channel CRD (e.g. `KafkaChannel`)


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Add 'channel-type-mappings' customisation option to Customizing kn docs.
This feature already existed and was documented as part of the [github docs for kn-client](https://github.com/knative/client/tree/11bc9779a7e3c9782132c2cd8be035a64b86febb/docs#eventing-configuration), but was missing from the official website. Please take a look at [this](https://github.com/knative/client/issues/1410#issuecomment-1498937341) comment.
- Also, replaced the config yaml with a better-commented version of the same, which already existed as part of the [github docs for kn-client](https://github.com/knative/client/tree/11bc9779a7e3c9782132c2cd8be035a64b86febb/docs#eventing-configuration).
