### PR TITLE
Fixes #6241 Broken Links in "Sender Identity for Knative Eventing" Doc

### DIFF
--- a/docs/eventing/features/sender-identity.md
+++ b/docs/eventing/features/sender-identity.md
@@ -29,8 +29,8 @@ OIDC authentication is currently supported for the following components:
     - [MTChannelBasedBroker](./../../brokers/broker-types/channel-based-broker/)
     - [Knative Broker for Apache Kafka](./../../brokers/broker-types/kafka-broker/)
 - Channels:
-    - InMemoryChannel
-    - KafkaChannel
+    - [InMemoryChannel](./../../channels/channels-crds/)
+    - [KafkaChannel](./../../channels/channels-crds/)
 - Sources:
     - [ApiServerSource](./../../sources/apiserversource/)
     - [PingSource](./../../sources/ping-source/)


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Fixes #6241 

## Proposed Changes <!-- Describe the changes the PR makes. -->

##  Troubleshooting item

****Error Description**** 

_Symptom:_ The following links are broken on the [Sender Identity for Knative Eventing](https://knative.dev/docs/eventing/features/sender-identity/) page:
1. [MTChannelBasedBroker](https://knative.dev/docs/eventing/features/brokers/broker-types/channel-based-broker/)
2. [Knative Broker for Apache Kafka](https://knative.dev/docs/eventing/features/brokers/broker-types/kafka-broker/)
3. [ApiServerSource](https://knative.dev/docs/eventing/features/sources/apiserversource/)
4. [PingSource](https://knative.dev/docs/eventing/features/sources/ping-source/)
5. [KafkaSource](https://knative.dev/docs/eventing/features/sources/kafka-source/) 

_Cause:_ The URLs use relative paths but are missing an additional `../`

_Solution:_ To solve this issue,  add additional   `../`
