### PR TITLE
Add documentation on fetching Knative supply-chain security attestations

### DIFF
--- a/config/nav.yml
+++ b/config/nav.yml
@@ -343,7 +343,9 @@ nav:
       - Eventing code samples: samples/eventing.md
     # Reference docs
     - Reference:
-      - Security: reference/security/README.md
+      - Security:
+        - Security Model and Disclosure: reference/security/README.md
+        - Verifying Knative Images: reference/security/verifying-images.md 
       - Release notes: reference/relnotes/README.md
     - Blog: /blog/
     - About:

--- a/docs/reference/security/verifying-images.md
+++ b/docs/reference/security/verifying-images.md
@@ -1,0 +1,49 @@
+# Verifying Knative Images
+
+Knative publishes SBOMs and SLSA provenance documents for each image in the
+Knative release. You can also use this information to configure [the sigstore
+policy controller](https://docs.sigstore.dev/policy-controller/overview/) or
+other admission controllers to check for these image attestations.
+
+## Prerequisites
+
+You will need to install the [cosign tool](https://github.com/sigstore/cosign/tree/main)
+to fetch and interact with the attestations stored in the container registry.
+
+## Knative SLSA Provenance (signed)
+
+The Knative build process produces a SLSA [in-toto](https://in-toto.io/)
+attestation for each image in the build process. For a given image in the
+Knative release manifests, you can verify the build attestation using the
+following:
+
+```bash
+cosign verify-attestation \
+  --certificate-oidc-issuer https://accounts.google.com \
+  --certificate-identity signer@knative-releases.iam.gserviceaccount.com \
+  --type slsaprovenance02 \
+  $IMAGE
+```
+
+Note that the in-toto document is base64 encoded in the `.payload` attribute
+of the attestation; you can use `jq` to extract this with the following
+invocation:
+
+```bash
+cosign verify-attestation \
+  --certificate-oidc-issuer https://accounts.google.com \
+  --certificate-identity signer@knative-releases.iam.gserviceaccount.com \
+  --type slsaprovenance02 \
+  $IMAGE | jq -r .payload | base64 --decode | jq
+```
+
+## Knative SBOMs
+
+For each container image, Knative publishes an SBOM corresponding to each
+image. These SBOMs are produced during compilation by the
+[`ko` tool](https://ko.build/), and can be downloaded using the `cosign download sbom`
+command. Note that the image references in the Knative manifests are to
+multi-architecture images; to extract the software components for a particular
+architecture (as different architectures may build with different libraries),
+you will need to run `cosign download sbom` on the architecture-specific image
+(e.g. for `linux/amd64`).


### PR DESCRIPTION
Adds documentation on how to consume Knative supply chain attestations.  Captures discussion from [this comment](https://github.com/knative/docs/pull/5775#discussion_r1414296163), where they are unlikely otherwise to be found.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds initial security documentation, focused on supply chain security.  Future security configuration documents should probably be added to the same location.
