### PR TITLE
sample-app: Add serviceName to postgresql manifest

### DIFF
--- a/code-samples/eventing/bookstore-sample-app/solution/db-service/200-create-postgre.yaml
+++ b/code-samples/eventing/bookstore-sample-app/solution/db-service/200-create-postgre.yaml
@@ -7,6 +7,7 @@ spec:
   selector:
     matchLabels:
       app: postgresql
+  serviceName: postgresql
   template:
     metadata:
       labels:

--- a/code-samples/eventing/bookstore-sample-app/start/db-service/200-create-postgre.yaml
+++ b/code-samples/eventing/bookstore-sample-app/start/db-service/200-create-postgre.yaml
@@ -7,6 +7,7 @@ spec:
   selector:
     matchLabels:
       app: postgresql
+  serviceName: postgresql
   template:
     metadata:
       labels:


### PR DESCRIPTION
To fix this error:

`error: error validating "db-service/200-create-postgre.yaml": error validating data: ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec; if you choose to ignore these errors, turn validation off with --validate=false`