### PR TITLE
Fix: wrong filters attribute in trigger document

### DIFF
--- a/docs/eventing/triggers/README.md
+++ b/docs/eventing/triggers/README.md
@@ -88,10 +88,10 @@ with `-extensions.
     spec:
       broker: default
       filters:
-        exact:
-          type: dev.knative.foo.bar
-        suffix:
-          myextension: -value
+        - exact:
+            type: dev.knative.foo.bar
+          suffix:
+            myextension: -value
       subscriber:
         ref:
           apiVersion: serving.knative.dev/v1


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

I tried to create a  Trigger object by following the guideline at https://knative.dev/docs/eventing/triggers/#trigger-filtering .

```yaml
apiVersion: eventing.knative.dev/v1
kind: Trigger
metadata:
  name: my-service-trigger
spec:
  broker: default
  filters:
    exact:
      type: dev.knative.foo.bar
    suffix:
      myextension: -value
  subscriber:
    ref:
      apiVersion: serving.knative.dev/v1
      kind: Service
      name: my-service
```

However, I got the error due to a wrong syntax since `spec.filters` expects an array of filters.

```
strict decoding error: unknown field "spec.filters.exact", unknown field "spec.filters.suffix"
```

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Fix a wrong attribute in Trigger filtering's example manifest file
