### PR TITLE
Fix broken Kubernetes API documentation links

### DIFF
--- a/docs/versioned/eventing/troubleshooting/README.md
+++ b/docs/versioned/eventing/troubleshooting/README.md
@@ -37,7 +37,7 @@ kubectl apply --filename example.yaml
 ## Triggering Events
 
 Knative events will occur whenever a Kubernetes
-[`Event`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#event-v1-core)
+[`Event`](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/)
 occurs in the `knative-debug` namespace. We can cause this to occur with the
 following commands:
 

--- a/docs/versioned/serving/deploying-from-private-registry.md
+++ b/docs/versioned/serving/deploying-from-private-registry.md
@@ -7,7 +7,7 @@ function: how-to
 
 # Deploying images from a private container registry
 
-You can configure your Knative cluster to deploy images from a private registry across multiple Services and Revisions. To do this, you must create a list of Kubernetes secrets ([`imagePullSecrets`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core)) by using your registry credentials. You must then add those secrets to the default [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for all Services, or the Revision template for a single Service.
+You can configure your Knative cluster to deploy images from a private registry across multiple Services and Revisions. To do this, you must create a list of Kubernetes secrets ([`imagePullSecrets`](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/)) by using your registry credentials. You must then add those secrets to the default [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) for all Services, or the Revision template for a single Service.
 
 ## Prerequisites
 

--- a/hack/reference-docs-gen-config.json
+++ b/hack/reference-docs-gen-config.json
@@ -13,7 +13,7 @@
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/kubernetes-api/{{arrIndex .PackageSegments -2}}/{{lower .TypeIdentifier}}/"
         },
         {
             "typeMatchPrefix": "^knative\\.dev/pkg/apis/duck",


### PR DESCRIPTION
Fixes #6525

Updated broken Kubernetes API documentation links from the deprecated v1.18 versioned format to the current Kubernetes API documentation structure.

## Links Updated
| Component | Old (Broken) | New (Working) |
|-----------|--------------|---------------|
| Pod v1 | `https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core` | `https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/` |
| Event v1 | `https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#event-v1-core` | `https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/` |

## Verification
- Verified no broken link.
