### PR TITLE
sample-app: Fix port of node-server-svc (80 to 8080)

### DIFF
--- a/code-samples/eventing/bookstore-sample-app/start/node-server/config/100-deployment.yaml
+++ b/code-samples/eventing/bookstore-sample-app/start/node-server/config/100-deployment.yaml
@@ -29,6 +29,6 @@ spec:
     app: node-server
   ports:
     - protocol: TCP
-      port: 80
+      port: 8080
       targetPort: 8000
   type: LoadBalancer

--- a/docs/bookstore/page-0.5/environment-setup.md
+++ b/docs/bookstore/page-0.5/environment-setup.md
@@ -270,7 +270,7 @@ node-server-svc          LoadBalancer   10.101.90.35    <pending>     80:31792/T
 If port forwarding is required, open a new terminal and run:
 
 ```shell
-kubectl port-forward svc/node-server-svc 8080:80
+kubectl port-forward svc/node-server-svc 8080:8080
 ```
 You should see the following output:
 


### PR DESCRIPTION
Without this, following the instructions that don't require port forwarding (e.g. using "minikube tunnel") fails: the service is exposed on port 80, which is not what the frontend expects.

After this commit the setup mimics that of the frontend service, which works both with and without port forwarding.