### PR TITLE
Use create instead of apply

### DIFF
--- a/docs/install/upgrade/upgrade-installation.md
+++ b/docs/install/upgrade/upgrade-installation.md
@@ -79,10 +79,10 @@ you need to run post-install jobs (see [here for details](#upgrade-existing-reso
 
 ```bash
 # Serving
-kubectl apply -f {{ artifact(repo="serving",file="serving-post-install-jobs.yaml")}}
+kubectl create -f {{ artifact(repo="serving",file="serving-post-install-jobs.yaml")}}
 
 # Eventing
-kubectl apply -f {{ artifact(repo="eventing",file="eventing-post-install.yaml")}}
+kubectl create -f {{ artifact(repo="eventing",file="eventing-post-install.yaml")}}
 ```
 
 Make sure that the jobs complete successfully before continuing:


### PR DESCRIPTION
- Use `kubectl create` instead of `kubectl apply` because of https://github.com/kubernetes/kubernetes/issues/44501
- Follow-up for https://github.com/knative/docs/issues/5759#issuecomment-1838550871

/assign @skonto 

/cherry-pick release-1.12