### PR TITLE
Add documentation for activator <> autoscaler connectivity metrics

### DIFF
--- a/docs/versioned/serving/observability/metrics/serving-metrics.md
+++ b/docs/versioned/serving/observability/metrics/serving-metrics.md
@@ -125,7 +125,7 @@ Name | Type | Description
 -|-|-
 `peer` | string | The peer service the activator is connecting to (e.g., `autoscaler`)
 
-This counter increments each time the activator fails to communicate with a peer. It complements the `kn.activator.reachable` gauge by providing a cumulative count of errors, which is useful for:
+This counter increments each time the activator fails to communicate with a peer. It complements the `kn.activator.stats.conn.reachable` gauge by providing a cumulative count of errors, which is useful for:
 
 - Detecting flaky connections that might be missed by point-in-time gauge sampling
 - Creating rate-based alerts (e.g., alert if error rate exceeds threshold over 5 minutes)


### PR DESCRIPTION
This PR adds documentation for the new `kn.activator.autoscaler.reachable` metric that was added in knative/serving.

## Changes

Added documentation for the `kn.activator.autoscaler.reachable` metric to the Activator section in the docs.

### Metric Details
- **Name:** `kn.activator.autoscaler.reachable`
- **Type:** Int64Gauge
- **Unit:** {reachable}
- **Values:** `1` (reachable), `0` (not reachable)
- **Description:** Whether the autoscaler is reachable from the activator

## Related PRs
https://github.com/knative/serving/pull/16318
