### PR TITLE
fix: url to point at the latest release and not the outdated one

### DIFF
--- a/docs/versioned/client/install-kn.md
+++ b/docs/versioned/client/install-kn.md
@@ -46,7 +46,7 @@ Before you install the Knative Operator CLI Plugin, first install the Knative CL
 
 === "MacOS"
 
-    1. Download the binary `kn-operator-darwin-amd64` for your system from the [release page](https://github.com/knative-extensions/kn-plugin-operator/releases/tag/knative-v1.7.1).
+    1. Download the binary `kn-operator-darwin-amd64` for your system from the [release page](https://github.com/knative-extensions/kn-plugin-operator/releases/latest).
 
     1. Rename the binary to `kn-operator`:
 


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

"Fixes #6490 " or "Add description of the problem this PR solves"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Update the outdated release to  https://github.com/knative-extensions/kn-plugin-operator/releases/latest