### PR TITLE
Extend owners to WG leads

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,10 @@ approvers:
 - steering-committee
 - knative-release-leads
 - ux-wg-leads
+- eventing-wg-leads
+- client-wg-leads
+- serving-wg-leads
+- functions-wg-leads
 reviewers:
 - docs-writers
 - docs-reviewers


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Extend owners to WG leads


I propose to extend the current approvers to at least WGs leads. Considering the fact our docs are shared effort between all WGs and components. I'd even go with wg-writers, but that's a bit more folks. 

/cc @knative/steering-committee 