### PR TITLE
fix: change OIDC disabled to enabled

### DIFF
--- a/docs/eventing/features/authorization.md
+++ b/docs/eventing/features/authorization.md
@@ -411,7 +411,7 @@ Data,
   {"message": "Hi from pingsource-2 from namespace-2"}
 ```
 
-When we remove now the EventPolicy again and keep OIDC disabled, the Broker will fall back to the default authorization mode, which is `allow-same-namespace`:
+When we remove now the EventPolicy again and keep OIDC enabled, the Broker will fall back to the default authorization mode, which is `allow-same-namespace`:
 
 ```
 $ kubectl -n namespace-1 delete eventpolicy event-policy


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

In the [Eventing / Features / Authorization / Example](https://knative.dev/docs/eventing/features/authorization/#example) docs is a "bug" in this sentence:

> When we remove now the EventPolicy again and keep OIDC _disabled_ , the Broker will fall back to the default authorization mode, which is `allow-same-namespace`:

The `allow-same-namespace` is only used when OIDC is kept **enabled** and no `EventPolicy` is active =>  _disabled_ should be **enabled**.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- :pencil2: Swap _disabled_ for **enabled**.
