### PR TITLE
update expected revision name for quickstart service

### DIFF
--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -14,7 +14,7 @@ In this tutorial, you will deploy a "Hello world" Knative Service that accepts t
     ```
     !!! Success "Expected output"
         ```{ .bash .no-copy }
-        Service hello created to latest revision 'hello-world' is available at URL:
+        Service hello created to latest revision 'hello-0001' is available at URL:
         http://hello.default.${LOADBALANCER_IP}.sslip.io
         ```
         The value of `${LOADBALANCER_IP}` above depends on your type of cluster,


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

When going to the Quickstart `Deploying a Knative Service` section I noticed that the revision name in the expected output when deploying a service using the CLI has changed from `hello-world` to `hello-0001`.

## Proposed Changes <!-- Describe the changes the PR makes. -->

Change

```{ .bash .no-copy }
Service hello created to latest revision 'hello-world' is available at URL:
http://hello.default.${LOADBALANCER_IP}.sslip.io
```

To

```{ .bash .no-copy }
Service hello created to latest revision 'hello-0001' is available at URL:
http://hello.default.${LOADBALANCER_IP}.sslip.io
```
