### PR TITLE
Fix typo in resource limit examples

### DIFF
--- a/docs/serving/configuration/config-defaults.md
+++ b/docs/serving/configuration/config-defaults.md
@@ -424,7 +424,7 @@ The `revision-ephemeral-storage-limit` value determines the default ephemeral st
           containers:
             - image: ghcr.io/knative/helloworld-go:latest
               resources:
-                requests:
+                limits:
                   ephemeral-storage: "750M"
     ```
 


### PR DESCRIPTION
a typo in the documentation for `revision-cpu-limit` and `revision-memory-limit`.