### PR TITLE
new design implementation for footer and removed the pre-footer section

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,6 +3,7 @@
   --md-primary-fg-color--dark: #0865AD;
   --md-primary-fg-color--light: #6695CA;
   --nav-item-color: #4d4d4d;
+  --md-footer-bg-color:#081729;
 }
 
 .md-clipboard {
@@ -356,6 +357,12 @@ border-radius: 20% 0 0 0 ;
 
 .md-footer-meta {
   background-color: var(--md-footer-bg-color);
+}
+
+.md-footer-meta__inner{
+  display:flex;
+  flex-direction: row;
+  margin:0.5rem 1.5rem;
 }
 
 .footer-links {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -497,10 +497,5 @@ border-radius: 20% 0 0 0 ;
     color: var(--nav-item-color);
   }
 }
-/* @media screen and (max-width:2600px){
-.md-footer-meta {
-  justify-content: space-between;
-}
-} */
 
   

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,7 +3,7 @@
   --md-primary-fg-color--dark: #0865AD;
   --md-primary-fg-color--light: #6695CA;
   --nav-item-color: #4d4d4d;
-  --md-footer-bg-color:#081729;
+  --md-footer-bg-color: #081729;
 }
 
 .md-clipboard {
@@ -360,9 +360,9 @@ border-radius: 20% 0 0 0 ;
 }
 
 .md-footer-meta__inner{
-  display:flex;
+  display: flex;
   flex-direction: row;
-  margin:0.5rem 1.5rem;
+  margin: 0.5rem 1.5rem;
 }
 
 .footer-links {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -357,6 +357,7 @@ border-radius: 20% 0 0 0 ;
 
 .md-footer-meta {
   background-color: var(--md-footer-bg-color);
+  width: 100%;
 }
 
 .md-footer-meta__inner{
@@ -369,6 +370,7 @@ border-radius: 20% 0 0 0 ;
   display: flex;
   flex-grow: 1;
   align-items: center;
+  justify-content: center;
 }
 
 .footer-links a {
@@ -495,3 +497,10 @@ border-radius: 20% 0 0 0 ;
     color: var(--nav-item-color);
   }
 }
+/* @media screen and (max-width:2600px){
+.md-footer-meta {
+  justify-content: space-between;
+}
+} */
+
+  

--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -454,7 +454,7 @@ h2.secondary-headline, h3.trusted-by {
 /* cncf notice container css */
 .cncf-notice-container {
   background-color: white;
-  padding-top: 0;
+  padding-top: 1rem;
 }
 
 .cncf-notice-container h3 {

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -265,49 +265,6 @@
     <h3>Knative is a <a href="https://www.cncf.io/">Cloud Native Computing Foundation</a> incubation project</h3>
     <img class="cncf-logo" src="images/home-images/cncf-color.png" alt="" draggable="false" />
   </section>
-
-  <section class="whats-next-container">
-    <div class="md-grid md-typeset">
-      <h1>What's Next?</h1>
-      <div class="component-flex">
-        <div class="pane">
-          <a href="https://slack.cncf.io" title="Slack Link">
-            <div class="twemoji">
-              {% include ".icons/fontawesome/brands/slack.svg" %}
-            </div>
-            <h2>Talk to us on Slack in #knative</h2>
-            <p class="normal-text">Interested in learning more, speaking to other contributors, or finding answers?</p>
-          </a>
-        </div>
-        <div class="pane">
-          <a href="{{ 'community/contributing' | url }}" title="Contributing Link">
-            <div class="twemoji">
-              {% include ".icons/fontawesome/brands/github.svg" %}
-            </div>
-            <h2>Contributions Welcome</h2>
-            <p class="normal-text">Want to join the fun on Github? New users are always welcome!</p>
-          </a>
-        </div>
-        <div class="pane">
-          <div class="whats-next-logo">
-            <a href="https://twitter.com/KnativeProject" title="Twitter Link">
-              <div class="twemoji">
-                <svg xmlns="http://www.w3.org/2000/svg" height="1em" viewBox="0 0 512 512"><path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z" /></svg>
-              </div>
-            </a>
-            <h1 style="font-size: 50px;">|</h1>
-            <a href="https://www.linkedin.com/company/knative" title="Linkedin Link">
-              <div class="twemoji">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -15 448 512"><path d="M100.3 448H7.4V148.9h92.9zM53.8 108.1C24.1 108.1 0 83.5 0 53.8a53.8 53.8 0 0 1 107.6 0c0 29.7-24.1 54.3-53.8 54.3zM447.9 448h-92.7V302.4c0-34.7-.7-79.2-48.3-79.2-48.3 0-55.7 37.7-55.7 76.7V448h-92.8V148.9h89.1v40.8h1.3c12.4-23.5 42.7-48.3 87.9-48.3 94 0 111.3 61.9 111.3 142.3V448z" /></svg>
-              </div>
-            </a>
-          </div>
-          <h2>Follow us</h2>
-          <p class="normal-text">For feature announcements, interesting Knative news, and other great things.</p>
-        </div>
-      </div>
-    </div>
-  </section>
 </div>
 {% endblock %}
 

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -59,7 +59,7 @@
 
   <!-- Further information -->
   <div class="md-footer-meta md-typeset">
-    <div class="md-footer-meta__inner md-grid">
+    <div class="md-footer-meta__inner">
 
       <!-- Copyright and theme information -->
       <div class="md-footer-copyright">


### PR DESCRIPTION
resolves #6035 

changes made :
1. replaced the footer background colour.
2. Move footer icons to the right.
3. Remove the pre-footer section of the previous design.
4. added space at the top of the cncf logo container.

proposed design :
<img width="1011" alt="Screenshot 2024-07-01 at 6 30 29 PM" src="https://github.com/knative/docs/assets/97099574/b9cf3409-94c0-4e8b-8534-eb93fba4a876">

Implementaion:

<img width="1439" alt="Screenshot 2024-07-01 at 6 30 45 PM" src="https://github.com/knative/docs/assets/97099574/a6b1752c-6332-46db-92a1-d080a5ad2885">
