### PR TITLE
docs: fix "Knaitve" -> "Knative" typo in Kafka broker docs

### DIFF
--- a/docs/versioned/eventing/brokers/broker-types/kafka-broker/configuring-kafka-features.md
+++ b/docs/versioned/eventing/brokers/broker-types/kafka-broker/configuring-kafka-features.md
@@ -7,7 +7,7 @@ function: how-to
 
 # Configuring Kafka Features
 
-There are many different configuration options for how Knative Eventing and the Knaitve Broker for Apache Kafka interact with the Apache Kafka clusters.
+There are many different configuration options for how Knative Eventing and the Knative Broker for Apache Kafka interact with the Apache Kafka clusters.
 
 ## Configure Knative Eventing Kafka features
 


### PR DESCRIPTION
Fix a small typo ("Knaitve" -> "Knative") in the Kafka broker "Configuring Kafka Features" documentation.

## Proposed Changes

- Correct "Knaitve" to "Knative" in `docs/versioned/eventing/brokers/broker-types/kafka-broker/configuring-kafka-features.md`.

/kind documentation

```release-note
NONE
```