### PR TITLE
Fix command kn quickstart to be kn-quickstart in install docs

### DIFF
--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -33,7 +33,7 @@ To get started, install the Knative `quickstart` plugin:
     1. Verify that the plugin is working by running the command:
 
         ```bash
-        kn quickstart --help
+        kn-quickstart --help
         ```
 
 === "Using Go"
@@ -59,7 +59,7 @@ To get started, install the Knative `quickstart` plugin:
     1. Verify that the plugin is working by running the command:
 
           ```bash
-          kn quickstart --help
+          kn-quickstart --help
           ```
 
 ## Run the Knative quickstart plugin
@@ -79,7 +79,7 @@ To get a local deployment of Knative, run the `quickstart` plugin:
 
     1. Install Knative and Kubernetes using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) by running:
         ```bash
-        kn quickstart kind
+        kn-quickstart kind
         ```
 
         !!! note
@@ -104,7 +104,7 @@ To get a local deployment of Knative, run the `quickstart` plugin:
             different value not lower than 3&nbsp;GB by setting a memory config in minikube.
             For example,  `minikube config set memory 4096` will use 4&nbsp;GB of RAM.
         ```bash
-        kn quickstart minikube
+        kn-quickstart minikube
         ```
 
     1. The output of the previous command asked you to run minikube tunnel.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

The command `kn quickstart` cannot be found as the binary is named `kn-quickstart`.
This PR renames the command to match the binary name.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Rename the command `kn quickstart` to `kn-quickstart`