### PR TITLE
add note about DOCKER_HOST for kn quickstart kind

### DIFF
--- a/docs/snippets/quickstart-install.md
+++ b/docs/snippets/quickstart-install.md
@@ -88,6 +88,13 @@ To get a local deployment of Knative, run the `quickstart` plugin:
             netstat -tnlp | grep 80
             ```
 
+        !!! note
+            Quickstart connects to the Docker daemon at `/var/run/docker.sock` and does not honor the socket selected by your current `docker context` (for example, when using Colima, Rancher Desktop, or Lima). If you see an error like `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`, set the `DOCKER_HOST` environment variable to your active socket before running the command. For example:
+            ```bash
+            export DOCKER_HOST=unix://$HOME/.lima/docker/sock/docker.sock
+            ```
+            You can find the endpoint for your active context by running `docker context ls`.
+
     1. After the plugin is finished, verify you have a cluster called `knative`:
 
         ```bash


### PR DESCRIPTION
<!-- General PR guidelines:

Most PRs should be opened against the main branch in the
[`knative/docs` GitHub repository](https://github.com/knative/docs).

Use one of the content templates when writing a new document:
- [Concept](docs/contributor/templates/template-concept.md) -- Conceptual topics explain how things
work or what things mean. They provide helpful context to readers. They do not include procedures.
- [Procedure](docs/contributor/templates/template-procedure.md) -- Procedural (how-to) topics
include detailed steps for performing a task as well as some context about the task.
- [Troubleshooting](docs/contributor/templates/template-troubleshooting.md) -- Troubleshooting
topics list common errors and solutions.
- [Blog](docs/contributor/templates/template-blog-entry.md) -- Instructions and a template that you
can use to help you post to the Knative blog.

When you add a new document to the /docs directory, the navigation menu updates automatically.
For more information, see the
[MkDocs documentation](https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation).

If your changes should also be in the most recent release, use [/cherrypick](https://prow.k8s.io/command-help#cherrypick) command; 
for example, "/cherrypick release-1.2" for Prow to generate a PR for the `release-1.2` branch.

For all resources for contributing to the Knative documentation, see the
[Knative contributor's guide](contribute-to-docs/README.md).

 -->

Fixes https://github.com/knative-extensions/kn-plugin-quickstart/issues/617
## Proposed Changes <!-- Describe the changes the PR makes. -->

Adds a snippet about setting `DOCKER_HOST` if running `kn quickstart kind` against a non-standard docker endpoint.