### PR TITLE
Document the use of HTTP/1 full duplex support

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -131,7 +131,7 @@ nav:
           - Using extensions enabled by QPOptions: serving/services/using-queue-extensions.md
           # TODO: Add security section to docs?
           - Configure resource requests and limits: serving/services/configure-requests-limits-services.md
-          - HTTPS redirection: serving/services/http-protocol.md
+          - Configuring HTTP: serving/services/http-protocol.md
           - Volume Support: serving/services/storage.md
         - Traffic management: serving/traffic-management.md
         - Configuring gradual rollout of traffic to Revisions: serving/rolling-out-latest-revision.md

--- a/docs/serving/services/http-protocol.md
+++ b/docs/serving/services/http-protocol.md
@@ -63,6 +63,11 @@ For more details on why the issue appears see [here](https://github.com/golang/g
 
 In order to enable the HTTP/1 full duplex support you can set the corresponding annotation at the service level as follows:
 
+!!! warning
+
+    Test with your http clients before enabling, as older clients may not provide support for HTTP/1 full duplex.
+
+
 ```yaml
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -77,6 +82,3 @@ spec:
 ...
 ```
 
-!!! warning
-
-    Test with your http clients before enabling, as older clients may not provide support for HTTP/1 full duplex.

--- a/docs/serving/services/http-protocol.md
+++ b/docs/serving/services/http-protocol.md
@@ -1,8 +1,10 @@
-# HTTPS redirection
+# Configuring HTTP
+
+## HTTPS redirection
 
 Operators can force HTTPS redirection for all Services. See the `http-protocol` mentioned in the [Enabling automatic TLS certificate provisioning](../encryption/enabling-automatic-tls-certificate-provisioning.md) page for more details.
 
-## Overriding the default HTTP behavior
+### Overriding the default HTTP behavior
 
 You can override the default behavior for each Service or global configuration.
 
@@ -50,3 +52,31 @@ You can override the default behavior for each Service or global configuration.
         network:
           http-protocol: "redirected"
     ```
+
+## HTTP/1 Full Duplex support per workload
+
+Knative services can turn on the support for [HTTP/1 full duplex](https://pkg.go.dev/net/http#ResponseController.EnableFullDuplex) end-to-end on the data path.
+This should be used in scenarios where the [related Golang issue](https://github.com/golang/go/issues/40747) is hit eg. the application server writes back to QP's reverse proxy before the latter has consumed the whole request.
+For more details on why the issue appears see [here](https://github.com/golang/go/issues/40747#issuecomment-1382404132).
+
+### Configure HTTP/1 Full Duplex support
+
+In order to enable the HTTP/1 full duplex support you can set the corresponding annotation at the service level as follows:
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example-service
+  namespace: default
+  annotations:
+    features.knative.dev/http-full-duplex: "Enabled"
+spec:
+  template:
+    spec:
+...
+```
+
+!!! warning
+
+    Test with your http clients before enabling, as older clients may not provide support for HTTP/1 full duplex.


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Documents https://github.com/knative/serving/issues/12387. Some similar docs from another project [here](https://caddyserver.com/docs/json/apps/http/servers/enable_full_duplex/).
- Adds proper warning for cases where clients may not support the feature.


