### PR TITLE
Add dynamic date on blog pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,12 @@ hack/__pycache__
 /temp/
 /temp-blog/
 /blog/site/
-/blog/overrides/
+!/blog/overrides/
+/blog/overrides/*
+!/blog/overrides/partials/
+/blog/overrides/partials/*
+!/blog/overrides/partials/source-file.html
+!/blog/overrides/partials/content.html
 /blog/docs/stylesheets/
 /node_modules/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ hack/__pycache__
 /blog/site/
 !/blog/overrides/
 /blog/overrides/*
+!/blog/overrides/assets/
+/blog/overrides/assets/*
+!/blog/overrides/assets/stylesheets
+/blog/overrides/assets/stylesheets/*
+!/blog/overrides/assets/stylesheets/content.css
 !/blog/overrides/partials/
 /blog/overrides/partials/*
 !/blog/overrides/partials/source-file.html

--- a/blog/docs/articles/build-deploy-manage-modern-serverless-workloads-using-knative-on-kubernetes.md
+++ b/blog/docs/articles/build-deploy-manage-modern-serverless-workloads-using-knative-on-kubernetes.md
@@ -2,8 +2,6 @@
 
 **Author: [Mark Chmarny](https://twitter.com/mchmarny), TL for Cloud OSS @Google**
 
-**Date: 2018-11-14**
-
   <article class="h-entry">
     <section data-field="description" class="p-summary">
       By now, Kubernetes should be the default target for your deployments. Yes, there are still use-cases where Kubernetes is not the optimal…

--- a/blog/docs/articles/distributed-tracing.md
+++ b/blog/docs/articles/distributed-tracing.md
@@ -2,8 +2,6 @@
 
 **Author: [Ben Moss](https://twitter.com/mossity), Software Engineer @ [VMware](http://vmware.com)**
 
-**Date: 2021-08-20**
-
 When trying to understand and diagnose our systems, one of the most basic tools
 we learn to lean on is the stack trace. Stack traces give us a structured view
 of the flow of logic that our program is executing in order to help us wrap our

--- a/blog/docs/articles/event-drive-app-knative-eventing-kogito.md
+++ b/blog/docs/articles/event-drive-app-knative-eventing-kogito.md
@@ -2,8 +2,6 @@
 
 **Authors: [Ricardo Zanini](https://twitter.com/zaninirica), Principal Software Engineer @ RedHat, and [Tihomir Surdilovic](https://twitter.com/tsurdilo), Software Developer @ Red Hat**
 
-**Date: 2020-12-17**
-
 [Kogito](https://kogito.kie.org/) is a platform for the development of cloud-native business automation applications. It is designed targeting cloud-native architectures, and it comes with a series of features to make it easy for architects and developers to create business applications.
 
 Kogito implements the [CNCF Serverless Workflow Project](https://github.com/serverlessworkflow/specification), which is a specification for defining workflow models that orchestrate event-driven, serverless applications. It focuses on defining a vendor-neutral, platform-independent, and declarative workflow model for orchestrating services that can be used across multiple cloud and container platforms. To date, the Serverless Workflow specification is a CNCF sandbox project.

--- a/blog/docs/articles/event-driven-image-bigquery-processing-pipelines.md
+++ b/blog/docs/articles/event-driven-image-bigquery-processing-pipelines.md
@@ -2,8 +2,6 @@
 
 **Author: [Mete Atamel](https://twitter.com/meteatamel), Software Engineer & Developer Advocate @ Google**
 
-**Date: 2020-06-19**
-
 In this blog post, I will outline two event-driven processing pipelines that I
 recently built with Knative Eventing. Along the way, I will explain event sources,
 custom events and other components provided by Knative, that greatly simplify the

--- a/blog/docs/articles/eventing-rabbitmq-announcement.md
+++ b/blog/docs/articles/eventing-rabbitmq-announcement.md
@@ -2,12 +2,10 @@
 
 **Author: Gab Satchi, Senior Software Engineer @ VMware**
 
-**Date: 2022-07-26**
-
 We’re excited to announce that [Eventing RabbitMQ](https://github.com/knative-extensions/eventing-rabbitmq) is now Generally Available (GA). With this milestone, the APIs provided will remain stable in future iterations.
 A quick start can be found [here](https://knative.dev/docs/eventing/broker/rabbitmq-broker/).
 
-# Key Features
+## Key Features
 
 ### Use any RabbitMQ instance
 

--- a/blog/docs/articles/from-cloudevent-to-apach-kafka-records-part-one.md
+++ b/blog/docs/articles/from-cloudevent-to-apach-kafka-records-part-one.md
@@ -2,8 +2,6 @@
 
 **Authors: Daniele Zonca, Senior Principal Software Engineer @ Red Hat, Matthias Weßendorf, Principal Software Engineer @ Red Hat**
 
-**Date: 2023-03-08**
-
 _In this blog post you will learn how to easily store incoming CloudEvents to an Apache Kafka Topic using the KafkaSink component._
 
 

--- a/blog/docs/articles/from-cloudevent-to-apache-kafka-records-part-two.md
+++ b/blog/docs/articles/from-cloudevent-to-apache-kafka-records-part-two.md
@@ -2,8 +2,6 @@
 
 **Authors: Daniele Zonca, Senior Principal Software Engineer @ Red Hat, Matthias Weßendorf, Senior Principal Software Engineer @ Red Hat**
 
-**Date: 2023-04-03**
-
 _In this blog post you will learn how to easily store incoming CloudEvents to an Apache Kafka Topic and using Knative Broker and Trigger APIs for content-based event routing._
 
 

--- a/blog/docs/articles/get-started-knative-eventing.md
+++ b/blog/docs/articles/get-started-knative-eventing.md
@@ -2,8 +2,6 @@
 
 **Author: [Johana Saladas](https://twitter.com/developing4data), software engineer at IBM**
 
-**Date: 2020-05-01**
-
 I’ve been exploring [Knative Eventing](https://knative.dev/docs/eventing/), a system that enables a cloud native eventing ecosystem to be easily deployed through the use of **event producers** and **event consumers.** Most of the work on this demo has been done in version 0.11, and I have also run it in version 0.13, and now it also works on version 0.15.
 
 This demo was presented at the first Knative Community Meetup, so you can also watch the video version here:

--- a/blog/docs/articles/getting-started-blog-p0.md
+++ b/blog/docs/articles/getting-started-blog-p0.md
@@ -2,8 +2,6 @@
 
 **Authors: [Calum Murray](https://www.linkedin.com/in/calum-ra-murray/) Software Engineering Intern @ [Red Hat](https://www.redhat.com/en), and [Leo Li](https://www.linkedin.com/in/haocheng-leo/) Software Engineering Intern @ [Red Hat](https://www.redhat.com/en)**
 
-**Date: 2023-07-11**
-
 ![](/blog/images/getting-started-blog-series/post0/person-chasing-logo.png)
 
 ## What is this blog series?

--- a/blog/docs/articles/getting-started-blog-p1.md
+++ b/blog/docs/articles/getting-started-blog-p1.md
@@ -2,8 +2,6 @@
 
 **Authors: [Calum Murray](https://www.linkedin.com/in/calum-ra-murray/) Software Engineering Intern @ [Red Hat](https://www.redhat.com/en), and [Leo Li](https://www.linkedin.com/in/haocheng-leo/) Software Engineering Intern @ [Red Hat](https://www.redhat.com/en)**
 
-**Date: 2023-07-11**
-
 Welcome back to this introductory blog series! In this article we are going to be providing an introduction to open source: what it is, why you should care, and how you can participate.
 
 ![](/blog/images/getting-started-blog-series/post1/hello-open-source.png)

--- a/blog/docs/articles/getting-started-blog-p2.md
+++ b/blog/docs/articles/getting-started-blog-p2.md
@@ -2,8 +2,6 @@
 
 **Authors: [Calum Murray](https://www.linkedin.com/in/calum-ra-murray/) Software Engineering Intern @ [Red Hat](https://www.redhat.com/en), and [Leo Li](https://www.linkedin.com/in/haocheng-leo/) Software Engineering Intern @ [Red Hat](https://www.redhat.com/en)**
 
-**Date: 2023-08-14**
-
 Hi, and welcome back to this introductory blog series! If you want an overview of the full blog series, please check out the [first article](/blog/articles/getting-started-blog-p0){:target="_blank"}.
 In this article we will be discussing __how to set up your development environment__ for Knative.
 A development environment is a place where you can modify and examine code without affecting the currently released code. For setting up your Knative development

--- a/blog/docs/articles/highlighting-value-knative-c-suite.md
+++ b/blog/docs/articles/highlighting-value-knative-c-suite.md
@@ -2,8 +2,6 @@
 
 **Authors: [Carlos Santana](https://twitter.com/csantanapr) (IBM) and [Omer Bensaadon](https://twitter.com/omer_bensaadon) (VMware)**
 
-**Date: 2021-11-04**
-
 <table style="border: 0;">
 <tr style="background-color: var(--md-default-bg-color);">
 <td style="border: 0;" width="33%">

--- a/blog/docs/articles/improved-ha-configuration.md
+++ b/blog/docs/articles/improved-ha-configuration.md
@@ -2,8 +2,6 @@
 
 **Author: Matthias Weßendorf, Senior Principal Software Engineer @ Red Hat**
 
-**Date: 2023-06-13**
-
 _In this blog post you will learn how to use the Knative Operator to maintain a fine-grain configuration for high availablitly of Knative workloads._
 
 The [Knative Operator](https://knative.dev/docs/install/operator/knative-with-operators/) gives you a declarative API to describe your Knative Serving and Eventing installation. The `spec` field has several properties to define the desired behavior.

--- a/blog/docs/articles/kafka-broker-with-isolated-data-plane.md
+++ b/blog/docs/articles/kafka-broker-with-isolated-data-plane.md
@@ -2,8 +2,6 @@
 
 **Author: Ali Ok, Principal Software Engineer @ Red Hat**
 
-**Date: 2023-02-03**
-
 _In this blog post, you will learn how to configure Knative's Apache Kafka Broker in isolated data plane mode._
 
 The [Knative Broker implementation for Apache Kafka](https://knative.dev/docs/eventing/brokers/broker-types/kafka-broker/) is a Kafka-native implementation of the [Knative Broker APIs](https://knative.dev/docs/eventing/brokers/), offering improvements over the usage of the Channel-based Knative Broker implementation, such as reduced network hops, support of any Kafka version and a better integration with Apache Kafka for the Broker and Trigger model.

--- a/blog/docs/articles/knative-eventing-vision.md
+++ b/blog/docs/articles/knative-eventing-vision.md
@@ -3,8 +3,6 @@
 **Authors: Pierangelo Di Pilato, Senior Software Engineer @ Red Hat, Matthias Weßendorf, Senior
 Principal Software Engineer @ Red Hat**
 
-**Date: 2023-08-07**
-
 ## What is next in Knative Eventing?
 
 Knative Eventing has made significant strides and solidified its position as the platform on

--- a/blog/docs/articles/knative-serving-in-k0s.md
+++ b/blog/docs/articles/knative-serving-in-k0s.md
@@ -2,8 +2,6 @@
 
 **Author: [Naveenraj Muthuraj](https://twitter.com/naveenraj_m), Graduate Student @ University of Alberta**
 
-**Date: 2023-27-03**
-
 _This work is an attempt to deploy **knative serving** in k0s with minimum resources. Let's try 1 CPU and 1 GB RAM._
 
 This document has three sections. In first section we capture the resource required by knative serving and k0s. In second section we monitor the actual resource used by Knative and k0s, to determine the size of our k0s (edge) node. Finally, we install knative serving with reduced resource request/limit to k0s node with 1 CPU and 1.5 GB RAM (Why 1.5 GB ? , see  [Knative + k0s resource usage](#knative-k0s-resource-usage) )

--- a/blog/docs/articles/knative-v0-3-autoscaling-a-love-story.md
+++ b/blog/docs/articles/knative-v0-3-autoscaling-a-love-story.md
@@ -2,8 +2,6 @@
 
 **Author: [Joseph Burnett](https://github.com/josephburnett), Software Engineer @ Google**
 
-**Date: 2019-03-27**
-
 <article class="h-entry">
 
 <section data-field="subtitle" class="p-summary">

--- a/blog/docs/articles/ko-fast-kubernetes-microservice-development-in-go.md
+++ b/blog/docs/articles/ko-fast-kubernetes-microservice-development-in-go.md
@@ -2,8 +2,6 @@
 
 **Author: [Matt Moore](https://twitter.com/mattomata), Founder/CTO @ Chainguard**
 
-**Date: 2018-12-18**
-
   <article class="h-entry">
     <section data-field="body" class="e-content">
       <section name="f298" class="section section--body section--first section--last">

--- a/blog/docs/articles/new_event_discovery_features.md
+++ b/blog/docs/articles/new_event_discovery_features.md
@@ -2,8 +2,6 @@
 
 **Authors: David Simansky, Senior Software Engineer @ Red Hat, Matthias Weßendorf, Senior Principal Software Engineer @ Red Hat**
 
-**Date: 2023-07-26**
-
 _In this blog post you will learn about the new enhancements in Knative Eventing around event discovery._
 
 Event discovery is an important part of event-driven applications, since it allows developers to better understand system dynamics and what events to consume. It does enable a more efficient and robust application design.

--- a/blog/docs/articles/orchestrating-cloud-events-with.md
+++ b/blog/docs/articles/orchestrating-cloud-events-with.md
@@ -2,8 +2,6 @@
 
 **Author: [Mauricio Salatino (Salaboy)](https://twitter.com/salaboy), Principal Software Engineer @ [Camunda](http://camunda.com) and [LearnK8s](http://learnk8s.io) Instructor**
 
-**Date: 2020-10-10**
-
 A couple of weeks ago, I presented at the **Knative Meetup** ([Video](https://www.youtube.com/watch?v=msDDdqmyEFA&list=PLQjzPfIiEQLIEpoCPxBYAVrjqy6LxLtQ8), [Slides](https://www.slideshare.net/salaboy/orchestrating-cloud-events-knative-meetup-2020)) about how you can leverage the Cloud Native workflow engine [Zeebe](http://zeebe.io) to understand, enhance and orchestrate your applications that are already using [CloudEvents](https://cloudevents.io).
 
 I wanted to expand a bit on how these tools can help you gain a deeper understanding of how your distributed applications are working.

--- a/blog/docs/articles/performance-test-with-slos.md
+++ b/blog/docs/articles/performance-test-with-slos.md
@@ -2,9 +2,6 @@
 
 **Author: [Srinivasan Parthasarathy](https://researcher.watson.ibm.com/researcher/view.php?person=us-spartha), Senior Research Scientist and Manager, DevSecOps @ [IBM Research](https://research.ibm.com)**
 
-**Date: 2022-07-18**
-
-
 Performance testing is a core building block in the robust delivery of HTTP and gRPC services. One way to accomplish this is by sending a stream of requests to the target service, and evaluating the responses for error and latency-related violations. From a developer’s perspective, this approach has three main considerations, namely, i) the load-related characteristics of the request stream, such as the request rate; ii) the shape of the requests, in particular, whether the service requires any payload/data to be sent as part of the requests; and iii) the service-level objectives (SLOs) used to validate the quality of the target service.
 
 You can use [Iter8](https://iter8.tools), the open source Kubernetes release optimizer, to flexibly launch performance tests for Knative services **in seconds**, with precise control over all of the above. This article introduces these capabilities.

--- a/blog/docs/articles/quickstart-with-knative.md
+++ b/blog/docs/articles/quickstart-with-knative.md
@@ -2,8 +2,6 @@
 
 **Author: Paul Schweigert, Senior Software Engineer @ IBM**
 
-**Date: 2021-09-17**
-
 We're pleased to announce that the [`quickstart` plugin](https://github.com/knative-extensions/kn-plugin-quickstart) for the Knative client is now available. The plugin allows users to very easily set up a local Knative environment with just a single command using a local [KinD](https://kind.sigs.k8s.io/) or [minikube](https://minikube.sigs.k8s.io/) cluster.
 
 ```

--- a/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
+++ b/blog/docs/articles/set-up-a-local-knative-environment-with-kind.md
@@ -2,8 +2,6 @@
 
 **Author: [Leon Stigter](https://twitter.com/retgits), Product @ AWS Cloud**
 
-**Date: 2020-06-03**
-
 !!! warning
 
     The [quickstart plugin](https://knative.dev/docs/getting-started/quickstart-install/) is now the recommended way to set up a local Knative environment for development purposes.

--- a/blog/docs/articles/single-node-kafka-development.md
+++ b/blog/docs/articles/single-node-kafka-development.md
@@ -2,8 +2,6 @@
 
 **Author: Matthias Weßendorf, Principal Software Engineer @ Red Hat**
 
-**Date: 2023-01-12**
-
 _In this blog post you will learn how to use a production-like environment for your local development with Knative Broker and Apache Kafka._
 
 The [Knative Broker implementation for Apache Kafka](https://knative.dev/docs/eventing/brokers/broker-types/kafka-broker/) is a Kafka-native implementation of the [Knative Broker APIs](https://knative.dev/docs/eventing/brokers/), offering improvements over the usage of the Channel-based Knative Broker implementation, such as reduced network hops, support of any Kafka version and a better integration with Apache Kafka for the Broker and Trigger model.

--- a/blog/docs/articles/workflow-as-function-flow.md
+++ b/blog/docs/articles/workflow-as-function-flow.md
@@ -2,8 +2,6 @@
 
 **Author: [Maciej Swiderski](https://twitter.com/SwiderskiMaciek), Software Engineer @ OpenEnterprise**
 
-**Date: 2021-08-20**
-
 Various organisations started to look into serverless as a way of building business logic that can take advantage of the cloud. As it might look at first, it's not an easy task to rely strictly on functions that represent independent logic pieces. There is a risk of losing the big picture and by that not having full control over day-to-day operations.
 
 Knative provides a great foundation to build upon when thinking about serverless, functions

--- a/blog/docs/events/fuzzing-audit-2023.md
+++ b/blog/docs/events/fuzzing-audit-2023.md
@@ -2,8 +2,6 @@
 
 **Author: [Adam Korczynski](https://twitter.com/AdamKorcz4), Security Engineer @ [Ada Logics](https://adalogics.com/)**
 
-**Date: 2023-07-13**
-
 Knative is happy to announce the completion of its fuzzing security audit. The audit was carried out by Ada Logics and is part of an initiative by the CNCF to [bring fuzzing to the CNCF landscape](https://www.cncf.io/blog/2022/06/28/improving-security-by-fuzzing-the-cncf-landscape). The audit spanned several months in late 2022 and early 2023 and resulted in 29 fuzzers written for 3 Knative sub-projects. The fuzzers found a single issue in a 3rd-party dependency that has been fixed.
 
 Read the full report for the audit here: [Knative Fuzzing Report](https://github.com/knative/docs/tree/main/reports/ADA-knative-fuzzing-audit-22-23.pdf).

--- a/blog/docs/events/google-summer-of-code-2022.md
+++ b/blog/docs/events/google-summer-of-code-2022.md
@@ -2,8 +2,6 @@
 
 **Author: [Ali OK](https://twitter.com/aliok_tr), Principal Software Engineer @ Red Hat**
 
-**Date: 2022-03-31**
-
 Knative community is participating in [Google Summer of Code](https://summerofcode.withgoogle.com/) (GSOC) program, part of the Cloud Native Computing Foundation (CNCF).
 
 [Google Summer of Code](https://summerofcode.withgoogle.com/) (GSoC for short) is a program that brings more contributors into open

--- a/blog/docs/events/google-summer-of-code-2023.md
+++ b/blog/docs/events/google-summer-of-code-2023.md
@@ -2,8 +2,6 @@
 
 **Author: [Ali OK](https://twitter.com/aliok_tr), Principal Software Engineer @ Red Hat**
 
-**Date: 2023-01-26**
-
 Knative community is participating in [Google Summer of Code](https://summerofcode.withgoogle.com/) (GSOC) program, part of the Cloud Native Computing Foundation (CNCF).
 
 [Google Summer of Code](https://summerofcode.withgoogle.com/) (GSoC for short) is a program that brings more contributors into open

--- a/blog/docs/events/knative-at-kubecon-na-2022.md
+++ b/blog/docs/events/knative-at-kubecon-na-2022.md
@@ -1,7 +1,5 @@
 # Knative at KubeCon ’22 North America
 
-**Date: 2022-10-20**
-
 There's less than a week until
 [KubeCon + KnativeCon North America 2022](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/)
 kicks off in Detroit, MI.

--- a/blog/docs/events/knative-at-kubecon-na-2023.md
+++ b/blog/docs/events/knative-at-kubecon-na-2023.md
@@ -1,5 +1,4 @@
 # How to catch news about Knative project during KubeCon + CloudNativeCon NA 2023
-Date: 2023-10-24
 
 ![image](images/kubecon.jpg)
 

--- a/blog/docs/events/knative-projectmeeting-kubecon-eu-2023.md
+++ b/blog/docs/events/knative-projectmeeting-kubecon-eu-2023.md
@@ -1,5 +1,4 @@
 # Announcing Knative Project meeting and Knative Kiosk in the expo area at KubeCon + CloudNativeCon Europe 2023
-Date: 2023-03-13
 
 ![image](images/kubecon.jpg)
 

--- a/blog/docs/events/security-audit-2023.md
+++ b/blog/docs/events/security-audit-2023.md
@@ -2,8 +2,6 @@
 
 **Author: [Adam Korczynski](https://twitter.com/AdamKorcz4), Security Engineer @ [Ada Logics](https://adalogics.com/)**
 
-**Date: 2023-11-27**
-
 Knative is happy to announce the completion of its third-party security audit conducted by [Ada Logics](https://adalogics.com/) and facilitated by the [Open Source Technology Improvement Fund](https://ostif.org/). This is Knative’s second third-party security audit in just a few months. In July this year, Knative completed a fuzzing security audit also conducted by Ada Logics. While the fuzzing security audit focused on improving the state of fuzzing Knative in an automated manner, today Knative completed an audit that focused on threat modelling, manual code auditing and a supply-chain risk assessment. 
 
 During the audit, Ada Logics was in close communication with the Knative team and shared findings ad hoc as the audit progressed. The Knative team and Ada Logics collaborated on mitigation and fixes of the issues found. 

--- a/blog/docs/events/virtual-office-hour-12-2022.md
+++ b/blog/docs/events/virtual-office-hour-12-2022.md
@@ -1,7 +1,5 @@
 # First 🌱 Knative Virtual Office Hour
 
-**Date: 2022-12-01**
-
 **Authors: [Alek Slominski](https://aslom.net/), [Evan Anderson](https://off-by-one.dev/), [Lance Ball](https://twitter.com/lanceball), and Paul Schweigert**
 
 ![Knative Booth](images/virtual-office-hour-12-2022-with-text.jpg)

--- a/blog/docs/releases/announcing-knative-1.0.md
+++ b/blog/docs/releases/announcing-knative-1.0.md
@@ -1,7 +1,5 @@
 # Announcing: Knative 1.0
 
-**Date: 2021-10-14**
-
 After more than 3 years of active development, with many [commercial adopters](https://github.com/knative/community/blob/main/ADOPTERS.MD), **we are pleased to announce the release of Knative 1.0 on Nov. 2, 2021.** Thanks to the over 600 contributors to Knative for helping us reach this milestone!
 
 During the last several years, Knative has overcome many initial limitations to become the most [widely-installed serverless layer on Kubernetes](https://www.cncf.io/wp-content/uploads/2020/11/CNCF_Survey_Report_2020.pdf). There were some challenges in figuring out what the bar for “1.0” was, as many components have been production-ready and battle-tested for quite some time now.

--- a/blog/docs/releases/knative-1.0.md
+++ b/blog/docs/releases/knative-1.0.md
@@ -4,8 +4,6 @@
 
 **Authors: [Carlos Santana](https://twitter.com/csantanapr) (IBM), [Omer Bensaadon](https://twitter.com/omer_bensaadon) (VMware), [Maria Cruz](https://twitter.com/marianarra_) (Google)**
 
-**Date: 2021-11-02**
-
 Today we release Knative 1.0, reaching an important milestone made possible thanks to the contributions and collaboration of over 600 developers. The Knative project was released by Google in July 2018, and it was developed in close partnership with VMWare, IBM, Red Hat, and SAP. Over the last 3 years, Knative has become [the most widely-installed serverless layer on Kubernetes.](https://www.cncf.io/wp-content/uploads/2020/11/CNCF_Survey_Report_2020.pdf)
 
 

--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -71,6 +71,9 @@ plugins:
       as_creation: "date"
       as_update: false
       datetime_format: "%Y-%m-%d"
+  git-revision-date-localized:
+      type: iso_date
+      enable_creation_date: true
 
 copyright: "Copyright © 2022 The Knative Authors"
 

--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -74,6 +74,8 @@ plugins:
   git-revision-date-localized:
       type: iso_date
       enable_creation_date: true
+      exclude:
+        - index.md
 
 copyright: "Copyright © 2022 The Knative Authors"
 

--- a/blog/overrides/assets/stylesheets/content.css
+++ b/blog/overrides/assets/stylesheets/content.css
@@ -1,0 +1,5 @@
+/* hack to hide blog posts title */
+.md-typeset h1:nth-of-type(2),
+.md-content__button:nth-of-type(2) {
+    display: none;
+}

