### PR TITLE
Add documentation for AWS sink and source authentication

### DIFF
--- a/docs/eventing/sinks/integration-sink/aws_s3.md
+++ b/docs/eventing/sinks/integration-sink/aws_s3.md
@@ -11,11 +11,30 @@ The `IntegrationSink` supports the Amazon Web Services (AWS) S3 service, through
 
 ## Amazon credentials
 
-For connecting to AWS the `IntegrationSink` uses Kubernetes `Secret`, present in the namespace of the resource. The `Secret` can be created like:
+There are two options for authenticating to AWS.
+
+### Access key and secret
+
+To use an IAM User access key and secret, create a Kubernetes `Secret` in the namespace of the resource. The `Secret` can be created like:
 
   ```bash
   kubectl -n <namespace> create secret generic my-secret --from-literal=aws.accessKey=<accessKey> --from-literal=aws.secretKey=<secretKey>
   ```
+Then in the `IntegrationSink` `.spec.aws.auth` section reference the `Secret` like this:
+```yaml
+      auth:
+        secret:
+          ref:
+            name: "my-secret"
+```
+
+### Pod Default Credentials
+
+If you are using IRSA or Pod Identity, you can create a Kubernetes `ServiceAccount` and associate it with an AWS IAM role. Then in the `IntegrationSink` `.spec.aws.auth` section specify the name of the `ServiceAccount`. This will assign the `ServiceAccount` to the `Deployment` resource created for the `IntegrationSink`.
+```yaml
+      auth:
+        serviceAccountName: "my-service-account"
+```
 
 ## AWS S3 Sink Example
 

--- a/docs/eventing/sinks/integration-sink/aws_sns.md
+++ b/docs/eventing/sinks/integration-sink/aws_sns.md
@@ -11,11 +11,30 @@ The `IntegrationSink` supports the Amazon Web Services (AWS) Simple Notification
 
 ## Amazon credentials
 
-For connecting to AWS the `IntegrationSink` uses Kubernetes `Secret`, present in the namespace of the resource. The `Secret` can be created like:
+There are two options for authenticating to AWS.
+
+### Access key and secret
+
+To use an IAM User access key and secret, create a Kubernetes `Secret` in the namespace of the resource. The `Secret` can be created like:
 
   ```bash
   kubectl -n <namespace> create secret generic my-secret --from-literal=aws.accessKey=<accessKey> --from-literal=aws.secretKey=<secretKey>
   ```
+Then in the `IntegrationSink` `.spec.aws.auth` section reference the `Secret` like this:
+```yaml
+      auth:
+        secret:
+          ref:
+            name: "my-secret"
+```
+
+### Pod Default Credentials
+
+If you are using IRSA or Pod Identity, you can create a Kubernetes `ServiceAccount` and associate it with an AWS IAM role. Then in the `IntegrationSink` `.spec.aws.auth` section specify the name of the `ServiceAccount`. This will assign the `ServiceAccount` to the `Deployment` resource created for the `IntegrationSink`.
+```yaml
+      auth:
+        serviceAccountName: "my-service-account"
+```
 
 ## AWS SNS Sink Example
 
