### PR TITLE
Update on Kind Local Registry Setup in knative-quickstart-plugin Doc

### DIFF
--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -83,6 +83,12 @@ To get a local deployment of Knative, run the `quickstart` plugin:
         ```
 
         !!! note
+            For [KinD](https://kind.sigs.k8s.io/), a local registry will no longer be created by default. Users will need to pass the `--registry` flag if they wish to create a local registry:
+            ```bash
+            kn quickstart kind --registry
+            ```
+
+        !!! note
             Quickstart uses Port 80, and it will fail to install if any other services are bound on that port. If you have a service using Port 80, you'll need to stop it before using Quickstart.
             To check if another service is using Port 80:
             ```bash


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

"Fixes #issue-number" or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->
[Concept] : I have added a note to quickstart-install.md. It states that for 
[KinD](https://kind.sigs.k8s.io/), a local registry will no longer be created by default. Users will now need to pass the --registry flag if they wish to create a local registry. 
This can be done using the command: `kn quickstart kind --registry`.
-
-
-
