### PR TITLE
add document for secure-pod-defaults feature and settings

### DIFF
--- a/docs/versioned/.nav.yml
+++ b/docs/versioned/.nav.yml
@@ -106,7 +106,6 @@ nav:
         - Installing Security-Guard: serving/app-security/security-guard-install.md
         - Security-guard quickstart: serving/app-security/security-guard-quickstart.md
         - Security-Guard example alerts: serving/app-security/security-guard-example-alerts.md
-        - SecurePodDefaults: serving/app-security/secure-pod-defaults.md
       # Serving - observability
       - Observability:
         - Collecting metrics: serving/observability/metrics/collecting-metrics.md
@@ -279,6 +278,7 @@ nav:
           - Configure gradual rollout of traffic to Revisions: serving/configuration/rolling-out-latest-revision-configmap.md
           - Config Revision Garbage Collection: serving/revisions/revision-admin-config-options.md
           - Configure the Defaults ConfigMap: serving/configuration/config-defaults.md
+          - Secure Pod Defaults: serving/app-security/secure-pod-defaults.md
           - Serving encryption configuration:
             - Overview: serving/encryption/encryption-overview.md
             - Configure cert-manager integration: serving/encryption/configure-certmanager-integration.md


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->



## Proposed Changes <!-- Describe the changes the PR makes. -->

- add a new page for secure-pod-defaults based on changes in PR: https://github.com/knative/serving/pull/16042 


/cc @dprotaso 