### PR TITLE
Remove as_updated field in rss plugin

### DIFF
--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -69,7 +69,6 @@ plugins:
     match_path: "(articles|steering|events|releases)/.*"
     date_from_meta:
       as_creation: "date"
-      as_update: false
       datetime_format: "%Y-%m-%d"
   git-revision-date-localized:
       type: iso_date


### PR DESCRIPTION
It should be defaulting to `False` anyway. Otherwise we have "expected string got bool error".

https://guts.github.io/mkdocs-rss-plugin/configuration/#categories_example