### PR TITLE
use GITHUB_TOKEN to have higher rate limits

### DIFF
--- a/.github/workflows/mkdocs-strict-verify.yaml
+++ b/.github/workflows/mkdocs-strict-verify.yaml
@@ -44,3 +44,5 @@ jobs:
 
     - name: Verify MkDocs
       run: ./hack/build.sh --strict
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The build process is hitting the GITHUB API rate limits - this passes the token to the build step so it get around it