### PR TITLE
docs: fix typos

### DIFF
--- a/docs/blog/articles/Knative-Serving-WebSockets.md
+++ b/docs/blog/articles/Knative-Serving-WebSockets.md
@@ -128,7 +128,7 @@ func OnError(conn *websocket.Conn, err error) {
 }
 ```
 
-In each of the handlers we log the remote address of the connected peer and of any incomming message through the `OnMessage` handler we echo it back to the sender.
+In each of the handlers we log the remote address of the connected peer and of any incoming message through the `OnMessage` handler we echo it back to the sender.
 
 ## Testing the WebSocket server
 
@@ -136,7 +136,7 @@ In each of the handlers we log the remote address of the connected peer and of a
 
     The easiest way to build and deploy Golang applications is using [ko](https://github.com/ko-build/ko), as described on the actual [sample application](https://github.com/knative/docs/tree/main/code-samples/serving/websockets-go).
 
-Once the Knative Serving application was deployed the the Kubernetes cluster, you can test it. For that you need to receive the actual URL for the service of the WebSocket application:
+Once the Knative Serving application was deployed to the Kubernetes cluster, you can test it. For that you need to receive the actual URL for the service of the WebSocket application:
 
 ```bash
 kubectl get ksvc
@@ -160,7 +160,7 @@ Afterward you can chat with the WebSocket server like:
 ```>
 ```
 
-The above is scaling to exactly one pod, since only one client was connected. Since Knative Serving allows you a dynamic scalling, a certain number of concurrent connections lead to a number of pods.
+The above is scaling to exactly one pod, since only one client was connected. Since Knative Serving allows you a dynamic scaling, a certain number of concurrent connections lead to a number of pods.
 
 Below is an example of a scaled out application when running a larger number of concurrent requests against it:
 

--- a/docs/blog/articles/ai_functions_llama_stack.md
+++ b/docs/blog/articles/ai_functions_llama_stack.md
@@ -35,7 +35,7 @@ For local development it is recommended to enable port-forwarding for the Llama 
 kubectl port-forward service/llamastackdistribution-sample-service 8321:8321 
 ```
 
-Now your scripts can access it via `locahost:8321`:
+Now your scripts can access it via `localhost:8321`:
 
 ```shell
 http localhost:8321/v1/version

--- a/docs/blog/articles/configurable-runtimeclassnames.md
+++ b/docs/blog/articles/configurable-runtimeclassnames.md
@@ -21,7 +21,7 @@ RuntimeClasses enable several things, including:
 - functionality
     - such as enabling GPU (e.g NVIDIA) or WASM (e.g Spinkube) support
     
-For example, a cluster administrator or cloud provider may wish to configure Knative Serving to specificly not use `runc` to run untrusted workloads that would be deployed by users on their platform.
+For example, a cluster administrator or cloud provider may wish to configure Knative Serving to specifically not use `runc` to run untrusted workloads that would be deployed by users on their platform.
 
 By default, Kubernetes does not have a default RuntimeClass feature/annotation (like StorageClass does) and it must be altered at a container runtime level as it is also inherited therein. This feature along with the ease of Knative Service config, it elevates the abilities of Knative Serving above standard Kubernetes.
 

--- a/docs/blog/articles/consuming_s3_data_with_knative.md
+++ b/docs/blog/articles/consuming_s3_data_with_knative.md
@@ -83,7 +83,7 @@ The `aws-s3-source` Kamelet is referenced as the `source` of the `Pipe` and send
 
 ## Creating a Knative Function as a consumer
 
