### PR TITLE
Add blog post for deploying Knative to remote clusters via Cluster Inventory API

### DIFF
--- a/docs/blog/.nav.yml
+++ b/docs/blog/.nav.yml
@@ -45,6 +45,7 @@ nav:
           - releases/announcing-knative-v0-3-release.md
           - releases/announcing-knative-v0-2-release.md
       - Articles:
+          - articles/deploying-knative-to-remote-clusters-with-operator.md
           - articles/gateway-api-ingress-with-knative-operator.md
           - articles/Enhancing-func-cli-ux.md
           - articles/knative-eventing-eda-agents.md

--- a/docs/blog/articles/deploying-knative-to-remote-clusters-with-operator.md
+++ b/docs/blog/articles/deploying-knative-to-remote-clusters-with-operator.md
@@ -1,0 +1,168 @@
+---
+title: "Deploying Knative to remote clusters with the Operator"
+linkTitle: "Deploying Knative to remote clusters with the Operator"
+author: "kahirokunn"
+author handle: https://github.com/kahirokunn
+date: 2026-05-07
+description: "How to deploy Knative Serving and Eventing to remote clusters with Knative Operator v1.22"
+type: "blog"
+---
+
+# Deploying Knative to remote clusters with the Operator
+
+**Author: [kahirokunn](https://github.com/kahirokunn)**
+
+_In this blog post you will learn how to use Knative Operator v1.22 to deploy Knative Serving and Eventing components to remote Kubernetes clusters from a hub cluster._
+
+Platform teams often manage more than one Kubernetes cluster. Some clusters are split by region, some by environment, and some by tenant or business unit. Until now, installing Knative across those clusters usually meant running a separate Operator in every cluster, or building extra automation around the installation manifests.
+
+Starting with Knative Operator v1.22, a single Operator can deploy Knative components to a different Kubernetes cluster. The cluster that runs the Operator acts as the **hub cluster**. The cluster that receives Knative Serving or Knative Eventing acts as a **spoke cluster**. You select the spoke by setting `spec.clusterProfileRef` on the `KnativeServing` or `KnativeEventing` custom resource.
+
+This feature uses the SIG-Multicluster Cluster Inventory API, introduced through [KEP-5339](https://github.com/kubernetes/enhancements/issues/5339). The Operator reads a `ClusterProfile` resource to discover the remote cluster endpoint and access provider, then runs the normal Knative installation pipeline against that remote cluster.
+
+If `spec.clusterProfileRef` is not set, nothing changes. The Operator keeps deploying Knative to the local cluster exactly as it did before.
+
+## Why this matters
+
+Multi-cluster support makes the Knative Operator a better fit for fleet-oriented platforms. You can keep the Knative installation API on the hub while still placing Serving and Eventing components close to the workloads that need them.
+
+This is useful when you want to:
+
+- manage Knative installations for many spoke clusters from one control point;
+- integrate with a fleet manager that publishes `ClusterProfile` resources;
+- keep using the same `KnativeServing` and `KnativeEventing` APIs for local and remote installs;
+- apply consistent configuration across regions or environments; and
+- delete a hub-side CR and let the Operator clean up the remote installation.
+
+The feature is intentionally based on the Cluster Inventory API instead of a specific fleet manager. A fleet system such as Open Cluster Management can publish the `ClusterProfile` resources, and proof-of-concept environments can register them manually.
+
+!!! important
+    Multi-cluster deployment is a beta feature in Knative Operator v1.22 and later. It depends on the SIG-Multicluster Cluster Inventory API, which is still in alpha. The API schema and recommended access provider plugins might change between releases.
+
+## How the Operator targets a remote cluster
+
+The Operator resolves the target cluster at the start of reconciliation. When `spec.clusterProfileRef` is present, it reads the referenced `ClusterProfile`, invokes the configured access provider plugin, and builds a Kubernetes client for the spoke cluster.
+
+After that, the existing install stages continue to run as usual, but they use the spoke client. This means the Operator still applies the standard Knative manifests, CRDs, ConfigMaps, Deployments, Services, and RBAC resources. The difference is where those resources land.
+
+For cleanup, the Operator uses a helper resource on the spoke cluster to anchor ownership of namespace-scoped Knative resources. Namespace-scoped resources are garbage collected through Kubernetes owner references. Cluster-scoped resources, such as ClusterRoles and CRDs, are removed explicitly by the hub-side finalizer.
+
+Always uninstall a remote Knative deployment by deleting the `KnativeServing` or `KnativeEventing` CR on the hub. If the spoke cluster is temporarily unreachable, the finalizer retries until the spoke can be reached again.
+
+## What you need before enabling it
+
+Before deploying Knative to a remote cluster, prepare the following pieces:
+
+- Knative Operator v1.22 or later.
+- A hub cluster running Kubernetes v1.35 or later. Knative v1.22 supports Kubernetes v1.34 for standard installations, but remote deployment uses Kubernetes image volumes on the hub to mount credential plugin binaries. That volume type is enabled by default starting in Kubernetes v1.35.
+- The Cluster Inventory API `ClusterProfile` CRD installed on the hub.
+- Network connectivity from the hub cluster to the spoke cluster API server.
+- A credential plugin that implements the Cluster Inventory API access provider interface.
+- Spoke-cluster RBAC permissions that let the returned credential manage Knative resources.
+
+The upstream Cluster Inventory API project publishes credential plugins such as `secretreader` and `kubeconfig-secretreader`. Use the plugin that matches how you want to store spoke credentials.
+
+For full prerequisites and setup steps, see [Deploy Knative to a remote cluster](https://knative.dev/docs/install/operator/multi-cluster-deployment/).
+
+## Enable multi-cluster support
+
+Multi-cluster support is disabled by default. If you install or upgrade the Operator with Helm, enable it through the `knative_operator.multicluster.*` values:
+
+```yaml
+knative_operator:
+  multicluster:
+    enabled: true
+    accessProvidersConfig:
+      providers:
+        - name: secretreader
+          execConfig:
+            apiVersion: client.authentication.k8s.io/v1
+            command: /credential-plugin/secretreader-plugin
+            provideClusterInfo: true
+    plugins:
+      - name: secretreader
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
+        mountPath: /credential-plugin
+    remoteDeploymentsPollInterval: 10s
+```
+
+The provider name in `accessProvidersConfig.providers[].name` must match the plugin name in `plugins[].name`. The Operator uses that name to connect the `ClusterProfile` access provider entry to the credential plugin configuration.
+
+If you do not use Helm, you can patch an existing Operator Deployment. The important pieces are the same: mount the access provider configuration, mount the credential plugin binary, and start the Operator with `--clusterprofile-provider-file`.
+
+## Register the spoke cluster
+
+The hub discovers spoke clusters through `ClusterProfile` resources. In production, a fleet manager can publish and update those resources. For a local test or proof of concept, you can create the `ClusterProfile` yourself and patch its status.
+
+A `ClusterProfile` includes the cluster manager identity in `spec`, and the remote access information in `status.accessProviders`. The Operator also checks that the `ControlPlaneHealthy` condition is `True`.
+
+The important relationship is:
+
+- `KnativeServing` or `KnativeEventing` points to a `ClusterProfile` by name and namespace.
+- The `ClusterProfile` advertises an access provider by name.
+- The Operator has a provider configuration with the same name.
+- The credential plugin returns credentials for the spoke cluster.
+
+After those pieces line up, the Operator can build a client for the spoke and reconcile Knative there.
+
+## Deploy Knative Serving to a spoke
+
+After enabling multi-cluster support and registering a `ClusterProfile`, set `spec.clusterProfileRef` on the `KnativeServing` CR:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  clusterProfileRef:
+    name: spoke-cluster-1
+    namespace: fleet-system
+  ingress:
+    kourier:
+      enabled: true
+  config:
+    network:
+      ingress-class: kourier.ingress.networking.knative.dev
+```
+
+Apply this CR on the hub cluster. The Operator runs on the hub, but the Serving resources are created on the spoke cluster described by `spoke-cluster-1`.
+
+For ingress, choose the implementation that fits the spoke. Kourier is the simplest path because the Operator can deploy it as part of the Serving installation. If you use Istio or Gateway API ingress, prepare the ingress implementation and gateway resources on the spoke before applying the `KnativeServing` CR.
+
+## Deploy Knative Eventing to a spoke
+
+Knative Eventing uses the same targeting field:
+
+```yaml
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  clusterProfileRef:
+    name: spoke-cluster-1
+    namespace: fleet-system
+```
+
+Apply this CR on the hub, then check the spoke cluster for the Eventing components.
+
+## Operating at fleet scale
+
+Each `KnativeServing` or `KnativeEventing` CR targets exactly one `ClusterProfile`. To deploy to several spokes, create one CR per spoke and use a naming convention that makes the target clear, such as `knative-serving-us-east` or `knative-eventing-prod-eu`.
+
+The `spec.clusterProfileRef` field is immutable after the CR is created. To move an installation to a different spoke, delete the existing CR and create a new one with the new `clusterProfileRef`.
+
+The Operator reports remote targeting through the `TargetClusterResolved` condition. If targeting fails, the condition reason points to the next action. For example, `ClusterProfileNotFound` means the referenced profile does not exist, `MulticlusterDisabled` means the Operator was not started with a provider file, and `AccessProviderFailed` means the credential plugin returned an error.
+
+For larger fleets, tune the remote readiness polling interval. The default is `10s`, but you can increase it with `--remote-deployments-poll-interval` or the Helm value `knative_operator.multicluster.remoteDeploymentsPollInterval`.
+
+## Conclusion
+
+Knative Operator v1.22 adds a new way to run Knative across a fleet: keep the Operator and installation API on a hub cluster, and deploy Serving or Eventing components to remote spoke clusters through `spec.clusterProfileRef`.
+
+This keeps the single-cluster path unchanged while giving platform teams a declarative API for remote installations, cleanup, and fleet integration through the Cluster Inventory API.
+
+To try it end to end, follow the [multi-cluster deployment guide](https://knative.dev/docs/install/operator/multi-cluster-deployment/).

--- a/docs/blog/articles/gateway-api-ingress-with-knative-operator.md
+++ b/docs/blog/articles/gateway-api-ingress-with-knative-operator.md
@@ -16,7 +16,7 @@ _In this blog post you will learn how to use the Knative Operator to manage Knat
 
 Starting with Knative v1.22, the Knative Operator supports `net-gateway-api` as an ingress option for Knative Serving. If your platform already standardizes on Kubernetes Gateway API resources such as `GatewayClass`, `Gateway`, and `HTTPRoute`, you can now keep the Knative ingress choice and gateway configuration together in the Operator-managed `KnativeServing` custom resource.
 
-Gateway API support in Knative is currently in beta. You must install a Gateway API implementation in your cluster before using `net-gateway-api`. Knative currently tests `net-gateway-api` against the Istio, Contour, and Envoy Gateway implementations. For tested versions, see the [`net-gateway-api` test version documentation](https://github.com/knative-extensions/net-gateway-api/blob/release-1.22/docs/test-version.md).
+Gateway API support in Knative is currently in beta. You must install a Gateway API implementation in your cluster before using `net-gateway-api`. Knative currently tests `net-gateway-api` against the Istio, Contour, and Envoy Gateway implementations. For tested versions, see the `net-gateway-api` [test version documentation](https://github.com/knative-extensions/net-gateway-api/blob/release-1.22/docs/test-version.md).
 
 ## What the Operator manages
 

--- a/docs/blog/articles/gateway-api-ingress-with-knative-operator.md
+++ b/docs/blog/articles/gateway-api-ingress-with-knative-operator.md
@@ -1,6 +1,16 @@
+---
+title: "Managing Gateway API ingress with the Knative Operator"
+linkTitle: "Managing Gateway API ingress with the Knative Operator"
+author: "kahirokunn"
+author handle: https://github.com/kahirokunn
+date: 2026-05-07
+description: "How to use the Knative Operator to manage Knative Serving with Gateway API ingress"
+type: "blog"
+---
+
 # Managing Gateway API ingress with the Knative Operator
 
-**Author: kahirokunn**
+**Author: [kahirokunn](https://github.com/kahirokunn)**
 
 _In this blog post you will learn how to use the Knative Operator to manage Knative Serving with Gateway API ingress._
 

--- a/docs/versioned/install/operator/multi-cluster-deployment.md
+++ b/docs/versioned/install/operator/multi-cluster-deployment.md
@@ -33,12 +33,12 @@ The Operator continues to manage the lifecycle of the CR from the hub. To delete
 Before you deploy Knative to a remote cluster, you must have:
 
 - Knative Operator v1.22 or later.
-- A hub cluster running Kubernetes v1.35 or later. The Operator loads credential plugin binaries through an image volume, a Kubernetes feature that became generally available in v1.35. No other delivery method for credential plugins is supported.
+- A hub cluster running Kubernetes v1.35 or later. Knative v1.22 supports Kubernetes v1.34 for standard installations, but multi-cluster support uses Kubernetes image volumes to mount credential plugin binaries on the hub. That volume type is enabled by default starting in Kubernetes v1.35. No other delivery method for credential plugins is supported.
 - The Cluster Inventory API `ClusterProfile` CRD installed on the hub cluster. See the installation instructions in the [kubernetes-sigs/cluster-inventory-api](https://github.com/kubernetes-sigs/cluster-inventory-api) repository.
 - Network connectivity from the hub cluster to each spoke cluster's API server. If the hub cannot reach a spoke directly, use a reverse tunnel such as the OCM cluster-proxy.
 - A credential plugin that implements the Cluster Inventory API access provider interface. The upstream `kubernetes-sigs/cluster-inventory-api` project publishes two plugins:
-    - `registry.k8s.io/cluster-inventory-api/secretreader:v0.1.0` reads a bearer token from a `Secret`'s `data.token` field.
-    - `registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.0` reads a complete kubeconfig from a `Secret`.
+    - `registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1` reads a bearer token from a `Secret`'s `data.token` field.
+    - `registry.k8s.io/cluster-inventory-api/kubeconfig-secretreader:v0.1.1` reads a complete kubeconfig from a `Secret`.
 
     Pick whichever matches the credential format you intend to use, or use a plugin from another source.
 - RBAC permissions on each spoke cluster that let the credential returned by the plugin create and manage Knative resources. See [Spoke RBAC requirements](#spoke-rbac-requirements).
@@ -76,11 +76,11 @@ knative_operator:
         - name: secretreader
           execConfig:
             apiVersion: client.authentication.k8s.io/v1
-            command: /credential-plugin/plugin-binary
+            command: /credential-plugin/secretreader-plugin
             provideClusterInfo: true
     plugins:
       - name: secretreader
-        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.0
+        image: registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1
         mountPath: /credential-plugin
     remoteDeploymentsPollInterval: 10s
 ```
@@ -120,7 +120,7 @@ If you do not use Helm, add multi-cluster support to an Operator that is already
           "name": "secretreader",
           "execConfig": {
             "apiVersion": "client.authentication.k8s.io/v1",
-            "command": "/credential-plugin/plugin-binary",
+            "command": "/credential-plugin/secretreader-plugin",
             "provideClusterInfo": true
           }
         }
@@ -175,7 +175,7 @@ A `ClusterProfile` resource on the hub describes one spoke. Register it in one o
 
 ### Register a ClusterProfile manually
 
-Manual registration prepares the spoke first, then publishes its endpoint and credentials on the hub. The examples below use the `secretreader` plugin (`registry.k8s.io/cluster-inventory-api/secretreader:v0.1.0`); replace image references and configuration fields with those required by the plugin you choose.
+Manual registration prepares the spoke first, then publishes its endpoint and credentials on the hub. The examples below use the `secretreader` plugin (`registry.k8s.io/cluster-inventory-api/secretreader:v0.1.1`); replace image references and configuration fields with those required by the plugin you choose.
 
 1. On the spoke cluster, create a `ServiceAccount`, the required permissions, and a token `Secret`:
 


### PR DESCRIPTION
Documents Knative Operator v1.22 multi-cluster deployment support in the Knative blog.

## Proposed Changes

- Add a new blog post about deploying Knative Serving and Eventing to remote clusters with the Knative Operator.
