### PR TITLE
Fix: Truncate MkDocs search results preview

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -672,3 +672,25 @@ a.md-header__button.md-logo img {
     display: none;
   }
 }
+
+.md-search-result__article {
+  max-height: none;
+}
+
+.md-search-result__teaser,
+article.md-search-result__article p:not(.md-search-result__meta) {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.5;
+  max-height: 4.5em;
+}
+
+.md-search-result__article > p {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Proposed Changes <!-- Describe the changes the PR makes. -->

- Truncate search result previews to 3 lines (about 100 characters) via custom CSS in `home.css`
- Update `mkdocs.yml` to ensure the CSS file is loaded
- Improves search result usability by preventing display of excessive content

Fixes #6316
close #6316 