### PR TITLE
Advertise qpoption maturity and provide a call to action to inform the maintainers of usage

### DIFF
--- a/docs/versioned/serving/queue-extensions.md
+++ b/docs/versioned/serving/queue-extensions.md
@@ -5,6 +5,12 @@ components:
 function: how-to
 ---
 
+!!! note
+
+    This integration is current [Alpha](https://github.com/knative/community/blob/main/mechanics/MATURITY-LEVELS.md#alpha-stage).
+    We're trying to guage usage of this so if you're using or interested please reach out to us in
+    [#knative-serving](https://cloud-native.slack.com/archives/C04LMU0AX60) slack.
+
 # Extending Queue Proxy image with QPOptions
 
 Knative service pods include two containers:

--- a/docs/versioned/serving/services/using-queue-extensions.md
+++ b/docs/versioned/serving/services/using-queue-extensions.md
@@ -5,6 +5,12 @@ components:
 function: explanation
 ---
 
+!!! note
+
+    This integration is current [Alpha](https://github.com/knative/community/blob/main/mechanics/MATURITY-LEVELS.md#alpha-stage).
+    We're trying to guage usage of this so if you're using or interested please reach out to us in
+    [#knative-serving](https://cloud-native.slack.com/archives/C04LMU0AX60) slack.
+
 # Using extensions enabled by QPOptions
 
 QPOptions is a Queue Proxy feature that enables extending Queue Proxy with additional Go packages. For example, the [security-guard](https://knative.dev/security-guard#section-readme) repository extends Queue Proxy by adding runtime security features to protect user services.


### PR DESCRIPTION
I don't want to advertise qpoptions in the docs. It's really an implementation detail for security guard at this point.