### PR TITLE
Remove instruction to remove the _example key from a ConfigMap

### DIFF
--- a/docs/versioned/serving/using-a-custom-domain.md
+++ b/docs/versioned/serving/using-a-custom-domain.md
@@ -31,6 +31,7 @@ You can change the default domain for all Knative Services on a cluster by modif
     apiVersion: v1
     data:
       knative.dev: ""
+      _example: | ...
     kind: ConfigMap
     [...]
     ```


### PR DESCRIPTION
Although removing the _example key is not an issue per se, it shouldn't be a recommended practice.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Removed clause to remove _example key in procedure
