### PR TITLE
fix: rm deprecated step

### DIFF
--- a/docs/eventing/brokers/broker-types/rabbitmq-broker/README.md
+++ b/docs/eventing/brokers/broker-types/rabbitmq-broker/README.md
@@ -65,32 +65,6 @@ This topic describes how to create a RabbitMQ Broker.
     ```
    Where `<filename>` is the name of the file you created in the previous step.
 
-## Create a RabbitMQBroker object
-
-1. Create a YAML file using the following template:
-
-    ```yaml
-    apiVersion: eventing.knative.dev/v1
-    kind: Broker
-    metadata:
-      annotations:
-        eventing.knative.dev/broker.class: RabbitMQBroker
-      name: <broker-name>
-    spec:
-      config:
-        apiVersion: eventing.knative.dev/v1alpha1
-        kind: RabbitmqBrokerConfig
-        name: <rabbitmq-broker-config-name>
-    ```
-    Where `<rabbitmq-broker-config-name>` is the name you gave your RabbitMQBrokerConfig in the step above.
-
-1. Apply the YAML file by running the command:
-
-    ```bash
-    kubectl apply -f <filename>
-    ```
-    Where `<filename>` is the name of the file you created in the previous step.
-
 ## Configure message ordering
 
 By default, Triggers will consume messages one at a time to preserve ordering. If ordering of events isn't important and higher performance is desired, you can configure this by using the


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- RabbitMQBroker is deprecated as mentioned here https://github.com/knative-sandbox/eventing-rabbitmq/tree/main/samples/quick-setup
