### PR TITLE
Rename and reword `auto-tls` feature to `external-domain-tls`

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -126,7 +126,7 @@ nav:
           - Configuring ingress class: serving/services/ingress-class.md
           - Configuring certificate class: serving/services/certificate-class.md
           - Configuring custom domains: serving/services/custom-domains.md
-          - Using a custom TLS certificate for DomainMapping: serving/services/byo-certificate.md
+          - Using a custom TLS certificate for DomainMapping: serving/services/custom-tls-certificate-domain-mapping.md
           - Using extensions enabled by QPOptions: serving/services/using-queue-extensions.md
           # TODO: Add security section to docs?
           - Configure resource requests and limits: serving/services/configure-requests-limits-services.md
@@ -147,18 +147,18 @@ nav:
         - Enabling requests to Knative services when additional authorization policies are enabled: serving/istio-authorization.md
         - Exclude namespaces from the Knative webhook: serving/webhook-customizations.md
         - Configuring high-availability components: serving/config-ha.md
-        - Configuring HTTPS connections: serving/using-a-tls-cert.md
-        - Enabling auto-TLS certs: serving/using-auto-tls.md
         - Configuring the ingress gateway: serving/setting-up-custom-ingress-gateway.md
         - Configuring domain names: serving/using-a-custom-domain.md
         - Converting a Kubernetes Deployment to a Knative Service: serving/convert-deployment-to-knative-service.md
         - Extending Queue Proxy image with QPOptions: serving/queue-extensions.md
-        # Serving config
         - Serving configuration:
           - Configure Deployment resources: serving/configuration/deployment.md
           - Configuring gradual rollout of traffic to Revisions: serving/configuration/rolling-out-latest-revision-configmap.md
           - Feature and extension flags: serving/configuration/feature-flags.md
           - Configure the Defaults ConfigMap: serving/configuration/config-defaults.md
+        - Serving encryption configuration:
+          - Using custom TLS certificates in the networking layer: serving/encryption/using-certificates-in-networking-layer.md
+          - Enabling automatic TLS certificate provisioning: serving/encryption/enabling-automatic-tls-certificate-provisioning.md
       # Serving - Application Security
       - Application security:
         - About Security-Guard: serving/app-security/security-guard-about.md

--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -1,7 +1,7 @@
 plugins:
   redirects:
     redirect_maps:
-      contributing/about.md: contributing/README.md
+      contributing/about.md: community/README.md
       eventing/broker/kafka-broker/kafka-configmap.md: eventing/configuration/kafka-channel-configuration.md
       eventing/broker/create-mtbroker.md: eventing/brokers/create-broker.md
       eventing/broker/example-mtbroker.md: eventing/brokers/broker-developer-config-options.md
@@ -17,7 +17,6 @@ plugins:
       reference/api/serving-api.md: serving/reference/serving-api.md
       community/about.md: community/governance.md
       contributing/contributing.md: community/contributing.md
-      contributing/about.md: community/governance.md
       contributing/README.md: community/README.md
       eventing/getting-started.md: getting-started/getting-started-eventing.md
       admin/collecting-logs/README.md: serving/observability/logging/collecting-logs.md
@@ -105,7 +104,7 @@ plugins:
       developer/serving/deploying-from-private-registry.md: serving/deploying-from-private-registry.md
       developer/serving/rolling-out-latest-revision.md: serving/rolling-out-latest-revision.md
       developer/serving/services/README.md: serving/services/README.md
-      developer/serving/services/byo-certificate.md: serving/services/byo-certificate.md
+      developer/serving/services/byo-certificate.md: serving/services/custom-tls-certificate-domain-mapping.md
       developer/serving/services/certificate-class.md: serving/services/certificate-class.md
       developer/serving/services/configure-requests-limits-services.md: serving/services/configure-requests-limits-services.md
       developer/serving/services/creating-services.md: serving/services/creating-services.md
