### PR TITLE
Phase 1: Adding documentation metadata tags

### DIFF
--- a/docs/about-analytics-cookies.md
+++ b/docs/about-analytics-cookies.md
@@ -2,6 +2,9 @@
 title: "Learn about Google Analytics cookies"
 linkTitle: "Learn about cookies"
 type: "docs"
+audience: developer
+components: []
+function: community
 ---
 
 By using this website, you are confirming that you accept our use of cookies for

--- a/docs/about/case-studies/README.md
+++ b/docs/about/case-studies/README.md
@@ -1,6 +1,11 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - eventing
+  - serving
+function: marketing
 ---
 
 # Knative Case Studies

--- a/docs/about/case-studies/deepc.md
+++ b/docs/about/case-studies/deepc.md
@@ -1,6 +1,10 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - eventing
+function: marketing
 ---
 <h1 style="color:#0071c7;font-size: 3em;">deepc Case Study</h1>
 <table style="border: 0;">

--- a/docs/about/case-studies/ibm.md
+++ b/docs/about/case-studies/ibm.md
@@ -1,6 +1,10 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - eventing
+function: marketing
 ---
 <h1 style="color:#0071c7;font-size: 3em;">IBM Case Study</h1>
 <table style="border: 0;">

--- a/docs/about/case-studies/outfit7.md
+++ b/docs/about/case-studies/outfit7.md
@@ -1,6 +1,10 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - serving
+function: marketing
 ---
 <h1 style="color:#0071c7;font-size: 3em;">Outfit7 Case Study</h1>
 <table style="border: 0;">

--- a/docs/about/case-studies/pnc.md
+++ b/docs/about/case-studies/pnc.md
@@ -1,6 +1,11 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - eventing
+  - serving
+function: marketing
 ---
 <h1 style="color:#0071c7;font-size: 3em;">PNC Bank Case Study</h1>
 <table style="border: 0;">

--- a/docs/about/case-studies/puppet.md
+++ b/docs/about/case-studies/puppet.md
@@ -1,6 +1,10 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - serving
+function: marketing
 ---
 <h1 style="color:#0071c7;font-size: 3em;">Puppet Case Study</h1>
 <table style="border: 0;">

--- a/docs/about/case-studies/sva.md
+++ b/docs/about/case-studies/sva.md
@@ -1,6 +1,10 @@
 ---
 hide:
   - toc
+audience: buyer
+components:
+  - eventing
+function: marketing
 ---
 <h1 style="color:#0071c7;font-size: 3em;">SVA System Vertrieb Alexander GmbH Case Study</h1>
 <table style="border: 0;">

--- a/docs/about/testimonials.md
+++ b/docs/about/testimonials.md
@@ -1,3 +1,11 @@
+---
+audience: buyer
+components:
+  - eventing
+  - serving
+function: marketing
+---
+
 <div class="testimonials">
   <h1>Testimonials</h1>
   <h3><b>Enterprise-grade Serverless on your own terms</b></h3>

--- a/docs/bookstore/create-slack-workspace/README.md
+++ b/docs/bookstore/create-slack-workspace/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Creating a Slack Workspace
 
 ![Image](images/image5.png)

--- a/docs/bookstore/disclaimer/README.md
+++ b/docs/bookstore/disclaimer/README.md
@@ -1,3 +1,9 @@
+---
+audience: developer
+components: []
+function: tutorial
+---
+
 # **Disclaimer**
 
 ![image](images/image2.png)

--- a/docs/bookstore/extra-challenge/README.md
+++ b/docs/bookstore/extra-challenge/README.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+  - functions
+function: tutorial
+---
+
 # **Extra Challenges**
 
 ![image](images/image5.png)

--- a/docs/bookstore/page-0.5/environment-setup.md
+++ b/docs/bookstore/page-0.5/environment-setup.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: tutorial
+---
+
 # Environment Setup
 
 ![Image](images/image20.png)

--- a/docs/bookstore/page-0/welcome-knative-bookstore-tutorial.md
+++ b/docs/bookstore/page-0/welcome-knative-bookstore-tutorial.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - functions
+  - serving
+function: tutorial
+---
+
 # Welcome: Knative Bookstore Tutorial
 
 ![Welcome Image](images/1.png)

--- a/docs/bookstore/page-1/send-review-comment-to-broker.md
+++ b/docs/bookstore/page-1/send-review-comment-to-broker.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Send Review Comment to Broker
 
 ![Image](images/image25.png)

--- a/docs/bookstore/page-2/sentiment-analysis-service-for-bookstore-reviews.md
+++ b/docs/bookstore/page-2/sentiment-analysis-service-for-bookstore-reviews.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+function: tutorial
+---
+
 # Sentiment Analysis Service for Bookstore Reviews
 
 ![Image1](images/image1.png)

--- a/docs/bookstore/page-3/create-bad-word-filter-service.md
+++ b/docs/bookstore/page-3/create-bad-word-filter-service.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+function: tutorial
+---
+
 # Create Bad Word Filter Service
 
 ![Image 4](images/image4.png)

--- a/docs/bookstore/page-3/solution-create-bad-word-filter-service.md
+++ b/docs/bookstore/page-3/solution-create-bad-word-filter-service.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+function: tutorial
+---
+
 # Solution - Create Bad Word Filter Service
 
 ![image](images/image4.png)

--- a/docs/bookstore/page-4/create-sequence-to-streamline-ML-workflows.md
+++ b/docs/bookstore/page-4/create-sequence-to-streamline-ML-workflows.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # **Create Knative Sequence to Streamline ML Workflows**
 
 ![image](images/image8.png)

--- a/docs/bookstore/page-5/deploy-database-service.md
+++ b/docs/bookstore/page-5/deploy-database-service.md
@@ -1,3 +1,9 @@
+---
+audience: developer
+components: []
+function: tutorial
+---
+
 # **Deploy the Database Service**
 
 ![image1](images/image1.png)

--- a/docs/bookstore/page-6/advanced-event-filtering.md
+++ b/docs/bookstore/page-6/advanced-event-filtering.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # **Advanced Event Filtering**
 
 ![Image](images/image4.png)

--- a/docs/bookstore/page-7/slack-sink-learning-knative-eventing-and-apache-camel-K-integration.md
+++ b/docs/bookstore/page-7/slack-sink-learning-knative-eventing-and-apache-camel-K-integration.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # **Slack sink - Learning Knative Eventing and the Apache Camel K integration**
 
 ![image](images/image2.png)

--- a/docs/client/README.md
+++ b/docs/client/README.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - functions
+  - serving
+function: explanation
+---
+
 # CLI tools
 
 The following CLI tools are supported for use with Knative.

--- a/docs/client/configure-kn.md
+++ b/docs/client/configure-kn.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - functions
+  - serving
+function: reference
+---
+
 # Customizing kn
 
 You can customize your `kn` CLI setup by creating a `config.yaml` configuration file. You can provide this configuration by using the `--config` flag, otherwise the configuration is picked up from a default location. The default configuration location conforms to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), and is different for Unix systems and Windows systems.

--- a/docs/client/install-kn.md
+++ b/docs/client/install-kn.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - functions
+  - serving
+function: how-to
+---
+
 # Installing the Knative CLI
 
 This guide provides details about how you can install the Knative `kn` CLI.

--- a/docs/client/kn-plugins.md
+++ b/docs/client/kn-plugins.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - functions
+  - serving
+function: reference
+---
+
 # kn plugins
 
 The `kn` CLI supports the use of plugins. Plugins enable you to extend the functionality of your `kn` installation by adding custom commands and other shared commands that are not part of the core distribution of `kn`.

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,3 +1,12 @@
+---
+audience: contributor
+components:
+  - eventing
+  - functions
+  - serving
+function: community
+---
+
 # How to Get Involved
 
 <!-- TODO: what is community, what are the touchpoints -->

