### PR TITLE
docs: add FUNC_USERNAME/PASSWORD env vars documentation

### DIFF
--- a/docs/snippets/proc-building-function.md
+++ b/docs/snippets/proc-building-function.md
@@ -22,3 +22,13 @@ The `build` command uses the project name and the image registry name to constru
 
 !!! note
     The coordinates for the **image registry** can be configured through an environment variable (`FUNC_REGISTRY`) as well.
+
+!!! tip "Private Registry Authentication"
+    For private registries that require authentication, you can set credentials using environment variables:
+    
+    - `FUNC_USERNAME`: The username for registry authentication
+    - `FUNC_PASSWORD`: The password for registry authentication
+    
+    These variables work with all builders: `host`, `s2i`, and `pack`.
+    
+    **Note:** Using environment variables is more secure than the `--password` flag because command-line arguments are visible to all users on the system via `ps`.

--- a/docs/snippets/proc-deploying-function.md
+++ b/docs/snippets/proc-deploying-function.md
@@ -46,6 +46,16 @@ The `deploy` command uses the function project name as the Knative Service name.
     http://hello.default.127.0.0.1.sslip.io
 ```
 
+!!! tip "Private Registry Authentication"
+    For private registries that require authentication, you can set credentials using environment variables:
+    
+    - `FUNC_USERNAME`: The username for registry authentication
+    - `FUNC_PASSWORD`: The password for registry authentication
+    
+    These variables work with all builders: `host`, `s2i`, and `pack`.
+    
+    **Note:** Using environment variables is more secure than the `--password` flag because command-line arguments are visible to all users on the system via `ps`.
+
 You can verify that your function has been successfully deployed by using the `invoke` command and observing the output:
 
 === "func"

--- a/docs/snippets/proc-running-function.md
+++ b/docs/snippets/proc-running-function.md
@@ -60,6 +60,15 @@ The `run` command builds an image for your function if required, and runs this i
     kn func run --build=false
     ```
 
+!!! tip "Private Registry Authentication"
+    For private registries that require authentication, you can set credentials using environment variables:
+    
+    - `FUNC_USERNAME`: The username for registry authentication
+    - `FUNC_PASSWORD`: The password for registry authentication
+    
+    These variables work with all builders: `host`, `s2i`, and `pack`.
+    
+    **Note:** Using environment variables is more secure than the `--password` flag because command-line arguments are visible to all users on the system via `ps`.
 You can verify that your function has been successfully run by using the `invoke` command and observing the output:
 
 === "func"


### PR DESCRIPTION
Fixes knative/func#3299

## Proposed Changes

- Added documentation for `FUNC_USERNAME` and `FUNC_PASSWORD` environment variables in [docs/snippets/proc-building-function.md](cci:7://file:///home/kunal/Desktop/docs-1/docs/snippets/proc-building-function.md:0:0-0:0).
- Added documentation for `FUNC_USERNAME` and `FUNC_PASSWORD` environment variables in [docs/snippets/proc-deploying-function.md](cci:7://file:///home/kunal/Desktop/docs-1/docs/snippets/proc-deploying-function.md:0:0-0:0).
- Clarified that these environment variables now work with all builders (`host`, `s2i`, and `pack`) for private registry authentication, following the refactoring in [knative/func#3298](https://github.com/knative/func/pull/3298).
- Since these are snippets, the updates will automatically appear in the "Building functions", "Deploying functions", and "Getting started" documentation pages.