--- a/blog/overrides/partials/content.html
+++ b/blog/overrides/partials/content.html
@@ -1,0 +1,20 @@
+<!-- based on https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/content.html   -->
+
+<style>
+    .md-typeset h1:nth-of-type(2),
+    .md-content__button:nth-of-type(2) {
+        display: none;
+    }
+</style>
+
+<h1 id="TODO">
+    {% for toc_item in page.toc %}
+        {{ toc_item.title }}
+        <a class="headerlink" href="{{ toc_item.url }}" title="Permanent link">¶</a>
+    {% endfor %}
+</h1>
+
+{% include "partials/source-file.html" %}
+
+<!-- Page content -->
+{{ page.content }}

--- a/blog/overrides/partials/content.html
+++ b/blog/overrides/partials/content.html
@@ -7,12 +7,19 @@
     }
 </style>
 
-<h1 id="TODO">
+
+{% if page.toc %}
     {% for toc_item in page.toc %}
-        {{ toc_item.title }}
-        <a class="headerlink" href="{{ toc_item.url }}" title="Permanent link">¶</a>
+        <h1 id="TODO">
+            {{ toc_item.title }}
+            <a class="headerlink" href="{{ toc_item.url }}" title="Permanent link">¶</a>
+        </h1>
     {% endfor %}