-In order to consume messages from the Knative broker, using Knative Function, we need will create a simple Golang function. Since the payload is sent as CloudEvents to the function we use the buildin `cloudevents` template, by executing the the following command:
+In order to consume messages from the Knative broker, using Knative Function, we will create a simple Golang function. Since the payload is sent as CloudEvents to the function we use the builtin `cloudevents` template, by executing the following command:
 
 ```
 $ func create -l go -t cloudevents s3-logger

--- a/docs/blog/articles/consuming_sqs_data_with_integrationsource.md
+++ b/docs/blog/articles/consuming_sqs_data_with_integrationsource.md
@@ -2,11 +2,11 @@
 
 **Author: Matthias Weßendorf, Senior Principal Software Engineer @ Red Hat**
 
-_In a [previous post](/blog/articles/consuming_s3_data_with_knative){:target="_blank"} we discussed the consumption of notifications from an AWS S3 bucket using Apache Camel K. While this is a good approach for getting data from cloud providers, like AWS, into Knative, the Knative Eventing team is aiming to integrate this at the core of its offering with a new CRD, the `IntegrationSource`. This post will describe howto receive SQS notifications and forward them to a regular Knative Broker for further processing._
+_In a [previous post](/blog/articles/consuming_s3_data_with_knative){:target="_blank"} we discussed the consumption of notifications from an AWS S3 bucket using Apache Camel K. While this is a good approach for getting data from cloud providers, like AWS, into Knative, the Knative Eventing team is aiming to integrate this at the core of its offering with a new CRD, the `IntegrationSource`. This post will describe how to receive SQS notifications and forward them to a regular Knative Broker for further processing._
 
 ## Installation
 
-The `IntegrationSource` will be part of Knative Eventing in a future release. Currently it is under development but already included in the `main` branch. For installing Knative Eventing from the sources you can follow the [develpoment guide](https://github.com/knative/eventing/blob/main/DEVELOPMENT.md){:target="_blank"}.
+The `IntegrationSource` will be part of Knative Eventing in a future release. Currently it is under development but already included in the `main` branch. For installing Knative Eventing from the sources you can follow the [development guide](https://github.com/knative/eventing/blob/main/DEVELOPMENT.md){:target="_blank"}.
 
 !!! note
 

--- a/docs/blog/articles/demystifying-activator-on-path.md
+++ b/docs/blog/articles/demystifying-activator-on-path.md
@@ -24,7 +24,7 @@ The Route reconciler will create the `Ingress` resource that will be picked up b
 
 Now, the creation of the PA triggers the KPA reconciler, which goes through certain steps to set up an autoscaling configuration for the revision:
 
-- creates an internal Decider resource that holds the initial desired scale in `decider.Status.DesiredScale`and
+- creates an internal Decider resource that holds the initial desired scale in `decider.Status.DesiredScale` and
   sets up a pod scaler via the multi-scaler component. The pod scaler calculates a new Scale result every two seconds and makes a decision based on the condition whether the desired scale isn't equal to the pod count. If it is not, it will trigger a new reconciliation for the KPA reconciler. The goal is the KPA to get the latest scale result.
 
 - creates a Metric resource that triggers the metrics collector controller to set up a scraper for the revision pods.

--- a/docs/blog/articles/enhancing-the-knative-experience.md
+++ b/docs/blog/articles/enhancing-the-knative-experience.md
@@ -68,4 +68,4 @@ Looking forward, the next steps involve implementing and evaluating the recommen
 
 ## Conclusion
 
-Overall, this project has been rewarding and some signicant insights have emerged from it. Sincere thanks are extended to all who contributed to this research. Implementing these recommendations within the existing ecosystem is an exciting prospect. It is firmly believed that by executing these actionable recommendations, the developer experience for everyone involved in Knative can be enhanced, and the bonds that unite the community can be strengthened!
+Overall, this project has been rewarding and some significant insights have emerged from it. Sincere thanks are extended to all who contributed to this research. Implementing these recommendations within the existing ecosystem is an exciting prospect. It is firmly believed that by executing these actionable recommendations, the developer experience for everyone involved in Knative can be enhanced, and the bonds that unite the community can be strengthened!

--- a/docs/blog/articles/event-drive-app-knative-eventing-kogito.md
+++ b/docs/blog/articles/event-drive-app-knative-eventing-kogito.md
@@ -99,7 +99,7 @@ Based on this generated service, you can build [an image](https://docs.jboss.org
 
 The Kogito Operator creates a Knative [Trigger](https://knative.dev/docs/eventing/triggers/) resource, that links the service and the broker together. In this example, it will filter events of type `new.patients.events`. This means that every time a new event of this type comes to the broker, it will be redirected to the Kogito service.
 
-The same concept also applies to [events produced by the workflow engine](https://docs.jboss.org/kogito/release/latest/html_single/#con-knative-eventing_kogito-developing-process-services). In this case, the operator will create a Knative [SinkBinding](https://knative.dev/docs/eventing/custom-event-source/sinkbinding/) resource, and will bind it to the Knative broker. Each time an event is produced by the service, a CloudEvent representing it will be sent to the broker. The image below ilustrates the implementation detail of a Kogito service emitting events to the Knative broker via SinkBinding.
+The same concept also applies to [events produced by the workflow engine](https://docs.jboss.org/kogito/release/latest/html_single/#con-knative-eventing_kogito-developing-process-services). In this case, the operator will create a Knative [SinkBinding](https://knative.dev/docs/eventing/custom-event-source/sinkbinding/) resource, and will bind it to the Knative broker. Each time an event is produced by the service, a CloudEvent representing it will be sent to the broker. The image below illustrates the implementation detail of a Kogito service emitting events to the Knative broker via SinkBinding.
 
 ![Knative and Kogito integration](images/kogito-knative-impl-producing-event.png)
 *Knative Eventing and Kogito service event producers*
@@ -120,6 +120,6 @@ To understand more about Knative Eventing and how the platform can help you crea
 
 ## About the Authors
 
-Ricardo Zanini is a Software Engineer currently working on Kogito Community project. Has has been working in the field of software engineering since 2000. He is a maintainer of the CNCF Serverless Workflow Specification.
+Ricardo Zanini is a Software Engineer currently working on Kogito Community project. He has been working in the field of software engineering since 2000. He is a maintainer of the CNCF Serverless Workflow Specification.
 
 Tihomir Surdilovic is a Software Developer at Red Hat working on business automation. He has been involved in business automation and open source since 2008. He also serves as an active lead of the CNCF Serverless Workflow Specification.

--- a/docs/blog/articles/event-driven-image-bigquery-processing-pipelines.md
+++ b/docs/blog/articles/event-driven-image-bigquery-processing-pipelines.md
@@ -13,7 +13,7 @@ instructions, as part of my [Knative Tutorial](https://github.com/meteatamel/kna
 ## Knative components used
 
 When creating these example pipelines, I relied on a few Knative components that greatly simplified
-my development. More specifially:
+my development. More specifically:
 
 1. [Event sources](https://knative.dev/docs/developer/eventing/sources/) allow you to
    read external events in your cluster. [Knative-GCP
@@ -135,7 +135,7 @@ Trigger the jobs:
 gcloud scheduler jobs run cre-scheduler-2bcb33d8-3165-4eca-9428-feb99bc320e2
 ```
 
