### PR TITLE
Chore: hide sub nav for 404 page

### DIFF
--- a/overrides/404.html
+++ b/overrides/404.html
@@ -1,0 +1,12 @@
+{% extends "main.html" %}
+{% block header %}
+  {% set is_404_page = true %}
+  {% include "partials/header.html" %}
+{% endblock %}
+
+{% block tabs %}
+{% endblock %}
+
+{% block content %}
+  <h1>404 - Not found</h1>
+{% endblock %}

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -143,9 +143,7 @@
   </nav>
 
   <!-- Sub Navigation tabs (sticky) -->
-  {% set page_url = page.url | default("") %}
-  {% set is_404_page = page_url in ["404/", "404.html"] %}
-  {% if not page.is_homepage and not is_404_page %}
+  {% if not page.is_homepage and not (is_404_page | default(false)) %}
     {% if "navigation.tabs.sticky" in features %}
       {% if "navigation.tabs" in features %}
         {% include "partials/tabs.html" %}

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -143,7 +143,9 @@
   </nav>
 
   <!-- Sub Navigation tabs (sticky) -->
-  {% if not page.is_homepage %}
+  {% set page_url = page.url | default("") %}
+  {% set is_404_page = page_url in ["404/", "404.html"] %}
+  {% if not page.is_homepage and not is_404_page %}
     {% if "navigation.tabs.sticky" in features %}
       {% if "navigation.tabs" in features %}
         {% include "partials/tabs.html" %}


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Fixes #6621 