### PR TITLE
Explain what `sample application` is, in `no-dns.md`

### DIFF
--- a/docs/snippets/no-dns.md
+++ b/docs/snippets/no-dns.md
@@ -1,5 +1,8 @@
 === "No DNS"
 
+    !!! tip
+        You can install the sample application following this Guide: [Deploying a Knative Service](/docs/getting-started/first-service/)
+
     If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (sslip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using,
     for example, minikube locally or IPv6 clusters.
 

--- a/docs/snippets/no-dns.md
+++ b/docs/snippets/no-dns.md
@@ -1,9 +1,6 @@
 === "No DNS"
 
-    !!! tip
-        You can install the sample application following this Guide: [Deploying a Knative Service](/docs/getting-started/first-service/)
-
-    If you are using `curl` to access the sample applications, or your own Knative app, and are unable to use the "Magic DNS (sslip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using,
+    If you are using `curl` to access [the sample applications](/docs/getting-started/first-service/), or your own Knative app, and are unable to use the "Magic DNS (sslip.io)" or "Real DNS" methods, there is a temporary approach. This is useful for those who wish to evaluate Knative without altering their DNS configuration, as per the "Real DNS" method, or cannot use the "Magic DNS" method due to using,
     for example, minikube locally or IPv6 clusters.
 
     To access your application using `curl` using this method:


### PR DESCRIPTION
This PR is a documentation enhancement. It adds the missing reference to the sample application.

## Proposed Changes <!-- Describe the changes the PR makes. -->

![image](https://github.com/knative/docs/assets/35857538/3e05622f-84b8-4332-b5d4-58d2ff1b9032)

The `helloworld-go application` here is a backward reference, as a newcomer, I have no idea where it is.

So I added a `tip` section, linking to the first service page - https://knative.dev/docs/getting-started/first-service/