### PR TITLE
Docs: Change namespace-wildcard-cert-selector value type from object to string

### DIFF
--- a/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning.md
+++ b/docs/serving/encryption/enabling-automatic-tls-certificate-provisioning.md
@@ -174,7 +174,7 @@ For example, you can use the following configurations:
 You can also configure the selector to opt-out when a specific label is on the namespace:
 
 ```yaml
-namespace-wildcard-cert-selector:
+namespace-wildcard-cert-selector: |-
   matchExpressions:
   - key: "networking.knative.dev/disableWildcardCert"
     operator: "NotIn"
@@ -185,7 +185,7 @@ This selects all namespaces where the label value is not in the set `"true"`.
 Or use existing kubernetes labels to select namespaces based on their name:
 
 ```yaml
-namespace-wildcard-cert-selector:
+namespace-wildcard-cert-selector: |-
   matchExpressions:
     - key: "kubernetes.io/metadata.name"
       operator: "In"


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

This PR proposes changes the docs on automatic TLS certificate provisioning. In the examples given under "Provisioning certificates per namespace (wildcard certificates)" objects are provided as values for `namespace-wildcard-cert-selector`, I think only strings can be values for ConfigMap data values. In the next section (Configure config-certmanager ConfigMap) a string is provided. 

## Proposed Changes <!-- Describe the changes the PR makes. -->

- ConfigMap's data values can only be of type String
