### PR TITLE
Update the button border radius on Tutorial page #6064

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -204,6 +204,7 @@ border-radius: 0.7rem 0 0 0 ;
 
 .md-typeset .md-button {
   color: #024c93;
+  border-radius: 0.7rem;
 }
 
 /* Giving h4 tag distinctive style because it is non-differntial with bold text */


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Fixes #6064  

This PR updates the border radius of the "Get started" buttons on the Tutorial page to match the border radius used on the home page.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Applied `border-radius: 0.7rem;` to the "Get started" buttons on the Tutorial page.

### Additional Context
- The home page uses `border-radius: 0.7rem;` for its buttons, and this change ensures consistency in the button styles across the website.
