### PR TITLE
Fix deprecation warnings and update CSS

### DIFF
--- a/blog/config/nav.yml
+++ b/blog/config/nav.yml
@@ -9,8 +9,6 @@ nav:
     - Knative CLI: /docs/client/
     - Code samples: /docs/samples/
     - Reference: /docs/reference/security/
-    - Community: /docs/community/
-    - About: /docs/about/testimonials/
   #####################################################
     # Blog
   #####################################################
@@ -96,3 +94,7 @@ nav:
           - events/install-fest-04-2022.md
           - events/knative-at-kubecon-eu-2019.md
           - events/knative-at-kubecon-seattle.md
+    #####################################################          
+    # keep the same order as on the main page
+    - About: /docs/about/testimonials/
+    - Community: /docs/community/

--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -27,8 +27,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences

--- a/config/nav.yml
+++ b/config/nav.yml
@@ -305,10 +305,7 @@ nav:
     - Reference:
       - Security: reference/security/README.md
       - Release notes: reference/relnotes/README.md
-    - Community:
-      - How To Get Involved: community/README.md
-      - Contribute to Knative: community/contributing.md
-      - Community Rules and Practices: community/governance.md
+    - Blog: /blog/
     - About:
       - Testimonials: about/testimonials.md
       - Case studies:
@@ -316,4 +313,7 @@ nav:
         - Outfit7: about/case-studies/outfit7.md
         - Puppet: about/case-studies/puppet.md
         - PNC Bank: about/case-studies/pnc.md
-    - Blog: /blog/
+    - Community:
+      - How To Get Involved: community/README.md
+      - Contribute to Knative: community/contributing.md
+      - Community Rules and Practices: community/governance.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 ---
 template: home.html
 title: Home
+hide:
+  - navigation
+  - toc
 hide_next: true
 ---

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -99,10 +99,13 @@ a.md-header__button.md-logo img {
   font-weight: bold;
 }
 
+.md-tabs__list li:nth-last-child(3) {
+  margin-left: auto;
+}
+
 .md-tabs__list li:nth-last-child(1),
 .md-tabs__list li:nth-last-child(2),
 .md-tabs__list li:nth-last-child(3) {
-  float: right;
   background-color: #024c93;
   color: white;
   padding: 0 2em;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,8 @@ markdown_extensions:
   # - mdx_include:
   #     base_path: docs
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - meta
   - pymdownx.superfences

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.7
+mkdocs-material<10.0
 mkdocs-exclude>=1.0
 mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5


### PR DESCRIPTION
# Changes
- As per title, this patch fixes the deprecation warning (including https://github.com/knative/docs/pull/5727)
- Re-order nav-items on the right, as this is now a `flexbox` instead of `display: block`
- Updates CSS and markdown settings to fix wrongly displayed home page, see https://github.com/knative/docs/pull/5727#issuecomment-1774835540

Fixes #5723