@@ -37,6 +56,6 @@ Below is an `IntegrationSink` to send data to AWS SNS:
           ref:
           name: "my-secret"
   ```
-Inside of the `aws.sns` object we define the name of the topic (or _arn_) and its region. The credentials for the AWS service are referenced from the `my-secret` Kubernetes `Secret` 
+Inside of the `aws.sns` object we define the name of the topic (or _arn_) and its region. The credentials for the AWS service are referenced from the `my-secret` Kubernetes `Secret`
 
 More details about the Apache Camel Kamelet [aws-sns-sink](https://camel.apache.org/camel-kamelets/latest/aws-sns-sink.html).

--- a/docs/eventing/sinks/integration-sink/aws_sqs.md
+++ b/docs/eventing/sinks/integration-sink/aws_sqs.md
@@ -11,11 +11,30 @@ The `IntegrationSink` supports the Amazon Web Services (AWS) Simple Queue Servic
 
 ## Amazon credentials
 
-For connecting to AWS the `IntegrationSink` uses Kubernetes `Secret`, present in the namespace of the resource. The `Secret` can be created like:
+There are two options for authenticating to AWS.
+
+### Access key and secret
+
+To use an IAM User access key and secret, create a Kubernetes `Secret` in the namespace of the resource. The `Secret` can be created like:
 
   ```bash
   kubectl -n <namespace> create secret generic my-secret --from-literal=aws.accessKey=<accessKey> --from-literal=aws.secretKey=<secretKey>
   ```
+Then in the `IntegrationSink` `.spec.aws.auth` section reference the `Secret` like this:
+```yaml
+      auth:
+        secret:
+          ref:
+            name: "my-secret"
+```
+
+### Pod Default Credentials
+
+If you are using IRSA or Pod Identity, you can create a Kubernetes `ServiceAccount` and associate it with an AWS IAM role. Then in the `IntegrationSink` `.spec.aws.auth` section specify the name of the `ServiceAccount`. This will assign the `ServiceAccount` to the `Deployment` resource created for the `IntegrationSink`.
+```yaml
+      auth:
+        serviceAccountName: "my-service-account"
+```
 
 ## AWS SQS Sink Example
 
@@ -37,6 +56,6 @@ Below is an `IntegrationSink` to send data to AWS SQS:
           ref:
           name: "my-secret"
   ```