-</h1>
+{% elif  page.title %}
+    <h1>
+        {{ page.title }}
+    </h1>
+{% endif %}
 
 {% include "partials/source-file.html" %}
 

--- a/blog/overrides/partials/content.html
+++ b/blog/overrides/partials/content.html
@@ -1,16 +1,8 @@
 <!-- based on https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/content.html   -->
 
-<style>
-    .md-typeset h1:nth-of-type(2),
-    .md-content__button:nth-of-type(2) {
-        display: none;
-    }
-</style>
-
-
 {% if page.toc %}
     {% for toc_item in page.toc %}
-        <h1 id="TODO">
+        <h1 id="{{ toc_item.url[1::] }}">
             {{ toc_item.title }}
             <a class="headerlink" href="{{ toc_item.url }}" title="Permanent link">¶</a>
         </h1>

--- a/blog/overrides/partials/content.html
+++ b/blog/overrides/partials/content.html
@@ -1,5 +1,6 @@
-<!-- based on https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/content.html   -->
+<link rel="stylesheet" href="{{ 'assets/stylesheets/content.css' | url }}" />
 
+<!-- based on https://github.com/squidfunk/mkdocs-material/blob/master/src/templates/partials/content.html   -->
 {% if page.toc %}
     {% for toc_item in page.toc %}
         <h1 id="{{ toc_item.url[1::] }}">

