### PR TITLE
Fix deprecation warning in Knative Verify

### DIFF
--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -27,8 +27,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.7
+mkdocs-material<10.0
 mkdocs-exclude>=1.0
 mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5


### PR DESCRIPTION
As per title, this patch fixes the deprecation warning.

As following docs mentions, this patch just changes:
* `python/name:materialx.emoji.twemoji` to `material.extensions.emoji.twemoji`.
* `python/name:materialx.emoji.to_svg` to `python/name:material.extensions.emoji.to_svg`.

https://pypi.org/project/mkdocs-material-extensions/
> NOTE: This project is now deprecated as MkDocs for Material now implements this logic directly. Users should migrate to using mkdocs-material's material.extensions.emoji.twemoji and material.extensions.emoji.to_svg in place of the respective materialx.emoji.twemoji and materialx.emoji.to_svg functions provided by this library.