### PR TITLE
Support Mermaid.js for diagrams

### DIFF
--- a/docs/snippets/about-eventing.md
+++ b/docs/snippets/about-eventing.md
@@ -4,6 +4,21 @@
 -->
 Knative Eventing is a collection of APIs that enable you to use an [event-driven architecture](https://en.wikipedia.org/wiki/Event-driven_architecture){target=_blank} with your applications. You can use these APIs to create components that route events from event producers (known as sources) to event consumers (known as sinks) that receive events. Sinks can also be configured to respond to HTTP requests by sending a response event.
 
+``` mermaid
+architecture-beta
+    group eventing[Eventing]
+    group sources[Event Sources]
+
+    service source(cloud)[Event Source] in sources
+    service broker(database)[Broker] in eventing
+    service trigger(server)[Trigger] in eventing
+    service sink(internet)[Event Target]
+
+    source{group}:T --> B:broker
+    broker:R -- L:trigger
+    trigger:B --> T:sink
+```
+
 Knative Eventing is a standalone platform that provides support for various types of workloads, including standard Kubernetes Services and Knative Serving Services.
 
 Knative Eventing uses standard HTTP POST requests to send and receive events between event producers and sinks. These events conform to the [CloudEvents specifications](https://cloudevents.io/){target=_blank}, which enables creating, parsing, sending, and receiving events in any programming language.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,11 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - attr_list
   - meta
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details
@@ -54,10 +58,11 @@ plugins:
     separator: '[\/\s\-\.]+'
   exclude:
     glob:
-      # Exclude files that contain hugo specific shortcodes
-      # (either the include shortcode or not-converted-yet tabs).
+      # Exclude files that are built into other parts of the documentation
       - snippets/*
       - smoketest.md
+  # This could be used to generate nav from the directory structure.
+  # It is currently disabled by the `nav` field in `config/nav.yml`.
   awesome-pages:
     filename: ".index"
     collapse_single_pages: true


### PR DESCRIPTION
Supports #6310

Currently, we have a wide variety of different graphic styles on our website.  I'm going to suggest narrowing our art sources to using either SVGs from a real drawing program, or generating them from [Mermaid.js markup](https://mermaid.js.org/), which is [supported (and recommended)](https://squidfunk.github.io/mkdocs-material/reference/diagrams/) by the Material MkDocs tool we use for the site

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Enable Mermaid code blocks
- Use these to create a top-level diagram for "what eventing is"

Once we have an icon library, we should look at [customizing mermaid](https://squidfunk.github.io/mkdocs-material/reference/diagrams/#customization) to [use a custom icon pack](https://mermaid.js.org/config/icons.html) with our icons.