### PR TITLE
fixed the aligment of sponsor section

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -124,7 +124,7 @@ h2.secondary-headline, h3.trusted-by {
 
 .scroller {
   max-width: 60vw;
-  
+  margin: auto;
 }
 
 .scroller__inner {


### PR DESCRIPTION

Changes: the current alignment of the sponsor seems to have no margin given resulting in default left and a negative white space.
<img width="1110" alt="image" src="https://github.com/knative/docs/assets/122612557/712816c4-be02-4ceb-bbab-cf68cdb385d7">

Changes made: made the sponsor section center to the screen for better white space.
<img width="1247" alt="image" src="https://github.com/knative/docs/assets/122612557/493d4b76-0d5f-44fa-9939-c9222fa811bc">
