### PR TITLE
docs: fix eventing gitlab source readme

### DIFF
--- a/code-samples/eventing/gitlab-source/README.md
+++ b/code-samples/eventing/gitlab-source/README.md
@@ -74,7 +74,7 @@ kubectl -n default apply -f event-display.yaml
 ### Create GitLab Tokens
 
 1. Create a
-   [personal access token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
+   [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html)
    which the GitLab source will use to register webhooks with the GitLab API.
    The token must have an "api" access scope in order to create repository
    webhooks. Also decide on a secret token that your source will use to

--- a/code-samples/eventing/gitlab-source/README.md
+++ b/code-samples/eventing/gitlab-source/README.md
@@ -153,7 +153,7 @@ kubectl -n default apply -f event-display.yaml
 ### Verify
 
 Verify that GitLab webhook was created by looking at the list of webhooks under
-**Settings >> Integrations** in your GitLab project. A hook should be listed
+**Settings >> Webhooks** in your GitLab project. A hook should be listed
 that points to your Knative cluster.
 
 Create a push event and check the logs of the Pod backing the


### PR DESCRIPTION
Add fix for eventing gitlab source readme

## Proposed Changes

- Use project access token instead of personal access token for gitlab source (which is more secure from security perspective)
-  Use right breadcrumb for gitlab webhook (Settings >> Webhooks)
