### PR TITLE
Document kubernetes.podspec-dnsconfig feature flag

### DIFF
--- a/docs/versioned/serving/configuration/feature-flags.md
+++ b/docs/versioned/serving/configuration/feature-flags.md
@@ -523,6 +523,34 @@ spec:
 ...
 ```
 
+### Kubernetes DNS Config
+
+* **Type**: Extension
+* **ConfigMap key:** `kubernetes.podspec-dnsconfig`
+
+This flag controls whether a [`DNS config`](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) can be specified.
+
+```yaml
+apiVersion: serving.knative.dev/v1
+kind: Service
+...
+spec:
+  template:
+    spec:
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 1.2.3.4
+        searches:
+          - ns1.svc.cluster-domain.example
+          - my.dns.search.suffix
+        options:
+          - name: ndots
+            value: "2"
+          - name: edns0
+...
+```
+
 ### Kubernetes Scheduler Name
 
 * **Type**: Extension


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Adds documentation for the `kubernetes.podspec-dnsconfig` extension flag in Knative Serving.
