### PR TITLE
Document current behaviour of scaling down with activation scale

### DIFF
--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -185,6 +185,9 @@ When the Revision is created, the larger of initial scale and lower bound is aut
 ## Scale Up Minimum
 
 This value controls the minimum number of replicas that will be created when the Revision scales up from zero.
+After the Revision has reached this scale one time, this value is ignored. This means that the Revision will scale down after the activation scale is reached if the actual traffic received needs a smaller scale.
+
+When the Revision is created, the larger of activation scale and lower bound is automatically chosen as the initial target scale.
 
 * **Global key:** n/a
 * **Per-revision annotation key:** `autoscaling.knative.dev/activation-scale`


### PR DESCRIPTION
The changes in this PR only reflect the existing behaviour of scale down operation by autoscaler when activation scale is set until the behaviour is changed in future.

Related Issue: https://github.com/knative/serving/issues/14017