-You should get an email with with a chart similar to this in a few minutes:
+You should get an email with a chart similar to this in a few minutes:
 
 ![Chart - United Kingdom](https://atamel.dev/img/2020/chart-unitedkingdom.png)
 

--- a/docs/blog/articles/from-cloudevent-to-apach-kafka-records-part-one.md
+++ b/docs/blog/articles/from-cloudevent-to-apach-kafka-records-part-one.md
@@ -111,4 +111,4 @@ It is important to note that the `KafkaSink` stores incoming CloudEvents as Kafk
 
 ### Outlook
 
-The messages stored in the Kafka topic backed by the Knative `KafkaSink` component can be easily consunmed by any consumer application in the larger ecosystem of the Apache Kafka community. The next post in this article will show how to use the Knative Broker implementation for Apache Kafka to store incoming events and make use of the Knative Eventing tools for routing based on CloudEvents metadata as this filtering feature is not directly build into Apache Kafka itself.
+The messages stored in the Kafka topic backed by the Knative `KafkaSink` component can be easily consumed by any consumer application in the larger ecosystem of the Apache Kafka community. The next post in this article will show how to use the Knative Broker implementation for Apache Kafka to store incoming events and make use of the Knative Eventing tools for routing based on CloudEvents metadata as this filtering feature is not directly build into Apache Kafka itself.

--- a/docs/blog/articles/getting-started-blog-p0.md
+++ b/docs/blog/articles/getting-started-blog-p0.md
@@ -23,8 +23,8 @@ concepts of Knative work, we hope that you will also learn something from these 
 ## Why are we writing this blog series?
 
 In the month prior to writing this blog post, we started our internship at Red Hat and began working on Knative. As such, we have just spent the past month
-learning all about how Knative works and making our first contributions to the project. We understand many of the pain points that new contributors face because 
-we just faced them ourselves. Our hope is that by creating this blog series we can alleviate some of these pain points for the contibutors who come after 
+learning all about how Knative works and making our first contributions to the project. We understand many of the pain points that new contributors face because
+we just faced them ourselves. Our hope is that by creating this blog series we can alleviate some of these pain points for the contributors who come after 
 us.
 
 ![Person reading a book](../images/getting-started-blog-series/post0/reading-side-doodle.png)

--- a/docs/blog/articles/getting-started-blog-p1.md
+++ b/docs/blog/articles/getting-started-blog-p1.md
@@ -51,7 +51,7 @@ Regardless of why you choose to participate in an open source project or communi
 
 2. The opportunity to get to know different technologies and be on the bleeding edge of innovation. Many innovations start in open source projects.
 
-3. You will be able to see your contributions impactins a large project with potentially very many users (for example one of the Knative repos has around 10M downloads), which can
+3. You will be able to see your contributions impacting a large project with potentially very many users (for example one of the Knative repos has around 10M downloads), which can
 feel very rewarding.
 
 With that being said, the fact that you are reading this means that you likely already want to participate in an open source project (hopefully **Knative**!), so let's dive into some
@@ -121,7 +121,7 @@ use them). This flow can be seen in the diagram below.
 
 ![Flowchart of opening an issue or a PR to contribute](../images/getting-started-blog-series/post1/open-source-workflow.png)
 