-Inside of the `aws.sqs` object we define the name of the queue (or _arn_) and its region. The credentials for the AWS service are referenced from the `my-secret` Kubernetes `Secret` 
+Inside of the `aws.sqs` object we define the name of the queue (or _arn_) and its region. The credentials for the AWS service are referenced from the `my-secret` Kubernetes `Secret`
 
 More details about the Apache Camel Kamelet [aws-sqs-sink](https://camel.apache.org/camel-kamelets/latest/aws-sqs-sink.html).

--- a/docs/eventing/sources/integration-source/aws_ddbstreams.md
+++ b/docs/eventing/sources/integration-source/aws_ddbstreams.md
@@ -11,11 +11,30 @@ The `IntegrationSource` supports the Amazon Web Services (AWS) DynamoDB Streams 
 
 ## Amazon credentials
 
-For connecting to AWS the `IntegrationSource` uses Kubernetes `Secret`, present in the namespace of the resource. The `Secret` can be created like:
+There are two options for authenticating to AWS.
+
+### Access key and secret
+
+To use an IAM User access key and secret, create a Kubernetes `Secret` in the namespace of the resource. The `Secret` can be created like:
 
   ```bash
   kubectl -n <namespace> create secret generic my-secret --from-literal=aws.accessKey=<accessKey> --from-literal=aws.secretKey=<secretKey>
   ```
+Then in the `IntegrationSource` `.spec.aws.auth` section reference the `Secret` like this:
+```yaml
+      auth:
+        secret:
+          ref:
+            name: "my-secret"
+```
+
+### Pod Default Credentials
+
+If you are using IRSA or Pod Identity, you can create a Kubernetes `ServiceAccount` and associate it with an AWS IAM role. Then in the `IntegrationSource` `.spec.aws.auth` section specify the name of the `ServiceAccount`. This will assign the `ServiceAccount` to the `Deployment` resource created for the `IntegrationSource`.
+```yaml
+      auth:
+        serviceAccountName: "my-service-account"
+```
 
 ## AWS DynamoDB Streams Example
 

--- a/docs/eventing/sources/integration-source/aws_s3.md
+++ b/docs/eventing/sources/integration-source/aws_s3.md
@@ -11,11 +11,30 @@ The `IntegrationSource` supports the Amazon Web Services (AWS) S3 service, throu
 
 ## Amazon credentials
 
-For connecting to AWS the `IntegrationSource` uses Kubernetes `Secret`, present in the namespace of the resource. The `Secret` can be created like:
+There are two options for authenticating to AWS.
+
+### Access key and secret
+
+To use an IAM User access key and secret, create a Kubernetes `Secret` in the namespace of the resource. The `Secret` can be created like:
 
   ```bash
   kubectl -n <namespace> create secret generic my-secret --from-literal=aws.accessKey=<accessKey> --from-literal=aws.secretKey=<secretKey>
   ```
+Then in the `IntegrationSource` `.spec.aws.auth` section reference the `Secret` like this:
+```yaml
+      auth:
+        secret:
+          ref:
+            name: "my-secret"
+```
+
+### Pod Default Credentials
+
+If you are using IRSA or Pod Identity, you can create a Kubernetes `ServiceAccount` and associate it with an AWS IAM role. Then in the `IntegrationSource` `.spec.aws.auth` section specify the name of the `ServiceAccount`. This will assign the `ServiceAccount` to the `Deployment` resource created for the `IntegrationSource`.
+```yaml
+      auth:
+        serviceAccountName: "my-service-account"
+```
 
 ## AWS S3 Source Example
 

--- a/docs/eventing/sources/integration-source/aws_sqs.md
+++ b/docs/eventing/sources/integration-source/aws_sqs.md
@@ -11,11 +11,30 @@ The `IntegrationSource` supports the Amazon Web Services (AWS) Simple Queue Serv
 
 ## Amazon credentials
 
-For connecting to AWS the `IntegrationSource` uses Kubernetes `Secret`, present in the namespace of the resource. The `Secret` can be created like:
+There are two options for authenticating to AWS.
+
+### Access key and secret
+
+To use an IAM User access key and secret, create a Kubernetes `Secret` in the namespace of the resource. The `Secret` can be created like:
 
   ```bash
   kubectl -n <namespace> create secret generic my-secret --from-literal=aws.accessKey=<accessKey> --from-literal=aws.secretKey=<secretKey>
   ```
+Then in the `IntegrationSource` `.spec.aws.auth` section reference the `Secret` like this:
+```yaml
+      auth:
+        secret:
+          ref:
+            name: "my-secret"
+```
+
+### Pod Default Credentials
+
+If you are using IRSA or Pod Identity, you can create a Kubernetes `ServiceAccount` and associate it with an AWS IAM role. Then in the `IntegrationSource` `.spec.aws.auth` section specify the name of the `ServiceAccount`. This will assign the `ServiceAccount` to the `Deployment` resource created for the `IntegrationSource`.
+```yaml
+      auth:
+        serviceAccountName: "my-service-account"
+```
 
 ## AWS SQS Source Example
 
@@ -35,13 +54,13 @@ Below is an `IntegrationSource` to receive data from AWS SQS.
       auth:
         secret:
           ref:
-          name: "my-secret"
+            name: "my-secret"
     sink:
       ref:
         apiVersion: eventing.knative.dev/v1
         kind: Broker
         name: default
   ```
-Inside of the `aws.sqs` object we define the name of the queue (or _arn_) and its region. The credentials for the AWS service are referenced from the `my-secret` Kubernetes `Secret` 
+Inside of the `aws.sqs` object we define the name of the queue (or _arn_) and its region. The credentials for the AWS service are referenced from the `my-secret` Kubernetes `Secret`
 
 More details about the Apache Camel Kamelet [aws-sqs-source](https://camel.apache.org/camel-kamelets/latest/aws-sqs-source.html).


### PR DESCRIPTION
Adds documentation for [Supporting using pod default credentials for Integration Source and Sink](https://github.com/knative/eventing/pull/8731)

## Proposed Changes
This adds documentation for using an AWS IAM role as the credentials for IntegrationSource and IntegrationSink.