### PR TITLE
Add WG leads to docs approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,12 @@ approvers:
 - steering-committee
 - knative-release-leads
 - ux-wg-leads
+# WG leads
+- client-wg-leads
+- eventing-wg-leads
+- functions-wg-leads
+- operations-wg-leads
+- serving-wg-leads
 reviewers:
 - docs-writers
 - docs-reviewers


### PR DESCRIPTION
Every time there is a new page added, I cannot approve PRs (example https://github.com/knative/docs/pull/5916), so I'm adding WG leads to the top-level directory approvers