### PR TITLE
Fix: changed the hover color for better visibility in navbar

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -120,7 +120,7 @@ a.md-header__button.md-logo img {
 .md-tabs__list li:nth-last-child(1) a:hover,
 .md-tabs__list li:nth-last-child(2) a:hover,
 .md-tabs__list li:nth-last-child(3) a:hover {
-  color: var(--md-accent-fg-color);
+  color: #f3f1f2;
 }
 
 .md-nav__title .md-nav__button.md-logo img,


### PR DESCRIPTION
Issue:
the current navbar hover have matching colour theme with the background resulting in visibility issue in design.
<img width="260" alt="image" src="https://github.com/knative/docs/assets/122612557/606e3628-c861-48d3-abc3-96cb1dd5621f">

Changes:
makes the hover colour a subtle grey , differentiating the foreground and the background.
<img width="200" alt="image" src="https://github.com/knative/docs/assets/122612557/9d5103b9-26a3-4a8e-85cc-6663aa9b9b9a">
