### PR TITLE
docs: prevent header tabs from overlapping on search expand

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -673,6 +673,49 @@ a.md-header__button.md-logo img {
   }
 }
 
+@media (min-width: 1025px) {
+  .md-header__source {
+    color: var(--md-primary-fg-color--dark);
+    flex: 0 0 auto !important;   
+    margin-left: 1rem;          
+  }
+  
+  [data-md-toggle="search"]:checked ~ .md-header .md-header__source {
+    transform: none !important;
+    margin-left: 1rem !important;
+  }
+  
+  .md-search__form {
+    border-radius: 10px;
+  }
+  
+  .md-search__inner {
+    max-width: 31rem;
+  }
+  
+  .md-search__input {
+    background-color: white;
+    border: black 1px solid;
+    border-radius: 10px;
+    width: 100%;
+  }
+  
+  .md-header__title {
+    flex: 0 0 auto !important;
+    min-width: 11rem;            
+    max-width: 16rem;             
+    margin-right: 0.75rem;
+  }
+  
+  .md-header__list {
+    gap: 0.75rem;
+  }
+}
+
+.md-search-result__article {
+  max-height: none;
+}
+
 .md-search-result__article {
   max-height: none;
 }


### PR DESCRIPTION
## Header tabs overlap when search expands [Fixes #6332]


<img width="1348" height="165" alt="problem" src="https://github.com/user-attachments/assets/97aa8e23-e269-4f62-8d2f-17ec4d9f2490" />

## Proposed Changes

- Fixed navigation layout shift when search is activated
- Restructured header to use separate sticky navigation container
- Maintained responsive design across all breakpoints

**Reference:** https://squidfunk.github.io/mkdocs-material/tutorials/


