### PR TITLE
Knative quickstart - content tab fixes, added success output for kn func

### DIFF
--- a/docs/snippets/proc-running-function.md
+++ b/docs/snippets/proc-running-function.md
@@ -16,7 +16,7 @@ The `run` command builds an image for your function if required, and runs this i
     func run [--registry <registry>]
     ```
 
-!!! note
+    !!! note
     The coordinates for the **image registry** can be configured through an environment variable (`FUNC_REGISTRY`) as well.
 
     Using this command also builds the function if necessary.
@@ -67,13 +67,7 @@ You can verify that your function has been successfully run by using the `invoke
     func invoke
     ```
 
-=== "kn func"
-
-    ```bash
-    kn func invoke
-    ```
-
-!!! Success "Expected output"
+    !!! Success "Expected output"
     ```{ .bash .no-copy }
     Received response
     POST / HTTP/1.1 hello.default.127.0.0.1.sslip.io
@@ -87,4 +81,16 @@ You can verify that your function has been successfully run by using the `invoke
       X-Forwarded-For: 10.244.0.15, 10.244.0.9
       X-Forwarded-Proto: http
     Body:
+    ```
+
+
+=== "kn func"
+
+    ```bash
+    kn func invoke
+    ```
+
+    !!! Success "Expected output"
+    ```{ .bash .no-copy }
+    INFO:root:OK: Request Received
     ```


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->
 
 iRaindrop = Bruce Hamilton bhamilton@expertsupport.com

The top two content tab sections in the quickstart, https://knative.dev/docs/getting-started/build-run-deploy-func/, needed attention. In the first, a note interrupted the tab functionality and in the second I added the "kn func invoke" example and moved the existing REST response the "func invoke" tab.

## Proposed Changes: <!-- Describe the changes the PR makes. -->

Formatting fixes applied for content tabs with correct output examples for func invoke and kn func invoke.
-
-
-