--- a/blog/overrides/partials/source-file.html
+++ b/blog/overrides/partials/source-file.html
@@ -1,0 +1,14 @@
+{% if page.meta.git_creation_date_localized and page.meta.git_revision_date_localized %}
+<!-- Source file information -->
+<!-- based on https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/howto/override-a-theme -->
+
+<p class="md-source-file">
+  <strong>
+    Published on:
+    {{ page.meta.git_creation_date_localized }}
+    ,&nbsp;
+    Revised on:
+    {{ page.meta.git_revision_date_localized }}
+  </strong>
+</p>
+{% endif %}

--- a/blog/overrides/partials/source-file.html
+++ b/blog/overrides/partials/source-file.html
@@ -3,12 +3,14 @@
 <!-- based on https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/howto/override-a-theme -->
 
 <p class="md-source-file">
-  <strong>
-    Published on:
-    {{ page.meta.git_creation_date_localized }}
-    ,&nbsp;
-    Revised on:
-    {{ page.meta.git_revision_date_localized }}
-  </strong>
+    <strong>
+        {% if page.meta.git_creation_date_localized == page.meta.git_revision_date_localized%}
+            Published on:
+            {{ page.meta.git_creation_date_localized }}
+        {% else %}
+            Revised on:
+            {{ page.meta.git_revision_date_localized }}
+        {% endif %}
+    </strong>
 </p>
 {% endif %}

