### PR TITLE
Add UX leads as docs reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,4 @@ approvers:
 reviewers:
 - docs-writers
 - docs-reviewers
+- ux-wg-leads


### PR DESCRIPTION
Currently, there are many PRs which are being opened to the docs repo regarding design changes (which I should review). But, since the UX leads group are only approvers and not reviewers on this repository, I don't have my review requested.

This PR adds the UX leads as docs reviewers (on top of the already existing approver permissions) so that we can get our reviews requested