### PR TITLE
Source cloudevents revision

### DIFF
--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -26,9 +26,6 @@ Create the CloudEvents Player Service:
         http://cloudevents-player.default.${LOADBALANCER_IP}.sslip.io
         ```
 
-    ??? question "Why is my Revision named something different!"
-        Because we didn't assign a `revision-name`, Knative Serving automatically created one for us. It's okay if your Revision is named something different.
-
 === "YAML"
     1. Copy the following YAML into a file named `cloudevents-player.yaml`:
         ```bash

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -22,7 +22,7 @@ Create the CloudEvents Player Service:
     ```
     !!! Success "Expected output"
         ```{ .bash .no-copy }
-        Service 'cloudevents-player' created to latest revision 'cloudevents-player-vwybw-1' is available at URL:
+        Service 'cloudevents-player' created to latest revision 'cloudevents-player-00001' is available at URL:
         http://cloudevents-player.default.${LOADBALANCER_IP}.sslip.io
         ```
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

When doing the `Creating your first source` section of the `Using a Knative Service as a source` tutorial I noticed that the service revision created was consistently labeled with `00001` rather than being randomly generated as the doc would imply. 

## Proposed Changes <!-- Describe the changes the PR makes. -->

I updated the expected output to have a revision of `00001` rather than `vwybw-1`. I also removed the `Why is my Revision name something different!` notice since the generated revision is no longer variable.