--- a/blog/overrides/partials/source-file.html
+++ b/blog/overrides/partials/source-file.html
@@ -4,10 +4,10 @@
 
 <p class="md-source-file">
     <strong>
-        {% if page.meta.git_creation_date_localized == page.meta.git_revision_date_localized%}
-            Published on:
-            {{ page.meta.git_creation_date_localized }}
-        {% else %}
+        Published on:
+        {{ page.meta.git_creation_date_localized }}
+        {% if page.meta.git_creation_date_localized != page.meta.git_revision_date_localized%}
+            ,&nbsp;
             Revised on:
             {{ page.meta.git_revision_date_localized }}
         {% endif %}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -94,7 +94,7 @@ fi
 
 # Create the blog
 # TODO copy templates, stylesheets, etc. into blog directory
-cp -r overrides blog/
+cp -rn overrides blog/
 cp -r docs/images docs/stylesheets blog/docs/
 pushd blog; mkdocs build -f mkdocs.yml -d "$SITE/blog"; popd
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,9 +50,6 @@ plugins:
   search:
     # Spaces, dashes, periods and forward-slash (so serving.knative.dev/blibble can be searched as blibble).
     separator: '[\/\s\-\.]+'
-  macros:
-    module_name: hack/macros
-    include_dir: docs/snippets
   exclude:
     glob:
       # Exclude files that contain hugo specific shortcodes
@@ -63,6 +60,9 @@ plugins:
     filename: ".index"
     collapse_single_pages: true
     strict: false
+  macros:
+    module_name: hack/macros
+    include_dir: docs/snippets
 
 copyright: "Copyright © 2022 The Knative Authors"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ mkdocs-material<10.0
 mkdocs-exclude>=1.0
 mkdocs-macros-plugin>=0.5.12
 mkdocs-awesome-pages-plugin>=2.5
+mkdocs-git-revision-date-localized-plugin>=1.2
 mkdocs-redirects>=1.0.3
 mkdocs-rss-plugin>=0.18.0
 pygithub==1.55


### PR DESCRIPTION
Fixes #5704

## Proposed Changes

- fix `NavPluginOrder` warning on docs local preview using native Python mkdocs CLI
- use [`mkdocs-git-revision-date-localized-plugin`](https://github.com/timvink/mkdocs-git-revision-date-localized-plugin) to add _latest update date_ and _creation date_ labels dynamically

### Additional Info

<img width="1547" alt="Warning_NavPluginOrder" src="https://github.com/knative/docs/assets/33416316/6a43bd67-19b0-4fb7-a111-d73d1daebb42">
