### PR TITLE
Update Rust example to 2021

### DIFF
--- a/community/samples/serving/helloworld-rust/Cargo.toml
+++ b/community/samples/serving/helloworld-rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hellorust"
 version = "0.0.0"
 publish = false
+edition = "2021"
 
 [dependencies]
 hyper = "0.12.3"

--- a/community/samples/serving/helloworld-rust/Dockerfile
+++ b/community/samples/serving/helloworld-rust/Dockerfile
@@ -1,13 +1,13 @@
 # Use the official Rust image.
 # https://hub.docker.com/_/rust
-FROM rust:1.27.0
+FROM rust:1.73.0
 
 # Copy local code to the container image.
 WORKDIR /usr/src/app
 COPY . .
 
 # Install production dependencies and build a release artifact.
-RUN cargo install
+RUN cargo install --path .
 
 # Service must listen to $PORT environment variable.
 # This default value facilitates local development.

--- a/community/samples/serving/helloworld-rust/README.md
+++ b/community/samples/serving/helloworld-rust/README.md
@@ -26,6 +26,7 @@ recreate the source files from this folder.
    name = "hellorust"
    version = "0.0.0"
    publish = false
+   edition = "2021"
 
    [dependencies]
    hyper = "0.12.3"
@@ -90,14 +91,14 @@ recreate the source files from this folder.
     ```docker
     # Use the official Rust image.
     # https://hub.docker.com/_/rust
-    FROM rust:1.27.0
+    FROM rust:1.73.0
 
     # Copy local code to the container image.
     WORKDIR /usr/src/app
     COPY . .
 
     # Install production dependencies and build a release artifact.
-    RUN cargo install
+    RUN cargo install --path .
 
     # Service must listen to $PORT environment variable.
     # This default value facilitates local development.

--- a/eventing/samples/writing-a-source/README.md
+++ b/eventing/samples/writing-a-source/README.md
@@ -47,7 +47,5 @@ Kubebuilder not your thing? Prefer the easy way? Check out these alternatives.
     without writing any controller code. It requires Metacontroller.
 *   [Metacontroller](https://metacontroller.app) can be used to write
     controllers as webhooks in any language.
-*   The [GitLab source](https://gitlab.com/triggermesh/gitlabsource) uses the
-    Python Kubernetes client library.
 *   The [Cloud Scheduler source](https://github.com/vaikas-google/csr) uses the
     standard Kubernetes Golang client library instead of Kubebuilder.


### PR DESCRIPTION
For context, I was following https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-service-other-languages and ran into a few issues when using Rust 2021, which was the default in CLion.

The 1.23.0 Rust Docker image does not support Rust 2021. After updating it to 1.73.0, `cargo install` had to be changed to `cargo install --path .`. This PR represents these changes.