@@ -209,7 +208,7 @@ plugins:
       serving/services/deployment.md: serving/configuration/deployment.md
       serving/services/http-option.md: serving/services/http-protocol.md
       serving/spec/knative-api-specification-1.0.md: https://github.com/knative/specs/blob/main/specs/serving/knative-api-specification-1.0.md
-      serving/using-an-ssl-cert/index.md: serving/using-a-tls-cert.md
+      serving/using-an-ssl-cert/index.md: serving/encryption/using-certificates-in-networking-layer.md
       serving/using-subroutes.md: serving/traffic-management.md
       about/case-studies/README.md: about/case-studies/deepc.md
       eventing/brokers/create-mtbroker.md: eventing/brokers/create-broker.md

--- a/docs/install/installing-cert-manager.md
+++ b/docs/install/installing-cert-manager.md
@@ -3,12 +3,11 @@
 Install the [Cert-Manager](https://github.com/jetstack/cert-manager) tool to
 obtain TLS certificates that you can use for secure HTTPS connections in
 Knative. For more information about enabling HTTPS connections in Knative, see
-[Configuring HTTPS with TLS certificates](../serving/using-a-tls-cert.md).
+[Using custom certificates in networking-layer](../serving/encryption/using-certificates-in-networking-layer.md).
 
 You can use cert-manager to either manually obtain certificates, or to enable
-Knative for automatic certificate provisioning. Complete instructions about
-automatic certificate provisioning are provided in
-[Enabling automatic TLS cert provisioning](../serving/using-auto-tls.md).
+Knative for automatic certificate provisioning. Complete instructions about this are provided in
+[Enabling automatic TLS certificate provisioning](../serving/encryption/enabling-automatic-tls-certificate-provisioning.md).
 
 Regardless of if your want to manually obtain certificates, or configure Knative
 for automatic provisioning, you can use the following steps to install
@@ -36,8 +35,8 @@ configuring Knative:
 - **Manual**: If you installed cert-manager to manually obtain certificates,
   continue to the following topic for instructions about creating a Kubernetes
   secret:
-  [Manually adding a TLS certificate](../serving/using-a-tls-cert.md#manually-adding-a-tls-certificate)
+  [Manually adding a TLS certificate](../serving/encryption/using-certificates-in-networking-layer.md#manually-adding-a-tls-certificate)
 
 - **Automatic**: If you installed cert-manager to use for automatic certificate
   provisioning, continue to the following topic to enable that feature:
-  [Enabling automatic TLS certificate provisioning in Knative](../serving/using-auto-tls.md)
+  [Enabling automatic TLS certificate provisioning](../serving/encryption/enabling-automatic-tls-certificate-provisioning.md)

--- a/docs/install/yaml-install/serving/install-serving-with-yaml.md
+++ b/docs/install/yaml-install/serving/install-serving-with-yaml.md
@@ -170,20 +170,9 @@ The following tabs expand to show instructions for installing each Serving exten
 === "TLS with cert-manager"
 
     Knative supports automatically provisioning TLS certificates through
-    [cert-manager](https://cert-manager.io/docs/). The following commands
-    install the components needed to support the provisioning of TLS certificates
-    through cert-manager.
-
-    1. Install [cert-manager version v1.0.0 or later](../../installing-cert-manager.md).
-
-    1. Install the component that integrates Knative with `cert-manager` by running the command:
-
-        ```bash
-        kubectl apply -f {{ artifact(repo="net-certmanager",file="release.yaml")}}
-        ```
-
-    1. Configure Knative to automatically configure TLS certificates by following the steps in
-    [Enabling automatic TLS certificate provisioning](../../../serving/using-auto-tls.md).
+    [cert-manager](https://cert-manager.io/docs/).
+    Follow the documentation in [Enabling automatic TLS certificate provisioning](../../../serving/encryption/enabling-automatic-tls-certificate-provisioning.md)
+    for more information.
 
 === "TLS with HTTP01"
 
@@ -204,11 +193,11 @@ The following tabs expand to show instructions for installing each Serving exten
           --patch '{"data":{"certificate-class":"net-http01.certificate.networking.knative.dev"}}'
         ```
 
-    3. Enable autoTLS by running the command:
+    3. Enable `external-domain-tls` by running the command:
 
         ```bash
         kubectl patch configmap/config-network \
           --namespace knative-serving \
           --type merge \
-          --patch '{"data":{"auto-tls":"Enabled"}}'
+          --patch '{"data":{"external-domain-tls":"Enabled"}}'
         ```

--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -10,7 +10,7 @@ Examples of supported Knative Serving use cases:
 - Autoscaling, including scaling pods down to zero.
 - Support for multiple networking layers, such as Contour, Kourier, and Istio, for integration into existing environments.
 
-Knative Serving supports both HTTP and [HTTPS](using-a-tls-cert.md) networking protocols.
+Knative Serving supports both HTTP and [HTTPS](encryption/using-certificates-in-networking-layer.md) networking protocols.
 
 ## Installation
 

--- a/docs/serving/encryption/using-certificates-in-networking-layer.md
+++ b/docs/serving/encryption/using-certificates-in-networking-layer.md
@@ -1,11 +1,11 @@
-# Configuring HTTPS with TLS certificates
+# Using custom certificates in the networking layers
 
-Learn how to configure secure HTTPS connections in Knative using TLS
-certificates
-([TLS replaces SSL](https://en.wikipedia.org/wiki/Transport_Layer_Security)).
-Configure secure HTTPS connections to enable your Knative services and routes to
-[terminate external TLS connections](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_interception).
-You can configure Knative to handle certificates that you manually specify, or
+Knative allows to use custom TLS certificates to enable secure HTTPS connections for your Knative Services 
+for the external domain (like `application.example.com`). Please note that we are working on bringing automatic HTTPS
+connections for cluster-local domains (like `application.namespace.svc.cluster.local`) as well
+(for more details see the [issue](https://github.com/knative/serving/issues/13472)).
+
+For external domains, you can configure Knative to handle certificates that you manually specify, or
 you can enable Knative to automatically obtain and renew certificates.
 
 You can use either [Certbot][cb] or [cert-manager][cm] to obtain certificates.
@@ -23,7 +23,7 @@ cert-manager tool:
   also use cert-manager to configure Knative to automatically obtain new TLS
   certificates and renew existing ones. If you want to enable Knative to
   automatically provision TLS certificates, instead see the
-  [Enabling automatic TLS certificate provisioning](using-auto-tls.md) topic.
+  [Enabling automatic TLS certificate provisioning](enabling-automatic-tls-certificate-provisioning.md) topic.
 
 By default, the [Let's Encrypt Certificate Authority (CA)][le] is used to
 demonstrate how to enable HTTPS connections, but you can configure Knative to
@@ -36,8 +36,7 @@ use and configure your certificate issuer to use the
 
 [cm]: https://github.com/jetstack/cert-manager
 [cm-docs]: https://cert-manager.readthedocs.io/en/latest/getting-started/
-[cm-providers]:
-  http://docs.cert-manager.io/en/latest/tasks/acme/configuring-dns01/index.html?highlight=supported%20DNS01%20providers#supported-dns01-providers
+[cm-providers]: https://cert-manager.io/docs/configuration/acme/dns01/
 [le]: https://letsencrypt.org
 [le-faqs]: https://letsencrypt.org/docs/faq/
 [cb]: https://certbot.eff.org
@@ -50,9 +49,8 @@ use and configure your certificate issuer to use the
 You must meet the following requirements to enable secure HTTPS connections:
 
 - Knative Serving must be installed. For details about installing the Serving
-  component, see the [Knative installation guides](../install/yaml-install/serving/install-serving-with-yaml.md).
-- You must configure your Knative cluster to use a
-  [custom domain](using-a-custom-domain.md).
+  component, see the [Knative installation guides](../../install/yaml-install/serving/install-serving-with-yaml.md).
+- You must configure your Knative cluster to use a [custom domain](../using-a-custom-domain.md).
 
 !!! warning
     Istio only supports a single certificate per Kubernetes cluster.
@@ -61,7 +59,7 @@ You must meet the following requirements to enable secure HTTPS connections:
 ## Obtaining a TLS certificate
 
 If you already have a signed certificate for your domain, see
-[Manually adding a TLS certificate](#manually-adding-a-tls-certificate) for
+[manually adding a TLS certificate](#manually-adding-a-tls-certificate) for
 details about configuring your Knative cluster.
 
 If you need a new TLS certificate, you can choose to use one of the following
@@ -117,31 +115,24 @@ You can install and use [cert-manager][cm] to either manually obtain a
 certificate or to configure your Knative cluster for automatic certificate
 provisioning:
 
-- **Manual certificates**: Install cert-manager and then use the tool to
-  manually obtain a certificate.
+**Manual certificates**: 
 
-  To use cert-manager to manually obtain certificates:
-
-  1.  [Install and configure cert-manager](../install/installing-cert-manager.md).
+  1.  [Install and configure cert-manager](../../install/installing-cert-manager.md).
 
   1.  Continue to the steps about
       [manually adding a TLS certificate](#manually-adding-a-tls-certificate) by
       creating and using a Kubernetes secret.
 
-- **Automatic certificates**: Configure Knative to use cert-manager for
-  automatically obtaining and renewing TLS certificate. The steps for installing
-  and configuring cert-manager for this method are covered in full in the
-  [Enabling automatic TLS cert provisioning](using-auto-tls.md) topic.
+**Automatic certificates**: 
+
+See [enabling automatic TLS certificate provisioning](enabling-automatic-tls-certificate-provisioning.md).
+
 
 ## Manually adding a TLS certificate
 
 If you have an existing certificate or have used one of the Certbot or
 cert-manager tool to manually obtain a new certificate, you can use the
-following steps to add that certificate to your Knative cluster.
-
-For instructions about enabling Knative for automatic certificate provisioning,
-see [Enabling automatic TLS cert provisioning](using-auto-tls.md). Otherwise,
-follow the steps in the relevant tab to manually add a certificate:
+following steps in the relevant tab to add that certificate to your Knative cluster.
 
 
 === "Contour"
@@ -184,7 +175,7 @@ follow the steps in the relevant tab to manually add a certificate:
         Where `<filename>` is the name of the file you created in the previous step.
 
     1. Update the Knative Contour plugin to use the certificate as a fallback
-       when autoTLS is disabled by running the command:
+       when `external-domain-tls` is disabled by running the command:
 
          ```bash
          kubectl patch configmap config-contour -n knative-serving \
@@ -262,4 +253,4 @@ follow the steps in the relevant tab to manually add a certificate:
 ## What's next:
 
 After your changes are running on your Knative cluster, you can begin using the
-HTTPS protocol for secure access your deployed Knative services.
+HTTPS protocol for secure access your deployed Knative services on external domains.

--- a/docs/serving/services/certificate-class.md
+++ b/docs/serving/services/certificate-class.md
@@ -1,6 +1,6 @@
 # Configuring a custom certificate class for a Service
 
-When autoTLS is enabled and Knative Services are created, a certificate class (`certificate-class`) is automatically chosen based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the certificate class is not specified, this defaults to `cert-manager.certificate.networking.knative.dev`. After `certificate-class` is configured, it is used for all Knative Services unless it is overridden with a `certificate-class` annotation.
+When `external-domain-tls` is enabled and Knative Services are created, a certificate class (`certificate-class`) is automatically chosen based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the certificate class is not specified, this defaults to `cert-manager.certificate.networking.knative.dev`. After `certificate-class` is configured, it is used for all Knative Services unless it is overridden with a `certificate-class` annotation.
 
 ## Using the certificate class annotation
 

--- a/docs/serving/services/custom-tls-certificate-domain-mapping.md
+++ b/docs/serving/services/custom-tls-certificate-domain-mapping.md
@@ -3,16 +3,17 @@
 {{ feature(beta="0.24") }}
 
 By providing the reference to an existing _TLS Certificate_ you can instruct a `DomainMapping` to use that
-certificate to secure the mapped service. Using this feature skips [autoTLS](../using-auto-tls.md) certificate creation.
+certificate to secure the mapped service. 
+Please note that for Services using this feature, the automatic certificate creation using [external-domain-tls](../encryption/enabling-automatic-tls-certificate-provisioning.md) is skipped.
 
 ## Prerequisites
 
 - You have followed the steps from [Configuring custom domains](custom-domains.md) and now have a working `DomainMapping`.
-- You must have a TLS certificate from your Certificate Authority provider or self-signed.
+- You must have a TLS certificate from your Certificate Authority provider or a self-signed certificate.
 
 ## Procedure
 
-1. Assuming you have obtained the `cert` and `key` files from your Certificate Authority provider or self-signed, create a plain Kubernetes [TLS Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) by running the command:
+1. Assuming you have obtained the `cert` and `key` files from your Certificate Authority provider or have self-signed certificate, create a plain Kubernetes [TLS Secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets) by running the command:
 
     Use kubectl to create the secret:
     ```bash

--- a/docs/serving/services/http-protocol.md
+++ b/docs/serving/services/http-protocol.md
@@ -1,6 +1,6 @@
 # HTTPS redirection
 
-Operators can force HTTPS redirection for all Services. See the `http-protocol` mentioned in the [Turn on AutoTLS](../using-auto-tls.md) page for more details.
+Operators can force HTTPS redirection for all Services. See the `http-protocol` mentioned in the [Enabling automatic TLS certificate provisioning](../encryption/enabling-automatic-tls-certificate-provisioning.md) page for more details.
 
 ## Overriding the default HTTP behavior
 

--- a/docs/serving/services/service-metrics.md
+++ b/docs/serving/services/service-metrics.md
@@ -25,7 +25,7 @@ Queue proxy exports metrics for the requests endpoint on port 9091. The metrics 
 address which can be set in the same configmap via `metrics.opencensus-address`. User can control the reporting period for both backends with
 `metrics.request-metrics-reporting-period-seconds`. If `metrics.request-metrics-reporting-period-seconds` is not set at all then the reporting period depends on the value of the global reporting period, `metrics.reporting-period-seconds`, that affects both control and data planes. If both properties are not available then the reporting period defaults to 5s for the Prometheus backend and 60s for the Opencensus one.
 
-Here is a sample configuration for the observability configmap in order to connect to the [OpenTelemetry collector](../../observability/metrics/collecting-metrics/#understanding-the-collector):
+Here is a sample configuration for the observability configmap in order to connect to the [OpenTelemetry collector](../observability/metrics/collecting-metrics.md#understanding-the-collector):
 
 ```
 metrics.request-metrics-backend-destination: "opencensus"


### PR DESCRIPTION
Partially https://github.com/knative/serving/issues/14368

## Proposed Changes
- Rename `auto-tls` to `external-domain-tls`
- Reword the existing pages to prepare for the future flags we introduce
  - Make it more clear that the current feature is only for external domains
  - Point to our existing work to bring HTTPS to cluster-local domains as well
- Remove duplications about installing cert-manager
- Reorder the navigation to have a new section for encryption. We'll add an overview page to that section to explain the three different parts of Serving Encryption in the future
- Rename pages to better reflect what they are trying to explain

Review links for changed pages:
- https://deploy-preview-5692--knative.netlify.app/docs/install/installing-cert-manager/
- https://deploy-preview-5692--knative.netlify.app/docs/install/yaml-install/serving/install-serving-with-yaml/
- https://deploy-preview-5692--knative.netlify.app/docs/serving/encryption/using-certificates-in-networking-layer/
- https://deploy-preview-5692--knative.netlify.app/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning/
- https://deploy-preview-5692--knative.netlify.app/docs/serving/services/custom-tls-certificate-domain-mapping/
- https://deploy-preview-5692--knative.netlify.app/docs/serving/services/http-protocol/

/hold - work in networking/serving is not merged yet