### PR TITLE
docs: update instructions on client code-sign verification

### DIFF
--- a/docs/reference/security/README.md
+++ b/docs/reference/security/README.md
@@ -35,10 +35,9 @@ Our releases from 1.9 are signed with [cosign](https://docs.sigstore.dev/cosign/
     ```
 
 !!! note
-    `COSIGN_EXPERIMENTAL=1` is used to allow verification of images signed
-    in `KEYLESS` mode. To learn more about keyless signing, please refer to
+    Knative images are signed in `KEYLESS` mode. To learn more about keyless signing, please refer to
     [Keyless Signatures](https://github.com/sigstore/cosign/blob/main/KEYLESS.md#keyless-signatures)
-    Our signing identity(Subject) for our releases is `signer@knative-nightly.iam.gserviceaccount.com` and the Issuer is `https://accounts.google.com`
+    Our signing identity(Subject) for our releases is `signer@knative-releases.iam.gserviceaccount.com` and the Issuer is `https://accounts.google.com`
 
 ### Apple macOS
 

--- a/docs/reference/security/README.md
+++ b/docs/reference/security/README.md
@@ -14,15 +14,17 @@ Our releases from 1.9 are signed with [cosign](https://docs.sigstore.dev/cosign/
 
 1. Download the files you want, and the `checksums.txt`, `checksum.txt.pem` and `checksums.txt.sig` files from the releases page:
     ```sh
-    # this example verifies the 1.9.0 kn cli from the knative/client repository
-    wget https://github.com/knative/client/releases/download/knative-v1.9.0/checksums.txt
-    wget https://github.com/knative/client/releases/download/knative-v1.9.0/kn-darwin-amd64
-    wget https://github.com/knative/client/releases/download/knative-v1.9.0/checksums.txt.sig
-    wget https://github.com/knative/client/releases/download/knative-v1.9.0/checksums.txt.pem
+    # this example verifies the 1.10.0 kn cli from the knative/client repository
+    wget https://github.com/knative/client/releases/download/knative-v1.10.0/checksums.txt
+    wget https://github.com/knative/client/releases/download/knative-v1.10.0/kn-darwin-amd64
+    wget https://github.com/knative/client/releases/download/knative-v1.10.0/checksums.txt.sig
+    wget https://github.com/knative/client/releases/download/knative-v1.10.0/checksums.txt.pem
     ```
 1. Verify the signature:
     ```sh
-    COSIGN_EXPERIMENTAL=1 cosign verify-blob \
+    cosign verify-blob \
+    --certificate-identity=signer@knative-releases.iam.gserviceaccount.com \
+    --certificate-oidc-issuer=https://accounts.google.com \
     --cert checksums.txt.pem \
     --signature checksums.txt.sig \
     checksums.txt


### PR DESCRIPTION
the client binary is code-sign verified with cosign in keyless mode and cosign has changed the way it's keyless code signing works since the docs were made here

## Proposed Changes 

- updates the docs for code-sign verification for client binary
