### PR TITLE
fix links to files on installation files page (#4998)

### DIFF
--- a/docs/install/yaml-install/eventing/eventing-installation-files.md
+++ b/docs/install/yaml-install/eventing/eventing-installation-files.md
@@ -12,10 +12,10 @@ The following table describes the installation files included in Knative Eventin
 
 | File name | Description | Dependencies|
 | --- | --- | --- |
-| eventing-core.yaml | Required: Knative Eventing core components. |  eventing-crds.yaml |
-| eventing-crds.yaml | Required: Knative Eventing core CRDs. |  none |
-| eventing-post-install.yaml | Jobs required for upgrading to a new minor version. | eventing-core.yaml, eventing-crds.yaml |
-| eventing-sugar-controller.yaml | Reconciler that watches for labels and annotations on certain resources to inject eventing components. | eventing-core.yaml |
-| eventing.yaml | Combines `eventing-core.yaml`, `mt-channel-broker.yaml`, and `in-memory-channel.yaml`. | none |
-| in-memory-channel.yaml | Components to configure In-Memory Channels. | eventing-core.yaml |
-| mt-channel-broker.yaml | Components to configure Multi-Tenant (MT) Channel Broker. | eventing-core.yaml |
+| [eventing-core.yaml]({{ artifact(repo="eventing",file="eventing-core.yaml")}}) | Required: Knative Eventing core components. |  [eventing-crds.yaml]({{ artifact(repo="eventing",file="eventing-crds.yaml")}}) |
+| [eventing-crds.yaml]({{ artifact(repo="eventing",file="eventing-crds.yaml")}}) | Required: Knative Eventing core CRDs. |  none |
+| [eventing-post-install.yaml]({{ artifact(repo="eventing",file="eventing-post-install.yaml")}}) | Jobs required for upgrading to a new minor version. | [eventing-core.yaml]({{ artifact(repo="eventing",file="eventing-core.yaml")}}), [eventing-crds.yaml]({{ artifact(repo="eventing",file="eventing-crds.yaml")}}) |
+| [eventing-sugar-controller.yaml]({{ artifact(repo="eventing",file="eventing-sugar-controller.yaml")}}) | Reconciler that watches for labels and annotations on certain resources to inject eventing components. | [eventing-core.yaml]({{ artifact(repo="eventing",file="eventing-core.yaml")}}) |
+| [eventing.yaml]({{ artifact(repo="eventing",file="eventing.yaml")}}) | Combines `eventing-core.yaml`, `mt-channel-broker.yaml`, and `in-memory-channel.yaml`. | none |
+| [in-memory-channel.yaml]({{ artifact(repo="eventing",file="in-memory-channel.yaml")}}) | Components to configure In-Memory Channels. | [eventing-core.yaml]({{ artifact(repo="eventing",file="eventing-core.yaml")}}) |
+| [mt-channel-broker.yaml]({{ artifact(repo="eventing",file="mt-channel-broker.yaml")}}) | Components to configure Multi-Tenant (MT) Channel Broker. | [eventing-core.yaml]({{ artifact(repo="eventing",file="eventing-core.yaml")}}) |

--- a/docs/install/yaml-install/serving/serving-installation-files.md
+++ b/docs/install/yaml-install/serving/serving-installation-files.md
@@ -11,9 +11,9 @@ The following table describes the installation files included in Knative Serving
 
 | File name | Description | Dependencies|
 | --- | --- | --- |
-| serving-core.yaml | Required: Knative Serving core components. | serving-crds.yaml |
-| serving-crds.yaml | Required: Knative Serving core CRDs. | none |
-| serving-default-domain.yaml | Configures Knative Serving to use [http://sslip.io](http://sslip.io) as the default DNS suffix. | serving-core.yaml |
-| serving-hpa.yaml | Components to autoscale Knative revisions through the Kubernetes Horizontal Pod Autoscaler. | serving-core.yaml |
-| serving-post-install-jobs.yaml | Additional jobs after installing `serving-core.yaml`. Currently it is the same as `serving-storage-version-migration.yaml`. | serving-core.yaml |
-| serving-storage-version-migration.yaml | Migrates the storage version of Knative resources, including Service, Route, Revision, and Configuration, from `v1alpha1` and `v1beta1` to `v1`. Required by upgrade from version 0.18 to 0.19. | serving-core.yaml |
+| [serving-core.yaml]({{ artifact(repo="serving",file="serving-core.yaml")}}) | Required: Knative Serving core components. | [serving-crds.yaml]({{ artifact(repo="serving",file="serving-crds.yaml")}}) |
+| [serving-crds.yaml]({{ artifact(repo="serving",file="serving-crds.yaml")}}) | Required: Knative Serving core CRDs. | none |
+| [serving-default-domain.yaml]({{ artifact(repo="serving",file="serving-default-domain.yaml")}}) | Configures Knative Serving to use [http://sslip.io](http://sslip.io) as the default DNS suffix. | [serving-core.yaml]({{ artifact(repo="serving",file="serving-core.yaml")}}) |
+| [serving-hpa.yaml]({{ artifact(repo="serving",file="serving-hpa.yaml")}}) | Components to autoscale Knative revisions through the Kubernetes Horizontal Pod Autoscaler. | [serving-core.yaml]({{ artifact(repo="serving",file="serving-core.yaml")}}) |
+| [serving-post-install-jobs.yaml]({{ artifact(repo="serving",file="serving-post-install-jobs.yaml")}}) | Additional jobs after installing `serving-core.yaml`. Currently it is the same as `serving-storage-version-migration.yaml`. | [serving-core.yaml]({{ artifact(repo="serving",file="serving-core.yaml")}}) |
+| [serving-storage-version-migration.yaml]({{ artifact(repo="serving",file="serving-storage-version-migration.yaml")}}) | Migrates the storage version of Knative resources, including Service, Route, Revision, and Configuration, from `v1alpha1` and `v1beta1` to `v1`. Required by upgrade from version 0.18 to 0.19. | [serving-core.yaml]({{ artifact(repo="serving",file="serving-core.yaml")}}) |


### PR DESCRIPTION
Use [artifact](https://github.com/knative/docs/blob/b7eadf9c492ee323505b714c54116e8c1e32c096/hack/macros.py#L104) macro to generate the link to the appropriate yaml files for the serving and eventing installation pages.

Fixes #4998