### PR TITLE
Add Gateway API kn operator CLI docs

### DIFF
--- a/docs/versioned/.nav.yml
+++ b/docs/versioned/.nav.yml
@@ -252,7 +252,6 @@ nav:
           - Configuring Knative Eventing CRDs: install/operator/configuring-eventing-cr.md
         - Installing plugins:
           - Install Istio for Knative: install/installing-istio.md
-          # TODO: docs for kourier, contour, gateway-api
           - Install Kafka for Knative: install/eventing/kafka-install.md
           - Install RabbitMQ for Knative: install/eventing/rabbitmq-install.md
           # N.B. this duplicates an "eventing" topic above, cross-referenced here.

--- a/docs/versioned/install/operator/configuring-serving-cr.md
+++ b/docs/versioned/install/operator/configuring-serving-cr.md
@@ -552,6 +552,75 @@ spec:
           service: custom-local-gateway.istio-system.svc.cluster.local
 ```
 
+## Configure the Gateway API ingress
+
+!!! warning
+    Gateway API support in Knative is currently in **Beta**. The API and configuration may change in future releases.
+    The Knative team currently tests with Istio, Contour, and Envoy Gateway implementations. For more details, see the
+    [net-gateway-api repository](https://github.com/knative-extensions/net-gateway-api).
+
+To use Gateway API as the networking layer, you need to configure the `spec.ingress.gateway-api` and `spec.config.network` fields in the KnativeServing CR.
+
+### Enable Gateway API
+
+To enable Gateway API as the ingress, apply the following KnativeServing CR:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  ingress:
+    gateway-api:
+      enabled: true
+  config:
+    network:
+      ingress-class: "gateway-api.ingress.networking.knative.dev"
+```
+
+### Configure Gateway API gateways
+
+You can configure external and local gateways for Gateway API by using the `spec.config.gateway` field. For example:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  ingress:
+    gateway-api:
+      enabled: true
+  config:
+    network:
+      ingress-class: "gateway-api.ingress.networking.knative.dev"
+    gateway:
+      external-gateways: |
+        - class: istio
+          gateway: istio-system/knative-gateway
+          service: istio-system/istio-ingressgateway
+      local-gateways: |
+        - class: istio
+          gateway: istio-system/knative-local-gateway
+          service: istio-system/knative-local-gateway
+```
+
+The key in `spec.config.gateway` is in the format of:
+
+```
+external-gateways: |
+  - class: <gateway-class>
+    gateway: <namespace>/<gateway-name>
+    service: <namespace>/<service-name>
+local-gateways: |
+  - class: <gateway-class>
+    gateway: <namespace>/<gateway-name>
+    service: <namespace>/<service-name>
+```
+
 ## Customize kourier-bootstrap for Kourier gateways:
 
 By default, Kourier contains envoy bootstrap configuration in the ConfigMap `kourier-bootstrap`. The `spec.ingress.kourier.bootstrap-configmap` field allows you to specify your customized bootstrap ConfigMap.

--- a/docs/versioned/install/operator/knative-with-operator-cli.md
+++ b/docs/versioned/install/operator/knative-with-operator-cli.md
@@ -123,6 +123,41 @@ you can configure Knative Serving with different ingresses:
         kn operator enable ingress --contour -n knative-serving
         ```
 
