### PR TITLE
update kn + quickstart installs for consistency

### DIFF
--- a/docs/snippets/install-kn.md
+++ b/docs/snippets/install-kn.md
@@ -45,13 +45,13 @@ The `kn` CLI also simplifies completion of otherwise complex procedures such as 
 
         Where `<path-to-binary-file>` is the path to the binary file you downloaded in the previous step, for example, `kn-darwin-amd64` or `kn-linux-amd64`.
 
-    1. Move the executable binary file to a directory on your PATH by running the command:
+    1. Move the executable binary file to a directory on your `PATH` by running the command:
 
         ```bash
         mv kn /usr/local/bin
         ```
 
-    1. Verify that the plugin is working by running the command:
+    1. Verify that `kn` commands are working properly. For example:
 
         ```bash
         kn version
@@ -61,22 +61,28 @@ The `kn` CLI also simplifies completion of otherwise complex procedures such as 
 
     1. Check out the `kn` client repository:
 
-          ```bash
-          git clone https://github.com/knative/client.git
-          cd client/
-          ```
+        ```bash
+        git clone https://github.com/knative/client.git
+        cd client/
+        ```
 
     1. Build an executable binary:
 
-          ```bash
-          hack/build.sh -f
-          ```
+        ```bash
+        hack/build.sh -f
+        ```
 
-    1. Move `kn` into your system path, and verify that `kn` commands are working properly. For example:
+    1. Move the executable binary file to a directory on your `PATH` by running the command:
 
-          ```bash
-          kn version
-          ```
+        ```bash
+        mv kn /usr/local/bin
+        ```
+
+    1. Verify that `kn` commands are working properly. For example:
+
+        ```bash
+        kn version
+        ```
 
 === "Using a container image"
 

--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -50,13 +50,13 @@ To get started, install the Knative `quickstart` plugin:
           hack/build.sh
           ```
 
-    1. Move the executable binary file to a directory on your `PATH`:
+    1. Move the executable binary file to a directory on your `PATH` by running the command:
 
           ```bash
           mv kn-quickstart /usr/local/bin
           ```
 
-     1. Verify that the plugin is working by running the command:
+    1. Verify that the plugin is working by running the command:
 
           ```bash
           kn quickstart --help


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

This PR is a minor documentation enhancement for the Knative `Install Knative using quickstart` document. It ensures that wording for the installation steps between methods are consistent.

## Proposed Changes <!-- Describe the changes the PR makes. -->

Update the PATH in step three of the `Install the Knative CLI` `Using a binary` section to be `PATH` to match the other `PATH` mentions in the installation steps.
![Screenshot 2023-09-28 at 1 55 55 PM](https://github.com/knative/docs/assets/47163043/c2efcd35-12e7-498e-b439-c673d0494dc5)

Add a step explaining how to move the `kn` binary to your `PATH`. The `Using a binary` method of this installation follows this pattern so I felt like the `Using Go` method should match.
![Screenshot 2023-09-28 at 1 53 23 PM](https://github.com/knative/docs/assets/47163043/3ba89b5a-150d-4235-9ef9-61a2e2443e2b)

Add "by running the command" to the end of step three of the `Install the Knative quickstart plugin` `Using Go` section so that it matched structure of the other executable move instructions in the document.
![Screenshot 2023-09-28 at 2 02 04 PM](https://github.com/knative/docs/assets/47163043/8328e37e-4005-405a-8fba-8eade541160a)
