### PR TITLE
Modify the description about Max revision timeout seconds

### DIFF
--- a/docs/serving/configuration/config-defaults.md
+++ b/docs/serving/configuration/config-defaults.md
@@ -79,7 +79,7 @@ The revision timeout value determines the default number of seconds to use for t
 {% raw %}
 The `max-revision-timeout-seconds` value determines the maximum number of seconds that can be used for `revision-timeout-seconds`. This value must be greater than or equal to `revision-timeout-seconds`. If omitted, the system default is used (600 seconds).
 
-If this value is increased, the activator's `terminationGraceTimeSeconds` should also be increased to prevent in-flight requests from being disrupted.
+If this value is increased, the activator's `terminationGracePeriodSeconds` should also be increased to prevent in-flight requests from being disrupted.
 {% endraw %}
 
 * **Global key:** `max-revision-timeout-seconds`


### PR DESCRIPTION
This PR is related to https://github.com/knative/serving/pull/14969 .

Because TerminationGrace`Period`Seconds is more appropriate than terminationGrace`Time`Seconds.
The document probably explain about fallowing value.
https://github.com/knative/serving/blob/6dc7097b740f6b0e6ae744abad5e84338a1b8066/config/core/deployments/activator.yaml#L124

I believe this PR makes this document more understandable.

Thank you.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Modified terminationGraceTimeSeconds in the document of Max revision timeout seconds to terminationGracePeriodSeconds.