### PR TITLE
kn quickstart kind : A local registry is no longer created by default.

### DIFF
--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -79,7 +79,7 @@ To get a local deployment of Knative, run the `quickstart` plugin:
 
     1. Install Knative and Kubernetes using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) by running:
         ```bash
-        kn quickstart kind
+        kn quickstart kind --registry
         ```
 
         !!! note


### PR DESCRIPTION
Fixes [https://github.com/knative/docs/issues/5778](https://github.com/knative/docs/issues/5778).

<img width="946" alt="image" src="https://github.com/knative/docs/assets/12080746/852cd9bb-481c-45d5-984e-2834ba7ba701">

The latest code shows that 
```
A local registry is no longer created by default.
To create a local registry, use the --registry flag.
```