--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -1,3 +1,12 @@
+---
+audience: contributor
+components:
+  - eventing
+  - functions
+  - serving
+function: community
+---
+
 # Contribute to Knative
 
 This is the starting point for becoming a contributor - improving code, improving docs, giving talks, etc.

--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -1,3 +1,9 @@
+---
+audience: contributor
+components: []
+function: community
+---
+
 # Community Rules and Practices
 
 This page provides links to documents for common Knative community practices and

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - eventing
+  - functions
+  - serving
+function: explanation
+---
+
 # Concepts
 
 The documentation in this section explains commonly referenced Knative concepts and abstractions, and helps to provide you with a better understanding of how Knative works.

--- a/docs/concepts/duck-typing.md
+++ b/docs/concepts/duck-typing.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: explanation
+---
+
 # Duck typing
 
 Knative enables [loose coupling](https://en.wikipedia.org/wiki/Loose_coupling) of its components by using [duck typing](https://en.wikipedia.org/wiki/Duck_typing).

--- a/docs/concepts/eventing-resources/brokers.md
+++ b/docs/concepts/eventing-resources/brokers.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Brokers
 
 --8<-- "about-brokers.md"

--- a/docs/concepts/serving-resources/revisions.md
+++ b/docs/concepts/serving-resources/revisions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Revisions
 
 --8<-- "about-revisions.md"

--- a/docs/eventing/README.md
+++ b/docs/eventing/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Knative Eventing - The Event-driven application platform for Kubernetes
 
 --8<-- "about-eventing.md"

--- a/docs/eventing/accessing-traces.md
+++ b/docs/eventing/accessing-traces.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+# And audience: developer for accessing traces
+components:
+  - eventing
+function: how-to
+---
+
 # Accessing CloudEvent traces
 
 Depending on the request tracing tool that you have installed on your Knative

--- a/docs/eventing/brokers/README.md
+++ b/docs/eventing/brokers/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # About Brokers
 
 --8<-- "about-brokers.md"

--- a/docs/eventing/brokers/broker-developer-config-options.md
+++ b/docs/eventing/brokers/broker-developer-config-options.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Developer configuration options
 
 ## Broker configuration 

--- a/docs/eventing/brokers/broker-types/README.md
+++ b/docs/eventing/brokers/broker-types/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Available Broker types
 
 The following broker types are available for use with Knative Eventing.

--- a/docs/eventing/brokers/broker-types/channel-based-broker/README.md
+++ b/docs/eventing/brokers/broker-types/channel-based-broker/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: how-to
+---
+
 # Channel based Broker
 
 The Channel based Broker (`MTChannelBasedBroker`) uses [Channels](../../../channels) for event routing. It is shipped by default with Knative Eventing.

--- a/docs/eventing/brokers/broker-types/kafka-broker/README.md
+++ b/docs/eventing/brokers/broker-types/kafka-broker/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: how-to
+---
+
 # Knative Broker for Apache Kafka
 
 The Knative Broker for Apache Kafka is an implementation of the Knative Broker API natively targeting Apache Kafka to reduce network hops and offering a better integration with Apache Kafka for the Broker and Trigger API model.

--- a/docs/eventing/brokers/broker-types/kafka-broker/configuring-kafka-features.md
+++ b/docs/eventing/brokers/broker-types/kafka-broker/configuring-kafka-features.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configuring Kafka Features
 
 There are many different configuration options for how Knative Eventing and the Knaitve Broker for Apache Kafka interact with the Apache Kafka clusters.

--- a/docs/eventing/brokers/broker-types/rabbitmq-broker/README.md
+++ b/docs/eventing/brokers/broker-types/rabbitmq-broker/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: explanation
+---
+
 # Creating a RabbitMQ Broker
 
 This topic describes how to create a RabbitMQ Broker.

--- a/docs/eventing/brokers/create-broker.md
+++ b/docs/eventing/brokers/create-broker.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Creating a Broker
 
 Once you have installed Knative Eventing and a Broker implementation, you can create an instance of a Broker.

--- a/docs/eventing/channels/README.md
+++ b/docs/eventing/channels/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Channels
 
 Channels are Kubernetes [custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) that define a single event forwarding and persistence layer.

--- a/docs/eventing/channels/channel-types-defaults.md
+++ b/docs/eventing/channels/channel-types-defaults.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Channel types and defaults
 
 Knative uses two types of Channels:

--- a/docs/eventing/channels/channels-crds.md
+++ b/docs/eventing/channels/channels-crds.md
@@ -1,3 +1,9 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
 <!--
 This is a generated file and should not be changed manually. All changes should follow the
 procedure:

--- a/docs/eventing/channels/create-default-channel.md
+++ b/docs/eventing/channels/create-default-channel.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Creating a Channel using cluster or namespace defaults
 
 Developers can create Channels of any supported implementation type by creating an instance of a

--- a/docs/eventing/channels/generator/ReadmeTemplate.gomd
+++ b/docs/eventing/channels/generator/ReadmeTemplate.gomd
@@ -1,3 +1,9 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
 {{ "" }}
 
 {{- /* This will be interpreted given a yamlChannels object. */ -}}

--- a/docs/eventing/channels/subscriptions.md
+++ b/docs/eventing/channels/subscriptions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Subscriptions
 
 After you have created a Channel and a Sink, you can create a Subscription to enable event delivery.

--- a/docs/eventing/configuration/broker-configuration.md
+++ b/docs/eventing/configuration/broker-configuration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configure Broker defaults
 
 If you have cluster administrator permissions for your Knative installation, you can modify ConfigMaps to change the global default configuration options for Brokers on the cluster.

--- a/docs/eventing/configuration/channel-configuration.md
+++ b/docs/eventing/configuration/channel-configuration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configure Channel defaults
 
 Knative Eventing provides a `default-ch-webhook` ConfigMap that contains the configuration settings that govern default Channel creation.

--- a/docs/eventing/configuration/kafka-channel-configuration.md
+++ b/docs/eventing/configuration/kafka-channel-configuration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configure Channels for Apache Kafka
 
 !!! note

--- a/docs/eventing/configuration/keda-configuration.md
+++ b/docs/eventing/configuration/keda-configuration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configure KEDA Autoscaling of Knative Kafka Resources
 
 All of the Knative Kafka components which dispatch events (source, channel broker) support scaling the dispatcher data plane with KEDA.

--- a/docs/eventing/configuration/sources-configuration.md
+++ b/docs/eventing/configuration/sources-configuration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configure event source defaults
 
 This topic describes how to configure defaults for Knative event sources. You can configure event sources depending on how they generate events.

--- a/docs/eventing/configuration/sugar-configuration.md
+++ b/docs/eventing/configuration/sugar-configuration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configure Sugar Controller
 
 This topic describes how to configure the Sugar Controller. You can configure the Sugar controller to create a Broker when a Namespace or Trigger is created with configured labels. See [Knative Eventing Sugar Controller](../sugar/README.md) for an example.

--- a/docs/eventing/custom-event-source/README.md
+++ b/docs/eventing/custom-event-source/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Custom event sources
 
 If you need to ingress events from an event producer that is not included in Knative, or from a producer that emits events which are not in the CloudEvent format that is used by Knative, you can do this by using one of the following methods:

--- a/docs/eventing/custom-event-source/containersource/README.md
+++ b/docs/eventing/custom-event-source/containersource/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Create a ContainerSource
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/custom-event-source/containersource/reference.md
+++ b/docs/eventing/custom-event-source/containersource/reference.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # ContainerSource reference
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/custom-event-source/custom-event-source/README.md
+++ b/docs/eventing/custom-event-source/custom-event-source/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Create a custom event source
 
 If you want to create a custom event source for a specific event producer type, you must create the components that enable forwarding events from that producer type to a Knative sink.

--- a/docs/eventing/custom-event-source/custom-event-source/controller.md
+++ b/docs/eventing/custom-event-source/custom-event-source/controller.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Create a controller
 
 You can use the sample repository [`update-codegen.sh`](https://github.com/knative-extensions/sample-source/blob/main/hack/update-codegen.sh) script to generate and inject the required components (the `clientset`, `cache`, `informers`, and `listers`) into your custom controller.

--- a/docs/eventing/custom-event-source/custom-event-source/publish-event-source.md
+++ b/docs/eventing/custom-event-source/custom-event-source/publish-event-source.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Publish an event source to your cluster
 
 1. Start a minikube cluster:

--- a/docs/eventing/custom-event-source/custom-event-source/receive-adapter.md
+++ b/docs/eventing/custom-event-source/custom-event-source/receive-adapter.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Create a receive adapter
 
 As part of the source reconciliation process, you must create and deploy the underlying receive adapter.

--- a/docs/eventing/custom-event-source/custom-event-source/sample-repo.md
+++ b/docs/eventing/custom-event-source/custom-event-source/sample-repo.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Using the Knative sample repository
 
 The Knative project provides a [sample repository](https://github.com/knative-extensions/sample-source) that contains a template for a basic event source controller and a receive adapter.

--- a/docs/eventing/custom-event-source/sinkbinding/README.md
+++ b/docs/eventing/custom-event-source/sinkbinding/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # SinkBinding
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/custom-event-source/sinkbinding/create-a-sinkbinding.md
+++ b/docs/eventing/custom-event-source/sinkbinding/create-a-sinkbinding.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Create a SinkBinding
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/custom-event-source/sinkbinding/reference.md
+++ b/docs/eventing/custom-event-source/sinkbinding/reference.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # SinkBinding reference
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/event-delivery.md
+++ b/docs/eventing/event-delivery.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Handling Delivery Failure
 
 You can configure event delivery parameters for Knative Eventing components that are applied in cases where an event fails to be delivered

--- a/docs/eventing/event-mesh.md
+++ b/docs/eventing/event-mesh.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Event Mesh
 
 An Event Mesh is dynamic, interconnected infrastructure which is designed to simplify distributing events from senders to recipients.  Similar to traditional message-channel architectures like Apache Kafka or RabbitMQ, an Event Mesh provides asynchronous (store-and-forward) delivery of messages which allows decoupling senders and recipients in time.  Unlike traditional message-channel based integration patterns, Event Meshes also simplify the routing concerns of senders and recipients by decoupling them from the underlying event transport infrastructure (which may be a federated set of solutions like Kafka, RabbitMQ, or cloud provider infrastructure).  The mesh transports events from producers to consumers via a network of interconnected _event brokers_ across any environment, and even between clouds in a seamless and loosely coupled way.

--- a/docs/eventing/event-registry/README.md
+++ b/docs/eventing/event-registry/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+# And function: how-to
+---
+
 # Event registry
 
 Knative Eventing defines an `EventType` object to make it easier for consumers to discover the types of events they can consume from Brokers or Channels.

--- a/docs/eventing/event-registry/eventmesh-backstage-plugin.md
+++ b/docs/eventing/event-registry/eventmesh-backstage-plugin.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: how-to
+---
+
 # Knative Event Mesh Backstage Plugin
 
 !!! info

--- a/docs/eventing/faq/README.md
+++ b/docs/eventing/faq/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Eventing FAQs
 
 ## What is a Sugar Controller?

--- a/docs/eventing/features/README.md
+++ b/docs/eventing/features/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Eventing Features
 
 To keep Knative innovative, the maintainers of this project have developed an

--- a/docs/eventing/features/authorization.md
+++ b/docs/eventing/features/authorization.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Knative Eventing Authorization
 
 **Tracking issue**: [#7256](https://github.com/knative/eventing/issues/7256)

--- a/docs/eventing/features/cross-namespace-event-links.md
+++ b/docs/eventing/features/cross-namespace-event-links.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Cross Namespace Event Links
 
 **Flag name**: `cross-namespace-event-links`

--- a/docs/eventing/features/delivery-retryafter.md
+++ b/docs/eventing/features/delivery-retryafter.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # DeliverySpec.RetryAfterMax field
 
 **Flag name**: `delivery-retryafter`

--- a/docs/eventing/features/delivery-timeout.md
+++ b/docs/eventing/features/delivery-timeout.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # DeliverySpec.Timeout field
 
 **Flag name**: `delivery-timeout`

--- a/docs/eventing/features/eventtype-auto-creation.md
+++ b/docs/eventing/features/eventtype-auto-creation.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # EventType auto creation for improved discoverability
 
 **Flag name**: `eventtype-auto-create`

--- a/docs/eventing/features/istio-integration.md
+++ b/docs/eventing/features/istio-integration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Eventing integration with Istio service mesh
 
 **Flag name**: `istio`

--- a/docs/eventing/features/kreference-group.md
+++ b/docs/eventing/features/kreference-group.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # KReference.Group field
 
 **Flag name**: `kreference-group`

--- a/docs/eventing/features/kreference-mapping.md
+++ b/docs/eventing/features/kreference-mapping.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Knative reference mapping
 
 **Flag name**: `kreference-mapping`

--- a/docs/eventing/features/new-apiserversource-filters.md
+++ b/docs/eventing/features/new-apiserversource-filters.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # New trigger filters
 
 **Flag name**: `new-apiserversource-filters`

--- a/docs/eventing/features/sender-identity.md
+++ b/docs/eventing/features/sender-identity.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Sender Identity for Knative Eventing
 
 **Flag name**: `authentication-oidc`

--- a/docs/eventing/features/transport-encryption.md
+++ b/docs/eventing/features/transport-encryption.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Transport Encryption for Knative Eventing
 
 **Flag name**: `transport-encryption`

--- a/docs/eventing/flows/README.md
+++ b/docs/eventing/flows/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Eventing Flows
 
 Knative Eventing provides a collection of [custom resource definitions (CRDs)](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) that you can use to define event flows:

--- a/docs/eventing/flows/parallel.md
+++ b/docs/eventing/flows/parallel.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Parallel
 
 Parallel CRD provides a way to easily define a list of branches, each receiving

--- a/docs/eventing/flows/sequence/README.md
+++ b/docs/eventing/flows/sequence/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Sequence
 
 Sequence CRD provides a way to define an in-order list of functions that will be

--- a/docs/eventing/flows/sequence/sequence-reply-to-event-display/README.md
+++ b/docs/eventing/flows/sequence/sequence-reply-to-event-display/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: how-to
+---
+
 # Sequence wired to event-display
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/flows/sequence/sequence-reply-to-sequence/README.md
+++ b/docs/eventing/flows/sequence/sequence-reply-to-sequence/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: how-to
+---
+
 # Sequence wired to another Sequence
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/flows/sequence/sequence-terminal/README.md
+++ b/docs/eventing/flows/sequence/sequence-terminal/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: how-to
+---
+
 # Sequence terminal
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/flows/sequence/sequence-with-broker-trigger/README.md
+++ b/docs/eventing/flows/sequence/sequence-with-broker-trigger/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: how-to
+---
+
 # Using Sequence with Broker and Trigger
 
 We are going to create the following logical configuration. We create a

--- a/docs/eventing/observability/logging/collecting-logs.md
+++ b/docs/eventing/observability/logging/collecting-logs.md
@@ -1,1 +1,8 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 --8<-- "collecting-logs.md"

--- a/docs/eventing/observability/logging/config-logging.md
+++ b/docs/eventing/observability/logging/config-logging.md
@@ -1,1 +1,8 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 --8<-- "configuring-logs.md"

--- a/docs/eventing/observability/metrics/collecting-metrics.md
+++ b/docs/eventing/observability/metrics/collecting-metrics.md
@@ -1,1 +1,8 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 --8<-- "collecting-metrics.md"

--- a/docs/eventing/observability/metrics/eventing-metrics.md
+++ b/docs/eventing/observability/metrics/eventing-metrics.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Knative Eventing metrics
 
 Administrators can view metrics for Knative Eventing components.

--- a/docs/eventing/reference/eventing-api.md
+++ b/docs/eventing/reference/eventing-api.md
@@ -1,1 +1,8 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 This file is updated to the correct version from the eventing repo (docs/eventing-api.md) during the build.

--- a/docs/eventing/sinks/README.md
+++ b/docs/eventing/sinks/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # About sinks
 
 When you create an event source, you can specify a _sink_ where events are sent to from the source. A sink is an _Addressable_ or a _Callable_ resource that can receive incoming events from other resources. Knative Services, Channels, and Brokers are all examples of sinks.

--- a/docs/eventing/sinks/integration-sink/README.md
+++ b/docs/eventing/sinks/integration-sink/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Knative Sink for Apache Camel Kamelet integrations
 
 ![stage](https://img.shields.io/badge/Stage-alpah-red?style=flat-square)

--- a/docs/eventing/sinks/integration-sink/aws_s3.md
+++ b/docs/eventing/sinks/integration-sink/aws_s3.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # AWS S3 Sink
 
 The `IntegrationSink` supports the Amazon Web Services (AWS) S3 service, through its `aws.s3` property.

--- a/docs/eventing/sinks/integration-sink/aws_sns.md
+++ b/docs/eventing/sinks/integration-sink/aws_sns.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # AWS Simple Notification Service Sink
 
 The `IntegrationSink` supports the Amazon Web Services (AWS) Simple Notification Service (SNS) service, through its `aws.sns` property.

--- a/docs/eventing/sinks/integration-sink/aws_sqs.md
+++ b/docs/eventing/sinks/integration-sink/aws_sqs.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # AWS Simple Queue Service Sink
 
 The `IntegrationSink` supports the Amazon Web Services (AWS) Simple Queue Service (SQS) service, through its `aws.sqs` property.

--- a/docs/eventing/sinks/integration-sink/logger.md
+++ b/docs/eventing/sinks/integration-sink/logger.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Log Sink
 
 The `IntegrationSink` supports the _Log Sink Kamelet_ that logs all data that it receives, through its `log` property. This sink useful for debugging purposes.

--- a/docs/eventing/sinks/job-sink.md
+++ b/docs/eventing/sinks/job-sink.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # JobSink, triggering long-running background jobs when events occurs
 
 Usually event processing combined with a Knative Service is expected to complete in a relative short

--- a/docs/eventing/sinks/kafka-sink.md
+++ b/docs/eventing/sinks/kafka-sink.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: how-to
+---
+
 # Knative Sink for Apache Kafka
 
 The `KafkaSink` is an Apache Kafka-native [Sink implementation](https://knative.dev/docs/eventing/sinks/) persisting the incoming CloudEvent to a configurable Apache Kafka Topic. This page shows how to install and configure the Knative `KafkaSink`.

--- a/docs/eventing/sources/README.md
+++ b/docs/eventing/sources/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Event sources
 
 An event source is a Kubernetes custom resource (CR), created by a developer or cluster administrator, that acts as a link between an event producer and an event _sink_.

--- a/docs/eventing/sources/apiserversource/README.md
+++ b/docs/eventing/sources/apiserversource/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # About ApiServerSource
 
 ![stage](https://img.shields.io/badge/Stage-stable-green?style=flat-square)

--- a/docs/eventing/sources/apiserversource/getting-started.md
+++ b/docs/eventing/sources/apiserversource/getting-started.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how to
+---
+
 # Creating an ApiServerSource object
 
 ![version](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/sources/apiserversource/reference.md
+++ b/docs/eventing/sources/apiserversource/reference.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # ApiServerSource reference
 
 ![version](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/sources/integration-source/README.md
+++ b/docs/eventing/sources/integration-source/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # Knative Source for Apache Camel Kamelet integrations
 
 ![stage](https://img.shields.io/badge/Stage-alpah-red?style=flat-square)

--- a/docs/eventing/sources/integration-source/aws_ddbstreams.md
+++ b/docs/eventing/sources/integration-source/aws_ddbstreams.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # AWS DynamoDB Streams
 
 The `IntegrationSource` supports the Amazon Web Services (AWS) DynamoDB Streams service, through its `aws.ddbStreams` property.

--- a/docs/eventing/sources/integration-source/aws_s3.md
+++ b/docs/eventing/sources/integration-source/aws_s3.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # AWS S3 Source
 
 The `IntegrationSource` supports the Amazon Web Services (AWS) S3 service, through its `aws.s3` property.

--- a/docs/eventing/sources/integration-source/aws_sqs.md
+++ b/docs/eventing/sources/integration-source/aws_sqs.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # AWS Simple Queue Service Source
 
 The `IntegrationSource` supports the Amazon Web Services (AWS) Simple Queue Service (SQS) service, through its `aws.sqs` property.

--- a/docs/eventing/sources/integration-source/timer.md
+++ b/docs/eventing/sources/integration-source/timer.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Timer Source
 
 The `IntegrationSource` supports the _Timer Kamelet_ for producing periodic messages with a custom payload, through its `timer` property.

--- a/docs/eventing/sources/kafka-source/README.md
+++ b/docs/eventing/sources/kafka-source/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: how-to
+---
+
 # Knative Source for Apache Kafka
 
 ![stage](https://img.shields.io/badge/Stage-stable-green?style=flat-square)

--- a/docs/eventing/sources/ping-source/README.md
+++ b/docs/eventing/sources/ping-source/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Creating a PingSource object
 
 ![stage](https://img.shields.io/badge/Stage-stable-green?style=flat-square)

--- a/docs/eventing/sources/ping-source/reference.md
+++ b/docs/eventing/sources/ping-source/reference.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # PingSource reference
 
 ![API version v1](https://img.shields.io/badge/API_Version-v1-green?style=flat-square)

--- a/docs/eventing/sources/rabbitmq-source/README.md
+++ b/docs/eventing/sources/rabbitmq-source/README.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+# And audience: administrator for install
+components:
+  - eventing
+function: how-to
+---
+
 # Creating a RabbitMQSource
 
 ![stage](https://img.shields.io/badge/Stage-stable-green?style=flat-square)

--- a/docs/eventing/sources/redis/README.md
+++ b/docs/eventing/sources/redis/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: explanation
+---
+
 # About RedisStreamSource
 
 ![stage](https://img.shields.io/badge/Stage-alpha-green?style=flat-square)

--- a/docs/eventing/sources/redis/getting-started.md
+++ b/docs/eventing/sources/redis/getting-started.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Creating a RedisStreamSource
 
 ![version](https://img.shields.io/badge/API_Version-v1alpha1-red?style=flat-square)

--- a/docs/eventing/sugar/README.md
+++ b/docs/eventing/sugar/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Knative Eventing Sugar Controller
 
 Knative Eventing Sugar Controller will react to configured labels

--- a/docs/eventing/transforms/README.md
+++ b/docs/eventing/transforms/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Event Transformation
 
 ## Overview

--- a/docs/eventing/transforms/event-transform-jsonata.md
+++ b/docs/eventing/transforms/event-transform-jsonata.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Event Transformations for JSON with JSONata
 
 ## Introduction to JSONata

--- a/docs/eventing/triggers/README.md
+++ b/docs/eventing/triggers/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Using Triggers
 
 A trigger represents a desire to subscribe to events from a specific broker.

--- a/docs/eventing/troubleshooting/README.md
+++ b/docs/eventing/troubleshooting/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: how-to
+---
+
 # Debugging Knative Eventing
 
 This is an evolving document on how to debug a non-working Knative Eventing

--- a/docs/functions/README.md
+++ b/docs/functions/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: explanation
+---
+
 # Knative Functions overview
 
 --8<-- "about-functions.md"

--- a/docs/functions/building-functions.md
+++ b/docs/functions/building-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Building functions
 
 --8<-- "build-func-intro.md"

--- a/docs/functions/creating-functions.md
+++ b/docs/functions/creating-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Creating functions
 
 --8<-- "create-a-function.md"

--- a/docs/functions/deploying-functions.md
+++ b/docs/functions/deploying-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Deploying functions
 
 --8<-- "deploy-func-intro.md"

--- a/docs/functions/install-func.md
+++ b/docs/functions/install-func.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Installing Knative Functions
 
 --8<-- "install-functions-intro.md"

--- a/docs/functions/invoking-functions.md
+++ b/docs/functions/invoking-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Invoking functions
 
 You can use the `func invoke` command to send a test request to invoke a

--- a/docs/functions/language-packs.md
+++ b/docs/functions/language-packs.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Language packs
 
 Language packs can be used to extend Knative Functions to support additional runtimes, function signatures, operating systems, and installed tooling for functions. Language Packs are distributed through Git repositories or as a directory on a disc.

--- a/docs/functions/running-functions.md
+++ b/docs/functions/running-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Running functions
 
 --8<-- "run-func-intro.md"

--- a/docs/functions/subscribing-functions.md
+++ b/docs/functions/subscribing-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: how-to
+---
+
 # Subscribe functions to CloudEvents
 
 ### Prerequisites

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: tutorial
+---
+
 # Welcome to the Knative Quickstart tutorial
 
 Following this Quickstart tutorial provides you with a simplified, local Knative installation by using the Knative `quickstart` plugin.

--- a/docs/getting-started/about-knative-functions.md
+++ b/docs/getting-started/about-knative-functions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: tutorial
+---
+
 # About Knative Functions
 
 --8<-- "about-functions.md"

--- a/docs/getting-started/build-run-deploy-func.md
+++ b/docs/getting-started/build-run-deploy-func.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: tutorial
+---
+
 # Building, running, or deploying functions
 
 After you have created a function project, you can build, run, or deploy your function, depending on your use case.

--- a/docs/getting-started/clean-up.md
+++ b/docs/getting-started/clean-up.md
@@ -1,6 +1,12 @@
 ---
+audience: developer
+components:
+  - serving
+  - eventing
+function: tutorial
 hide_next: true
 ---
+
 # Clean Up
 
 We recommend that you delete the cluster used for this tutorial to free up resources

--- a/docs/getting-started/create-a-function.md
+++ b/docs/getting-started/create-a-function.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: tutorial
+---
+
 # Creating a function
 
 --8<-- "create-a-function.md"

--- a/docs/getting-started/first-autoscale.md
+++ b/docs/getting-started/first-autoscale.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: tutorial
+---
+
 # Autoscaling
 
 Knative Serving provides automatic scaling, also known as **autoscaling**. This means that a Knative Service by default scales down to zero running pods when it is not in use.

--- a/docs/getting-started/first-broker.md
+++ b/docs/getting-started/first-broker.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Sources, Brokers, and Triggers
 
 As part of the `kn quickstart` install, an InMemoryChannel-backed Broker is installed on your kind cluster.

--- a/docs/getting-started/first-service.md
+++ b/docs/getting-started/first-service.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: tutorial
+---
+
 # Deploying a Knative Service
 
 In this tutorial, you will deploy a "Hello world" Knative Service that accepts the environment variable `TARGET` and prints `Hello ${TARGET}!`.

--- a/docs/getting-started/first-source.md
+++ b/docs/getting-started/first-source.md
@@ -1,3 +1,11 @@
+---
+audience: developer
+components:
+  - eventing
+  - serving
+function: tutorial
+---
+
 # Using a Knative Service as a source
 
 In this tutorial, you will use the [CloudEvents Player](https://github.com/ruromero/cloudevents-player){target=blank} app to showcase the core concepts of Knative Eventing. By the end of this tutorial, you should have an architecture that looks like this:

--- a/docs/getting-started/first-traffic-split.md
+++ b/docs/getting-started/first-traffic-split.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: tutorial
+---
+
 # Traffic splitting
 
 Traffic splitting is useful for [blue/green deployments](https://martinfowler.com/bliki/BlueGreenDeployment.html){target=blank_} and [canary deployments](https://martinfowler.com/bliki/CanaryRelease.html){target=blank_}.

--- a/docs/getting-started/first-trigger.md
+++ b/docs/getting-started/first-trigger.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # Using Triggers and sinks
 
 In the last topic we used the CloudEvents Player as an event source to send events to the Broker.

--- a/docs/getting-started/getting-started-eventing.md
+++ b/docs/getting-started/getting-started-eventing.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: tutorial
+---
+
 # About Knative Eventing
 
 Knative Eventing provides you with helpful tools that can be used to create event-driven applications, by easily attaching event sources, triggers, and other options to your Knative Services.

--- a/docs/getting-started/install-func.md
+++ b/docs/getting-started/install-func.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - functions
+function: tutorial
+---
+
 # Installing Knative Functions
 
 --8<-- "install-functions-intro.md"

--- a/docs/getting-started/next-steps.md
+++ b/docs/getting-started/next-steps.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: tutorial
+---
+
 # Next Steps
 
 This topic provides a list of resources to help you continue your Knative journey.

--- a/docs/getting-started/quickstart-install.md
+++ b/docs/getting-started/quickstart-install.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: tutorial
+---
+
 # Install Knative using quickstart
 
 Following this quickstart tutorial provides you with a simplified, local Knative installation by using the Knative `quickstart` plugin.

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: tutorial
+---
+
 # Welcome to the Knative Tutorial
 
 ### **Quick Start Tutorial**

--- a/docs/getting-started/which-knative.md
+++ b/docs/getting-started/which-knative.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: explanation
+---
+
 # Which Knative Component Should I Use?
 
 Knative is a project that simplifies the deployment of applications onto Kubernetes. Knative, as a project, contains a few different components. The purpose of this document is to explain them and advise on when you would use a specific component. 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: reference
+---
+
 # Installing Knative
 
 !!! note

--- a/docs/install/installing-backstage-plugins.md
+++ b/docs/install/installing-backstage-plugins.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Installing Knative Backstage Plugins
 
 Knative community is planning to provide a set of Backstage plugins for Knative and their respective backends.

--- a/docs/install/installing-cert-manager.md
+++ b/docs/install/installing-cert-manager.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Installing cert-manager for TLS certificates
 
 Knative leverages [cert-manager](https://github.com/jetstack/cert-manager) to request TLS certificates

--- a/docs/install/installing-istio.md
+++ b/docs/install/installing-istio.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Installing Istio for Knative
 
 This guide walks you through manually installing and customizing Istio for use

--- a/docs/install/knative-offerings.md
+++ b/docs/install/knative-offerings.md
@@ -1,3 +1,11 @@
+---
+audience: buyer
+components:
+  - serving
+  - eventing
+function: reference
+---
+
 # Knative Offerings
 
 Knative has a rich community with many vendors participating, and many of those

--- a/docs/install/operator/configuring-eventing-cr.md
+++ b/docs/install/operator/configuring-eventing-cr.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Configuring the Eventing Operator custom resource
 
 You can configure the Knative Eventing operator by modifying settings in the `KnativeEventing` custom resource (CR).

--- a/docs/install/operator/configuring-serving-cr.md
+++ b/docs/install/operator/configuring-serving-cr.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring the Knative Serving Operator custom resource
 
 You can modify the KnativeServing CR to configure different options for Knative Serving.

--- a/docs/install/operator/configuring-with-operator.md
+++ b/docs/install/operator/configuring-with-operator.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Configuring Knative by using the Operator
 
 The Operator manages the configuration of a Knative installation, including propagating values from the `KnativeServing` and `KnativeEventing` custom resources to system [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/).

--- a/docs/install/operator/knative-with-operator-cli.md
+++ b/docs/install/operator/knative-with-operator-cli.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Install by using the Knative Operator CLI Plugin
 
 Knative provides a CLI Plugin to install, configure and manage Knative via the command lines. This CLI plugin facilitates

--- a/docs/install/operator/knative-with-operators.md
+++ b/docs/install/operator/knative-with-operators.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Install by using the Knative Operator
 
 Knative provides a [Kubernetes Operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to install, configure and manage Knative.

--- a/docs/install/quickstart-install.md
+++ b/docs/install/quickstart-install.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: tutorial
+---
+
 # Install Knative using quickstart
 
 Following this quickstart tutorial provides you with a simplified, local Knative installation by using the Knative `quickstart` plugin.

--- a/docs/install/troubleshooting.md
+++ b/docs/install/troubleshooting.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Troubleshooting a Knative Installation
 
 This page describes how you can troubleshoot a Knative installation. Please try these instructions before filing a bug report.

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Uninstalling Knative
 
 To uninstall an Operator-based Knative installation, see the following [Uninstall an Operator-based Knative Installation](#uninstall-an-operator-based-knative-installation) procedure.

--- a/docs/install/upgrade/README.md
+++ b/docs/install/upgrade/README.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Upgrading Knative
 
 Knative supports upgrading by a single [minor](https://semver.org/) version number. For example, if you have v0.21.0 installed, you must upgrade to v0.22.0 before attempting to upgrade to v0.23.0.

--- a/docs/install/upgrade/check-install-version.md
+++ b/docs/install/upgrade/check-install-version.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Checking your Knative version
 
 To check the version of your Knative installation, use one of the following commands,

--- a/docs/install/upgrade/upgrade-installation-with-operator.md
+++ b/docs/install/upgrade/upgrade-installation-with-operator.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Upgrading using the Knative Operator
 
 This topic describes how to upgrade Knative if you installed using the Operator.

--- a/docs/install/upgrade/upgrade-installation.md
+++ b/docs/install/upgrade/upgrade-installation.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Upgrading with kubectl
 
 If you installed Knative using YAML, you can use the `kubectl apply` command in

--- a/docs/install/yaml-install/README.md
+++ b/docs/install/yaml-install/README.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: reference
+---
+
 # About YAML-based installation
 
 You can install the Serving component, Eventing component, or both on your cluster

--- a/docs/install/yaml-install/eventing/eventing-installation-files.md
+++ b/docs/install/yaml-install/eventing/eventing-installation-files.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: reference
+---
+
 # Knative Eventing installation files
 
 This guide provides reference information about the core Knative Eventing YAML files, including:

--- a/docs/install/yaml-install/eventing/install-eventing-with-yaml.md
+++ b/docs/install/yaml-install/eventing/install-eventing-with-yaml.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - eventing
+function: how-to
+---
+
 # Installing Knative Eventing using YAML files
 
 This topic describes how to install Knative Eventing by applying YAML files using the `kubectl` CLI.

--- a/docs/install/yaml-install/serving/install-serving-with-yaml-on-IBM-Z-and-IBM-P.md
+++ b/docs/install/yaml-install/serving/install-serving-with-yaml-on-IBM-Z-and-IBM-P.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Install a networking layer on IBM Z and IBM Power platforms
 
 This additional step is required for installing the Kourier networking layer on IBM Z and IBM Power platforms.

--- a/docs/install/yaml-install/serving/install-serving-with-yaml.md
+++ b/docs/install/yaml-install/serving/install-serving-with-yaml.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Installing Knative Serving using YAML files
 
 This topic describes how to install Knative Serving by applying YAML files using the `kubectl` CLI.

--- a/docs/install/yaml-install/serving/serving-installation-files.md
+++ b/docs/install/yaml-install/serving/serving-installation-files.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Knative Serving installation files
 
 This guide provides reference information about the core Knative Serving YAML files, including:

--- a/docs/reference/relnotes/README.md
+++ b/docs/reference/relnotes/README.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: reference
+---
+
 # Knative release notes
 
 For details about the Knative releases, see the following pages:

--- a/docs/reference/security/README.md
+++ b/docs/reference/security/README.md
@@ -1,3 +1,12 @@
+---
+audience: developer
+components:
+  - functions
+  - serving
+  - eventing
+function: how-to
+---
+
 # Knative Security and Disclosure Information
 
 This page describes Knative security and disclosure information.

--- a/docs/reference/security/verifying-images.md
+++ b/docs/reference/security/verifying-images.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: how-to
+---
+
 # Verifying Knative Images
 
 Knative publishes SBOMs and SLSA provenance documents for each image in the

--- a/docs/samples/README.md
+++ b/docs/samples/README.md
@@ -1,3 +1,11 @@
+---
+audience: administrator
+components:
+  - serving
+  - eventing
+function: reference
+---
+
 # Knative code samples
 
 You can use Knative code samples to help you get up and running with common use

--- a/docs/samples/eventing.md
+++ b/docs/samples/eventing.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - eventing
+function: reference
+---
+
 # Knative Eventing code samples
 
 Use the following code samples to help you understand the various use cases for

--- a/docs/samples/serving.md
+++ b/docs/samples/serving.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Knative Serving code samples
 
 Use the following code samples to help you understand the various Knative

--- a/docs/serving/README.md
+++ b/docs/serving/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Knative Serving
 
 --8<-- "about-serving.md"

--- a/docs/serving/accessing-traces.md
+++ b/docs/serving/accessing-traces.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Accessing request traces
 
 Depending on the request tracing tool that you have installed on your Knative

--- a/docs/serving/app-security/security-guard-about.md
+++ b/docs/serving/app-security/security-guard-about.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: explanation
+---
+
 # About Security-Guard
 
 Security-Guard provides visibility into the security status of deployed Knative Services, by monitoring the behaviors of user containers and events. Security-Guard also supports optional blocking of events and termination of user container instances, all based on behavior.

--- a/docs/serving/app-security/security-guard-example-alerts.md
+++ b/docs/serving/app-security/security-guard-example-alerts.md
@@ -1,3 +1,9 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
 
 # Security-Guard example alerts
 

--- a/docs/serving/app-security/security-guard-install.md
+++ b/docs/serving/app-security/security-guard-install.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Installing Security-Guard
 
 Here we show how to install Security-Guard in Knative. Security-Guard is an enhancement to knative-Serving and needs to be installed after the Knative-Serving is successfully installed.

--- a/docs/serving/app-security/security-guard-quickstart.md
+++ b/docs/serving/app-security/security-guard-quickstart.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: tutorial
+---
+
 # Security-Guard monitoring quickstart
 
 This tutorial shows how you can use Security-Guard to protect a deployed Knative Service.

--- a/docs/serving/architecture.md
+++ b/docs/serving/architecture.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Knative Serving Architecture
 
 Knative Serving consists of several components forming the backbone of the Serverless Platform.

--- a/docs/serving/autoscaling/README.md
+++ b/docs/serving/autoscaling/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Autoscaling
 
 Knative Serving provides automatic scaling, or _autoscaling_, for applications to match incoming demand. This is provided by default, by using the Knative Pod Autoscaler (KPA).

--- a/docs/serving/autoscaling/autoscale-go/README.md
+++ b/docs/serving/autoscaling/autoscale-go/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Autoscale Sample App - Go
 
 A demonstration of the autoscaling capabilities of a Knative Serving Revision.

--- a/docs/serving/autoscaling/autoscaler-types.md
+++ b/docs/serving/autoscaling/autoscaler-types.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Supported Autoscaler types
 
 Knative Serving supports the implementation of Knative Pod Autoscaler (KPA) and Kubernetes' Horizontal Pod Autoscaler (HPA). This topic lists the features and limitations of each of these Autoscalers, as well as how to configure them.

--- a/docs/serving/autoscaling/autoscaling-metrics.md
+++ b/docs/serving/autoscaling/autoscaling-metrics.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Metrics
 
 The metric configuration defines which metric type is watched by the Autoscaler.

--- a/docs/serving/autoscaling/autoscaling-targets.md
+++ b/docs/serving/autoscaling/autoscaling-targets.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Targets
 
 Configuring a target provide the Autoscaler with a value that it tries to maintain for the configured metric for a revision.

--- a/docs/serving/autoscaling/concurrency.md
+++ b/docs/serving/autoscaling/concurrency.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Configuring concurrency
 
 Concurrency determines the number of simultaneous requests that can be processed by each replica of an application at any given time.

--- a/docs/serving/autoscaling/kpa-specific.md
+++ b/docs/serving/autoscaling/kpa-specific.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Additional autoscaling configuration for Knative Pod Autoscaler
 
 The following settings are specific to the Knative Pod Autoscaler (KPA).

--- a/docs/serving/autoscaling/rps-target.md
+++ b/docs/serving/autoscaling/rps-target.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Configuring the requests per second (RPS) target
 
 This setting specifies a target for requests-per-second per replica of an application. Your revision must also be configured to use the `rps` [metric annotation](autoscaling-metrics.md).

--- a/docs/serving/autoscaling/scale-bounds.md
+++ b/docs/serving/autoscaling/scale-bounds.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Configuring scale bounds
 
 You can configure upper and lower bounds to control autoscaling behavior.

--- a/docs/serving/autoscaling/scale-to-zero.md
+++ b/docs/serving/autoscaling/scale-to-zero.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Configuring scale to zero
 
 !!! warning

--- a/docs/serving/config-ha.md
+++ b/docs/serving/config-ha.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring high-availability components
 
 Active/passive high availability (HA) is a standard feature of Kubernetes APIs that helps to ensure that APIs stay operational if a disruption occurs. In an HA deployment, if an active controller crashes or is deleted, another controller is available to take over processing of the APIs that were being serviced by the controller that is now unavailable.

--- a/docs/serving/configuration/config-defaults.md
+++ b/docs/serving/configuration/config-defaults.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Configuring the Defaults ConfigMap
 
 The `config-defaults` ConfigMap, known as the Defaults ConfigMap, contains settings that determine how Knative sets default values for resources.

--- a/docs/serving/configuration/deployment.md
+++ b/docs/serving/configuration/deployment.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Configure Deployment resources
 
 The `config-deployment` ConfigMap, known as the Deployment ConfigMap, contains settings that determine how Kubernetes `Deployment` resources, which back Knative services, are configured. This ConfigMap is located in the `knative-serving` namespace.

--- a/docs/serving/configuration/feature-flags.md
+++ b/docs/serving/configuration/feature-flags.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Feature and extension flags
 
 The Knative API is designed to be portable, and abstracts away specific implementation details for user deployments. The intention of the API is to empower users to surface extra features and extensions that are possible within their platform of choice.

--- a/docs/serving/configuration/rolling-out-latest-revision-configmap.md
+++ b/docs/serving/configuration/rolling-out-latest-revision-configmap.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 {% include "gradual-rollout-intro.md" %}
 
 ## Procedure

--- a/docs/serving/convert-deployment-to-knative-service.md
+++ b/docs/serving/convert-deployment-to-knative-service.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Converting a Kubernetes Deployment to a Knative Service
 
 This topic shows how to convert a Kubernetes Deployment to a Knative Service.

--- a/docs/serving/deploying-from-private-registry.md
+++ b/docs/serving/deploying-from-private-registry.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Deploying images from a private container registry
 
 You can configure your Knative cluster to deploy images from a private registry across multiple Services and Revisions. To do this, you must create a list of Kubernetes secrets ([`imagePullSecrets`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core)) by using your registry credentials. You must then add those secrets to the default [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for all Services, or the Revision template for a single Service.

--- a/docs/serving/encryption/cluster-local-domain-tls.md
+++ b/docs/serving/encryption/cluster-local-domain-tls.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configure cluster-local domain encryption
 
 {% include "encryption-notice.md" %}

--- a/docs/serving/encryption/configure-certmanager-integration.md
+++ b/docs/serving/encryption/configure-certmanager-integration.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring Knative cert-manager integration
 
 Knative Serving relies on a bridging component to use cert-manager for automated certificate provisioning. 

--- a/docs/serving/encryption/encryption-overview.md
+++ b/docs/serving/encryption/encryption-overview.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: explanation
+---
+
 # Serving Encryption Overview
 
 {% include "encryption-notice.md" %}

--- a/docs/serving/encryption/external-domain-tls.md
+++ b/docs/serving/encryption/external-domain-tls.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configure external domain encryption
 
 Knative allows to use either use custom TLS certificates or to use automatically generated TLS certificates 

--- a/docs/serving/encryption/system-internal-tls.md
+++ b/docs/serving/encryption/system-internal-tls.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configure Knative system-internal encryption
 
 {% include "encryption-notice.md" %}

--- a/docs/serving/istio-authorization.md
+++ b/docs/serving/istio-authorization.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Enabling requests to Knative services when additional authorization policies are enabled
 
 Knative Serving system pods, such as the activator and autoscaler components, require access to your deployed Knative services.

--- a/docs/serving/knative-kubernetes-services.md
+++ b/docs/serving/knative-kubernetes-services.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Kubernetes services
 
 This guide describes the

--- a/docs/serving/load-balancing/README.md
+++ b/docs/serving/load-balancing/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Load balancing
 
 You can turn on Knative load balancing, by placing the _Activator service_ in the request path to act as a load balancer. To do this, you must first ensure that individual pod addressability is enabled.

--- a/docs/serving/load-balancing/activator-capacity.md
+++ b/docs/serving/load-balancing/activator-capacity.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring Activator capacity
 
 If there is more than one Activator in the system, Knative puts as many Activators on the request path as required to handle the current request load plus the target burst capacity. If the target burst capacity is 0, Knative only puts the Activator into the request path if the Revision is scaled to zero.

--- a/docs/serving/load-balancing/target-burst-capacity.md
+++ b/docs/serving/load-balancing/target-burst-capacity.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Configuring target burst capacity
 
 _Target burst capacity_ is a [global and per-revision](../autoscaling/autoscaler-types.md#global-versus-per-revision-settings) integer setting that determines the size of traffic burst a Knative application can handle without buffering.

--- a/docs/serving/observability/logging/collecting-logs.md
+++ b/docs/serving/observability/logging/collecting-logs.md
@@ -1,1 +1,8 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 --8<-- "collecting-logs.md"

--- a/docs/serving/observability/logging/config-logging.md
+++ b/docs/serving/observability/logging/config-logging.md
@@ -1,1 +1,8 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 --8<-- "configuring-logs.md"

--- a/docs/serving/observability/logging/request-logging.md
+++ b/docs/serving/observability/logging/request-logging.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring Request Log Settings
 
 The request logging for knative serving is managed through the `config-observability` ConfigMap in `knative-serving` namespace. The request logs will be printed by the queue-proxy sidecar.

--- a/docs/serving/observability/metrics/collecting-metrics.md
+++ b/docs/serving/observability/metrics/collecting-metrics.md
@@ -1,1 +1,8 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 --8<-- "collecting-metrics.md"

--- a/docs/serving/observability/metrics/serving-metrics.md
+++ b/docs/serving/observability/metrics/serving-metrics.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Knative Serving metrics
 
 Administrators can monitor Serving control plane based on the metrics exposed by each Serving component.

--- a/docs/serving/queue-extensions.md
+++ b/docs/serving/queue-extensions.md
@@ -1,3 +1,10 @@
+---
+audience: contributor
+components:
+  - serving
+function: how-to
+---
+
 # Extending Queue Proxy image with QPOptions
 
 Knative service pods include two containers:

--- a/docs/serving/request-flow.md
+++ b/docs/serving/request-flow.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # HTTP Request Flows
 
 While [the overview](/docs/serving) describes the logical components and

--- a/docs/serving/revisions/README.md
+++ b/docs/serving/revisions/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # About Revisions
 
 --8<-- "about-revisions.md"

--- a/docs/serving/revisions/revision-admin-config-options.md
+++ b/docs/serving/revisions/revision-admin-config-options.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: reference
+---
+
 # Administrator configuration options
 
 If you have cluster administrator permissions for your Knative installation, you can modify ConfigMaps to change the global default configuration options for Revisions of Knative Services on the cluster.

--- a/docs/serving/revisions/revision-developer-config-options.md
+++ b/docs/serving/revisions/revision-developer-config-options.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Developer configuration options
 
 While Revisions cannot be created manually without modifying the Configuration of a Knative Service, you can modify the spec of an existing Revision to change its behavior.

--- a/docs/serving/rolling-out-latest-revision.md
+++ b/docs/serving/rolling-out-latest-revision.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 {% include "gradual-rollout-intro.md" %}
 
 ## Procedure

--- a/docs/serving/services/README.md
+++ b/docs/serving/services/README.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # About Knative Services
 
 Knative Services are used to deploy an application. To create an application using Knative, you must create a YAML file that defines a Service. This YAML file specifies metadata about the application, points to the hosted image of the app, and allows the Service to be configured.

--- a/docs/serving/services/certificate-class.md
+++ b/docs/serving/services/certificate-class.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Configuring a custom certificate class for a Service
 
 When `external-domain-tls` is enabled and Knative Services are created, a certificate class (`certificate-class`) is automatically chosen based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the certificate class is not specified, this defaults to `cert-manager.certificate.networking.knative.dev`. After `certificate-class` is configured, it is used for all Knative Services unless it is overridden with a `certificate-class` annotation.

--- a/docs/serving/services/configure-probing.md
+++ b/docs/serving/services/configure-probing.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Configuring Probing
 
 ## General understanding of Knative Probing

--- a/docs/serving/services/configure-requests-limits-services.md
+++ b/docs/serving/services/configure-requests-limits-services.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Configure resource requests and limits
 
 You can configure resource limits and requests, specifically for CPU and memory, for individual Knative services.

--- a/docs/serving/services/creating-services.md
+++ b/docs/serving/services/creating-services.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Creating a Service
 
 You can create a Knative service by applying a YAML file or using the `kn service create` CLI command.

--- a/docs/serving/services/custom-domains.md
+++ b/docs/serving/services/custom-domains.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Configuring custom domains
 
 {{ feature(beta="0.24") }}

--- a/docs/serving/services/custom-tls-certificate-domain-mapping.md
+++ b/docs/serving/services/custom-tls-certificate-domain-mapping.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Using a custom TLS certificate for DomainMapping
 
 {{ feature(beta="0.24") }}

--- a/docs/serving/services/http-protocol.md
+++ b/docs/serving/services/http-protocol.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring HTTP
 
 ## HTTPS redirection

--- a/docs/serving/services/ingress-class.md
+++ b/docs/serving/services/ingress-class.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Configuring Services custom ingress class
 
 When a Knative Service is created an ingress class (`ingress-class`) is automatically assigned to it, based on the value in the `config-network` ConfigMap located inside the `knative-serving` namespace. This ConfigMap is part of Knative Serving installation. If the ingress class is not specified, this defaults to `istio.ingress.networking.knative.dev`. Once configured the `ingress-class` is used for all Knative Services unless it is overridden with an `ingress-class` annotation.

--- a/docs/serving/services/private-services.md
+++ b/docs/serving/services/private-services.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Configuring private Services
 
 By default, Services deployed through Knative use the `.svc.cluster.local` domain, meaning

--- a/docs/serving/services/service-metrics.md
+++ b/docs/serving/services/service-metrics.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: reference
+---
+
 # Service metrics
 
 Every Knative Service has a proxy container that proxies the connections to the application container. A number of metrics are reported for the queue proxy performance.

--- a/docs/serving/services/storage.md
+++ b/docs/serving/services/storage.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Volume Support for Knative services
 
 You can provide data storage for Knative Services by configuring different volumes types.

--- a/docs/serving/services/using-queue-extensions.md
+++ b/docs/serving/services/using-queue-extensions.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: explanation
+---
+
 # Using extensions enabled by QPOptions
 
 QPOptions is a Queue Proxy feature that enables extending Queue Proxy with additional Go packages. For example, the [security-guard](https://knative.dev/security-guard#section-readme) repository extends Queue Proxy by adding runtime security features to protect user services.

--- a/docs/serving/setting-up-custom-ingress-gateway.md
+++ b/docs/serving/setting-up-custom-ingress-gateway.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring the ingress gateway
 
 Knative uses a shared ingress Gateway to serve all incoming traffic within

--- a/docs/serving/tag-resolution.md
+++ b/docs/serving/tag-resolution.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Tag resolution
 
 Knative Serving resolves image tags to a digest when you create a Revision. This

--- a/docs/serving/traffic-management.md
+++ b/docs/serving/traffic-management.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Traffic management
 
 You can manage traffic routing to different Revisions of a Knative Service by modifying the `traffic` spec of the Service resource.

--- a/docs/serving/troubleshooting/debugging-application-issues.md
+++ b/docs/serving/troubleshooting/debugging-application-issues.md
@@ -1,3 +1,10 @@
+---
+audience: developer
+components:
+  - serving
+function: how-to
+---
+
 # Debugging application issues
 
 If you have deployed an application but are having issues, you can use the following steps to troubleshoot the application.

--- a/docs/serving/using-a-custom-domain.md
+++ b/docs/serving/using-a-custom-domain.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Configuring domain names
 
 You can customize the domain of an individual Knative Service, or set a global default domain for all Services created on a cluster. The fully qualified domain name for a route by default is `{route}.{namespace}.svc.cluster.local`.

--- a/docs/serving/webhook-customizations.md
+++ b/docs/serving/webhook-customizations.md
@@ -1,3 +1,10 @@
+---
+audience: administrator
+components:
+  - serving
+function: how-to
+---
+
 # Exclude namespaces from the Knative webhook
 
 The Knative webhook examines resources that are created, read, updated, or deleted. This includes system namespaces, which can cause issues during an upgrade if the webhook becomes non-responsive. Cluster administrators may want to disable the Knative webhook on system namespaces to prevent issues during upgrades.


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

In preparation for a [CNCF TechDocs Assessment](https://github.com/cncf/techdocs/issues/315), start labelling Knative documentation with metadata to assist with re-organizing content to different information architecture options (we will still need manual review, but this may simplify that review).

I'm using a schema with 3 fields:

| field | allowed values | explanation |
|---|---|---|
| `audience` | `developer`, `administrator`, `buyer`, `contributor` | **Who** the target audience is; ensure documents have a clear, single audience |
| `components` | `eventing`, `functions`, `serving` (list) | **What** components are featured on the page. |
| `function` | `marketing`, `community`, `tutorial`, `how-to`, `reference`, `explanation` | A [diataxis](https://diataxis.fr/) tag or "marketing" or "community" indicating the needs addressed by the documentation. |
