### PR TITLE
Improve installation roadmap with clearer guidance on setup paths

### DIFF
--- a/docs/versioned/install/README.md
+++ b/docs/versioned/install/README.md
@@ -21,6 +21,33 @@ You can install the Serving and Eventing components independently of one another
 
 ## Installation roadmap
 
+Knative can be installed in different ways depending on your environment, components, and preferred installation method. The following guidance helps you choose the appropriate path.
+
+### Environment
+
+- **Local development (testing / learning)**
+  - Use Quickstart with `kind` or `Minikube`
+- **Server / production environments**
+  - Use YAML-based installation or the Knative Operator on a managed or on-prem Kubernetes cluster
+
+### Installation methods
+
+- **Quickstart** – for local development and evaluation  
+- **YAML manifests** – for manual, fine-grained control  
+- **Knative Operator** – for simplified installation and lifecycle management  
+
+### Components
+
+- **Serving** – deploy and manage serverless workloads  
+- **Eventing** – build event-driven architectures  
+
+### Platform considerations
+
+- Supported platforms include Kubernetes clusters on Linux, macOS, and Windows  
+- Local setups are intended for development and testing only  
+
+---
+
 Use the following table to determine your installation method. If you just want to get an understanding of Knative functionality at this time, install the quickstart.
 
 |  | Quickstart | YAML-based | Knative Operator |


### PR DESCRIPTION

<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

"Fixes #6305"

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Added guidance on:
      environment selection (local vs production)
      installation methods (Quickstart, YAML, Knative Operator)
      Knative components (Serving, Eventing)
      platform considerations
- Retained existing roadmap table and installation steps
