### PR TITLE
Revert "Fix deprecation warning (#5727)"

### DIFF
--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -27,8 +27,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material<10.0
+mkdocs-material==8.2.7
 mkdocs-exclude>=1.0
 mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5


### PR DESCRIPTION
This reverts commit 7aed08da133242c26e036b486afd6fe6497475e4.

https://github.com/knative/docs/pull/5727 fixes the warning but brakes the format.

/cc @pmbanugo