### PR TITLE
feat: add an index.md for getting-started section, with accurate link…

### DIFF
--- a/docs/versioned/getting-started/tutorial.md
+++ b/docs/versioned/getting-started/tutorial.md
@@ -13,15 +13,14 @@ Choose your learning path based on your goals and experience level.
 
 ---
 
-### Getting Started with Knative
+## Getting Started with Knative
 
-**Perfect for:** First-time users, developers evaluating Knative, and those wanting hands-on experience
+**Perfect for:** First-time users and developers wanting hands-on experience
 
 Comprehensive guide with multiple learning paths:
-- Quick local installation (10 minutes with kind/minikube)
-- Step-by-step tutorials for Serving, Eventing, and Functions
-- Guidance for evaluators and decision makers
-- Links to production installation options
+
+  - Quick local installation (10 minutes with kind/minikube)
+  - Step-by-step tutorials for Serving, Eventing, and Functions
 
 **What you'll learn:** Deploy your first service, explore autoscaling, build event-driven applications, and create serverless functions.
 
@@ -29,7 +28,7 @@ Comprehensive guide with multiple learning paths:
 
 ---
 
-### Knative Bookstore: End-to-End Sample Application
+## Knative Bookstore: End-to-End Sample Application
 
 **Perfect for:** Learning Knative through a real-world application
 
@@ -43,25 +42,28 @@ Build a complete online bookstore application from scratch and explore Knative's
 
 ---
 
-### Quick Links
+## Not sure where to start?
 
-Not sure where to start? Here are common paths:
+Here are common paths:
 
-- **Want to try Knative in 10 minutes?** → [Quick Start Tutorial](../getting-started/README.md#i-want-to-try-knative-quickly)
-- **Need to understand Knative first?** → [Getting Started for Evaluators](../getting-started/README.md#i-want-to-understand-knative-first)
-- **Building event-driven apps?** → [Eventing Tutorial](../getting-started/README.md#i-want-to-explore-event-driven-features)
-- **Creating serverless functions?** → [Functions Tutorial](../getting-started/README.md#i-want-to-build-serverless-functions)
-- **Ready for production?** → [Installation Guide](../install/README.md)
+  - **Want to try Knative in 10 minutes?** → [Quick Start Tutorial](../getting-started/README.md#i-want-to-try-knative-quickly)
+  - **Need to understand Knative first?** → [Technical Overview](../README.md)
+  - **Building event-driven apps?** → [Eventing Tutorial](../getting-started/README.md#i-want-to-explore-event-driven-features)
+  - **Creating serverless functions?** → [Functions Tutorial](../getting-started/README.md#i-want-to-build-serverless-functions)
+  - **Ready for production?** → [Installation Guide](../install/README.md)
 
 ---
 
-### Prerequisites
+## Prerequisites
 
 **For Quick Start Tutorial:**
-- Docker
-- kubectl
-- 3 CPUs, 3 GB RAM
+
+  - Docker
+  - kubectl
+  - 3 CPUs, 3 GB RAM
 
 **For Bookstore Tutorial:**
-- Kubernetes cluster (local or cloud)
-- Basic familiarity with Kubernetes concepts
+
+  - Kubernetes cluster (local or cloud)
+  - Basic familiarity with Kubernetes concepts
+  


### PR DESCRIPTION
Adds a streamlined, navigation-focused `index.md` to `/docs/versioned/getting-started/` for Knative docs. This landing page provides clear orientation with accurate links and meta-navigation to existing tutorials, based on verified documentation structure. The update replaces broken/obsolete links, references current docs, simplifies function resources, and improves user journeys.  
Fixes #6314 – ensures readers access the correct guides and resources.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Adds concise `index.md` navigation hub to getting-started
- Replaces outdated or missing links with verified documentation paths
- Removes duplicate/obsolete files and clarifies user journeys

closes #6314 