### PR TITLE
Updated the links in Bookstore Sample App

### DIFF
--- a/code-samples/eventing/bookstore-sample-app/README.md
+++ b/code-samples/eventing/bookstore-sample-app/README.md
@@ -4,7 +4,7 @@ This folder contains code samples for the Knative Bookstore tutorial, an end-to-
 
 ## Tutorial
 
-For a comprehensive guide on building this application and learning about Knative, please visit the [Knative Bookstore Tutorial](https://knative.dev/bookstore/page-0/welcome-knative-bookstore-tutorial/).
+For a comprehensive guide on building this application and learning about Knative, please visit the [Knative Bookstore Tutorial](https://knative.dev/docs/bookstore/page-0/welcome-knative-bookstore-tutorial/).
 
 This tutorial covers:
 - Setting up your environment

--- a/code-samples/eventing/bookstore-sample-app/solution/README.md
+++ b/code-samples/eventing/bookstore-sample-app/solution/README.md
@@ -3,7 +3,7 @@
 
 Welcome to the solution directory of the Knative Bookstore tutorial. This directory contains the fully implemented version of the event-driven bookstore application using Knative.
 
-You can find the tutorial for this solution [here](https://knative.dev/bookstore/page-0/welcome-knative-bookstore-tutorial/).
+You can find the tutorial for this solution [here](https://knative.dev/docs/bookstore/page-0/welcome-knative-bookstore-tutorial/).
 
 ## Directory Structure
 

--- a/code-samples/eventing/bookstore-sample-app/solution/slack-sink/README.md
+++ b/code-samples/eventing/bookstore-sample-app/solution/slack-sink/README.md
@@ -11,7 +11,7 @@ When a CloudEvent with the type `new-review-comment` is sent to the Knative Even
 ## Install prerequisites
 
 ### Prerequisite 1: Install Camel CLI
-Install the Camel K CLI (`kamel`) on your local machine. You can find the installation instructions [here](https://camel.apache.org/camel-k/2.2.x/cli/cli.html){:target="_blank"}.
+Install the Camel K CLI (`kamel`) on your local machine. You can find the installation instructions [here](https://camel.apache.org/camel-k/2.4.x/cli/cli.html){:target="_blank"}.
 
 **Troubleshot**: If after installation you run `kamel version` and you get an error message, you may need to add the `kamel` binary to your system's PATH. You can do this by moving the `kamel` binary to a directory that is already in your PATH, or by adding the directory where `kamel` is located to your PATH.
 
@@ -29,7 +29,7 @@ $ kamel install --registry docker.io --organization <your-organization> --regist
 
 Replace the placeholders with your actual Docker registry information.
 
-If you are using other container registries, you may need to read more [here](https://camel.apache.org/camel-k/2.2.x/installation/registry/registry.html){:target="_blank"} for the installation. 
+If you are using other container registries, you may need to read more [here](https://camel.apache.org/camel-k/2.4.x/installation/registry/registry.html){:target="_blank"} for the installation. 
 
 You will see this message if the installation is successful:
 

--- a/code-samples/eventing/bookstore-sample-app/start/README.md
+++ b/code-samples/eventing/bookstore-sample-app/start/README.md
@@ -16,7 +16,7 @@ Here's an overview of the components you'll be working with:
 
 1. Familiarize yourself with the directory structure above.
 2. Each subdirectory contains starter code and placeholders for the services you'll be building.
-3. Follow the [Knative Bookstore Tutorial](https://knative.dev/bookstore/page-0/welcome-knative-bookstore-tutorial/) for step-by-step instructions on how to implement each component.
+3. Follow the [Knative Bookstore Tutorial](https://knative.dev/docs/bookstore/page-0/welcome-knative-bookstore-tutorial/) for step-by-step instructions on how to implement each component.
 4. As you progress through the tutorial, you'll be adding code and configurations to these directories.
 
 Remember, this is just the starting point. By the end of the tutorial, you'll have a fully functional event-driven bookstore application.

--- a/code-samples/eventing/bookstore-sample-app/start/db-service/README.md
+++ b/code-samples/eventing/bookstore-sample-app/start/db-service/README.md
@@ -102,7 +102,7 @@ Note box: However, Knative Service supports Volumes and Persistent Volumes, whic
 
 2. When should I use Knative Service, and what would be the best use case for it?
 
-You can read more about the best use cases for Knative Service [here](https://knative.dev/docs/serving/samples/{:target="_blank"}!
+You can read more about the best use cases for Knative Service [here](https://knative.dev/docs/serving/samples/){:target="_blank"}!
 
 ## Conclusion
 By following this guide, you have successfully deployed a PostgreSQL server on a Kubernetes cluster, set up persistent storage, and initialized your database using a Kubernetes job. Congratulations! Your bookstore now has the database service.

--- a/code-samples/eventing/bookstore-sample-app/start/slack-sink/README.md
+++ b/code-samples/eventing/bookstore-sample-app/start/slack-sink/README.md
@@ -11,7 +11,7 @@ When a CloudEvent with the type `new-review-comment` is sent to the Knative Even
 ## Install prerequisites
 
 ### Prerequisite 1: Install Camel CLI
-Install the Camel K CLI (`kamel`) on your local machine. You can find the installation instructions [here](https://camel.apache.org/camel-k/2.2.x/cli/cli.html){:target="_blank"}.
+Install the Camel K CLI (`kamel`) on your local machine. You can find the installation instructions [here](https://camel.apache.org/camel-k/2.4.x/cli/cli.html){:target="_blank"}.
 
 **Troubleshot**: If after installation you run `kamel version` and you get an error message, you may need to add the `kamel` binary to your system's PATH. You can do this by moving the `kamel` binary to a directory that is already in your PATH, or by adding the directory where `kamel` is located to your PATH.
 
@@ -29,7 +29,7 @@ $ kamel install --registry docker.io --organization <your-organization> --regist
 
 Replace the placeholders with your actual Docker registry information.
 
-If you are using other container registries, you may need to read more [here](https://camel.apache.org/camel-k/2.2.x/installation/registry/registry.html){:target="_blank"} for the installation. 
+If you are using other container registries, you may need to read more [here](https://camel.apache.org/camel-k/2.4.x/installation/registry/registry.html){:target="_blank"} for the installation. 
 
 You will see this message if the installation is successful:
 


### PR DESCRIPTION
fixes #6224 
Some of the links in Bookstore Sample App (https://github.com/knative/docs/tree/main/code-samples/eventing/bookstore-sample-app) were broken. Checked and fixed all the broken links. All the links now redirect user to the correct destination.