### PR TITLE
Enable copy for code blocks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ theme:
     - navigation.tracking
     - navigation.tabs.sticky
     - navigation.top
+    - content.code.copy
 
 markdown_extensions:
   # - mdx_include:


### PR DESCRIPTION
Context: https://cloud-native.slack.com/archives/C04LY5G9ED7/p1704358780773299

## Proposed Changes
- Enables copy buttons on code (shell) blocks

/assign @skonto 