### PR TITLE
Add linux foundation trademark

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,11 +28,6 @@
   status = 301
 
 [[redirects]]
-  from = "/about-analytics-cookies/"
-  to = "/development/about-analytics-cookies/"
-  status = 301
-
-[[redirects]]
   from = "/docs/help/contributor/*"
   to = "https://github.com/knative/docs/blob/main/contribute-to-docs/README.md"
   status = 301

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -110,7 +110,7 @@
           <button type="button" class="md-button md-button--primary" onclick="acceptcookie()">Accept</button>
           <div class="opt-out">
             <hr>
-            <p><a href="/development/about-analytics-cookies/">Learn about analytics cookies and how you can take steps to opt-out from sharing your usage data.</a></p>
+            <p><a href="/docs/about-analytics-cookies/">Learn about analytics cookies and how you can take steps to opt-out from sharing your usage data.</a></p>
             <button type="button" class="md-button" onclick="optout()">I understand how to opt-out, hide this notice.</button>
           </div>
         </div>
@@ -121,7 +121,7 @@
 <div class="cookienotice md-typeset">
   <div class="text">
     <p>We use analytics and cookies to understand site traffic. Information about your use of
-      our site is shared with Google for that purpose. <a href="/development/about-analytics-cookies/">Learn more.</a>
+      our site is shared with Google for that purpose. <a href="/docs/about-analytics-cookies/">Learn more.</a>
     </p>
   </div>
   <div class="buttons">

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -73,8 +73,9 @@
       </div>
 
       <div class="footer-links md-footer-copyright">
+        <a href="https://www.linuxfoundation.org/legal/trademark-usage">Trademarks</a> |
         <a href="https://policies.google.com/privacy">Privacy Policy</a> |
-        <a href="/development/about-analytics-cookies/">Cookie Usage</a> |
+        <a href="/docs/about-analytics-cookies/">Cookie Usage</a> |
         <a href="https://github.com/knative/docs/blob/main/LICENSE">Apache-2.0 LICENSE</a> |
         <a href="https://github.com/knative/docs/blob/main/LICENSE-docs">CC BY 4.0 LICENSE</a> |
         <a href="https://squidfunk.github.io/mkdocs-material/">Made by Material MkDocs</a>
@@ -98,7 +99,7 @@
   </div>
 </footer>
 
-<!-- Cookie Bannier -->
+<!-- Cookie Banner -->
 <div id="cookieModal" class="md-typeset modal custom fade" role="dialog" data-backdrop="false">
   <div class="modal-dialog modal-xl">
     <div class="modal-content">


### PR DESCRIPTION
## Proposed Changes
- Add Linux Foundation trademark link
- Fix cookie-banner link (no need to route it to pre-release any more)

Fixes #5829

/assign @knative/steering-committee 
/assign @knative/technical-oversight-committee 