-Now, if you are not familiar with this process, it probably feels very confusing. So, to demistify it further, let's break down each part and discuss them in detail.
+Now, if you are not familiar with this process, it probably feels very confusing. So, to demystify it further, let's break down each part and discuss them in detail.
 
 ### Propose a Change
 
@@ -218,7 +218,7 @@ In both cases, you will want to go through the basic flow to create a PR or MR. 
 If you are using GitLab and are unsure of how to do this, you can follow the instructions [here](https://docs.gitlab.com/ee/user/project/repository/forking_workflow.html#merge-changes-back-upstream){:target="_blank"}.
 
 When creating your PR/MR it is important to provide the context of why you are making the changes, what you changes, and how people can test your changes. It is good practice to 
-include a link to the issue the PR/MR is addressing, and to give a bried description of the changes you made. Additionally, your PR/MR should have a brief and descriptive title
+include a link to the issue the PR/MR is addressing, and to give a brief description of the changes you made. Additionally, your PR/MR should have a brief and descriptive title
 to make it clearer to reviewers what it contains.
 
 If your changes are incomplete, you will want to mark the PR/MR as a __draft__, to indicate to reviewers that your work is not complete. Instructions for GitHub are 

--- a/docs/blog/articles/getting-started-blog-p2.md
+++ b/docs/blog/articles/getting-started-blog-p2.md
@@ -49,7 +49,7 @@ follow the instructions [in this article](https://go.dev/doc/install){:target="_
 In order to edit the code, you will need to have an editor installed. One of the most popular and free editor used these days is [VSCode](https://code.visualstudio.com/){:target="_blank"}, 
 although the paid JetBrains editors such as [GoLand](https://www.jetbrains.com/go/){:target="_blank"}, and [IntelliJ IDEA](https://www.jetbrains.com/idea/){:target="_blank"} are also very powerful. It's worth noting that there is a community edition of IntelliJ IDEA which is free and quite powerful.
 Some also prefer to go old school and use [Vim](https://www.vim.org/){:target="_blank"}, [Emacs](https://www.gnu.org/software/emacs/){:target="_blank"}, or the newer fork of Vim, [Neovim](https://neovim.io/){:target="_blank"}
-(which actually has all the language support that VSCode has if you are willing to configure it yourself). While your choise of editor doesn't impact the quality of code
+(which actually has all the language support that VSCode has if you are willing to configure it yourself). While your choice of editor doesn't impact the quality of code
 which you will produce, it is crucial that you choose one and become comfortable working in it as much of your productivity will come from your ability to use your editor.
 
 ### Running Knative Locally
@@ -86,7 +86,7 @@ and then alias docker to podman. To create this alias you must:
 
 - If you are using fish, add `alias docker=podman` to your `config.fish` file.
 
-Similar to setting up Docker, once you have Podman installed onto your system aand your alias set up, you will need to have a docker registry account and run `docker login`.
+Similar to setting up Docker, once you have Podman installed onto your system and your alias set up, you will need to have a docker registry account and run `docker login`.
 However, you will need to provide which registry to log in to. So, you will need to run `docker login docker.io`. Once again, note that we recommend using Docker instead of
 Podman.
 
@@ -161,7 +161,7 @@ some useful plugins for your IDE.
 #### Useful IDE plugins
 
 The plugins we are sharing here are the ones which we have found most helpful, although there are many more useful plugins out there to explore! If you find anything which
-you think might interest other commmunity members, share it with us [on Slack](https://cloud-native.slack.com/archives/C04LN0620E8){:target="_blank"}.
+you think might interest other community members, share it with us [on Slack](https://cloud-native.slack.com/archives/C04LN0620E8){:target="_blank"}.
 
 ##### Kubernetes
 

--- a/docs/blog/articles/highlighting-value-knative-c-suite.md
+++ b/docs/blog/articles/highlighting-value-knative-c-suite.md
@@ -96,8 +96,8 @@ Knative Eventing expands the possibilities for event-driven architecture. Applic
 
 <p>Every business unit is now developing code, and developer productivity is key to keeping pace with demand. We need to support the productivity of experts throughout the organization that are now deploying code using Python, Rust, and other development environments in their work as researchers, analysts, and data scientists. Knative accelerates their productivity immensely.
 
-<p><i>“It should be possible for somebody with an algorithm to have it on the platform in an hour.”</i>
-<br>- Andrew Webber Senior Software Engineer of deepc, a medtech company that simplifies and improves the workflow in medical imaging diagnostics with pioneering AI and software technologys
+<p><i>”It should be possible for somebody with an algorithm to have it on the platform in an hour.”</i>
+<br>- Andrew Webber Senior Software Engineer of deepc, a medtech company that simplifies and improves the workflow in medical imaging diagnostics with pioneering AI and software technologies
 
 <h3 style="font-weight: bold;">Create flexibility when choosing cloud vendors and pursuing future opportunities.</h3>
 

--- a/docs/blog/articles/improved-ha-configuration.md
+++ b/docs/blog/articles/improved-ha-configuration.md
@@ -2,7 +2,7 @@
 
 **Author: Matthias Weßendorf, Senior Principal Software Engineer @ Red Hat**
 
-_In this blog post you will learn how to use the Knative Operator to maintain a fine-grain configuration for high availablitly of Knative workloads._
+_In this blog post you will learn how to use the Knative Operator to maintain a fine-grain configuration for high availability of Knative workloads._
 
 The [Knative Operator](https://knative.dev/docs/install/operator/knative-with-operators/) gives you a declarative API to describe your Knative Serving and Eventing installation. The `spec` field has several properties to define the desired behavior.
 

--- a/docs/blog/articles/knative-serving-in-k0s.md
+++ b/docs/blog/articles/knative-serving-in-k0s.md
@@ -24,7 +24,7 @@ If you just want to install knative serving in k0s, you can directly skip to [Kn
     * [Say Hello Edge!](#say-hello-edge)
 
 
-## Resource Requirment Analysis
+## Resource Requirement Analysis
 
 In this section we will determine the default Installation resource requirement needed for knative-serving and k0s.
 
@@ -137,7 +137,7 @@ MiB Swap:   1942.0 total,   1942.0 free,      0.0 used.    670.7 avail Mem
 ```
 CPU used by BaseOS in idle state 0.7%
 
-The results obtained are comporable to experiments by Neil [[1](#resources)]
+The results obtained are comparable to experiments by Neil [[1](#resources)]
 
 ### Knative + k0s Default resource requirement
 

--- a/docs/blog/articles/kubevirt_meets_eventing.md
+++ b/docs/blog/articles/kubevirt_meets_eventing.md
@@ -103,11 +103,11 @@ This use case can be elegantly handled with Knative Eventing and Functions-as-a-
 
 Data flow: _VM Operation_ --> _Event Creation_ --> _Event Processing_ --> _Automation_
 
-### Trimmimg the fat from the Event-Payload
+### Trimming the fat from the Event-Payload
 
 As mentioned above, the `ApiServerSource` is listening for events and forwards them as CloudEvents to an addressable or a callable resource. However, the challenge is that the produced events are data-heavy, making downstream processing tricky. "Downstream processing" != the further processing of the received data.
 
-Below is a complete example of a _virtual machine creation_ event, which the `ApiServerSource` wraps into its `dev.knative.apiserver.resource.add` CloudEvent (with some sections ommited for brevity):
+Below is a complete example of a _virtual machine creation_ event, which the `ApiServerSource` wraps into its `dev.knative.apiserver.resource.add` CloudEvent (with some sections omitted for brevity):
 
 ```shell
 Context Attributes,
@@ -330,7 +330,7 @@ trigger-kn-py-psql-vmdata-fn-add               broker-apiserversource       ksvc
 trigger-kn-py-psql-vmdata-fn-delete            broker-apiserversource       ksvc:kn-py-psql-vmdata-fn                                        5h38m   7 OK / 7     True
 ```
 
-Fasten your seatbelt 🚀 The complete event-flow is in-place and the function will feet the desired data into the DB.
+Fasten your seatbelt 🚀 The complete event-flow is in-place and the function will feed the desired data into the DB.
 
 Example output:
 

--- a/docs/blog/articles/llm-agents-overview.md
+++ b/docs/blog/articles/llm-agents-overview.md
@@ -102,7 +102,7 @@ When all the tools just are an API wrapper, all that is needed to define any too
 1. The name of the tool
 2. A description of the tool
 3. The parameters the tool accepts
-4. How to mape the parameters into the API of the tool
+4. How to map the parameters into the API of the tool
 
 Notice that everything in the above list is just _metadata_ about the tool, and that using these four pieces
 of metadata we are able to define _any_ tool we want the LLM to be able to call. This is an extremely important

--- a/docs/blog/articles/new_event_discovery_features.md
+++ b/docs/blog/articles/new_event_discovery_features.md
@@ -68,12 +68,12 @@ default     93774a924a741245a94313745d78e69f   dev.knative.sources.ping   /apis/
 ```
 #### Auto Event Type creation
 
-Furthermore to improve the experience with consumption and creation of `EventTypes`, there's a new experimental feature to automatically create `EventTypes` objects based on processed events on the broker ingress and in-memory channels. Instead of manually creating them as yaml manifests along the application code that talks to the Broker or Channel API. This behaviour can be enabled by feature flag `eventtype-auto-creation` in `config-features` ConfigMap. For futher details and examples please refer to [the documentation](https://knative.dev/docs/eventing/experimental-features/eventtype-auto-creation/).
+Furthermore to improve the experience with consumption and creation of `EventTypes`, there's a new experimental feature to automatically create `EventTypes` objects based on processed events on the broker ingress and in-memory channels. Instead of manually creating them as yaml manifests along the application code that talks to the Broker or Channel API. This behaviour can be enabled by feature flag `eventtype-auto-creation` in `config-features` ConfigMap. For further details and examples please refer to [the documentation](https://knative.dev/docs/eventing/experimental-features/eventtype-auto-creation/).
 
 
 
 ### Conclusion
 
-This blog post introduced new features and improvements to `EventType` discoroverability. The main motivation is to harden the position of developer's insight into the event-driven applications to ease up the discovery and speed up development. 
+This blog post introduced new features and improvements to `EventType` discoverability. The main motivation is to harden the position of developer's insight into the event-driven applications to ease up the discovery and speed up development. 
 
 We look forward from the community to further enhance `EventType` API and discoverability. Please reach out on the CNCF Slack's [#knative-eventing](https://cloud-native.slack.com/archives/C04LMU33V1S) or GitHub [issues](https://github.com/knative/eventing/issues).

--- a/docs/blog/articles/orchestrating-cloud-events-with.md
+++ b/docs/blog/articles/orchestrating-cloud-events-with.md
@@ -46,7 +46,7 @@ Zeebe comes with Camunda Operate, which allows you to see all this information i
 
 ## Decorate / Enhance
 
-Now that you have the power of a workflow engine, you can leverage some of its features to decorate or enhance your applications. An ehnchanced version of the workflow model could look like this:
+Now that you have the power of a workflow engine, you can leverage some of its features to decorate or enhance your applications. An enhanced version of the workflow model could look like this:
 
 ![Workflow model v2](https://github.com/salaboy/orchestrating-cloud-events/blob/master/imgs/tickets-v2.png?raw=true)
 
@@ -80,7 +80,7 @@ Version 3 of the Workflow Model shows a more complex diagram, where a subprocess
 
 ![Workflow Model V3](https://github.com/salaboy/orchestrating-cloud-events/blob/master/imgs/tickets-v3.png?raw=true)
 
-The worfklow can react on the CloudEvent **Customer Abandoned Queue** at any given time inside the **Customer Buying Tickets** stage. This will trigger the Customer **Clean Up** event to garbage collect all the data related with the Customer Session from all the services caching data.
+The workflow can react on the CloudEvent **Customer Abandoned Queue** at any given time inside the **Customer Buying Tickets** stage. This will trigger the Customer **Clean Up** event to garbage collect all the data related with the Customer Session from all the services caching data.
 
 In the following screenshot, inside Camunda Operate, you can quickly visualize how many instances of the workflows are at a given stage as well as how many workflows have finished, and in which state they finished:
 
@@ -88,7 +88,7 @@ In the following screenshot, inside Camunda Operate, you can quickly visualize h
 
 Another advantage of using a workflow engine is flow control. By using flow control elements such as Exclusive Gateways, you can delegate some high-level decisions (usually encoding business logic) to the workflow engine:
 
-![Workfloe Model V4](https://github.com/salaboy/orchestrating-cloud-events/blob/master/imgs/tickets-v4.png?raw=true)
+![Workflow Model V4](https://github.com/salaboy/orchestrating-cloud-events/blob/master/imgs/tickets-v4.png?raw=true)
 
 As you can see in the above model, the exclusive gateway is being used to choose between two different paths based on a condition. In this case, the condition is evaluating how many tickets are being reserved by the customer and, based on that, the model is choosing between a normal credit card payment or a more complex money transfer.
 

--- a/docs/blog/articles/workflow-as-function-flow.md
+++ b/docs/blog/articles/workflow-as-function-flow.md
@@ -10,7 +10,7 @@ and various broker implementations that provide different characteristics from e
 
 At the same time, workflows in various formats have been seen as a good way to express business logic that enables understanding of the big picture. Combining both workflows and Knative Eventing is the main topic of this article.
 
-## Worfklow as a function flow
+## Workflow as a function flow
 
 Workflows date from the Service Oriented Architecture (SOA) times, when standards such as BPEL and then BPMN were introduced. Various vendors started to build platforms that were built around the workflow concepts, often called Process Management Suites or Business Process Management (BPM).
 

--- a/docs/blog/releases/announcing-knative-v0-20-release.md
+++ b/docs/blog/releases/announcing-knative-v0-20-release.md
@@ -118,7 +118,7 @@ kn service create myservice --image gcr.io/myproject/myservice:latest --target s
 
 The `--scale` option for `kn service create` and `kn service update` allows now also ranges as values:
 - `--scale 1..5` : Scale down to a minimal 1 replica and up to 5 replicas
-- `--scale 1.. ` : Set scale-min to to 1 but leave scale-max untouched (when used for a service update)
+- `--scale 1.. ` : Set scale-min to 1 but leave scale-max untouched (when used for a service update)
 - `--scale ..5 ` : Set scale-max to 5 but leave scale-min untouched (when used for a service update)
 - `--scale 5..5` : Set scale-min and scale-max both to 5 (same as `--scale 5`)
 


### PR DESCRIPTION
Hi,

I found a few typos while reading the articles so I ~~manually checked the rest of them~~ asked my friend Claude to spend a few GPU seconds on this.

I'm sure the same could be done for other parts of the documentation without much human effort, wasn't sure if you would find this helpful but I can of course do that also e.g. for the `versioned` knative docs.

Thanks, Vincent