### PR TITLE
Update web community info to remove TOC and duplication of audience info

### DIFF
--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -35,9 +35,6 @@ provides information about our various working groups.
 - [Steering Committee (SC)](https://github.com/knative/community/blob/main/STEERING-COMMITTEE.md):
 describes our steering committee.
 
-- [Technical Oversight Committee (TOC)](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md):
-describes our technical oversight committee.
-
 - [Annual reports](https://github.com/knative/community/tree/main/annual_reports):
 lists previous annual reports.
 
@@ -55,9 +52,6 @@ how we manage pull requests.
 
 - [SC election process](https://github.com/knative/community/blob/main/mechanics/SC.md):
 elcection process for our steering committee.
-
-- [TOC election process](https://github.com/knative/community/blob/main/mechanics/TOC.md):
-election process for our technical oversight committee.
 
 - [Repository Guidelines](https://github.com/knative/community/blob/main/REPOSITORY-GUIDELINES.md):
 how we create and remove core repositories.
@@ -91,43 +85,3 @@ If you want to add an event to the calendar please send an email to
 or post to the `#knative` channel in the CNCF [Slack](https://slack.cncf.io) workspace.
 
 <iframe src="https://calendar.google.com/calendar/embed?src=knative.team_9q83bg07qs5b9rrslp5jor4l6s%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-
-## Knative's audience
-
-Knative is designed for different personas:
-
-![Diagram that displays different Audiences for Knative](images/knative-audience.svg)
-
-### Developers
-
-Knative components offer developers Kubernetes-native APIs for deploying
-serverless-style functions, applications, and containers to an auto-scaling
-runtime.
-
-To join the conversation, head over to the
-[Knative users](https://groups.google.com/d/forum/knative-users) Google group.
-
-### Operators
-
-Knative components are intended to be integrated into more polished products
-that cloud service providers or in-house teams in large enterprises can then
-operate.
-
-Any enterprise or cloud provider can adopt Knative components into their own
-systems and pass the benefits along to their customers.
-
-### Contributors
-
-With a clear project scope, lightweight governance model, and clean lines of
-separation between pluggable components, the Knative project establishes an
-efficient contributor workflow.
-
-Knative is a diverse, open, and inclusive community.
-Your own path to becoming a Knative contributor can begin in any of the
-following components:
-
-## Knative authors
-
-Knative is an open source project with an active development community.
-The project was started by Google but has contributions from a growing number of industry-leading companies.
-For a current list of the authors, see [Authors](https://github.com/knative/serving/blob/main/AUTHORS).


### PR DESCRIPTION
Fixes a few outdated items noticed during graduation governance review.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Remove mentions of the TOC now that it has been merged with the steering committee.
- Remove a duplicate mention of the Knative audiences, which is also at the top of https://knative.dev/docs/community/
