### PR TITLE
Using workloads instead of deployments on the documentation

### DIFF
--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -315,7 +315,7 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  deployments:
+  workloads:
   - name: eventing-controller
     resources:
     - container: eventing-controller
@@ -352,7 +352,7 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  deployments:
+  workloads:
   - name: eventing-controller
     nodeSelector:
       disktype: hdd
@@ -386,7 +386,7 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  deployments:
+  workloads:
   - name: eventing-controller
     tolerations:
     - key: "key1"
@@ -428,7 +428,7 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  deployments:
+  workloads:
   - name: eventing-controller
     affinity:
       nodeAffinity:
@@ -456,7 +456,7 @@ metadata:
   name: knative-eventing
   namespace: knative-eventing
 spec:
-  deployments:
+  workloads:
   - name: eventing-controller
     env:
     - container: eventing-controller

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -407,7 +407,7 @@ spec:
 
 By default, Knative Serving runs a single instance of each deployment. The `spec.high-availability` field allows you to configure the number of replicas for all deployments managed by the operator.
 
-The following configuration specifies a replica count of 3 for the deployments:
+The following configuration specifies a replica count of 3 for the workloads:
 
 ```yaml
 apiVersion: operator.knative.dev/v1beta1
@@ -459,7 +459,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  deployments:
+  workloads:
   - name: controller
     resources:
     - container: controller
@@ -490,7 +490,7 @@ metadata:
 spec:
   high-availability:
     replicas: 2
-  deployments:
+  workloads:
   - name: webhook
     replicas: 3
     labels:
@@ -522,7 +522,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  deployments:
+  workloads:
   - name: webhook
     nodeSelector:
       disktype: hdd
@@ -556,7 +556,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  deployments:
+  workloads:
   - name: activator
     tolerations:
     - key: "key1"
@@ -598,7 +598,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  deployments:
+  workloads:
   - name: activator
     affinity:
       nodeAffinity:
@@ -626,7 +626,7 @@ metadata:
   name: knative-serving
   namespace: knative-serving
 spec:
-  deployments:
+  workloads:
   - name: controller
     env:
     - container: controller


### PR DESCRIPTION

## Proposed Changes <!-- Describe the changes the PR makes. -->

- The operators do support `workload` field and we should not use `deployments` anymore. Workloads is a better name since we do support also statefulsets.
- 