### PR TITLE
Fix footer styling issue

### DIFF
--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -23,10 +23,10 @@
             {% include ".icons/material/arrow-left.svg" %}
           </div>
           <div class="md-footer__title">
+            <span class="md-footer__direction">
+              {{ lang.t("footer.previous") }}
+            </span>
             <div class="md-ellipsis">
-              <span class="md-footer__direction">
-                {{ lang.t("footer.previous") }}
-              </span>
               {{ page.previous_page.title }}
             </div>
           </div>
@@ -42,10 +42,10 @@
           rel="next"
         >
           <div class="md-footer__title">
+            <span class="md-footer__direction">
+              {{ lang.t("footer.next") }}
+            </span>
             <div class="md-ellipsis">
-              <span class="md-footer__direction">
-                {{ lang.t("footer.next") }}
-              </span>
               {{ page.next_page.title }}
             </div>
           </div>


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Currently, in the footer of our website's documentation section, the 'Next' and 'Previous' links are shown in front of the page's title, and they have different font sizes. I'm sure this wasn't done on purpose. The problem is because the title and the navigation links are in the same class, which messes up the styles.

To fix this, I moved the footer text outside of that class. This way, the existing styles won't get overridden by the class styles.

### Before

![image](https://github.com/knative/docs/assets/111359305/b520ceb4-d7cc-40c5-adea-9c99a75bed42)

### After

![image](https://github.com/knative/docs/assets/111359305/fe05475a-4c57-4c2c-802a-17ef8a3b3e52)
