### PR TITLE
Fix blog search worker path

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -63,7 +63,7 @@
         "search.result.term.missing": lang.t("search.result.term.missing"),
         "select.version": lang.t("select.version")
       },
-      "search": "assets/javascripts/workers/search.973d3a69.min.js" | url,
+      "search": "assets/javascripts/workers/search.2c215733.min.js" | url,
       "tags": _.tags or none,
       "version": _.version or none
     } | tojson -}}


### PR DESCRIPTION
Fixes blog search initialization failing due to a stale MkDocs Material search worker path.

## Proposed Changes

- Update the overridden search worker path in `overrides/main.html` to restore blog search results.

<img width="1860" height="836" alt="CleanShot 2026-05-07 at 23 37 07@2x" src="https://github.com/user-attachments/assets/d26212e0-8b87-4cd7-bf12-027c8571a6b9" />