+=== "Gateway API"
+
+    !!! warning
+        Gateway API support in Knative is currently in **Beta**. The API and configuration may change in future releases.
+        The Knative team currently tests with Istio, Contour, and Envoy Gateway implementations. For more details, see the
+        [net-gateway-api repository](https://github.com/knative-extensions/net-gateway-api).
+
+    The following steps configure Knative Serving to use Gateway API as the networking layer:
+
+    1. You must have a Gateway API implementation installed in your cluster (for example, Istio, Contour,
+    or Envoy Gateway). Refer to your chosen implementation's documentation for installation instructions.
+
+    1. Install the Gateway API CRDs if they are not already installed on your cluster:
+
+        ```bash
+        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/latest/download/standard-install.yaml
+        ```
+
+    1. To configure Knative Serving to use Gateway API, run the command as follows:
+
+        ```bash
+        kn operator enable ingress --gateway-api -n knative-serving
+        ```
+
+    !!! note
+        By default, the net-gateway-api controller uses Istio's Gateway resources
+        (`istio-system/knative-gateway` for external traffic and `istio-system/knative-local-gateway`
+        for cluster-local traffic). If you are using Istio as your Gateway API implementation,
+        no additional gateway configuration is needed.
+
+        If you are using a different Gateway API implementation such as Contour or Envoy Gateway,
+        you must configure `spec.config.gateway` in the KnativeServing CR to specify the correct
+        gateway references. For details, see
+        [Configure the Gateway API ingress](configuring-serving-cr.md#configure-the-gateway-api-ingress).
+
 ## Install the Knative Eventing component
 
 You can install Knative Eventing of any specific version under any specific namespace. By default, the namespace is `knative-eventing`,

--- a/docs/versioned/install/operator/knative-with-operators.md
+++ b/docs/versioned/install/operator/knative-with-operators.md
@@ -263,6 +263,83 @@ Knative Serving with different ingresses:
 
         Save this for configuring DNS later.
 
+=== "Gateway API"
+
+    !!! warning
+        Gateway API support in Knative is currently in **Beta**. The API and configuration may change in future releases.
+        The Knative team currently tests with Istio, Contour, and Envoy Gateway implementations. For more details, see the
+        [net-gateway-api repository](https://github.com/knative-extensions/net-gateway-api).
+
+    The following steps configure Knative Serving to use Gateway API as the networking layer:
+
+    1. You must have a Gateway API implementation installed in your cluster (for example, Istio, Contour,
+    or Envoy Gateway). Refer to your chosen implementation's documentation for installation instructions.
+
+    1. Install the Gateway API CRDs if they are not already installed on your cluster:
+
+        ```bash
+        kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/latest/download/standard-install.yaml
+        ```
+
+    1. Ensure that a `Gateway` resource exists in your cluster for Knative to use. If your Gateway API
+    implementation does not create one automatically, create it according to your implementation's documentation.
+    For more information on configuring gateway references, see
+    [Configure the Gateway API ingress](configuring-serving-cr.md#configure-the-gateway-api-ingress).
+
+    1. To configure Knative Serving to use Gateway API, add `spec.ingress.gateway-api`
+    and `spec.config.network` to your Serving CR YAML file as follows:
+
+        ```yaml
+        apiVersion: operator.knative.dev/v1beta1
+        kind: KnativeServing
+        metadata:
+          name: knative-serving
+          namespace: knative-serving
+        spec:
+          # ...
+          ingress:
+            gateway-api:
+              enabled: true
+          config:
+            network:
+              ingress-class: "gateway-api.ingress.networking.knative.dev"
+        ```
+
+    !!! note
+        By default, the net-gateway-api controller uses Istio's Gateway resources
+        (`istio-system/knative-gateway` for external traffic and `istio-system/knative-local-gateway`
+        for cluster-local traffic). If you are using Istio as your Gateway API implementation,
+        no additional gateway configuration is needed.
+
+        If you are using a different Gateway API implementation such as Contour or Envoy Gateway,
+        you must configure `spec.config.gateway` in the KnativeServing CR to specify the correct
+        gateway references. For details, see
+        [Configure the Gateway API ingress](configuring-serving-cr.md#configure-the-gateway-api-ingress).
+
+    1. Apply the YAML file for your Serving CR by running the command:
+
+        ```bash
+        kubectl apply -f <filename>.yaml
+        ```
+
+        Where `<filename>` is the name of your Serving CR file.
+
+    1. Verify that the Knative Gateway API components are deployed:
+
+        ```bash
+        kubectl get deployment -n knative-serving
+        ```
+
+        You should see the `net-gateway-api-controller` deployment in the list of deployments.
+
+    1. Fetch the External IP or CNAME by checking your Gateway status:
+
+        ```bash
+        kubectl get gateway --all-namespaces
+        ```
+
+        The `ADDRESS` column shows the external IP or hostname. Save this for configuring DNS later.
+
 ### Verify the Knative Serving deployment
 
 1. Monitor the Knative deployments:


### PR DESCRIPTION
## Summary
- Add Gateway API tab to the Knative Operator CLI plugin installation docs (`knative-with-operator-cli.md`)
- Documents the `kn operator enable ingress --gateway-api` command

This is the CLI counterpart of the Operator-side Gateway API support added in knative/operator#2251 (merged 2026-03-19).

> **Note**: This PR depends on the Operator docs PR (#6591) being merged first, and requires the `kn-plugin-operator` Gateway API support to be released.

Related:
- knative/operator#2251 — Operator-side implementation (merged)
- https://github.com/knative-extensions/kn-plugin-operator — CLI plugin

## Test plan
- [ ] Verify the Gateway API tab renders correctly in `knative-with-operator-cli.md`
- [ ] Verify the link to `configuring-serving-cr.md#configure-the-gateway-api-ingress` works

/cc @houshengbo