### PR TITLE
Add link to community roles to contributor page

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -65,6 +65,10 @@ Share your samples with the community.
 - [Link existing code samples](../samples/README.md#external-code-samples):
 Link to your Knative samples that live on another site.
 
+## Contributor Roles
+
+To learn more about the roles individuals can assume within the Knative community such as member, approver, or working group lead, see the [community roles documentation](https://github.com/knative/community/blob/main/ROLES.md).
+
 ## Learn and connect
 
 Using or want to use Knative? Have any questions? Find out more here:


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

It was mentioned on the TOC call today that some folks were finding it difficult to find the different contributor roles, so this PR adds an explicit link to them from the "contributor" page.

