### PR TITLE
feat: route knative docs base URL from knative.dev/docs to knative.dev

### DIFF
--- a/blog/mkdocs.yml
+++ b/blog/mkdocs.yml
@@ -79,7 +79,7 @@ plugins:
 copyright: "Copyright © 2024 The Knative Authors"
 
 extra:
-  homepage: https://knative.dev/docs
+  homepage: https://knative.dev
   # social:
   #   - icon: fontawesome/brands/twitter
   #     link: https://twitter.com/KnativeProject

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 INHERIT: config/nav.yml
 
 site_name: Knative
-site_url: https://knative.dev/docs
+site_url: https://knative.dev
 site_description: Knative Documentation
 extra_css:
   - stylesheets/extra.css

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,15 @@
   from = "/docs/help/contributor/*"
   to = "https://github.com/knative/docs/blob/main/contribute-to-docs/README.md"
   status = 301
+
+# Redirect from /docs/* to root to handle the base URL change
+[[redirects]]
+  from = "/docs/*"
+  to = "/:splat"
+  status = 301
+
+# Ensure the root path serves the docs
+[[redirects]]
+  from = "/"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
# Migrate documentation from /docs/* to root domain with 301 redirects

## Overview
This PR restructures the Knative documentation URL hierarchy by moving content from `https://knative.dev/docs/*` to `https://knative.dev/*`, creating a cleaner and more intuitive navigation experience.

fixes: https://github.com/knative/docs/issues/6292

## Changes Made

### Configuration Updates
- **mkdocs.yml**: Updated `site_url` from `https://knative.dev/docs` to `https://knative.dev`
- **blog/mkdocs.yml**: Updated homepage reference to point to root domain
- **netlify.toml**: Added comprehensive redirect rules for seamless URL migration

### Redirect Strategy
```toml
# Redirect all /docs/* paths to root-relative equivalents
[[redirects]]
  from = "/docs/*"
  to = "/:splat"
  status = 301

# Serve root path as the documentation homepage  
[[redirects]]
  from = "/"
  to = "/index.html"
  status = 200
```

## Benefits
- **Improved UX**: Shorter, cleaner URLs that are easier to share and remember
- **SEO Preservation**: 301 redirects maintain search engine rankings and link equity
- **Zero Downtime**: Backward compatibility ensures no broken links or service interruption
- **Future-Proof**: Simplified URL structure supports better site organization

## Testing Completed
- ✅ Verified `/docs/*` → `/*` redirects function correctly
- ✅ Confirmed root domain serves documentation properly
- ✅ Validated internal link functionality
- ✅ Tested backward compatibility with existing bookmarks
- ✅ Confirmed SEO-friendly 301 redirect behavior

## Impact
- **Immediate**: Documentation accessible at cleaner root URLs
- **Gradual**: Search engines will re-index URLs over time
- **No Breaking Changes**: All existing `/docs/*` URLs remain functional via redirects
